### PR TITLE
Alex/cos 938 events adjust renewal opportunity on setting unsetting

### DIFF
--- a/packages/server/events-processing-platform/domain/opportunity/aggregate/aggregate.go
+++ b/packages/server/events-processing-platform/domain/opportunity/aggregate/aggregate.go
@@ -41,6 +41,10 @@ func (a *OpportunityAggregate) When(evt eventstore.Event) error {
 		return a.onRenewalOpportunityUpdate(evt)
 	case event.OpportunityUpdateNextCycleDateV1:
 		return a.onOpportunityUpdateNextCycleDate(evt)
+	case event.OpportunityCloseWinV1:
+		return a.onOpportunityCloseWin(evt)
+	case event.OpportunityCloseLooseV1:
+		return a.onOpportunityCloseLoose(evt)
 	default:
 		err := eventstore.ErrInvalidEventType
 		err.EventType = evt.GetEventType()
@@ -178,5 +182,27 @@ func (a *OpportunityAggregate) onRenewalOpportunityUpdate(evt eventstore.Event) 
 		a.Opportunity.Source.SourceOfTruth = eventData.Source
 	}
 
+	return nil
+}
+
+func (a *OpportunityAggregate) onOpportunityCloseWin(evt eventstore.Event) error {
+	var eventData event.OpportunityCloseWinEvent
+	if err := evt.GetJsonData(&eventData); err != nil {
+		return errors.Wrap(err, "GetJsonData")
+	}
+	a.Opportunity.InternalStage = model.OpportunityInternalStageStringClosedWon
+	a.Opportunity.ClosedAt = &eventData.ClosedAt
+	a.Opportunity.UpdatedAt = eventData.UpdatedAt
+	return nil
+}
+
+func (a *OpportunityAggregate) onOpportunityCloseLoose(evt eventstore.Event) error {
+	var eventData event.OpportunityCloseLooseEvent
+	if err := evt.GetJsonData(&eventData); err != nil {
+		return errors.Wrap(err, "GetJsonData")
+	}
+	a.Opportunity.InternalStage = model.OpportunityInternalStageStringClosedLost
+	a.Opportunity.ClosedAt = &eventData.ClosedAt
+	a.Opportunity.UpdatedAt = eventData.UpdatedAt
 	return nil
 }

--- a/packages/server/events-processing-platform/domain/opportunity/command/close_loose_opportunity_command.go
+++ b/packages/server/events-processing-platform/domain/opportunity/command/close_loose_opportunity_command.go
@@ -1,0 +1,22 @@
+package command
+
+import (
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/eventstore"
+	"time"
+)
+
+type CloseLooseOpportunityCommand struct {
+	eventstore.BaseCommand
+	AppSource string
+	UpdatedAt *time.Time
+	ClosedAt  *time.Time
+}
+
+func NewCloseLooseOpportunityCommand(opportunityId, tenant, loggedInUserId, appSource string, updatedAt, closedAt *time.Time) *CloseLooseOpportunityCommand {
+	return &CloseLooseOpportunityCommand{
+		BaseCommand: eventstore.NewBaseCommand(opportunityId, tenant, loggedInUserId),
+		UpdatedAt:   updatedAt,
+		ClosedAt:    closedAt,
+		AppSource:   appSource,
+	}
+}

--- a/packages/server/events-processing-platform/domain/opportunity/command/close_win_opportunity_command.go
+++ b/packages/server/events-processing-platform/domain/opportunity/command/close_win_opportunity_command.go
@@ -1,0 +1,22 @@
+package command
+
+import (
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/eventstore"
+	"time"
+)
+
+type CloseWinOpportunityCommand struct {
+	eventstore.BaseCommand
+	AppSource string
+	UpdatedAt *time.Time
+	ClosedAt  *time.Time
+}
+
+func NewCloseWinOpportunityCommand(opportunityId, tenant, loggedInUserId, appSource string, updatedAt, closedAt *time.Time) *CloseWinOpportunityCommand {
+	return &CloseWinOpportunityCommand{
+		BaseCommand: eventstore.NewBaseCommand(opportunityId, tenant, loggedInUserId),
+		UpdatedAt:   updatedAt,
+		ClosedAt:    closedAt,
+		AppSource:   appSource,
+	}
+}

