### PR TITLE
[COS-550] - Stop real time import when overlaps with historic import

### DIFF
--- a/packages/runner/sync-gmail-raw/cron/cron.go
+++ b/packages/runner/sync-gmail-raw/cron/cron.go
@@ -149,7 +149,7 @@ func syncEmailsInState(config *config.Config, services *service.Services, state 
 								}
 
 								if importedEmails > config.SyncData.BatchSize {
-									err = services.Repositories.UserGmailImportPageTokenRepository.ActivateGmailImportState(tenant.Name, emailForUser.RawEmail, gmailImportState.State)
+									err = services.Repositories.UserGmailImportPageTokenRepository.ActivateGmailImportState(tenant.Name, emailForUser.RawEmail, entity.REAL_TIME)
 									if err != nil {
 										logrus.Errorf("failed to update gmail import state: %v", err)
 										return
@@ -160,6 +160,9 @@ func syncEmailsInState(config *config.Config, services *service.Services, state 
 										logrus.Errorf("failed to get gmail import state: %v", err)
 										return
 									}
+								} else {
+									logrus.Infof("gmail import state for tenant: %s and username: %s is not active for real time. skipping real time import", tenant.Name, emailForUser.RawEmail)
+									return
 								}
 							} else {
 								logrus.Infof("gmail import state for tenant: %s and username: %s is not active for real time. skipping real time import", tenant.Name, emailForUser.RawEmail)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Refactor:
- Updated the `syncEmailsInState` function in the Gmail synchronization module. The function now activates the Gmail import state based on the number of imported emails. This change does not affect the existing functionality but provides more precise control over the activation of real-time Gmail import. This will help in better management of email imports and improve the efficiency of the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->