### PR TITLE
(fix|COS-232): Allow users to close the dialog by pressing the 'Esc' key

### DIFF
--- a/packages/apps/spaces/ui/overlay/AlertDialog/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/packages/apps/spaces/ui/overlay/AlertDialog/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -47,6 +47,7 @@ export const ConfirmDeleteDialog = ({
       isOpen={isOpen}
       onClose={onClose}
       leastDestructiveRef={cancelRef}
+      closeOnEsc
     >
       <AlertDialogOverlay>
         <AlertDialogContent


### PR DESCRIPTION
This change was made to improve the user experience by providing a quick escape route in case the user changes their mind. Now, when the user is faced with the delete confirmation dialog, they can simply press the 'Esc' key to close this dialog. This functionality adheres more closely to the default user expectations of a dialog behavior.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

