### PR TITLE
Fix panic error in sync gmail

### DIFF
--- a/packages/runner/sync-gmail/service/email_service.go
+++ b/packages/runner/sync-gmail/service/email_service.go
@@ -431,6 +431,9 @@ func extractLines(input string) []string {
 }
 
 func (s *emailService) extractEmailAddresses(input string) []string {
+	if input == "" {
+		return []string{""}
+	}
 	// Regular expression pattern to match email addresses between <>
 	emailPattern := `<(.*?)>`
 
@@ -480,11 +483,7 @@ func (s *emailService) extractEmailAddresses(input string) []string {
 		return emailAddresses
 	}
 
-	if input != "" {
-		return []string{input}
-	}
-
-	return nil
+	return []string{input}
 }
 
 type EmailRawData struct {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Improved the handling of empty email addresses in our Gmail synchronization service. This update ensures consistent behavior when encountering empty email fields, enhancing the reliability of the service. Users can expect a more stable experience when syncing their Gmail accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->