### PR TITLE
fix 3004 :Updated middleware to ignore searchParams for 'comms-api'

### DIFF
--- a/packages/apps/spaces/middleware.ts
+++ b/packages/apps/spaces/middleware.ts
@@ -81,8 +81,8 @@ function getRedirectUrl(
       '/' +
       request.nextUrl.pathname.substring('/comms-api/'.length);
     requestHeaders.set(
-        'X-Openline-Mail-Api-Key',
-        process.env.COMMS_MAIL_API_KEY as string,
+      'X-Openline-Mail-Api-Key',
+      process.env.COMMS_MAIL_API_KEY as string,
     );
   } else if (request.nextUrl.pathname.startsWith('/oasis-api/')) {
     requestHeaders.set('X-Openline-USERNAME', userName);
@@ -118,7 +118,7 @@ function getRedirectUrl(
     );
   }
 
-  if (request.nextUrl.searchParams) {
+  if (request.nextUrl.searchParams && !request.nextUrl.pathname.startsWith('/comms-api/')) {
     newURL = newURL + '?' + request.nextUrl.searchParams.toString();
   }
 


### PR DESCRIPTION
Changes are made in the middleware.ts file to ignore searchParams if the pathname starts with '/comms-api/'. Update was necessary to prevent carrying over unnecessary search parameters which could potentially mess with the 'comms-api' endpoints. The change ensures cleaner and more efficient interactions with the 'comms-api'.

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

