### PR TITLE
(feat|COS-1011): Implemented new ui for services modals

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/AccountPanel.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/AccountPanel.tsx
@@ -27,13 +27,14 @@ export const AccountPanel = () => {
 
   const { isModalOpen } = useAccountPanelStateContext();
   const client = getGraphQLClient();
-  const { data, isInitialLoading, error } = useGetContractsQuery(client, {
+  const { data, isInitialLoading } = useGetContractsQuery(client, {
     id,
   });
+
   if (isInitialLoading) {
     return <AccountPanelSkeleton />;
   }
-  if (!data?.organization?.contracts?.length && error) {
+  if (!data?.organization?.contracts?.length) {
     return <EmptyContracts name={data?.organization?.name || ''} />;
   }
 

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Contract.dto.ts
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Contract.dto.ts
@@ -39,8 +39,18 @@ export class ContractDTO implements TimeToRenewalForm {
     this.contractUrl = data?.contractUrl ?? '';
   }
 
-  static toForm(data?: TimeToRenewalData | null): TimeToRenewalForm {
-    return new ContractDTO(data);
+  static toForm(
+    organizationName: string,
+    data?: TimeToRenewalData | null,
+  ): TimeToRenewalForm {
+    const formData = new ContractDTO(data);
+
+    return {
+      ...formData,
+      name: formData.name?.length
+        ? formData.name
+        : `${organizationName}'s contract`,
+    };
   }
 
   static toPayload(

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractSubtitle.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractSubtitle.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import { Flex } from '@ui/layout/Flex';
+import { Text } from '@ui/typography/Text';
+import { DateTimeUtils } from '@spaces/utils/date';
+import { Contract, ContractStatus, ContractRenewalCycle } from '@graphql/types';
+
+function getLabelFromValue(value: string): string | undefined {
+  if (ContractRenewalCycle.AnnualRenewal === value) {
+    return 'annually';
+  }
+  if (ContractRenewalCycle.MonthlyRenewal === value) {
+    return 'monthly';
+  }
+}
+export const ContractSubtitle = ({ data }: { data: Contract }) => {
+  const hasStartedService =
+    data?.serviceStartedAt && !DateTimeUtils.isFuture(data.serviceStartedAt);
+
+  const serviceStartDate =
+    data?.serviceStartedAt && DateTimeUtils.isFuture(data.serviceStartedAt)
+      ? DateTimeUtils.format(
+          data.serviceStartedAt,
+          DateTimeUtils.dateWithAbreviatedMonth,
+        )
+      : null;
+  const renewalDate = data?.opportunities?.[0]?.renewedAt
+    ? DateTimeUtils.format(
+        data?.opportunities?.[0]?.renewedAt,
+        DateTimeUtils.dateWithAbreviatedMonth,
+      )
+    : null;
+  const endDate = data?.endedAt
+    ? DateTimeUtils.format(data.endedAt, DateTimeUtils.dateWithAbreviatedMonth)
+    : null;
+
+  if (!data?.signedAt) {
+    return <Text>No start date or services yet</Text>;
+  }
+
+  return (
+    <Flex flexDir='column' alignItems='flex-start' justifyContent='center'>
+      {serviceStartDate && <Text>Service starts on {serviceStartDate}</Text>}
+      {hasStartedService && data.status !== ContractStatus.Ended && (
+        <Text>
+          Renews {getLabelFromValue(data.renewalCycle)} on {renewalDate}
+        </Text>
+      )}
+      {data?.endedAt && DateTimeUtils.isFuture(data.endedAt) && (
+        <Text>Ends on {endDate}</Text>
+      )}
+      {!DateTimeUtils.isFuture(data.endedAt) && <Text>Ended on {endDate}</Text>}
+    </Flex>
+  );
+};

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Services/ServicesList.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Services/ServicesList.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 
-import { Box } from '@ui/layout/Box';
 import { Flex } from '@ui/layout/Flex';
 import { Text } from '@ui/typography/Text';
 import { Divider } from '@ui/presentation/Divider';
 import { BilledType, ServiceLineItem } from '@graphql/types';
 import { formatCurrency } from '@spaces/utils/getFormattedCurrencyNumber';
-import { useUpdateServiceModalContext } from '@organization/src/components/Tabs/panels/AccountPanel/context/AccountModalsContext';
-import { UpdateServiceModal } from '@organization/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/UpdateServiceModal';
+
+import { UpdateServiceModal } from './modals/UpdateServiceModal';
+import { useUpdateServiceModalContext } from './../../context/AccountModalsContext';
 
 function getBilledTypeLabel(billedType: BilledType): string {
   switch (billedType) {
@@ -18,7 +18,9 @@ function getBilledTypeLabel(billedType: BilledType): string {
     case BilledType.None:
       return '';
     case BilledType.Once:
-      return '/one-time';
+      return ' one-time';
+    case BilledType.Usage:
+      return '/use';
     default:
       return '';
   }
@@ -33,10 +35,19 @@ const ServiceItem = ({
 }) => {
   return (
     <>
-      <Box
+      <Flex
+        as='button'
+        flexDir='column'
         cursor='pointer'
         onClick={() => onOpen(data)}
         _hover={{ '& button': { opacity: 1 } }}
+        _focusVisible={{
+          '&': {
+            boxShadow: 'var(--chakra-shadows-outline)',
+            outline: 'none',
+            borderRadius: 'md',
+          },
+        }}
         sx={{ '& button': { opacity: 0 } }}
       >
         {data.name && (
@@ -46,18 +57,17 @@ const ServiceItem = ({
         )}
         <Flex justifyContent='space-between'>
           <Text>
-            {data.billed === BilledType.Once ? (
-              `${formatCurrency(data.price ?? 0)} one-time`
-            ) : (
+            {![BilledType.Usage, BilledType.Once].includes(data.billed) && (
               <>
                 {data.quantity} {data.quantity > 1 ? 'licenses' : 'license'}
                 <Text as='span' fontSize='sm' mx={1}>
                   x
                 </Text>
-                {formatCurrency(data.price ?? 0)}
-                {getBilledTypeLabel(data.billed)}
               </>
             )}
+
+            {formatCurrency(data.price ?? 0)}
+            {getBilledTypeLabel(data.billed)}
           </Text>
           {/*<IconButton*/}
           {/*  transition='opacity 0.2s linear'*/}
@@ -68,12 +78,11 @@ const ServiceItem = ({
           {/*  icon={<Delete boxSize='4' />}*/}
           {/*/>*/}
         </Flex>
-      </Box>
+      </Flex>
     </>
   );
 };
 
-// todo use generated type after gql schema for Services item is merged
 interface ServicesListProps {
   data?: Array<ServiceLineItem>;
 }

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/OneTimeServiceForm.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/OneTimeServiceForm.tsx
@@ -1,14 +1,19 @@
 'use client';
 
+import { BilledType } from '@graphql/types';
 import { FormInput, FormControl } from '@ui/form/Input';
 import { FormCurrencyInput } from '@ui/form/CurrencyInput';
 import { CurrencyDollar } from '@ui/media/icons/CurrencyDollar';
 
 interface OneTimeServiceModalProps {
   formId: string;
+  billedType: BilledType;
 }
 
-export const OneTimeServiceForm = ({ formId }: OneTimeServiceModalProps) => {
+export const OneTimeServiceForm = ({
+  formId,
+  billedType,
+}: OneTimeServiceModalProps) => {
   return (
     <>
       <FormControl>
@@ -34,9 +39,11 @@ export const OneTimeServiceForm = ({ formId }: OneTimeServiceModalProps) => {
         formId={formId}
         w='full'
         height='auto'
-        placeholder='Price'
+        placeholder={
+          billedType === BilledType.Once ? 'One-time price' : 'Price'
+        }
         isLabelVisible
-        label='Price'
+        label={billedType === BilledType.Once ? 'Price' : 'Price/usage'}
         min={0}
         leftElement={<CurrencyDollar boxSize={4} color='gray.500' />}
       />

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/RecurringService.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/RecurringService.tsx
@@ -11,14 +11,12 @@ import { Certificate02 } from '@ui/media/icons/Certificate02';
 import { CurrencyDollar } from '@ui/media/icons/CurrencyDollar';
 import { billedTypeOptions } from '@organization/src/components/Tabs/panels/AccountPanel/utils';
 
-interface SubscriptionServiceFromProps {
+interface RecurringServiceFormProps {
   formId: string;
 }
 
-const [_, ...subscriptionOptions] = billedTypeOptions;
-export const SubscriptionServiceFrom = ({
-  formId,
-}: SubscriptionServiceFromProps) => {
+const [_, _1, ...subscriptionOptions] = billedTypeOptions;
+export const RecurringServiceFrom = ({ formId }: RecurringServiceFormProps) => {
   const initialRef = useRef(null);
 
   return (

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/Service.dto.ts
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/Service.dto.ts
@@ -38,7 +38,8 @@ export class ServiceDTO implements ServiceForm {
     this.price = data?.price;
     this.appSource = data?.appSource;
     this.billed =
-      billedTypeOptions.find((o) => o.value === data?.billed) ?? null;
+      billedTypeOptions.find((o) => o.value === data?.billed) ??
+      billedTypeOptions[2];
   }
 
   static toForm(data?: ServiceItem): ServiceForm {

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/UpdateServiceModal.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/UpdateServiceModal.tsx
@@ -6,12 +6,16 @@ import { useForm } from 'react-inverted-form';
 import { produce } from 'immer';
 import { useQueryClient } from '@tanstack/react-query';
 
+import { Box } from '@ui/layout/Box';
 import { Button } from '@ui/form/Button';
+import { Text } from '@ui/typography/Text';
 import { FeaturedIcon } from '@ui/media/Icon';
 import { Heading } from '@ui/typography/Heading';
 import { toastError } from '@ui/presentation/Toast';
 import { DotSingle } from '@ui/media/icons/DotSingle';
+import { FormAutoresizeTextarea } from '@ui/form/Textarea';
 import { BilledType, ServiceLineItem } from '@graphql/types';
+import { FormCheckbox } from '@ui/form/Checkbox/FormCheckbox';
 import { getGraphQLClient } from '@shared/util/getGraphQLClient';
 import { useUpdateServiceMutation } from '@organization/src/graphql/updateService.generated';
 import {
@@ -27,11 +31,11 @@ import {
   ModalOverlay,
 } from '@ui/overlay/Modal';
 import { OneTimeServiceForm } from '@organization/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/OneTimeServiceForm';
+import { RecurringServiceFrom } from '@organization/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/RecurringService';
 import {
   ServiceDTO,
   ServiceForm,
 } from '@organization/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/Service.dto';
-import { SubscriptionServiceFrom } from '@organization/src/components/Tabs/panels/AccountPanel/Contract/Services/modals/SubscriptionServiceForm';
 
 interface SubscriptionServiceModalProps {
   isOpen: boolean;
@@ -140,17 +144,47 @@ export const UpdateServiceModal = ({
             <DotSingle color='primary.600' />
           </FeaturedIcon>
           <Heading fontSize='lg' mt='4'>
-            {data?.billed === BilledType.Once
-              ? 'Update one-time service'
-              : 'Update subscription service'}
+            Modify this
+            {data?.billed === BilledType.Once && ' one-time service'}
+            {data?.billed === BilledType.Usage && ' service'}
+            {data?.billed !== BilledType.Once &&
+              data?.billed !== BilledType.Usage &&
+              ' recurring service'}
           </Heading>
         </ModalHeader>
         <ModalBody pb='0'>
-          {data?.billed === BilledType.Once ? (
-            <OneTimeServiceForm formId={formId} />
+          {data?.billed === BilledType.Once ||
+          data?.billed === BilledType.Usage ? (
+            <OneTimeServiceForm formId={formId} billedType={data.billed} />
           ) : (
-            <SubscriptionServiceFrom formId={formId} />
+            <RecurringServiceFrom formId={formId} />
           )}
+          <Box
+            p={2}
+            my={2}
+            border='1px solid'
+            borderColor='gray.100'
+            bg='gray.25'
+            borderRadius='md'
+          >
+            <FormCheckbox formId={formId} name='todo'>
+              <Text fontSize='sm'>This is a retroactive correction</Text>
+            </FormCheckbox>
+          </Box>
+
+          <div>
+            <Text as='label' htmlFor='reason' fontSize='sm'>
+              <b>Reason for change</b> (optional)
+            </Text>
+            <FormAutoresizeTextarea
+              pt='0'
+              formId={formId}
+              name='reason'
+              id='reason'
+              spellCheck='false'
+              placeholder={`What this modification about?`}
+            />
+          </div>
         </ModalBody>
         <ModalFooter p='6'>
           <Button variant='outline' w='full' onClick={onClose}>
@@ -159,11 +193,13 @@ export const UpdateServiceModal = ({
           <Button
             ml='3'
             w='full'
+            isLoading={updateService.status === 'loading'}
+            loadingText='Modifying service...'
             variant='outline'
             colorScheme='primary'
             onClick={updateServiceData}
           >
-            Update
+            Modify
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/EmptyContracts.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/EmptyContracts.tsx
@@ -123,6 +123,8 @@ export const EmptyContracts: FC<{ name: string }> = ({ name }) => {
         <Button
           fontSize='sm'
           size='sm'
+          isLoading={createContract.status === 'loading'}
+          loadingText='Creating contract...'
           colorScheme='primary'
           mt={6}
           variant='outline'

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/utils.ts
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/utils.ts
@@ -1,6 +1,5 @@
 import { QueryClient } from '@tanstack/react-query';
 
-import { DateTimeUtils } from '@spaces/utils/date';
 import { SelectOption } from '@shared/types/SelectOptions';
 import { useOrganizationAccountDetailsQuery } from '@organization/src/graphql/getAccountPanelDetails.generated';
 import {
@@ -51,47 +50,7 @@ export const billingFrequencyOptions: SelectOption<ContractRenewalCycle>[] = [
 
 export const billedTypeOptions: SelectOption<BilledType>[] = [
   { label: 'Once', value: BilledType.Once },
-
+  { label: 'Usage', value: BilledType.Usage },
   { label: 'Monthly', value: BilledType.Monthly },
   { label: 'Annually', value: BilledType.Annually },
 ];
-
-export function calculateNextRenewalDate(
-  serviceStartedAt: string,
-  renewalCycle: ContractRenewalCycle,
-): string {
-  const difference = DateTimeUtils.differenceInMonths(
-    new Date().toISOString(),
-    serviceStartedAt,
-  );
-  switch (renewalCycle) {
-    case ContractRenewalCycle.AnnualRenewal: {
-      const differenceInYears = Math.ceil(difference / 12);
-
-      let nextRenewal = DateTimeUtils.addYears(
-        serviceStartedAt,
-        differenceInYears,
-      ).toISOString();
-      if (!DateTimeUtils.isBeforeNow(nextRenewal)) {
-        nextRenewal = DateTimeUtils.addYears(nextRenewal, 1).toISOString();
-      }
-
-      return nextRenewal;
-    }
-    case ContractRenewalCycle.MonthlyRenewal: {
-      const difference = DateTimeUtils.differenceInMonths(
-        new Date().toISOString(),
-        serviceStartedAt,
-      );
-      let nextRenewal = DateTimeUtils.addMonth(serviceStartedAt, difference);
-
-      if (!DateTimeUtils.isBeforeNow(nextRenewal.toISOString())) {
-        nextRenewal = DateTimeUtils.addMonth(nextRenewal.toISOString(), 1);
-      }
-
-      return nextRenewal.toISOString();
-    }
-    default:
-      return '';
-  }
-}

--- a/packages/apps/spaces/app/src/types/__generated__/graphql.types.ts
+++ b/packages/apps/spaces/app/src/types/__generated__/graphql.types.ts
@@ -101,6 +101,7 @@ export enum BilledType {
   Monthly = 'MONTHLY',
   None = 'NONE',
   Once = 'ONCE',
+  Usage = 'USAGE',
 }
 
 export type BillingDetails = {
@@ -2965,6 +2966,7 @@ export type ServiceLineItem = Node & {
   __typename?: 'ServiceLineItem';
   appSource: Scalars['String'];
   billed: BilledType;
+  comments: Scalars['String'];
   createdAt: Scalars['Time'];
   createdBy?: Maybe<User>;
   externalLinks: Array<ExternalSystem>;
@@ -2990,6 +2992,7 @@ export type ServiceLineItemInput = {
 export type ServiceLineItemUpdateInput = {
   appSource?: InputMaybe<Scalars['String']>;
   billed?: InputMaybe<BilledType>;
+  comments?: InputMaybe<Scalars['String']>;
   externalReference?: InputMaybe<ExternalSystemReferenceInput>;
   name?: InputMaybe<Scalars['String']>;
   price?: InputMaybe<Scalars['Float']>;

--- a/packages/apps/spaces/ui/form/Checkbox/CustomCheckbox.tsx
+++ b/packages/apps/spaces/ui/form/Checkbox/CustomCheckbox.tsx
@@ -8,7 +8,7 @@ import {
   useMultiStyleConfig,
 } from '@chakra-ui/react';
 
-interface CustomCheckboxProps extends Omit<CheckboxProps, 'onChange'> {
+export interface CustomCheckboxProps extends Omit<CheckboxProps, 'onChange'> {
   onChange?: (value: string) => void;
 }
 

--- a/packages/apps/spaces/ui/form/Checkbox/FormCheckbox.tsx
+++ b/packages/apps/spaces/ui/form/Checkbox/FormCheckbox.tsx
@@ -1,0 +1,34 @@
+import { useField } from 'react-inverted-form';
+import React, { PropsWithChildren } from 'react';
+
+import { CheckboxProps } from '@chakra-ui/react';
+
+import { CustomCheckbox } from '@ui/form/Checkbox/CustomCheckbox';
+
+interface FormCheckboxProps extends Omit<CheckboxProps, 'onChange'> {
+  name: string;
+  formId: string;
+}
+
+export const FormCheckbox = ({
+  name,
+  formId,
+  children,
+  ...rest
+}: PropsWithChildren<FormCheckboxProps>) => {
+  const { getInputProps } = useField(name, formId);
+  const { value: isChecked, onChange } = getInputProps();
+
+  return (
+    <CustomCheckbox
+      isChecked={isChecked}
+      onChange={onChange}
+      top='0'
+      size='md'
+      zIndex='10'
+      {...rest}
+    >
+      {children}
+    </CustomCheckbox>
+  );
+};


### PR DESCRIPTION
What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new search bar for enhanced navigation and user experience.
  - Added a dynamic heading in the update service modal to reflect service type.
  - Implemented a new checkbox for retroactive correction in service modals.
  - Created a new `ContractSubtitle` component for improved contract information display.
  - Added "Usage" as a new billing type option across relevant components.

- **Enhancements**
  - Updated service creation and update modals to include additional billing types and improved form handling.
  - Improved loading state feedback when creating contracts.

- **Bug Fixes**
  - Fixed the default billing type assignment in the `ServiceDTO` class to prevent null values.

- **Refactor**
  - Simplified error handling in the `AccountPanel` component.
  - Updated `ContractDTO` to include `organizationName` in the form data.
  - Enhanced `ContractCard` component with new layout and interaction elements.

- **Style**
  - Adjusted styles and attributes for components to align with new features and enhancements.

- **Documentation**
  - Updated component prop descriptions to reflect new and modified features.

- **Chores**
  - Removed unused code and comments to clean up the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->