### PR TITLE
(fix|cos-741): Change parent input position

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
@@ -203,6 +203,22 @@ export const AboutPanel = () => {
           placeholder={placeholders.valueProposition}
         />
 
+        {!data?.organization?.subsidiaries?.length && (
+          <ParentOrgInput
+            id={id}
+            parentOrg={
+              data?.organization?.subsidiaryOf?.[0]?.organization?.id
+                ? {
+                    label:
+                      data?.organization?.subsidiaryOf?.[0]?.organization?.name,
+                    value:
+                      data?.organization?.subsidiaryOf?.[0]?.organization?.id,
+                  }
+                : null
+            }
+          />
+        )}
+
         <VStack
           flex='1'
           align='flex-start'
@@ -298,22 +314,7 @@ export const AboutPanel = () => {
             placeholder='Social link'
             leftElement={<Icons.Share7 color='gray.500' />}
           />
-          {!data?.organization?.subsidiaries?.length && (
-            <ParentOrgInput
-              id={id}
-              parentOrg={
-                data?.organization?.subsidiaryOf?.[0]?.organization?.id
-                  ? {
-                      label:
-                        data?.organization?.subsidiaryOf?.[0]?.organization
-                          ?.name,
-                      value:
-                        data?.organization?.subsidiaryOf?.[0]?.organization?.id,
-                    }
-                  : null
-              }
-            />
-          )}
+
           {!!data?.organization?.subsidiaries?.length && (
             <Branches
               id={id}


### PR DESCRIPTION
The position of ParentOrgInput was improved in AboutPanel. The component is now on top, showing right after the value proposition instead of being located after social links. This change improves user navigation by providing hierarchical data in a more constructive order, following primary overview details


What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

New Features:
- Enhanced the organization information panel with conditional rendering of the `ParentOrgInput` and `Branches` components based on the presence of subsidiaries. This provides a more intuitive user interface for organizations with and without subsidiaries.
- Improved the organization hierarchy display by moving the `ParentOrgInput` component below the `SocialLinkInput` component, offering a more logical flow of information.

Refactor:
- Updated the `ParentOrgInput` component to use the `data.organization.subsidiaryOf` values, ensuring accurate representation of parent organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->