### PR TITLE
Add trailing slash to axios post request in ComposeEmail

### DIFF
--- a/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/email/compose-email/ComposeEmail.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/email/compose-email/ComposeEmail.tsx
@@ -107,7 +107,7 @@ export const ComposeEmail: FC<ComposeEmail> = ({
     }
 
     return axios
-      .post(`/comms-api/mail/send`, request, {
+      .post(`/comms-api/mail/send/`, request, {
         headers: {
           'Content-Type': 'application/json',
         },


### PR DESCRIPTION
This change adds a trailing slash to the axios post request in the ComposeEmail component. This is done to maintain consistency and adherence to the defined convention. All post request URLs in the app should end with a trailing slash.

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

