### PR TITLE
fix 2931:Fixed app crash

### DIFF
--- a/packages/apps/spaces/utils/getParticipantsName.ts
+++ b/packages/apps/spaces/utils/getParticipantsName.ts
@@ -64,7 +64,12 @@ const getName = (
   return email || rawEmail || '';
 };
 
-export const getParticipant = (participant: EmailParticipant): string => {
+export const getEmailParticipantName = (
+  participant: EmailParticipant,
+): string => {
+  if (!participant?.emailParticipant) {
+    return '';
+  }
   const { emailParticipant } = participant;
   const { contacts, users, email, rawEmail } = emailParticipant;
 
@@ -81,13 +86,13 @@ export const getEmailParticipantsName = (
   participants: EmailParticipant[],
 ): string => {
   return participants
-    ?.map((participant) => getParticipant(participant))
+    ?.map((participant) => getEmailParticipantName(participant))
     .join(', ');
 };
 
 export const getParticipantNameAndEmail = (
   participant: EmailParticipant,
-  keyName= 'email',
+  keyName = 'email',
 ): { [x: string]: string; label: string } => {
   const { emailParticipant } = participant;
   const { contacts, users, email, rawEmail } = emailParticipant;


### PR DESCRIPTION
Renamed function `getParticipant` to `getEmailParticipantName` for improved code readability. The function name change provides more context on the data it's supposed to return. This refactor also adds a check for the existence of `participant.emailParticipant` before attempting to destructure it, to prevent possible run-time errors.


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

