### PR TITLE
fix: #1193 Reset logger after navigating to different page

### DIFF
--- a/packages/apps/spaces/components/ui-kit/molecules/conversation-timeline-item/ConversationTimelineItem.tsx
+++ b/packages/apps/spaces/components/ui-kit/molecules/conversation-timeline-item/ConversationTimelineItem.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Message, Reply } from '../../atoms';
+import { Button, Message } from '../../atoms';
 import axios from 'axios';
 import { gql } from 'graphql-request';
 import { toast } from 'react-toastify';
@@ -97,6 +97,22 @@ export const ConversationTimelineItem: React.FC<Props> = ({
         msg.senderUsername.type == 1 ? msg.senderUsername.identifier : '',
     };
   };
+
+  useEffect(() => {
+    return () => {
+      setEmailEditorData({
+        //@ts-expect-error fixme later
+        handleSubmit: () => null,
+        to: [],
+        subject: '',
+        respondTo: '',
+      });
+      setEditorMode({
+        mode: EditorMode.Note,
+        submitButtonLabel: 'Log into timeline',
+      });
+    };
+  }, []);
   useEffect(() => {
     setLoadingMessages(true);
     axios


### PR DESCRIPTION
## Proposed changes
- reset logger state when user navigates away from page

## Changes

[x] reset logger when conversation timeline item unmounted

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

