### PR TITLE
(fix|COS-294): Fix content formatting for html content in stubs

### DIFF
--- a/packages/apps/spaces/ui/presentation/HtmlContentRenderer/HtmlContentRenderer.tsx
+++ b/packages/apps/spaces/ui/presentation/HtmlContentRenderer/HtmlContentRenderer.tsx
@@ -68,7 +68,7 @@ export const HtmlContentRenderer: React.FC<HtmlContentRendererProps> = ({
       {...rest}
       sx={{
         '& ol, ul': {
-          pl: '5',
+          pl: showAsInlineText ? 0 : '5',
         },
         '& pre': {
           whiteSpace: 'normal',


### PR DESCRIPTION
The padding-left value for 'ol' and 'ul' tags within HtmlContentRenderer was previously hardcoded to '5'. This change dynamically sets the padding-left value based on the state of 'showAsInlineText'.

This is necessary to ensure the correct presentation of html content in different contexts.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

