### PR TITLE
feat 3391 Remember previewed event (organization event)

### DIFF
--- a/packages/apps/spaces/app/components/RootSidenav/RootSidenav.tsx
+++ b/packages/apps/spaces/app/components/RootSidenav/RootSidenav.tsx
@@ -18,21 +18,24 @@ interface RootSidenavProps {
 export const RootSidenav = ({ isOwner }: RootSidenavProps) => {
   const router = useRouter();
   const pathname = usePathname();
-  const [activeTab, setActiveTab] = useLocalStorage(
+  const [lastActivePosition, setLastActivePosition] = useLocalStorage(
     `customeros-player-last-position`,
     { root: 'organization' },
   );
 
   useEffect(() => {
     if (pathname === '/') {
-      setActiveTab({ ...activeTab, root: 'organization' });
+      setLastActivePosition({ ...lastActivePosition, root: 'organization' });
     }
     if (pathname && pathname !== '/') {
-      setActiveTab({ ...activeTab, root: pathname.substring(1) });
+      setLastActivePosition({
+        ...lastActivePosition,
+        root: pathname.substring(1),
+      });
     }
   }, []);
   const handleItemClick = (path: string) => {
-    setActiveTab({ ...activeTab, root: path });
+    setLastActivePosition({ ...lastActivePosition, root: path });
     router.push(`/${path}`);
   };
 

--- a/packages/apps/spaces/app/organizations/[id]/components/OrganizationSidenav/OrganizationSidenav.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/OrganizationSidenav/OrganizationSidenav.tsx
@@ -19,9 +19,9 @@ export const OrganizationSidenav = () => {
   const params = useParams();
   const searchParams = useSearchParams();
 
-  const [activeTab, setActiveTab] = useLocalStorage(
+  const [lastActivePosition, setLastActivePosition] = useLocalStorage(
     `customeros-player-last-position`,
-    { [params?.id as string]: 'about' },
+    { [params?.id as string]: 'tab=about' },
   );
 
   const graphqlClient = getGraphQLClient();
@@ -35,7 +35,10 @@ export const OrganizationSidenav = () => {
     const urlSearchParams = new URLSearchParams(searchParams ?? '');
     urlSearchParams.set('tab', tab);
 
-    setActiveTab({ ...activeTab, [params?.id as string]: tab });
+    setLastActivePosition({
+      ...lastActivePosition,
+      [params?.id as string]: urlSearchParams.toString(),
+    });
     // todo remove, for now needed
     router.push(`?${urlSearchParams}`);
   };
@@ -61,7 +64,7 @@ export const OrganizationSidenav = () => {
             size='xs'
             variant='ghost'
             aria-label='Go back'
-            onClick={() => router.push(`/${activeTab?.root || 'organization'}`)}
+            onClick={() => router.push(`/${lastActivePosition?.root || 'organization'}`)}
             icon={<Icons.ArrowNarrowLeft color='gray.700' boxSize='6' />}
           />
 

--- a/packages/apps/spaces/app/organizations/[id]/components/Timeline/OrganizationTimeline.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Timeline/OrganizationTimeline.tsx
@@ -111,6 +111,7 @@ export const OrganizationTimeline: FC = () => {
       )}
       <TimelineEventPreviewContextContextProvider
         data={timelineEmailEvents || []}
+        id={id}
       >
         <Virtuoso
           ref={virtuoso}

--- a/packages/apps/spaces/app/organizations/[id]/components/Timeline/preview/TimelineEventsPreviewContext/TimelineEventPreviewContext.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Timeline/preview/TimelineEventsPreviewContext/TimelineEventPreviewContext.tsx
@@ -2,6 +2,7 @@ import { PropsWithChildren, RefObject, useContext } from 'react';
 import { createContext, useState, useEffect, useRef } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { InteractionEvent } from '@graphql/types';
+import { useLocalStorage } from 'usehooks-ts';
 
 export const noop = () => undefined;
 
@@ -31,7 +32,13 @@ export const useTimelineEventPreviewContext = () => {
 export const TimelineEventPreviewContextContextProvider = ({
   children,
   data = [],
-}: PropsWithChildren<{ data: InteractionEvent[] }>) => {
+  id = '',
+}: PropsWithChildren<{ data: InteractionEvent[]; id: string }>) => {
+  const [lastActivePosition, setLastActivePosition] = useLocalStorage(
+    `customeros-player-last-position`,
+    { [id]: 'tab=about' },
+  );
+
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalContent, setModalContent] = useState<InteractionEvent | null>(
     null,
@@ -45,6 +52,10 @@ export const TimelineEventPreviewContextContextProvider = ({
     const params = new URLSearchParams(searchParams ?? '');
     params.set('events', content.id);
     router.push(`?${params}`);
+    setLastActivePosition({
+      ...lastActivePosition,
+      [id]: params.toString(),
+    });
     setModalContent(content);
   };
 

--- a/packages/apps/spaces/app/settings/SettingsSidenav/SettingsSidenav.tsx
+++ b/packages/apps/spaces/app/settings/SettingsSidenav/SettingsSidenav.tsx
@@ -14,7 +14,7 @@ import { useLocalStorage } from 'usehooks-ts';
 export const SettingsSidenav = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [activeTab, setActiveTab] = useLocalStorage(
+  const [lastActivePosition, setLastActivePosition] = useLocalStorage(
     `customeros-player-last-position`,
     { ['settings']: 'oauth', root: 'organization' },
   );
@@ -24,7 +24,7 @@ export const SettingsSidenav = () => {
   const handleItemClick = (tab: string) => () => {
     const params = new URLSearchParams(searchParams ?? '');
     params.set('tab', tab);
-    setActiveTab({ ...activeTab, settings: tab });
+    setLastActivePosition({ ...lastActivePosition, settings: tab });
     // todo remove, for now needed
     router.push(`?${params}`);
   };
@@ -49,7 +49,7 @@ export const SettingsSidenav = () => {
           size='xs'
           variant='ghost'
           aria-label='Go back'
-          onClick={() => router.push(`/${activeTab.root}`)}
+          onClick={() => router.push(`/${lastActivePosition.root}`)}
           icon={<Icons.ArrowNarrowLeft color='gray.700' boxSize='6' />}
         />
 

--- a/packages/apps/spaces/components/finder/finder-table/OrganizationTableCell.tsx
+++ b/packages/apps/spaces/components/finder/finder-table/OrganizationTableCell.tsx
@@ -16,17 +16,18 @@ import {
 
 interface OrganizationTableCellProps {
   organization: Organization;
-  activeTab?: string;
+  lastPositionParams?: string;
 }
 
 export const OrganizationTableCell = ({
   organization,
-  activeTab,
+  lastPositionParams,
 }: OrganizationTableCellProps) => {
   const router = useRouter();
   const [isHovered, setIsHovered] = useState(false);
-
-  const href = `/organizations/${organization.id}?tab=${activeTab || 'about'}`;
+  const href = `/organizations/${organization.id}?${
+    lastPositionParams || 'tab=about'
+  }`;
   const hasParent = !!organization.subsidiaryOf?.length;
   const fullName = hasParent
     ? organization.subsidiaryOf[0].organization.name

--- a/packages/apps/spaces/components/organization/organization-list/OrganizationListColumns.tsx
+++ b/packages/apps/spaces/components/organization/organization-list/OrganizationListColumns.tsx
@@ -23,7 +23,7 @@ export const columns = (tabs?: { [key: string]: string } | null) => [
         <OrganizationTableCell
           key={props.getValue().id}
           organization={props.getValue()}
-          activeTab={tabs?.[props.getValue()?.id]}
+          lastPositionParams={tabs?.[props.getValue()?.id]}
         />
       );
     },


### PR DESCRIPTION
## Proposed changes

This commit introduces a feature that retains the last active tab position in an organization's timeline. The 'useLocalStorage' method was imported and used to store the last active position. This update will improve user experience by reducing the need for re-navigation.

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

