### PR TITLE
fix: table virtualizer & fetchMore page setting

### DIFF
--- a/packages/apps/spaces/components/organization/organization-list/OrganizationList.tsx
+++ b/packages/apps/spaces/components/organization/organization-list/OrganizationList.tsx
@@ -66,7 +66,7 @@ export const OrganizationList: React.FC<OrganizationListProps> = ({
 
   const [tableInstance, setTableInstance] =
     useState<TableInstance<Organization> | null>(null);
-  const [page, setPagination] = useState(1);
+  const [_, setPagination] = useState(1);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [enableSelection, setEnableSelection] = useState(false);
   const [selection, setSelection] = useState<RowSelectionState>({});
@@ -110,7 +110,7 @@ export const OrganizationList: React.FC<OrganizationListProps> = ({
       variables: {
         pagination: {
           page: 1,
-          limit: 20,
+          limit: 40,
         },
         where: {
           AND: filters,
@@ -129,17 +129,18 @@ export const OrganizationList: React.FC<OrganizationListProps> = ({
 
   const handleFetchMore = useCallback(() => {
     setPagination((prev) => {
+      fetchMore({
+        variables: {
+          pagination: {
+            limit: variables.pagination.limit,
+            page: prev + 1,
+          },
+        },
+      });
+
       return prev + 1;
     });
-    fetchMore({
-      variables: {
-        pagination: {
-          limit: variables.pagination.limit,
-          page: page + 1,
-        },
-      },
-    });
-  }, [page, fetchMore, variables.pagination.limit]);
+  }, [fetchMore, variables.pagination.limit, setPagination]);
 
   const handleMergeOrganizations = (table: TableInstance<Organization>) => {
     const organizationIds = Object.keys(selection)

--- a/packages/apps/spaces/hooks/useFinderOrganizationTableData/useFinderOrganizationTableData.ts
+++ b/packages/apps/spaces/hooks/useFinderOrganizationTableData/useFinderOrganizationTableData.ts
@@ -26,7 +26,7 @@ export const useFinderOrganizationTableData = (
   const initialVariables = {
     pagination: {
       page: 1,
-      limit: 20,
+      limit: 40,
     },
     where: undefined as InputMaybe<Filter> | undefined,
   };

--- a/packages/apps/spaces/ui/presentation/Table/Table.tsx
+++ b/packages/apps/spaces/ui/presentation/Table/Table.tsx
@@ -52,7 +52,7 @@ export const Table = <T extends object>({
   columns,
   isLoading,
   onFetchMore,
-  totalItems = 50,
+  totalItems = 40,
   onSortingChange,
   onSelectionChange,
   renderTableActions,
@@ -86,8 +86,8 @@ export const Table = <T extends object>({
 
   const { rows } = table.getRowModel();
   const rowVirtualizer = useVirtualizer({
-    count: !data.length && isLoading ? 15 : totalItems,
-    overscan: 25,
+    count: !data.length && isLoading ? 40 : totalItems,
+    overscan: 10,
     getScrollElement: () => scrollElementRef.current,
     estimateSize: () => 21,
   });


### PR DESCRIPTION
## Proposed changes

This PR fixes an issue in the Table Virtualizer where the `overscan` property was higher or equal to the initial `count` property which in turn was causing the query to request first 3 pages instead of only the first.
Another issue solved was `handleFetchMore` which was causing an infinite loop due to bad handling of `setPagination` inside of it.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

