### PR TITLE
(fix|COS-494): Fix issue tag display for active status

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/IssuesPanel/IssueCard/IssueCard.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/IssuesPanel/IssueCard/IssueCard.tsx
@@ -106,7 +106,7 @@ export const IssueCard = ({ issue }: IssueCardProps) => {
             {/*)}*/}
           </Flex>
 
-          {['closed', 'solved'].includes(issue.status.toLowerCase()) && (
+          {!['closed', 'solved'].includes(issue.status.toLowerCase()) && (
             <Tag
               size='sm'
               variant='outline'


### PR DESCRIPTION
The condition for showing tags on the IssueCard was updated. Previously, a tag would only appear when the issue status is 'closed' or 'solved'. This logic was inverted to now show a tag unless the status is 'closed' or 'solved', thereby enhancing visibility of active issues.

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Update: Adjusted the visibility of status tags on issue cards in the Spaces app. Now, tags will appear for issues that are neither "closed" nor "solved", providing a clearer visual cue for issues that still require attention. This change enhances the user's ability to quickly identify and prioritize unresolved issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->