### PR TITLE
Add previous renewal cycle to update contract event

### DIFF
--- a/packages/server/events-processing-platform/domain/contract/aggregate/commands.go
+++ b/packages/server/events-processing-platform/domain/contract/aggregate/commands.go
@@ -93,6 +93,7 @@ func (a *ContractAggregate) updateContract(ctx context.Context, cmd *command.Upd
 		cmd.ExternalSystem,
 		source,
 		updatedAtNotNil,
+		a.Contract.RenewalCycle,
 	)
 	if err != nil {
 		tracing.TraceErr(span, err)

--- a/packages/server/events-processing-platform/domain/contract/event/contract_update.go
+++ b/packages/server/events-processing-platform/domain/contract/event/contract_update.go
@@ -10,31 +10,33 @@ import (
 )
 
 type ContractUpdateEvent struct {
-	Tenant           string                     `json:"tenant" validate:"required"`
-	Name             string                     `json:"name"`
-	ContractUrl      string                     `json:"contractUrl"`
-	UpdatedAt        time.Time                  `json:"updatedAt"`
-	ServiceStartedAt *time.Time                 `json:"serviceStartedAt,omitempty"`
-	SignedAt         *time.Time                 `json:"signedAt,omitempty"`
-	EndedAt          *time.Time                 `json:"endedAt,omitempty"`
-	RenewalCycle     string                     `json:"renewalCycle"`
-	Status           string                     `json:"status"`
-	ExternalSystem   commonmodel.ExternalSystem `json:"externalSystem,omitempty"`
-	Source           string                     `json:"source"`
+	Tenant               string                     `json:"tenant" validate:"required"`
+	Name                 string                     `json:"name"`
+	ContractUrl          string                     `json:"contractUrl"`
+	UpdatedAt            time.Time                  `json:"updatedAt"`
+	ServiceStartedAt     *time.Time                 `json:"serviceStartedAt,omitempty"`
+	SignedAt             *time.Time                 `json:"signedAt,omitempty"`
+	EndedAt              *time.Time                 `json:"endedAt,omitempty"`
+	RenewalCycle         string                     `json:"renewalCycle"`
+	PreviousRenewalCycle string                     `json:"previousRenewalCycle"`
+	Status               string                     `json:"status"`
+	ExternalSystem       commonmodel.ExternalSystem `json:"externalSystem,omitempty"`
+	Source               string                     `json:"source"`
 }
 
-func NewContractUpdateEvent(aggregate eventstore.Aggregate, dataFields model.ContractDataFields, externalSystem commonmodel.ExternalSystem, source string, updatedAt time.Time) (eventstore.Event, error) {
+func NewContractUpdateEvent(aggr eventstore.Aggregate, dataFields model.ContractDataFields, externalSystem commonmodel.ExternalSystem, source string, updatedAt time.Time, previousRenewalCycle string) (eventstore.Event, error) {
 	eventData := ContractUpdateEvent{
-		Tenant:           aggregate.GetTenant(),
-		Name:             dataFields.Name,
-		ContractUrl:      dataFields.ContractUrl,
-		ServiceStartedAt: dataFields.ServiceStartedAt,
-		SignedAt:         dataFields.SignedAt,
-		EndedAt:          dataFields.EndedAt,
-		RenewalCycle:     dataFields.RenewalCycle.String(),
-		Status:           dataFields.Status.String(),
-		UpdatedAt:        updatedAt,
-		Source:           source,
+		Tenant:               aggr.GetTenant(),
+		Name:                 dataFields.Name,
+		ContractUrl:          dataFields.ContractUrl,
+		ServiceStartedAt:     dataFields.ServiceStartedAt,
+		SignedAt:             dataFields.SignedAt,
+		EndedAt:              dataFields.EndedAt,
+		RenewalCycle:         dataFields.RenewalCycle.String(),
+		PreviousRenewalCycle: previousRenewalCycle,
+		Status:               dataFields.Status.String(),
+		UpdatedAt:            updatedAt,
+		Source:               source,
 	}
 	if externalSystem.Available() {
 		eventData.ExternalSystem = externalSystem
@@ -44,7 +46,7 @@ func NewContractUpdateEvent(aggregate eventstore.Aggregate, dataFields model.Con
 		return eventstore.Event{}, errors.Wrap(err, "failed to validate ContractUpdateEvent")
 	}
 
-	event := eventstore.NewBaseEvent(aggregate, ContractUpdateV1)
+	event := eventstore.NewBaseEvent(aggr, ContractUpdateV1)
 	if err := event.SetJsonData(&eventData); err != nil {
 		return eventstore.Event{}, errors.Wrap(err, "error setting json data for ContractUpdateEvent")
 	}

--- a/packages/server/events-processing-platform/eventstore/errors.go
+++ b/packages/server/events-processing-platform/eventstore/errors.go
@@ -13,7 +13,6 @@ var (
 	ErrInvalidAggregate    = errors.New("invalid aggregate")
 	ErrInvalidAggregateID  = errors.New("invalid aggregate id")
 	ErrInvalidEventVersion = errors.New("invalid event version")
-	ErrMissingTenant       = errors.New("missing tenant")
 )
 
 type InvalidEventTypeError struct {

--- a/packages/server/events-processing-platform/service/test/contract_service_it_test.go
+++ b/packages/server/events-processing-platform/service/test/contract_service_it_test.go
@@ -270,6 +270,7 @@ func TestContractService_UpdateContract(t *testing.T) {
 	require.Equal(t, "Updated Contract", eventData.Name)
 	require.Equal(t, "http://new.contract.url", eventData.ContractUrl)
 	require.Equal(t, model.MonthlyRenewal.String(), eventData.RenewalCycle)
+	require.Equal(t, "", eventData.PreviousRenewalCycle)
 	require.Equal(t, model.Live.String(), eventData.Status)
 	require.True(t, timeNow.Equal(eventData.UpdatedAt))
 	require.True(t, timeNow.Equal(*eventData.ServiceStartedAt))

--- a/packages/server/events-processing-platform/subscriptions/graph/contract_event_handler_it_test.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/contract_event_handler_it_test.go
@@ -129,7 +129,8 @@ func TestContractEventHandler_OnUpdate(t *testing.T) {
 		},
 		commonmodel.ExternalSystem{},
 		constants.SourceOpenline,
-		now)
+		now,
+		"")
 	require.Nil(t, err, "failed to create event")
 
 	// EXECUTE
@@ -195,7 +196,8 @@ func TestContractEventHandler_OnUpdate_CurrentSourceOpenline_UpdateSourceNonOpen
 		},
 		commonmodel.ExternalSystem{},
 		"hubspot",
-		now)
+		now,
+		"")
 	require.Nil(t, err, "failed to create event")
 
 	// EXECUTE


### PR DESCRIPTION
## Proposed changes

Add previous renewal cycle to update contract event

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `RenewalCycle` field to track contract renewal cycles.

- **Enhancements**
  - Updated event structures to include `PreviousRenewalCycle` for better tracking of contract changes.

- **Bug Fixes**
  - Removed the unused `ErrMissingTenant` error to clean up the codebase.

- **Tests**
  - Added new assertions in integration tests to validate the `PreviousRenewalCycle` field behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->