### PR TITLE
invoke bash instead of sh

### DIFF
--- a/deployment/k8s/local-minikube/1-deploy-customer-os-base-infrastructure-local.sh
+++ b/deployment/k8s/local-minikube/1-deploy-customer-os-base-infrastructure-local.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 MINIKUBE_STATUS=$(minikube status)
 MINIKUBE_STARTED_STATUS_TEXT='Running'


### PR DESCRIPTION
[[ ]] is a bash operator that doesn't exist in sh, some operating systems link sh to bash (or zsh) but others do not (like debian) and the script fails