### PR TITLE
fix: preview modal closing when dragging mouse to the backdrop

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Timeline/preview/TimelinePreviewBackdrop.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Timeline/preview/TimelinePreviewBackdrop.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, PropsWithChildren } from 'react';
+import { useState, useEffect, PropsWithChildren, useRef } from 'react';
 
 import { Flex } from '@ui/layout/Flex';
 import { Card } from '@ui/presentation/Card';
@@ -16,6 +16,7 @@ export const TimelinePreviewBackdrop = ({
   children,
   onCloseModal,
 }: TimelinePreviewBackdropProps) => {
+  const mouseTarget = useRef<string | null>(null);
   const [isMounted, setIsMounted] = useState(false); // needed for delaying the backdrop filter
   const { isModalOpen, modalContent } = useTimelineEventPreviewStateContext();
   const { closeModal } = useTimelineEventPreviewMethodsContext();
@@ -39,10 +40,18 @@ export const TimelinePreviewBackdrop = ({
       cursor='pointer'
       backdropFilter='blur(3px)'
       justify='center'
+      id='timeline-preview-backdrop'
       background={isMounted ? 'rgba(16, 24, 40, 0.45)' : 'rgba(16, 24, 40, 0)'}
       align='center'
       transition='all 0.1s linear'
-      onClick={onCloseModal ?? closeModal}
+      onMouseUp={() => {
+        if (mouseTarget.current === 'timeline-preview-card') {
+          mouseTarget.current = null;
+        } else {
+          closeModal();
+          onCloseModal?.();
+        }
+      }}
     >
       <ScaleFade
         in={isModalOpen}
@@ -62,6 +71,11 @@ export const TimelinePreviewBackdrop = ({
           w='544px'
           minW='544px'
           cursor='default'
+          id='timeline-preview-card'
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            mouseTarget.current = e.currentTarget.id;
+          }}
           onClick={(e) => e.stopPropagation()}
         >
           {children}


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Refactor:
- Enhanced the interaction with the timeline preview backdrop in the Spaces app. This includes modifications to the `onMouseUp` and `onClick` event handlers to improve user experience when interacting with different mouse targets.
- Added an `id` attribute to the backdrop and card elements for better accessibility and interaction.
- Introduced an `onMouseDown` event handler to the card element to improve event propagation and user interaction. 

These changes aim to provide a smoother and more intuitive user experience when interacting with the timeline preview backdrop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->