### PR TITLE
fix #3000: Updated API key header key and removed unnecessary headers…

### DIFF
--- a/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/email/compose-email/ComposeEmail.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/email/compose-email/ComposeEmail.tsx
@@ -106,11 +106,7 @@ export const ComposeEmail: FC<ComposeEmail> = ({
       request.subject = subject;
     }
     return axios
-      .post(`/comms-api/mail/send`, request, {
-        headers: {
-          'X-Openline-Mail-Api-Key': `${process.env.COMMS_MAIL_API_KEY}`,
-        },
-      })
+      .post(`/comms-api/mail/send`, request,)
       .then((res) => {
         if (res.data) {
           reset();

--- a/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/email/compose-email/ComposeEmail.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/email/compose-email/ComposeEmail.tsx
@@ -106,7 +106,7 @@ export const ComposeEmail: FC<ComposeEmail> = ({
       request.subject = subject;
     }
     return axios
-      .post(`/comms-api/mail/send`, request,)
+      .post(`/comms-api/mail/send`, request)
       .then((res) => {
         if (res.data) {
           reset();

--- a/packages/apps/spaces/middleware.ts
+++ b/packages/apps/spaces/middleware.ts
@@ -81,8 +81,8 @@ function getRedirectUrl(
       '/' +
       request.nextUrl.pathname.substring('/comms-api/'.length);
     requestHeaders.set(
-      'X-Openline-API-KEY',
-      process.env.COMMS_MAIL_API_KEY as string,
+        'X-Openline-Mail-Api-Key',
+        process.env.COMMS_MAIL_API_KEY as string,
     );
   } else if (request.nextUrl.pathname.startsWith('/oasis-api/')) {
     requestHeaders.set('X-Openline-USERNAME', userName);


### PR DESCRIPTION
… object in post request

This commit modifies the header key from 'X-Openline-API-KEY' to 'X-Openline-Mail-Api-Key' to streamline the variable naming convention with the rest of the application. This change was done in spaces/middleware.ts. Additionally, the headers object in ComposeEmail.tsx is removed from the post request, because the necessary headers have already set in the middleware. Also added a console log for debugging purposes.

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

