### PR TITLE
fix #3463: Update last active position on modal close

### DIFF
--- a/packages/apps/spaces/app/organizations/[id]/components/Timeline/preview/TimelineEventsPreviewContext/TimelineEventPreviewContext.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Timeline/preview/TimelineEventsPreviewContext/TimelineEventPreviewContext.tsx
@@ -65,6 +65,10 @@ export const TimelineEventPreviewContextContextProvider = ({
     params.delete('events');
     setIsModalOpen(false);
     setModalContent(null);
+    setLastActivePosition({
+      ...lastActivePosition,
+      [id]: params.toString(),
+    });
     router.push(`?${params}`);
   };
 


### PR DESCRIPTION
The TimelineEventPreviewContext closing function is updated to save the last active position. This change keeps track of the page's last active state before closing the modal, ensuring that the user is brought back to the correct point after the modal closure and navigating back / forth to given org details page.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

