### PR TITLE
(fix|COS-489): Fix condition and data reference in LogEntryStub.tsx

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/logEntry/LogEntryStub.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/logEntry/LogEntryStub.tsx
@@ -27,7 +27,7 @@ function getAuthor(user: User | Contact) {
     return user.name;
   }
 
-  if (!user.firstName || !user.lastName) {
+  if (user.firstName || user.lastName) {
     return `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim();
   }
 
@@ -36,7 +36,7 @@ function getAuthor(user: User | Contact) {
 
 export const LogEntryStub = ({ data }: LogEntryStubProps) => {
   const { openModal } = useTimelineEventPreviewContext();
-  const fullName = getAuthor(data.logEntryCreatedBy);
+  const fullName = getAuthor(data?.logEntryCreatedBy);
   const getLogEntryIcon = useCallback((type: string | null) => {
     switch (type) {
       case 'email':


### PR DESCRIPTION
Changed condition to show full name and safe reference for data in LogEntryStub.tsx. Previously, the logic was incorrect and would not properly display user's full name unless either firstName or lastName was missing. Also ensured data is not null before trying to access 'logEntryCreatedBy'. Avoiding potential errors and hence, improving reliability of the application.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Improved the reliability of displaying author names in the Timeline feature. Previously, there could be issues if the author's first or last name was missing. Now, the system is more robust and can handle these situations gracefully. This ensures that users always see accurate and complete information about who created each log entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->