### PR TITLE
Scroll item to view after collapse, unify font size for timeline items

### DIFF
--- a/packages/apps/spaces/components/ui-kit/atoms/timeline-item/timeline-item.module.scss
+++ b/packages/apps/spaces/components/ui-kit/atoms/timeline-item/timeline-item.module.scss
@@ -45,4 +45,6 @@
   border: var(--border-divider);
   width: 100%;
   position: relative;
+  font-size: var(--font-size-sm);
+  font-weight: normal;
 }

--- a/packages/apps/spaces/components/ui-kit/molecules/email-timeline-item/EmailTimelineItem.tsx
+++ b/packages/apps/spaces/components/ui-kit/molecules/email-timeline-item/EmailTimelineItem.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import sanitizeHtml from 'sanitize-html';
 import styles from './email-timeline-item.module.scss';
 import { Button } from '../../atoms';
@@ -22,41 +22,32 @@ export const EmailTimelineItem: React.FC<Props> = ({
   children,
 }) => {
   const [expanded, toggleExpanded] = useState(false);
+  const timelineItemRef = useRef<HTMLDivElement>(null);
 
+  const handleToggleExpanded = () => {
+    toggleExpanded(!expanded);
+    if (timelineItemRef?.current && expanded) {
+      timelineItemRef?.current?.scrollIntoView();
+    }
+  };
   return (
-    <article className={`${styles.emailContainer}`}>
-      <div className={styles.emailData}>
-        <table className={styles.emailDataTable}>
-          <tr>
-            <th className={styles.emailParty}>From:</th>
-            <td>{sender}</td>
-          </tr>
-          <tr>
-            <th className={styles.emailParty}>To:</th>
-            <td>
-              {
-                <div className={styles.emailRecipients}>
-                  {typeof recipients === 'string'
-                    ? recipients
-                    : recipients.map((recipient) => (
-                        <span className={styles.emailRecipient} key={recipient}>
-                          {recipient}
-                        </span>
-                      ))}
-                </div>
-              }
-            </td>
-          </tr>
-
-          {!!cc?.length && (
+    <>
+      <div ref={timelineItemRef} className={styles.scrollToView} />
+      <article className={`${styles.emailContainer}`}>
+        <div className={styles.emailData}>
+          <table className={styles.emailDataTable}>
             <tr>
-              <th className={styles.emailParty}>CC:</th>
+              <th className={styles.emailParty}>From:</th>
+              <td>{sender}</td>
+            </tr>
+            <tr>
+              <th className={styles.emailParty}>To:</th>
               <td>
                 {
                   <div className={styles.emailRecipients}>
-                    {typeof cc === 'string'
-                      ? cc
-                      : cc.map((recipient) => (
+                    {typeof recipients === 'string'
+                      ? recipients
+                      : recipients.map((recipient) => (
                           <span
                             className={styles.emailRecipient}
                             key={recipient}
@@ -68,56 +59,78 @@ export const EmailTimelineItem: React.FC<Props> = ({
                 }
               </td>
             </tr>
-          )}
-          {!!bcc?.length && (
-            <tr>
-              <th className={styles.emailParty}>BCC:</th>
-              <td>
-                {
-                  <div className={styles.emailRecipients}>
-                    {typeof bcc === 'string'
-                      ? bcc
-                      : bcc.map((recipient) => (
-                          <span
-                            className={styles.emailRecipient}
-                            key={recipient}
-                          >
-                            {recipient}
-                          </span>
-                        ))}
-                  </div>
-                }
-              </td>
-            </tr>
-          )}
-          <tr>
-            <th className={styles.emailParty}>Subject:</th>
-            <td>{subject}</td>
-          </tr>
-        </table>
 
-        <div className={styles.stamp}>
-          <div />
+            {!!cc?.length && (
+              <tr>
+                <th className={styles.emailParty}>CC:</th>
+                <td>
+                  {
+                    <div className={styles.emailRecipients}>
+                      {typeof cc === 'string'
+                        ? cc
+                        : cc.map((recipient) => (
+                            <span
+                              className={styles.emailRecipient}
+                              key={recipient}
+                            >
+                              {recipient}
+                            </span>
+                          ))}
+                    </div>
+                  }
+                </td>
+              </tr>
+            )}
+            {!!bcc?.length && (
+              <tr>
+                <th className={styles.emailParty}>BCC:</th>
+                <td>
+                  {
+                    <div className={styles.emailRecipients}>
+                      {typeof bcc === 'string'
+                        ? bcc
+                        : bcc.map((recipient) => (
+                            <span
+                              className={styles.emailRecipient}
+                              key={recipient}
+                            >
+                              {recipient}
+                            </span>
+                          ))}
+                    </div>
+                  }
+                </td>
+              </tr>
+            )}
+            <tr>
+              <th className={styles.emailParty}>Subject:</th>
+              <td>{subject}</td>
+            </tr>
+          </table>
+
+          <div className={styles.stamp}>
+            <div />
+          </div>
         </div>
-      </div>
-      <div
-        className={`${styles.emailContentContainer} ${
-          !expanded ? styles.eclipse : ''
-        }`}
-        style={{ maxHeight: expanded ? 'fit-content' : '80px' }}
-      >
         <div
-          className={`text-overflow-ellipsis ${styles.emailContent}`}
-          dangerouslySetInnerHTML={{ __html: sanitizeHtml(emailContent) }}
-        ></div>
-        {!expanded && <div className={styles.eclipse} />}
-      </div>
-      <div className={styles.toggleExpandButton}>
-        <Button onClick={() => toggleExpanded(!expanded)} mode='link'>
-          {expanded ? 'Collapse' : 'Expand'}
-        </Button>
-        {children}
-      </div>
-    </article>
+          className={`${styles.emailContentContainer} ${
+            !expanded ? styles.eclipse : ''
+          }`}
+          style={{ height: expanded ? '100%' : '80px' }}
+        >
+          <div
+            className={`text-overflow-ellipsis ${styles.emailContent}`}
+            dangerouslySetInnerHTML={{ __html: sanitizeHtml(emailContent) }}
+          ></div>
+          {!expanded && <div className={styles.eclipse} />}
+        </div>
+        <div className={styles.toggleExpandButton}>
+          <Button onClick={() => handleToggleExpanded()} mode='link'>
+            {expanded ? 'Collapse' : 'Expand'}
+          </Button>
+          {children}
+        </div>
+      </article>
+    </>
   );
 };

--- a/packages/apps/spaces/components/ui-kit/molecules/email-timeline-item/email-timeline-item.module.scss
+++ b/packages/apps/spaces/components/ui-kit/molecules/email-timeline-item/email-timeline-item.module.scss
@@ -26,6 +26,11 @@
   margin-right: 8px;
 }
 
+.scrollToView {
+  position: absolute;
+  top: -15px;
+}
+
 .emailContentContainer {
   position: relative;
   display: block;


### PR DESCRIPTION
## Proposed changes

- unify font-size for timeline items
- after collapsing email scroll to top of previewed item

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

