### PR TITLE
fix 2641: Add .vercelignore to ignore unnecessary files

### DIFF
--- a/packages/apps/spaces/.vercelignore
+++ b/packages/apps/spaces/.vercelignore
@@ -1,0 +1,6 @@
+node_modules
+.cache
+.output
+/build/
+/public/build
+/api/index.js


### PR DESCRIPTION
## Changes

This commit adds a .vercelignore file to the 'spaces' app. This is done to ensure that unnecessary files such as 'node_modules', '.cache', '.output', '/build/', '/public/build', and '/api/index.js' are ignored during deployments. This change is crucial to avoid bloating deployments and only include necessary files, thereby speeding up the deployment process.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

