### PR TITLE
(fix|cos-514): Enlarge maximum width of IssueStub component.

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/issue/IssueStub.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Timeline/events/issue/IssueStub.tsx
@@ -27,7 +27,7 @@ export const IssueStub: FC<{ data: IssueWithAliases }> = ({ data }) => {
       background='white'
       flexDirection='row'
       position='unset'
-      maxW={476}
+      maxW={502}
       cursor='pointer'
       boxShadow='none'
       border='1px solid'


### PR DESCRIPTION
The maximum width of the IssueStub component was increased from 476 to 502.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Style: Adjusted the maximum width of the IssueStub component in the Spaces app. 

This minor visual adjustment enhances the layout of the timeline events, providing a more balanced and aesthetically pleasing view. Users may notice a slight increase in the width of issue-related entries on the timeline, improving readability and overall user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->