### PR TITLE
(fix|COS-909): Fix HtmlContentRenderer for zero-width non-joiners

### DIFF
--- a/packages/apps/spaces/ui/presentation/HtmlContentRenderer/HtmlContentRenderer.tsx
+++ b/packages/apps/spaces/ui/presentation/HtmlContentRenderer/HtmlContentRenderer.tsx
@@ -28,7 +28,7 @@ export const HtmlContentRenderer: React.FC<HtmlContentRendererProps> = ({
   ...rest
 }) => {
   const linkifiedContent = sanitizeHtml(
-    linkifyHtml(htmlContent, {
+    linkifyHtml(htmlContent.replace(/&zwnj;/g, ''), {
       defaultProtocol: 'https',
       rel: 'noopener noreferrer',
     }),


### PR DESCRIPTION
This commit modifies the HtmlContentRenderer to replace zero-width non-joiner characters from the html content string before processing it with linkifyHtml function. This ensures that the HTML contents render properly irrespective of the presence of zero-width non-joiner characters which may cause rendering issues in some cases.


What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved link generation in text content by handling special characters correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->