### PR TITLE
(fix|COS-617): Fix my portfolio page results

### DIFF
--- a/packages/apps/spaces/app/organizations/page.tsx
+++ b/packages/apps/spaces/app/organizations/page.tsx
@@ -91,14 +91,21 @@ export default function OrganizationsPage() {
   }, [sorting]);
 
   const { data, isFetching, isLoading, hasNextPage, fetchNextPage } =
-    useGetOrganizationsInfiniteQuery(client, {
-      pagination: {
-        page: 1,
-        limit: 40,
+    useGetOrganizationsInfiniteQuery(
+      client,
+      {
+        pagination: {
+          page: 1,
+          limit: 40,
+        },
+        sort: sortBy,
+        where,
       },
-      sort: sortBy,
-      where,
-    });
+      {
+        enabled:
+          preset === 'portfolio' ? !!globalCache?.global_Cache?.user.id : true,
+      },
+    );
 
   const flatData = useMemo(
     () =>

--- a/packages/apps/spaces/app/src/components/Providers/Providers.tsx
+++ b/packages/apps/spaces/app/src/components/Providers/Providers.tsx
@@ -2,26 +2,49 @@
 
 import { useState } from 'react';
 import { RecoilRoot } from 'recoil';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
+
+import { createIDBPersister } from '@shared/util/indexedDBPersister';
 import { AnalyticsProvider } from '@shared/components/Providers/AnalyticsProvider';
+
 import { NextAuthProvider } from './SessionProvider';
 
 interface ProvidersProps {
+  sessionEmail?: string | null;
   children: React.ReactNode;
 }
 
-export const Providers = ({ children }: ProvidersProps) => {
-  const [queryClient] = useState(() => new QueryClient());
+const hostname =
+  typeof window !== 'undefined' ? window?.location?.hostname : 'platform';
+
+export const Providers = ({ children, sessionEmail }: ProvidersProps) => {
+  const [persister] = useState(() =>
+    createIDBPersister(`${sessionEmail ?? 'cos'}-${hostname}`),
+  );
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            cacheTime: 1000 * 60 * 60 * 24, // 24 hours
+          },
+        },
+      }),
+  );
 
   return (
-    <QueryClientProvider client={queryClient}>
+    <PersistQueryClientProvider
+      client={queryClient}
+      persistOptions={{ persister }}
+    >
       <ReactQueryDevtools initialIsOpen={false} position='bottom-right' />
       <RecoilRoot>
         <NextAuthProvider>
           <AnalyticsProvider>{children}</AnalyticsProvider>
         </NextAuthProvider>
       </RecoilRoot>
-    </QueryClientProvider>
+    </PersistQueryClientProvider>
   );
 };


### PR DESCRIPTION

Restore persisted query client as it was not causing the issue

 Added an additional check under the "enabled" option: the query fires only if the preset equals 'portfolio' and a valid user ID exists, or if the preset doesn't equal 'portfolio'. This ensures that query won't be called until async params data is available

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Enhanced the organization page's data fetching capabilities, allowing for more efficient sorting and filtering of organizations. This update will provide a smoother and more intuitive user experience.
- New Feature: Updated the Providers component to include data persistence using IndexedDB. This means your session data will be stored locally and remain available even after a browser refresh or restart, improving the reliability and user experience of the application.
- Improvement: Introduced a new 'enabled' option for data queries, providing more control over when these queries are activated. This will help optimize the application's performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->