### PR TITLE
(fix|COS-491): Simplify Heading properties in IssueCard component

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/IssuesPanel/IssueCard/IssueCard.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/IssuesPanel/IssueCard/IssueCard.tsx
@@ -84,13 +84,7 @@ export const IssueCard = ({ issue }: IssueCardProps) => {
           />
 
           <Flex direction='column' flex={1}>
-            <Heading
-              size='sm'
-              fontSize='sm'
-              noOfLines={1}
-              maxW={260}
-              whiteSpace='nowrap'
-            >
+            <Heading size='sm' fontSize='sm' noOfLines={1} maxW={260}>
               {issue?.subject ?? '[No subject]'}
             </Heading>
 


### PR DESCRIPTION
The properties of Heading component in IssueCard.tsx had additional 'whiteSpace' assigned. This property was redundant as it did not affect the layout or functionality of the component. Hence, to optimize the code and improve readability, it has been removed.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Style Update: Improved readability of issue titles in the Spaces app. The titles within the 'Issues' panel will now wrap to the next line if they exceed a certain length, ensuring that longer titles are fully visible and easy to read. This change enhances the user experience by making sure all issue information is clearly displayed, regardless of title length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->