### PR TITLE
(fix|COS-371): Add margin adjustments based on sender type in timeline events

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/email/EmailPreviewModal.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/email/EmailPreviewModal.tsx
@@ -75,7 +75,6 @@ export const EmailPreviewModal: React.FC<EmailPreviewModalProps> = ({
   const { to, cc, bcc } = getEmailParticipantsByType(event?.sentTo || []);
   const from = getEmailParticipantsNameAndEmail(event?.sentBy || [], 'value');
   const formId = 'compose-email-preview-modal';
-
   const defaultValues: ComposeEmailDtoI = new ComposeEmailDto({
     to: getEmailParticipantsNameAndEmail(
       [...(event?.sentBy ?? []), ...(to ?? [])],

--- a/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/email/EmailStub.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/email/EmailStub.tsx
@@ -26,6 +26,8 @@ export const EmailStub: FC<{ email: InteractionEventWithDate }> = ({
   });
 
   const { to, cc } = getEmailParticipantsByType(email?.sentTo || []);
+  const isSendByTenant = (email?.sentBy?.[0] as EmailParticipant)
+    ?.emailParticipant?.users?.length;
 
   return (
     <>
@@ -45,6 +47,7 @@ export const EmailStub: FC<{ email: InteractionEventWithDate }> = ({
         onClick={() => openModal(email)}
         _hover={{ boxShadow: 'md' }}
         transition='all 0.2s ease-out'
+        ml={isSendByTenant ? 6 : 0}
       >
         <CardBody px='3' py='2' pr='0' overflow={'hidden'} flexDirection='row'>
           <VStack align='flex-start' spacing={0}>

--- a/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/intercom/IntercomMessageCard.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/intercom/IntercomMessageCard.tsx
@@ -16,6 +16,7 @@ interface IntercomMessageCardProps extends PropsWithChildren {
   onClick?: () => void;
   date: string;
   w?: CardProps['w'];
+  ml?: CardProps['ml'];
   showDateOnHover?: boolean;
 }
 
@@ -28,6 +29,7 @@ export const IntercomMessageCard: React.FC<IntercomMessageCardProps> = ({
   children,
   date,
   w,
+  ml,
   showDateOnHover,
 }) => {
   return (
@@ -35,6 +37,7 @@ export const IntercomMessageCard: React.FC<IntercomMessageCardProps> = ({
       <Card
         variant='outline'
         size='md'
+        ml={ml}
         fontSize='14px'
         background='white'
         flexDirection='row'

--- a/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/intercom/IntercomStub.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/intercom/IntercomStub.tsx
@@ -26,7 +26,8 @@ export const IntercomStub: FC<{ intercomEvent: InteractionEventWithDate }> = ({
     (intercomEvent?.sentBy?.[0] as JobRoleParticipant)?.jobRoleParticipant
       ?.contact ||
     (intercomEvent?.sentBy?.[0] as UserParticipant)?.userParticipant;
-
+  const isSentByTenantUser =
+    intercomEvent?.sentBy?.[0]?.__typename === 'UserParticipant';
   if (!intercomSender) {
     return null;
   }
@@ -54,6 +55,7 @@ export const IntercomStub: FC<{ intercomEvent: InteractionEventWithDate }> = ({
       onClick={() => openModal(intercomEvent)}
       date={DateTimeUtils.formatTime(intercomEvent?.date)}
       showDateOnHover
+      ml={isSentByTenantUser ? 6 : 0}
     >
       {!!intercomEventReplies?.length && (
         <Flex mt={1}>

--- a/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/meeting/MeetingStub.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/meeting/MeetingStub.tsx
@@ -18,6 +18,8 @@ interface MeetingStubProps {
 
 export const MeetingStub = ({ data }: MeetingStubProps) => {
   const owner = getParticipantName(data.createdBy[0]);
+  const isSentByTenantUser =
+    data.createdBy[0]?.__typename === 'UserParticipant';
   const firstParticipant = getParticipantName(data.attendedBy?.[0]);
   const [participants, remaining] = getParticipants(data);
   const { openModal } = useTimelineEventPreviewContext();
@@ -40,6 +42,7 @@ export const MeetingStub = ({ data }: MeetingStubProps) => {
       onClick={() => openModal(data)}
       _hover={{ boxShadow: 'md' }}
       transition='all 0.2s ease-out'
+      ml={isSentByTenantUser ? 6 : 0}
     >
       <CardBody px='3' py='2'>
         <Flex w='full' justify='space-between' position='relative' gap='3'>

--- a/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/slack/SlackMessageCard.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/slack/SlackMessageCard.tsx
@@ -17,6 +17,7 @@ interface SlackMessageCardProps extends PropsWithChildren {
   onClick?: () => void;
   date: string;
   w?: CardProps['w'];
+  ml?: CardProps['ml'];
   showDateOnHover?: boolean;
 }
 
@@ -29,6 +30,7 @@ export const SlackMessageCard: React.FC<SlackMessageCardProps> = ({
   children,
   date,
   w,
+  ml,
   showDateOnHover,
 }) => {
   const displayContent: string = (() => {
@@ -45,6 +47,7 @@ export const SlackMessageCard: React.FC<SlackMessageCardProps> = ({
   return (
     <>
       <Card
+        ml={ml}
         variant='outline'
         size='md'
         fontSize='14px'

--- a/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/slack/SlackStub.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/slack/SlackStub.tsx
@@ -25,7 +25,8 @@ export const SlackStub: FC<{ slackEvent: InteractionEventWithDate }> = ({
     (slackEvent?.sentBy?.[0] as JobRoleParticipant)?.jobRoleParticipant
       ?.contact ||
     (slackEvent?.sentBy?.[0] as UserParticipant)?.userParticipant;
-
+  const isSentByTenantUser =
+    slackEvent?.sentBy?.[0]?.__typename === 'UserParticipant';
   const slackEventReplies = slackEvent.interactionSession?.events?.filter(
     (e) => e?.id !== slackEvent?.id,
   );
@@ -48,6 +49,7 @@ export const SlackStub: FC<{ slackEvent: InteractionEventWithDate }> = ({
       onClick={() => openModal(slackEvent)}
       date={DateTimeUtils.formatTime(slackEvent?.date)}
       showDateOnHover
+      ml={isSentByTenantUser ? 6 : 0}
     >
       {!!slackEventReplies?.length && (
         <Flex mt={1}>


### PR DESCRIPTION
Update styling of timeline events and message cards to consider sender type. This change includes adding specific margin-left when the sender type is 'UserParticipant'. This allows differentiating visually the events sent by Tenant's Users vs contacts. The changes affect Slack, Intercom, Meeting and Email events.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

