### PR TITLE
fix #3174 Improved formatting of large numbers in renewal forecast ui.

### DIFF
--- a/packages/apps/spaces/app/organizations/[id]/components/Tabs/panels/AccountPanel/RenewalForecast/RenewalForecast.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Tabs/panels/AccountPanel/RenewalForecast/RenewalForecast.tsx
@@ -14,6 +14,7 @@ import { RenewalForecastModal } from './RenewalForecastModal';
 import { RenewalForecast as RenewalForecastT } from '@graphql/types';
 import { getUserDisplayData } from '@spaces/utils/getUserEmail';
 import { DateTimeUtils } from '@spaces/utils/date';
+import { formatCurrency } from '@spaces/utils/getFormattedCurrencyNumber';
 
 export type RenewalForecastType = RenewalForecastT & { amount?: string | null };
 
@@ -71,6 +72,7 @@ export const RenewalForecast: FC<{
               <Flex align='center'>
                 <Heading
                   size='sm'
+                  whiteSpace='nowrap'
                   fontWeight='semibold'
                   color='gray.700'
                   mr={2}
@@ -94,13 +96,7 @@ export const RenewalForecast: FC<{
             </Flex>
 
             <Heading fontSize='2xl' color={!amount ? 'gray.400' : 'gray.700'}>
-              {!amount
-                ? 'Unknown'
-                : Intl.NumberFormat('en-US', {
-                    style: 'currency',
-                    currency: 'USD',
-                    minimumFractionDigits: 0,
-                  }).format(parseFloat(`${amount}`))}
+              {!amount ? 'Unknown' : formatCurrency(amount)}
             </Heading>
           </Flex>
         </CardBody>

--- a/packages/apps/spaces/utils/getFormattedCurrencyNumber.ts
+++ b/packages/apps/spaces/utils/getFormattedCurrencyNumber.ts
@@ -1,0 +1,22 @@
+function abbreviateNumber(num: number): string {
+  const SI_SYMBOL = ['', 'K', 'M', 'G', 'T', 'P', 'E'];
+  const tier = (Math.log10(Math.abs(num)) / 3) | 0;
+  if (tier == 0) return num.toString();
+  const suffix = SI_SYMBOL[tier];
+  const scale = Math.pow(10, tier * 3);
+  const scaled = num / scale;
+  return scaled.toFixed(1) + suffix;
+}
+
+export function formatCurrency(amount: number): string {
+  if (`${amount}`.length >= 6) {
+    const abbreviatedNumber = abbreviateNumber(amount);
+    return `$${abbreviatedNumber}`;
+  } else {
+    return Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+    }).format(amount);
+  }
+}


### PR DESCRIPTION
Added a new utility function formatCurrency in getFormattedCurrencyNumber.ts file to better handle currency formatting. It also handles large number abbreviations. This was applied to amount display in the RenewalForecast component

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

