### PR TITLE
(fix|COS-491): Limit issue subject length in IssueCard

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/IssuesPanel/IssueCard/IssueCard.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/IssuesPanel/IssueCard/IssueCard.tsx
@@ -84,7 +84,13 @@ export const IssueCard = ({ issue }: IssueCardProps) => {
           />
 
           <Flex direction='column' flex={1}>
-            <Heading size='sm' fontSize='sm'>
+            <Heading
+              size='sm'
+              fontSize='sm'
+              noOfLines={1}
+              maxW={260}
+              whiteSpace='nowrap'
+            >
               {issue?.subject ?? '[No subject]'}
             </Heading>
 


### PR DESCRIPTION
Updated IssueCard to restrict the length of the issue subject to avoid text overlapping in UI. Modified Heading component, adjusting maximum width to 260 and whitespace to nowrap.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Improvement: Enhanced the readability of the 'Issues' section in the Spaces app. The update introduces a more streamlined display of issue headings, ensuring long text does not overflow. This change improves the user experience by making the interface cleaner and easier to navigate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->