### PR TITLE
[COS-912] - Execute compute last touchpoint on org show

### DIFF
--- a/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
@@ -505,6 +505,17 @@ func (r *mutationResolver) OrganizationShow(ctx context.Context, id string) (str
 		return response.Id, nil
 	}
 
+	_, err = r.Clients.OrganizationClient.RefreshLastTouchpoint(ctx, &organizationpb.OrganizationIdGrpcRequest{
+		Tenant:         common.GetTenantFromContext(ctx),
+		OrganizationId: id,
+		LoggedInUserId: common.GetUserIdFromContext(ctx),
+	})
+	if err != nil {
+		tracing.TraceErr(span, err)
+		graphql.AddErrorf(ctx, "Failed to refresh the last touchpoint %s", id)
+		return response.Id, nil
+	}
+
 	return response.Id, nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved organization interaction tracking by automatically refreshing the last touchpoint when viewing an organization's details. 

- **Error Handling**
  - Added error tracing for better visibility and troubleshooting if the touchpoint refresh process fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->