### PR TITLE
fix: #2772 Change initial page in pagination from 0 to 1

### DIFF
--- a/packages/apps/spaces/hooks/useUser/useUsers.ts
+++ b/packages/apps/spaces/hooks/useUser/useUsers.ts
@@ -26,7 +26,7 @@ export const useUsers = (): Result => {
     if (!ownerListResult.ownerList.length) {
       loadUsers({
         variables: {
-          pagination: { page: 0, limit: 100 },
+          pagination: { page: 1, limit: 100 },
         },
       }).then((res) => {
         const ownerList = (res.data?.users?.content ?? [])


### PR DESCRIPTION
## Changes
Adjusted the initial page number for the loadUsers function from 0 to 1 to align with the standard pagination index, which starts from 1, not 0. This change is necessary to ensure data is loaded correctly from the first page.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

