### PR TITLE
feat #3534: Add external links to slack events in timeline

### DIFF
--- a/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/slack/SlackMessageCard.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/slack/SlackMessageCard.tsx
@@ -7,10 +7,10 @@ import User from '@spaces/atoms/icons/User';
 import { ViewInSlackButton } from '@organization/components/Timeline/events/slack/ViewInSlackButton';
 // @ts-expect-error types not available
 import { escapeForSlackWithMarkdown } from 'slack-to-html';
-import sanitizeHtml from 'sanitize-html';
 
 interface SlackMessageCardProps extends PropsWithChildren {
   name: string;
+  sourceUrl?: string | null;
   profilePhotoUrl?: null | string;
   content: string;
   onClick?: () => void;
@@ -21,6 +21,7 @@ interface SlackMessageCardProps extends PropsWithChildren {
 
 export const SlackMessageCard: React.FC<SlackMessageCardProps> = ({
   name,
+  sourceUrl,
   profilePhotoUrl,
   content,
   onClick,
@@ -30,9 +31,7 @@ export const SlackMessageCard: React.FC<SlackMessageCardProps> = ({
   showDateOnHover,
 }) => {
   const displayContent: string = (() => {
-    const sanitizeContent = sanitizeHtml(
-      content.replace(/\n/g, '<br/>'),
-    );
+    const sanitizeContent = content.replace(/\n/g, '<br/>');
     const slack = escapeForSlackWithMarkdown(sanitizeContent);
     const regex = /(@[\w]+)/g;
     return slack.replace(
@@ -54,7 +53,7 @@ export const SlackMessageCard: React.FC<SlackMessageCardProps> = ({
         position='unset'
         cursor={onClick ? 'pointer' : 'unset'}
         boxShadow='xs'
-        borderColor='gray.100'
+        borderColor='gray.200'
         onClick={() => onClick?.()}
         _hover={{
           '&:hover .slack-stub-date': {
@@ -78,7 +77,7 @@ export const SlackMessageCard: React.FC<SlackMessageCardProps> = ({
               }
               src={profilePhotoUrl || undefined}
             />
-            <Flex direction='column' flex={1}>
+            <Flex direction='column' flex={1} position='relative'>
               <Flex justifyContent='space-between' flex={1}>
                 <Flex>
                   <Text color='gray.700' fontWeight={600}>
@@ -87,16 +86,18 @@ export const SlackMessageCard: React.FC<SlackMessageCardProps> = ({
                   <Text
                     color={showDateOnHover ? 'transparent' : 'gray.500'}
                     ml={2}
+                    fontSize='xs'
                     className='slack-stub-date'
                   >
                     {date}
                   </Text>
                 </Flex>
 
-                <ViewInSlackButton url='' />
+                <ViewInSlackButton url={sourceUrl} />
               </Flex>
               <Text
                 className='slack-container'
+                pointerEvents={showDateOnHover ? 'none' : 'initial'}
                 noOfLines={showDateOnHover ? 4 : undefined}
                 dangerouslySetInnerHTML={{ __html: displayContent }}
               />

--- a/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/slack/SlackStub.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/slack/SlackStub.tsx
@@ -80,6 +80,7 @@ export const SlackStub: FC<{ slackEvent: InteractionEventWithDate }> = ({
       <SlackMessageCard
         name={getName(slackSender)}
         profilePhotoUrl={slackSender?.profilePhotoUrl}
+        sourceUrl={slackEvent?.externalLinks?.[0]?.externalUrl}
         content={slackEvent?.content || ''}
         onClick={() => openModal(slackEvent)}
         date={DateTimeUtils.formatTime(slackEvent?.date)}

--- a/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/slack/SlackThreadPreviewModal.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/slack/SlackThreadPreviewModal.tsx
@@ -32,8 +32,6 @@ export const SlackThreadPreviewModal: React.FC = () => {
   const { closeModal, modalContent } = useTimelineEventPreviewContext();
   const event = modalContent as InteractionEvent;
   const slackSender = getParticipant(event?.sentBy);
-  console.log('🏷️ ----- modalContent: '
-      , modalContent);
   const slackEventReplies =
     event?.interactionSession?.events?.filter((e) => e?.id !== event?.id) || [];
 
@@ -86,6 +84,7 @@ export const SlackThreadPreviewModal: React.FC = () => {
           w='full'
           name={getName(slackSender)}
           profilePhotoUrl={slackSender?.profilePhotoUrl}
+          sourceUrl={event?.externalLinks?.[0]?.externalUrl}
           content={event?.content || ''}
           // @ts-expect-error typescript does not work well with aliases
           date={DateTimeUtils.timeAgo(event?.date, { addSuffix: true })}

--- a/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/slack/ViewInSlackButton.tsx
+++ b/packages/apps/spaces/app/organizations/[id]/components/Timeline/events/slack/ViewInSlackButton.tsx
@@ -4,23 +4,29 @@ import { IconButton } from '@ui/form/IconButton';
 import ExternalLink from '@spaces/atoms/icons/ExternalLink';
 import Slack from '@spaces/atoms/icons/Slack';
 import { Tooltip } from '@ui/overlay/Tooltip';
+import { getExternalUrl } from '@spaces/utils/getExternalLink';
 
-export const ViewInSlackButton: FC<{ url: string }> = ({ url }) => {
+export const ViewInSlackButton: FC<{ url?: string | null }> = ({ url }) => {
   const [hovered, setHovered] = useState(false);
 
   return (
-    <Tooltip
-      label='' //View in Slack
-      variant='dark'
-      hasArrow
-    >
+    <Tooltip label={url ? 'View in Slack' : ''} variant='dark' hasArrow>
       <IconButton
         aria-label='View in slack'
         size='xs'
-        isDisabled
+        position='absolute'
+        right={0}
+        isDisabled={!url}
         variant={hovered ? 'ghost' : 'outline'}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (url) {
+            window.open(getExternalUrl(url), '_blank', 'noopener');
+          }
+        }}
         icon={
           hovered ? (
             <ExternalLink height={16} color='var(--chakra-colors-gray-500)' />

--- a/packages/apps/spaces/app/organizations/[id]/graphql/getTimeline.generated.ts
+++ b/packages/apps/spaces/app/organizations/[id]/graphql/getTimeline.generated.ts
@@ -194,6 +194,10 @@ export type GetTimelineQuery = {
               externalUrl?: string | null;
             }>;
           } | null;
+          externalLinks: Array<{
+            __typename?: 'ExternalSystem';
+            externalUrl?: string | null;
+          }>;
           repliesTo?: { __typename?: 'InteractionEvent'; id: string } | null;
           summary?: {
             __typename?: 'Analysis';
@@ -532,6 +536,9 @@ export const GetTimelineDocument = `
             externalId
             externalUrl
           }
+        }
+        externalLinks {
+          externalUrl
         }
         repliesTo {
           id

--- a/packages/apps/spaces/app/organizations/[id]/graphql/getTimeline.graphql
+++ b/packages/apps/spaces/app/organizations/[id]/graphql/getTimeline.graphql
@@ -48,6 +48,9 @@ query GetTimeline($organizationId: ID!, $from: Time!, $size: Int!) {
             externalUrl
           }
         }
+        externalLinks {
+          externalUrl
+        }
         repliesTo {
           id
         }

--- a/packages/apps/spaces/app/types/__generated__/graphql.types.ts
+++ b/packages/apps/spaces/app/types/__generated__/graphql.types.ts
@@ -825,6 +825,7 @@ export type InteractionEvent = Node & {
   createdAt: Scalars['Time'];
   eventIdentifier?: Maybe<Scalars['String']>;
   eventType?: Maybe<Scalars['String']>;
+  externalLinks: Array<ExternalSystem>;
   id: Scalars['ID'];
   includes: Array<Attachment>;
   interactionSession?: Maybe<InteractionSession>;

--- a/packages/apps/spaces/components/finder/finder-table/OrganizationTableCell.tsx
+++ b/packages/apps/spaces/components/finder/finder-table/OrganizationTableCell.tsx
@@ -84,7 +84,7 @@ export const OrganizationTableCell = ({
                   size='xs'
                   borderRadius='5px'
                   onClick={() =>
-                    window.open(getExternalUrl(organization.website ?? '/'))
+                    window.open(getExternalUrl(organization.website ?? '/'),'_blank','noopener')
                   }
                   aria-label='organization website'
                   icon={<Icons.LinkExternal2 color='gray.500' />}

--- a/packages/apps/spaces/styles/remirror-editor.scss
+++ b/packages/apps/spaces/styles/remirror-editor.scss
@@ -629,6 +629,7 @@ display: none
   position: relative;
   padding-left: 10px;
   border-radius: 0;
+  vertical-align: bottom;
 
   &:before {
     content: '';
@@ -638,6 +639,7 @@ display: none
     width: 3px;
     height: 100%;
     border-radius: 8px;
+    bottom: 0;
   }
 
 }


### PR DESCRIPTION
The update introduces an external link to slack events in the application timeline. These external links allow users to directly open the originating slack message in a new browser tab. Code concerning the graphql getTimeline query, slack stub, slack message card, and organization table cell were changed to include this feature. The feature enhances user experience by facilitating direct access to embedded resources.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

