### PR TITLE
fix #3313: Fix duplicated participant name

### DIFF
--- a/packages/apps/spaces/utils/getParticipantsName.ts
+++ b/packages/apps/spaces/utils/getParticipantsName.ts
@@ -119,22 +119,18 @@ export const getParticipantNameAndEmail = (
   const { contacts, users, email, rawEmail } = emailParticipant;
 
   if (contacts.length) {
-    const label = contacts
-      .map((c) => (c?.name ? c.name : `${c.firstName} ${c.lastName}`))
-      .join(' ')
-      .trim();
+    const label = contacts.find((c) => c?.name || c?.firstName || c?.lastName);
+
     return {
-      label,
+      label: label?.name || `${label?.firstName} ${label?.lastName}`.trim(),
       [keyName]: email || rawEmail || '',
     };
   }
   if (users.length) {
-    const label = users
-      .map((c) => `${c.firstName} ${c.lastName}`)
-      .join(' ')
-      .trim();
+    const label = users.find((c) => c?.firstName || c?.lastName);
+
     return {
-      label,
+      label: `${label?.firstName} ${label?.lastName}`.trim(),
       [keyName]: email || rawEmail || '',
     };
   }


### PR DESCRIPTION
Refactor participants' name retrieval method
The methods to retrieve the names of the participants in `getParticipantsName.ts` and in `EmailMetaDataEntry.tsx` have been streamlined by finding the first available participant name, instead of joining all names together.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

