### PR TITLE
fix 3053 & #3056: Remove unnecessary check in ComposeEmail.tsx

### DIFF
--- a/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/email/compose-email/ComposeEmail.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/email/compose-email/ComposeEmail.tsx
@@ -135,10 +135,6 @@ export const ComposeEmail: FC<ComposeEmail> = ({
   const handleModeChange = useCallback(
     (newMode: string) => {
       let newDefaultValues = defaultValues;
-
-      if (mode === newMode) {
-        return;
-      }
       if (newMode === REPLY_MODE) {
         newDefaultValues = new ComposeEmailDto({
           to: from,
@@ -167,7 +163,6 @@ export const ComposeEmail: FC<ComposeEmail> = ({
         });
       }
       setMode(newMode);
-
       setDefaultValues(newDefaultValues);
     },
     [defaultValues, subject, state.values.content, from, cc, bcc],


### PR DESCRIPTION
This commit removes an unnecessary mode comparison in the ComposeEmail component which was causing redundancy. The removed condition check was blocking the recomposition of default email values when the email mode remained the same. It turns out this check was excessive and redundant. Removing this will improve performance and simplification of the code.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

