### PR TITLE
(fix|COS-488): Implement error handling for inaccessible organization details page

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/page.tsx
+++ b/packages/apps/spaces/app/organization/[id]/page.tsx
@@ -8,7 +8,6 @@ import {
 } from '@organization/src/graphql/getCanAccessOrganization.generated';
 import { getServerGraphQLClient } from '@shared/util/getServerGraphQLClient';
 import NotFound from './src/components/NotFound/NotFound';
-import { GraphQLClient } from 'graphql-request';
 
 interface OrganizationPageProps {
   params: { id: string };
@@ -20,9 +19,15 @@ export default async function OrganizationPage({
   params,
 }: OrganizationPageProps) {
   const client = getServerGraphQLClient();
-  const result = await fetchOrganizationAccess({ client, id: params.id });
 
-  if (!result) {
+  try {
+    await client.request<GetCanAccessOrganizationQuery>(
+      GetCanAccessOrganizationDocument,
+      {
+        id: params.id,
+      },
+    );
+  } catch (error) {
     return <NotFound />;
   }
 
@@ -39,25 +44,4 @@ export default async function OrganizationPage({
       </MainSection>
     </>
   );
-}
-
-interface FetchOrganizationAccessArgs {
-  client: GraphQLClient;
-  id: string;
-}
-
-async function fetchOrganizationAccess({
-  client,
-  id,
-}: FetchOrganizationAccessArgs): Promise<GetCanAccessOrganizationQuery | null> {
-  try {
-    return await client.request<GetCanAccessOrganizationQuery>(
-      GetCanAccessOrganizationDocument,
-      {
-        id,
-      },
-    );
-  } catch (error) {
-    return null;
-  }
 }

--- a/packages/apps/spaces/app/organization/[id]/src/components/NotFound/NotFound.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/NotFound/NotFound.tsx
@@ -1,0 +1,61 @@
+'use client';
+import { Box } from '@ui/layout/Box';
+import { Flex } from '@ui/layout/Flex';
+import { Text } from '@ui/typography/Text';
+import { FeaturedIcon } from '@ui/media/Icon';
+import { Heading } from '@ui/typography/Heading';
+import { SearchSm } from '@ui/media/icons/SearchSm';
+import HalfCirclePattern from '../../../../../src/assets/HalfCirclePattern';
+
+export default function NotFound() {
+  return (
+    <Box
+      p={0}
+      flex={1}
+      as={Flex}
+      flexDirection='column'
+      backgroundRepeat='no-repeat'
+      backgroundSize='contain'
+      w='100vw'
+      position='relative'
+      alignItems='center'
+      justifyContent='center'
+      backgroundColor='gray.25'
+      border='1px solid'
+      borderColor='gray.200'
+      borderRadius='xl'
+    >
+      <Box
+        position='absolute'
+        height='50vh'
+        maxH='768px'
+        width='768px'
+        top='50%'
+        left='50%'
+        style={{
+          transform: 'translate(-50%, -90%) rotate(180deg)',
+        }}
+      >
+        <HalfCirclePattern />
+      </Box>
+      <Flex
+        position='relative'
+        direction='column'
+        alignItems='center'
+        justifyContent='center'
+        h='50vh'
+      >
+        <FeaturedIcon colorScheme='primary' size='lg'>
+          <SearchSm boxSize='5' />
+        </FeaturedIcon>
+        <Heading fontWeight={600} fontSize='5xl' color='gray.900' py={6}>
+          This organization does not exist
+        </Heading>
+        <Text color='gray.600' fontSize='2xl' pb={12} px={8} textAlign='center'>
+          It appears the organization does not exist or you do not have
+          sufficient rights to preview it.
+        </Text>
+      </Flex>
+    </Box>
+  );
+}

--- a/packages/apps/spaces/app/organization/[id]/src/graphql/getCanAccessOrganization.generated.ts
+++ b/packages/apps/spaces/app/organization/[id]/src/graphql/getCanAccessOrganization.generated.ts
@@ -1,0 +1,104 @@
+// @ts-nocheck remove this when typscript-react-query plugin is fixed
+import * as Types from '../../../../src/types/__generated__/graphql.types';
+
+import { GraphQLClient } from 'graphql-request';
+import { RequestInit } from 'graphql-request/dist/types.dom';
+import {
+  useQuery,
+  useInfiniteQuery,
+  UseQueryOptions,
+  UseInfiniteQueryOptions,
+} from '@tanstack/react-query';
+
+function fetcher<TData, TVariables extends { [key: string]: any }>(
+  client: GraphQLClient,
+  query: string,
+  variables?: TVariables,
+  requestHeaders?: RequestInit['headers'],
+) {
+  return async (): Promise<TData> =>
+    client.request({
+      document: query,
+      variables,
+      requestHeaders,
+    });
+}
+export type GetCanAccessOrganizationQueryVariables = Types.Exact<{
+  id: Types.Scalars['ID'];
+}>;
+
+export type GetCanAccessOrganizationQuery = {
+  __typename?: 'Query';
+  organization?: { __typename?: 'Organization'; id: string } | null;
+};
+
+export const GetCanAccessOrganizationDocument = `
+    query GetCanAccessOrganization($id: ID!) {
+  organization(id: $id) {
+    id
+  }
+}
+    `;
+export const useGetCanAccessOrganizationQuery = <
+  TData = GetCanAccessOrganizationQuery,
+  TError = unknown,
+>(
+  client: GraphQLClient,
+  variables: GetCanAccessOrganizationQueryVariables,
+  options?: UseQueryOptions<GetCanAccessOrganizationQuery, TError, TData>,
+  headers?: RequestInit['headers'],
+) =>
+  useQuery<GetCanAccessOrganizationQuery, TError, TData>(
+    ['GetCanAccessOrganization', variables],
+    fetcher<
+      GetCanAccessOrganizationQuery,
+      GetCanAccessOrganizationQueryVariables
+    >(client, GetCanAccessOrganizationDocument, variables, headers),
+    options,
+  );
+useGetCanAccessOrganizationQuery.document = GetCanAccessOrganizationDocument;
+
+useGetCanAccessOrganizationQuery.getKey = (
+  variables: GetCanAccessOrganizationQueryVariables,
+) => ['GetCanAccessOrganization', variables];
+export const useInfiniteGetCanAccessOrganizationQuery = <
+  TData = GetCanAccessOrganizationQuery,
+  TError = unknown,
+>(
+  pageParamKey: keyof GetCanAccessOrganizationQueryVariables,
+  client: GraphQLClient,
+  variables: GetCanAccessOrganizationQueryVariables,
+  options?: UseInfiniteQueryOptions<
+    GetCanAccessOrganizationQuery,
+    TError,
+    TData
+  >,
+  headers?: RequestInit['headers'],
+) =>
+  useInfiniteQuery<GetCanAccessOrganizationQuery, TError, TData>(
+    ['GetCanAccessOrganization.infinite', variables],
+    (metaData) =>
+      fetcher<
+        GetCanAccessOrganizationQuery,
+        GetCanAccessOrganizationQueryVariables
+      >(
+        client,
+        GetCanAccessOrganizationDocument,
+        { ...variables, ...(metaData.pageParam ?? {}) },
+        headers,
+      )(),
+    options,
+  );
+
+useInfiniteGetCanAccessOrganizationQuery.getKey = (
+  variables: GetCanAccessOrganizationQueryVariables,
+) => ['GetCanAccessOrganization.infinite', variables];
+useGetCanAccessOrganizationQuery.fetcher = (
+  client: GraphQLClient,
+  variables: GetCanAccessOrganizationQueryVariables,
+  headers?: RequestInit['headers'],
+) =>
+  fetcher<
+    GetCanAccessOrganizationQuery,
+    GetCanAccessOrganizationQueryVariables
+  >(client, GetCanAccessOrganizationDocument, variables, headers);

--- a/packages/apps/spaces/app/organization/[id]/src/graphql/getCanAccessOrganization.graphql
+++ b/packages/apps/spaces/app/organization/[id]/src/graphql/getCanAccessOrganization.graphql
@@ -1,0 +1,5 @@
+query GetCanAccessOrganization($id: ID!) {
+    organization(id: $id) {
+        id
+    }
+}


### PR DESCRIPTION
Enhanced the application's flow by adding a mechanism that verifies the visibility and existence of an organization prior to generating the details page. This was achieved through the following updates:

- Implemented a new fetch function that leverages GraphQL to authenticate if a user has the required access to an organization.
- Integrated this fetch function into the main page logic.
- Introduced a new `NotFound` component, which is displayed anytime a user attempts to access an organization that is not accessible or does not exist.

This solution ensures a robust application experience by preventing errors and gracefully managing cases where users try to view unavailable or restricted organizations.


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a new function to verify user access to specific organizations, enhancing security and user management.
- New Feature: Added a custom 'NotFound' error page for instances when an organization does not exist, improving user experience by providing clear and friendly error messages.
- Refactor: Optimized the import order in the 'OrganizationPage' function for better code readability and maintenance.
- New Feature: Implemented new GraphQL queries and hooks for fetching organization access data, improving data retrieval efficiency and application performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->