--- a/packages/server/events-processing-platform/domain/opportunity/command_handler/close_loose_opportunity_handler.go
+++ b/packages/server/events-processing-platform/domain/opportunity/command_handler/close_loose_opportunity_handler.go
@@ -1,0 +1,78 @@
+package command_handler
+
+import (
+	"context"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/config"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/opportunity/aggregate"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/opportunity/command"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/eventstore"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/logger"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/tracing"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/validator"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"time"
+)
+
+type CloseLooseOpportunityCommandHandler interface {
+	Handle(ctx context.Context, cmd *command.CloseLooseOpportunityCommand) error
+}
+
+type closeLooseOpportunityCommandHandler struct {
+	log logger.Logger
+	es  eventstore.AggregateStore
+	cfg config.Utils
+}
+
+func NewCloseLooseOpportunityCommandHandler(log logger.Logger, es eventstore.AggregateStore, cfg config.Utils) CloseLooseOpportunityCommandHandler {
+	return &closeLooseOpportunityCommandHandler{
+		log: log,
+		es:  es,
+		cfg: cfg,
+	}
+}
+
+func (h *closeLooseOpportunityCommandHandler) Handle(ctx context.Context, cmd *command.CloseLooseOpportunityCommand) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "CloseLooseOpportunityCommandHandler.Handle")
+	defer span.Finish()
+	tracing.SetCommandHandlerSpanTags(ctx, span, cmd.Tenant, cmd.LoggedInUserId)
+	span.LogFields(log.Object("command", cmd))
+
+	// Validate the command fields
+	validationError, done := validator.Validate(cmd, span)
+	if done {
+		return validationError
+	}
+
+	for attempt := 0; attempt == 0 || attempt < h.cfg.RetriesOnOptimisticLockException; attempt++ {
+		opportunityAggregate, err := aggregate.LoadOpportunityAggregate(ctx, h.es, cmd.Tenant, cmd.ObjectID)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
+		// Apply the command to the aggregate
+		if err = opportunityAggregate.HandleCommand(ctx, cmd); err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
+
+		err = h.es.Save(ctx, opportunityAggregate)
+		if err == nil {
+			return nil // Save successful
+		}
+
+		if eventstore.IsEventStoreErrorCodeWrongExpectedVersion(err) {
+			// Handle concurrency error
+			span.LogFields(log.Int("retryAttempt", attempt+1))
+			time.Sleep(utils.BackOffExponentialDelay(attempt)) // backoffDelay is a function that increases the delay with each attempt
+			continue                                           // Retry
+		} else {
+			// Some other error occurred
+			tracing.TraceErr(span, err)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/packages/server/events-processing-platform/domain/opportunity/command_handler/close_win_opportunity_handler.go
+++ b/packages/server/events-processing-platform/domain/opportunity/command_handler/close_win_opportunity_handler.go
@@ -1,0 +1,78 @@
+package command_handler
+
+import (
+	"context"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/config"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/opportunity/aggregate"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/opportunity/command"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/eventstore"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/logger"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/tracing"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/validator"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"time"
+)
+
+type CloseWinOpportunityCommandHandler interface {
+	Handle(ctx context.Context, cmd *command.CloseWinOpportunityCommand) error
+}
+
+type closeWinOpportunityCommandHandler struct {
+	log logger.Logger
+	es  eventstore.AggregateStore
+	cfg config.Utils
+}
+
+func NewCloseWinOpportunityCommandHandler(log logger.Logger, es eventstore.AggregateStore, cfg config.Utils) CloseWinOpportunityCommandHandler {
+	return &closeWinOpportunityCommandHandler{
+		log: log,
+		es:  es,
+		cfg: cfg,
+	}
+}
+
+func (h *closeWinOpportunityCommandHandler) Handle(ctx context.Context, cmd *command.CloseWinOpportunityCommand) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "CloseWinOpportunityCommandHandler.Handle")
+	defer span.Finish()
+	tracing.SetCommandHandlerSpanTags(ctx, span, cmd.Tenant, cmd.LoggedInUserId)
+	span.LogFields(log.Object("command", cmd))
+
+	// Validate the command fields
+	validationError, done := validator.Validate(cmd, span)
+	if done {
+		return validationError
+	}
+
+	for attempt := 0; attempt == 0 || attempt < h.cfg.RetriesOnOptimisticLockException; attempt++ {
+		opportunityAggregate, err := aggregate.LoadOpportunityAggregate(ctx, h.es, cmd.Tenant, cmd.ObjectID)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
+		// Apply the command to the aggregate
+		if err = opportunityAggregate.HandleCommand(ctx, cmd); err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
+
+		err = h.es.Save(ctx, opportunityAggregate)
+		if err == nil {
+			return nil // Save successful
+		}
+
+		if eventstore.IsEventStoreErrorCodeWrongExpectedVersion(err) {
+			// Handle concurrency error
+			span.LogFields(log.Int("retryAttempt", attempt+1))
+			time.Sleep(utils.BackOffExponentialDelay(attempt)) // backoffDelay is a function that increases the delay with each attempt
+			continue                                           // Retry
+		} else {
+			// Some other error occurred
+			tracing.TraceErr(span, err)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/packages/server/events-processing-platform/domain/opportunity/command_handler/command_handlers.go
+++ b/packages/server/events-processing-platform/domain/opportunity/command_handler/command_handlers.go
@@ -13,6 +13,8 @@ type CommandHandlers struct {
 	CreateRenewalOpportunity              CreateRenewalOpportunityCommandHandler
 	UpdateRenewalOpportunity              UpdateRenewalOpportunityCommandHandler
 	UpdateRenewalOpportunityNextCycleDate UpdateRenewalOpportunityNextCycleDateCommandHandler
+	CloseWinOpportunity                   CloseWinOpportunityCommandHandler
+	CloseLooseOpportunity                 CloseLooseOpportunityCommandHandler
 }
 
 func NewCommandHandlers(log logger.Logger, cfg *config.Config, es eventstore.AggregateStore) *CommandHandlers {
@@ -22,5 +24,7 @@ func NewCommandHandlers(log logger.Logger, cfg *config.Config, es eventstore.Agg
 		CreateRenewalOpportunity:              NewCreateRenewalOpportunityCommandHandler(log, es),
 		UpdateRenewalOpportunity:              NewUpdateRenewalOpportunityCommandHandler(log, es, cfg.Utils),
 		UpdateRenewalOpportunityNextCycleDate: NewUpdateRenewalOpportunityNextCycleDateCommandHandler(log, es, cfg.Utils),
+		CloseWinOpportunity:                   NewCloseWinOpportunityCommandHandler(log, es, cfg.Utils),
+		CloseLooseOpportunity:                 NewCloseLooseOpportunityCommandHandler(log, es, cfg.Utils),
 	}
 }

--- a/packages/server/events-processing-platform/domain/opportunity/event/events.go
+++ b/packages/server/events-processing-platform/domain/opportunity/event/events.go
@@ -6,4 +6,6 @@ const (
 	OpportunityCreateRenewalV1       = "V1_OPPORTUNITY_CREATE_RENEWAL"
 	OpportunityUpdateRenewalV1       = "V1_OPPORTUNITY_UPDATE_RENEWAL"
 	OpportunityUpdateNextCycleDateV1 = "V1_OPPORTUNITY_UPDATE_NEXT_CYCLE_DATE"
+	OpportunityCloseWinV1            = "V1_OPPORTUNITY_CLOSE_WIN"
+	OpportunityCloseLooseV1          = "V1_OPPORTUNITY_CLOSE_LOOSE"
 )

--- a/packages/server/events-processing-platform/domain/opportunity/event/opportunity_close_loose.go
+++ b/packages/server/events-processing-platform/domain/opportunity/event/opportunity_close_loose.go
@@ -1,0 +1,32 @@
+package event
+
+import (
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/eventstore"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/validator"
+	"github.com/pkg/errors"
+	"time"
+)
+
+type OpportunityCloseLooseEvent struct {
+	Tenant    string    `json:"tenant" validate:"required"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	ClosedAt  time.Time `json:"closedAt" validate:"required"`
+}
+
+func NewOpportunityCloseLooseEvent(aggregate eventstore.Aggregate, updatedAt, closedAt time.Time) (eventstore.Event, error) {
+	eventData := OpportunityCloseLooseEvent{
+		Tenant:    aggregate.GetTenant(),
+		UpdatedAt: updatedAt,
+		ClosedAt:  closedAt,
+	}
+
+	if err := validator.GetValidator().Struct(eventData); err != nil {
+		return eventstore.Event{}, errors.Wrap(err, "failed to validate OpportunityCloseLooseEvent")
+	}
+
+	event := eventstore.NewBaseEvent(aggregate, OpportunityCloseLooseV1)
+	if err := event.SetJsonData(&eventData); err != nil {
+		return eventstore.Event{}, errors.Wrap(err, "error setting json data for OpportunityCloseLooseEvent")
+	}
+	return event, nil
+}

--- a/packages/server/events-processing-platform/domain/opportunity/event/opportunity_close_win.go
+++ b/packages/server/events-processing-platform/domain/opportunity/event/opportunity_close_win.go
@@ -1,0 +1,32 @@
+package event
+
+import (
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/eventstore"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/validator"
+	"github.com/pkg/errors"
+	"time"
+)
+
+type OpportunityCloseWinEvent struct {
+	Tenant    string    `json:"tenant" validate:"required"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	ClosedAt  time.Time `json:"closedAt" validate:"required"`
+}
+
+func NewOpportunityCloseWinEvent(aggregate eventstore.Aggregate, updatedAt, closedAt time.Time) (eventstore.Event, error) {
+	eventData := OpportunityCloseWinEvent{
+		Tenant:    aggregate.GetTenant(),
+		UpdatedAt: updatedAt,
+		ClosedAt:  closedAt,
+	}
+
+	if err := validator.GetValidator().Struct(eventData); err != nil {
+		return eventstore.Event{}, errors.Wrap(err, "failed to validate OpportunityCloseWinEvent")
+	}
+
+	event := eventstore.NewBaseEvent(aggregate, OpportunityCloseWinV1)
+	if err := event.SetJsonData(&eventData); err != nil {
+		return eventstore.Event{}, errors.Wrap(err, "error setting json data for OpportunityCloseWinEvent")
+	}
+	return event, nil
+}

--- a/packages/server/events-processing-platform/domain/opportunity/model/opportunity.go
+++ b/packages/server/events-processing-platform/domain/opportunity/model/opportunity.go
@@ -33,6 +33,7 @@ type Opportunity struct {
 	InternalStage     OpportunityInternalStageString `json:"internalStage"`
 	ExternalStage     string                         `json:"externalStage"`
 	EstimatedClosedAt *time.Time                     `json:"estimatedClosedAt,omitempty"`
+	ClosedAt          *time.Time                     `json:"closedAt,omitempty"`
 	OwnerUserId       string                         `json:"ownerUserId"`
 	CreatedByUserId   string                         `json:"createdByUserId"`
 	Source            commonmodel.Source             `json:"source"`

--- a/packages/server/events-processing-platform/graph_db/data_mapper.go
+++ b/packages/server/events-processing-platform/graph_db/data_mapper.go
@@ -184,8 +184,11 @@ func MapDbNodeToCommentEntity(node dbtype.Node) *entity.CommentEntity {
 	return &comment
 }
 
-func MapDbNodeToOpportunityEntity(node dbtype.Node) *entity.OpportunityEntity {
-	props := utils.GetPropsFromNode(node)
+func MapDbNodeToOpportunityEntity(node *dbtype.Node) *entity.OpportunityEntity {
+	if node == nil {
+		return nil
+	}
+	props := utils.GetPropsFromNode(*node)
 	opportunity := entity.OpportunityEntity{
 		Id:                utils.GetStringPropOrEmpty(props, "id"),
 		Name:              utils.GetStringPropOrEmpty(props, "name"),
@@ -196,6 +199,7 @@ func MapDbNodeToOpportunityEntity(node dbtype.Node) *entity.OpportunityEntity {
 		InternalStage:     utils.GetStringPropOrEmpty(props, "internalStage"),
 		ExternalStage:     utils.GetStringPropOrEmpty(props, "externalStage"),
 		EstimatedClosedAt: utils.GetTimePropOrNil(props, "estimatedClosedAt"),
+		ClosedAt:          utils.GetTimePropOrNil(props, "closedAt"),
 		GeneralNotes:      utils.GetStringPropOrEmpty(props, "generalNotes"),
 		NextSteps:         utils.GetStringPropOrEmpty(props, "nextSteps"),
 		Comments:          utils.GetStringPropOrEmpty(props, "comments"),

--- a/packages/server/events-processing-platform/graph_db/entity/contract.go
+++ b/packages/server/events-processing-platform/graph_db/entity/contract.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
 	"time"
 )
 
@@ -18,4 +19,8 @@ type ContractEntity struct {
 	SignedAt         *time.Time
 	ServiceStartedAt *time.Time
 	EndedAt          *time.Time
+}
+
+func (c ContractEntity) IsEnded() bool {
+	return c.EndedAt != nil && c.EndedAt.Before(utils.Now())
 }

--- a/packages/server/events-processing-platform/graph_db/entity/opportunity.go
+++ b/packages/server/events-processing-platform/graph_db/entity/opportunity.go
@@ -26,6 +26,7 @@ type OpportunityEntity struct {
 	InternalStage     string
 	ExternalStage     string
 	EstimatedClosedAt *time.Time
+	ClosedAt          *time.Time
 	OwnerUserId       string
 	CreatedByUserId   string
 	GeneralNotes      string

--- a/packages/server/events-processing-platform/subscriptions/graph/graph_subscriber.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/graph_subscriber.go
@@ -305,6 +305,10 @@ func (s *GraphSubscriber) When(ctx context.Context, evt eventstore.Event) error 
 		return s.opportunityEventHandler.OnCreateRenewal(ctx, evt)
 	case opportunityevent.OpportunityUpdateRenewalV1:
 		return s.opportunityEventHandler.OnUpdateRenewal(ctx, evt)
+	case opportunityevent.OpportunityCloseWinV1:
+		return s.opportunityEventHandler.OnCloseWin(ctx, evt)
+	case opportunityevent.OpportunityCloseLooseV1:
+		return s.opportunityEventHandler.OnCloseLoose(ctx, evt)
 
 	case contractevent.ContractCreateV1:
 		return s.contractEventHandler.OnCreate(ctx, evt)

--- a/packages/server/events-processing-platform/subscriptions/graph/opportunity_event_handler_it_test.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/opportunity_event_handler_it_test.go
@@ -99,7 +99,7 @@ func TestOpportunityEventHandler_OnCreate(t *testing.T) {
 	require.NotNil(t, opportunityDbNode)
 
 	// verify opportunity
-	opportunity := graph_db.MapDbNodeToOpportunityEntity(*opportunityDbNode)
+	opportunity := graph_db.MapDbNodeToOpportunityEntity(opportunityDbNode)
 	require.Equal(t, opportunityId, opportunity.Id)
 	require.Equal(t, entity.DataSource(constants.SourceOpenline), opportunity.Source)
 	require.Equal(t, constants.AppSourceEventProcessingPlatform, opportunity.AppSource)
@@ -167,7 +167,7 @@ func TestOpportunityEventHandler_OnCreateRenewal(t *testing.T) {
 	require.NotNil(t, opportunityDbNode)
 
 	// verify opportunity
-	opportunity := graph_db.MapDbNodeToOpportunityEntity(*opportunityDbNode)
+	opportunity := graph_db.MapDbNodeToOpportunityEntity(opportunityDbNode)
 	require.Equal(t, opportunityId, opportunity.Id)
 	require.Equal(t, entity.DataSource(constants.SourceOpenline), opportunity.Source)
 	require.Equal(t, constants.AppSourceEventProcessingPlatform, opportunity.AppSource)
@@ -219,7 +219,7 @@ func TestOpportunityEventHandler_OnUpdateNextCycleDate(t *testing.T) {
 	require.NotNil(t, opportunityDbNode)
 
 	// Validate that the opportunity next cycle date is updated in the repository
-	opportunity := graph_db.MapDbNodeToOpportunityEntity(*opportunityDbNode)
+	opportunity := graph_db.MapDbNodeToOpportunityEntity(opportunityDbNode)
 	require.Equal(t, opportunityId, opportunity.Id)
 	require.Equal(t, updatedAt, opportunity.UpdatedAt)
 	require.Equal(t, renewedAt, *opportunity.RenewalDetails.RenewedAt)
@@ -272,7 +272,7 @@ func TestOpportunityEventHandler_OnUpdate(t *testing.T) {
 	require.NotNil(t, opportunityDbNode)
 
 	// verify opportunity
-	opportunity := graph_db.MapDbNodeToOpportunityEntity(*opportunityDbNode)
+	opportunity := graph_db.MapDbNodeToOpportunityEntity(opportunityDbNode)
 	require.Equal(t, opportunityId, opportunity.Id)
 	require.Equal(t, now, opportunity.UpdatedAt)
 	require.Equal(t, "updated opportunity", opportunity.Name)
@@ -325,7 +325,7 @@ func TestOpportunityEventHandler_OnUpdate_OnlyAmountIsChangedByFieldsMask(t *tes
 	require.NotNil(t, opportunityDbNode)
 
 	// verify opportunity
-	opportunity := graph_db.MapDbNodeToOpportunityEntity(*opportunityDbNode)
+	opportunity := graph_db.MapDbNodeToOpportunityEntity(opportunityDbNode)
 	require.Equal(t, opportunityId, opportunity.Id)
 	require.Equal(t, now, opportunity.UpdatedAt)
 	require.Equal(t, "test opportunity", opportunity.Name)
@@ -385,7 +385,7 @@ func TestOpportunityEventHandler_OnUpdateRenewal_AmountAndRenewalChangedByUser(t
 	require.NotNil(t, opportunityDbNode)
 
 	// verify opportunity
-	opportunity := graph_db.MapDbNodeToOpportunityEntity(*opportunityDbNode)
+	opportunity := graph_db.MapDbNodeToOpportunityEntity(opportunityDbNode)
 	require.Equal(t, opportunityId, opportunity.Id)
 	require.Equal(t, now, opportunity.UpdatedAt)
 	require.Equal(t, "MEDIUM", opportunity.RenewalDetails.RenewalLikelihood)
@@ -460,7 +460,7 @@ func TestOpportunityEventHandler_OnUpdateRenewal_OnlyCommentsChangedByUser_DoNot
 	require.NotNil(t, opportunityDbNode)
 
 	// verify opportunity
-	opportunity := graph_db.MapDbNodeToOpportunityEntity(*opportunityDbNode)
+	opportunity := graph_db.MapDbNodeToOpportunityEntity(opportunityDbNode)
 	require.Equal(t, opportunityId, opportunity.Id)
 	require.Equal(t, now, opportunity.UpdatedAt)
 	require.Equal(t, "HIGH", opportunity.RenewalDetails.RenewalLikelihood)
@@ -528,7 +528,7 @@ func TestOpportunityEventHandler_OnUpdateRenewal_LikelihoodChangedByUser_Generat
 	require.NotNil(t, opportunityDbNode)
 
 	// verify opportunity
-	opportunity := graph_db.MapDbNodeToOpportunityEntity(*opportunityDbNode)
+	opportunity := graph_db.MapDbNodeToOpportunityEntity(opportunityDbNode)
 	require.Equal(t, opportunityId, opportunity.Id)
 	require.Equal(t, now, opportunity.UpdatedAt)
 	require.Equal(t, "MEDIUM", opportunity.RenewalDetails.RenewalLikelihood)
@@ -554,4 +554,78 @@ func TestOpportunityEventHandler_OnUpdateRenewal_LikelihoodChangedByUser_Generat
 	require.Equal(t, tenantName, eventData1.Tenant)
 	require.Equal(t, float64(0), eventData1.Amount)
 	require.Equal(t, float64(0), eventData1.MaxAmount)
+}
+
+func TestOpportunityEventHandler_OnCloseWin(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx, testDatabase)(t)
+
+	// Prepare test data in Neo4j
+	neo4jt.CreateTenant(ctx, testDatabase.Driver, tenantName)
+	opportunityId := neo4jt.CreateOpportunity(ctx, testDatabase.Driver, tenantName, entity.OpportunityEntity{
+		InternalStage: string(model.OpportunityInternalStageStringOpen),
+	})
+	now := utils.Now()
+
+	// Prepare the event handler
+	opportunityEventHandler := &OpportunityEventHandler{
+		log:          testLogger,
+		repositories: testDatabase.Repositories,
+	}
+
+	closeOpportunityEvent, err := event.NewOpportunityCloseWinEvent(aggregate.NewOpportunityAggregateWithTenantAndID(tenantName, opportunityId), now, now)
+	require.Nil(t, err)
+
+	// Execute the event handler
+	err = opportunityEventHandler.OnCloseWin(ctx, closeOpportunityEvent)
+	require.Nil(t, err)
+
+	// Assert Neo4j Node
+	opportunityDbNode, err := neo4jt.GetNodeById(ctx, testDatabase.Driver, constants.NodeLabel_Opportunity, opportunityId)
+	require.Nil(t, err)
+	require.NotNil(t, opportunityDbNode)
+
+	// Validate that the opportunity next cycle date is updated in the repository
+	opportunity := graph_db.MapDbNodeToOpportunityEntity(opportunityDbNode)
+	require.Equal(t, opportunityId, opportunity.Id)
+	require.Equal(t, now, opportunity.UpdatedAt)
+	require.Equal(t, now, *opportunity.ClosedAt)
+	require.Equal(t, string(model.OpportunityInternalStageStringClosedWon), opportunity.InternalStage)
+}
+
+func TestOpportunityEventHandler_OnCloseLoose(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx, testDatabase)(t)
+
+	// Prepare test data in Neo4j
+	neo4jt.CreateTenant(ctx, testDatabase.Driver, tenantName)
+	opportunityId := neo4jt.CreateOpportunity(ctx, testDatabase.Driver, tenantName, entity.OpportunityEntity{
+		InternalStage: string(model.OpportunityInternalStageStringOpen),
+	})
+	now := utils.Now()
+
+	// Prepare the event handler
+	opportunityEventHandler := &OpportunityEventHandler{
+		log:          testLogger,
+		repositories: testDatabase.Repositories,
+	}
+
+	closeOpportunityEvent, err := event.NewOpportunityCloseLooseEvent(aggregate.NewOpportunityAggregateWithTenantAndID(tenantName, opportunityId), now, now)
+	require.Nil(t, err)
+
+	// Execute the event handler
+	err = opportunityEventHandler.OnCloseLoose(ctx, closeOpportunityEvent)
+	require.Nil(t, err)
+
+	// Assert Neo4j Node
+	opportunityDbNode, err := neo4jt.GetNodeById(ctx, testDatabase.Driver, constants.NodeLabel_Opportunity, opportunityId)
+	require.Nil(t, err)
+	require.NotNil(t, opportunityDbNode)
+
+	// Validate that the opportunity next cycle date is updated in the repository
+	opportunity := graph_db.MapDbNodeToOpportunityEntity(opportunityDbNode)
+	require.Equal(t, opportunityId, opportunity.Id)
+	require.Equal(t, now, opportunity.UpdatedAt)
+	require.Equal(t, now, *opportunity.ClosedAt)
+	require.Equal(t, string(model.OpportunityInternalStageStringClosedLost), opportunity.InternalStage)
 }


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to close opportunities as a win or a loss, with corresponding updates to the opportunity's status and timestamps.

- **Enhancements**
  - Added new command handlers for processing win and loss closures of opportunities.
  - Implemented new event types for opportunity closure actions.
  - Updated opportunity repository interface to include methods for closing opportunities.

- **Bug Fixes**
  - Adjusted renewal opportunity handling in contracts to account for ended contracts.
  - Fixed potential nil pointer dereference in graph database data mapping.

- **Testing**
  - Added integration tests for new opportunity closure functionality and event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->