### PR TITLE
(fix|COS-564): Remove access check in Organization Page.

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/page.tsx
+++ b/packages/apps/spaces/app/organization/[id]/page.tsx
@@ -2,12 +2,6 @@ import { SideSection } from './src/components/SideSection';
 import { MainSection } from './src/components/MainSection';
 import { Panels, TabsContainer } from './src/components/Tabs';
 import { OrganizationTimelineWithActionsContext } from './src/components/Timeline/OrganizationTimelineWithActionsContext';
-import {
-  GetCanAccessOrganizationDocument,
-  GetCanAccessOrganizationQuery,
-} from '@organization/src/graphql/getCanAccessOrganization.generated';
-import { getServerGraphQLClient } from '@shared/util/getServerGraphQLClient';
-import NotFound from './src/components/NotFound/NotFound';
 import { TimelineContextsProvider } from '@organization/src/components/TimelineContextsProvider';
 
 interface OrganizationPageProps {
@@ -19,19 +13,6 @@ export default async function OrganizationPage({
   searchParams,
   params,
 }: OrganizationPageProps) {
-  const client = getServerGraphQLClient();
-
-  try {
-    await client.request<GetCanAccessOrganizationQuery>(
-      GetCanAccessOrganizationDocument,
-      {
-        id: params.id,
-      },
-    );
-  } catch (error) {
-    return <NotFound />;
-  }
-
   return (
     <TimelineContextsProvider id={params.id}>
       <SideSection>


### PR DESCRIPTION

When user creates organization sometimes request for this org id results in 404. This is major problem for the users. Therefore code related to showing not found message for orgs that are actually not existing or parts of different tenant was removed as this is minor issue for now

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Refactor: Simplified the code within the organization page of the Spaces app. 
- Change: Removed the automatic access check for organizations. 

Please note, the removal of the automatic access check may impact how users interact with organizations within the app. The details of this change will be communicated separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->