### PR TITLE
Cleanup graphql from deprecated queries and properties

### DIFF
--- a/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
+++ b/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
@@ -102,7 +102,7 @@
     },
     {
       "name": "Check service line items data consistency",
-      "query": "CALL {MATCH (sli:ServiceLineItem)<-[:HAS_SERVICE]-(c:Contract) WITH sli, count(c) AS sizeContracts WHERE sizeContracts <> 1 RETURN count(sli) AS cnt UNION MATCH (sli:ServiceLineItem) WHERE sli.endedAt > sli.startedAt RETURN count(sli) as cnt UNION MATCH (sli:ServiceLineItem) WHERE sli.createdAt is null OR sli.updatedAt is null OR sli.startedAt is null OR sli.billed is null OR sli.billed = '' return count(sli) as cnt} return sum(cnt)"
+      "query": "CALL {MATCH (sli:ServiceLineItem)<-[:HAS_SERVICE]-(c:Contract) WITH sli, count(c) AS sizeContracts WHERE sizeContracts <> 1 RETURN count(sli) AS cnt UNION MATCH (sli:ServiceLineItem) WHERE sli.endedAt > sli.startedAt RETURN count(sli) as cnt UNION MATCH (sli:ServiceLineItem) WHERE sli.createdAt is null OR sli.updatedAt is null OR sli.startedAt is null OR sli.billed is null OR sli.billed = '' OR sli.parentId is null OR sli.parentId = '' return count(sli) as cnt} return sum(cnt)"
     }
   ]
 }

--- a/packages/server/comms-api/go.mod
+++ b/packages/server/comms-api/go.mod
@@ -18,10 +18,10 @@ require (
 	github.com/gorilla/websocket v1.5.1
 	github.com/joho/godotenv v1.5.1
 	github.com/machinebox/graphql v0.2.2
-	github.com/openline-ai/openline-customer-os/packages/server/customer-os-api v0.0.0-20231123194903-77ec1248f93b
+	github.com/openline-ai/openline-customer-os/packages/server/customer-os-api v0.0.0-00010101000000-000000000000
 	github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-auth v0.0.0-20231123194903-77ec1248f93b
 	github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module v0.0.0-20231123194903-77ec1248f93b
-	github.com/openline-ai/openline-customer-os/packages/server/file-store-api v0.0.0-20231123155829-38910834a690
+	github.com/openline-ai/openline-customer-os/packages/server/file-store-api v0.0.0-20231128144155-d4740b1bf596
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/redis/go-redis/v9 v9.3.0
 	github.com/sirupsen/logrus v1.9.3

--- a/packages/server/comms-api/go.sum
+++ b/packages/server/comms-api/go.sum
@@ -209,8 +209,8 @@ github.com/opencontainers/runc v1.1.5 h1:L44KXEpKmfWDcS02aeGm8QNTFXTo2D+8MYGDIJ/
 github.com/opencontainers/runc v1.1.5/go.mod h1:1J5XiS+vdZ3wCyZybsuxXZWGrgSr8fFJHLXuG2PsnNg=
 github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-auth v0.0.0-20231123194903-77ec1248f93b h1:tJQQWFcSHbFOhdVfa8KVWLkbMxKihLDpRGBmbVH5P/o=
 github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-auth v0.0.0-20231123194903-77ec1248f93b/go.mod h1:H9g1bMNSvYuL+yY+vnmdWglM8Y9StsmmfFeD6dZz3yM=
-github.com/openline-ai/openline-customer-os/packages/server/file-store-api v0.0.0-20231123155829-38910834a690 h1:XP3Agda/bNHGU+/KYmmM7j1rMlcKRcfStbWpnKz0z7Y=
-github.com/openline-ai/openline-customer-os/packages/server/file-store-api v0.0.0-20231123155829-38910834a690/go.mod h1:wPK0I1d09bUDI+tPP8Sjno6MWC5vDZHpbfskwjOt0qU=
+github.com/openline-ai/openline-customer-os/packages/server/file-store-api v0.0.0-20231128144155-d4740b1bf596 h1:MkTQcwgsjyUqGuYLl9vWmm7VU+sYSVq2N1wgSCZrQ18=
+github.com/openline-ai/openline-customer-os/packages/server/file-store-api v0.0.0-20231128144155-d4740b1bf596/go.mod h1:BMCY48H9FJEXgbDhPgJtnqc9KgLi6yRmEDjdddPt7Ok=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=

--- a/packages/server/comms-api/test/graph/resolver/dashboard.resolvers.go
+++ b/packages/server/comms-api/test/graph/resolver/dashboard.resolvers.go
@@ -28,32 +28,32 @@ func (r *queryResolver) DashboardCustomerMap(ctx context.Context) ([]*model.Dash
 }
 
 // DashboardMRRPerCustomer is the resolver for the dashboard_MRRPerCustomer field.
-func (r *queryResolver) DashboardMRRPerCustomer(ctx context.Context, year int) (*model.DashboardMRRPerCustomer, error) {
+func (r *queryResolver) DashboardMRRPerCustomer(ctx context.Context, period *model.DashboardPeriodInput) (*model.DashboardMRRPerCustomer, error) {
 	panic(fmt.Errorf("not implemented: DashboardMRRPerCustomer - dashboard_MRRPerCustomer"))
 }
 
 // DashboardGrossRevenueRetention is the resolver for the dashboard_GrossRevenueRetention field.
-func (r *queryResolver) DashboardGrossRevenueRetention(ctx context.Context, year int) (*model.DashboardGrossRevenueRetention, error) {
+func (r *queryResolver) DashboardGrossRevenueRetention(ctx context.Context, period *model.DashboardPeriodInput) (*model.DashboardGrossRevenueRetention, error) {
 	panic(fmt.Errorf("not implemented: DashboardGrossRevenueRetention - dashboard_GrossRevenueRetention"))
 }
 
 // DashboardARRBreakdown is the resolver for the dashboard_ARRBreakdown field.
-func (r *queryResolver) DashboardARRBreakdown(ctx context.Context, year int) (*model.DashboardARRBreakdown, error) {
+func (r *queryResolver) DashboardARRBreakdown(ctx context.Context, period *model.DashboardPeriodInput) (*model.DashboardARRBreakdown, error) {
 	panic(fmt.Errorf("not implemented: DashboardARRBreakdown - dashboard_ARRBreakdown"))
 }
 
 // DashboardRevenueAtRisk is the resolver for the dashboard_RevenueAtRisk field.
-func (r *queryResolver) DashboardRevenueAtRisk(ctx context.Context, year int) (*model.DashboardRevenueAtRisk, error) {
+func (r *queryResolver) DashboardRevenueAtRisk(ctx context.Context, period *model.DashboardPeriodInput) (*model.DashboardRevenueAtRisk, error) {
 	panic(fmt.Errorf("not implemented: DashboardRevenueAtRisk - dashboard_RevenueAtRisk"))
 }
 
 // DashboardRetentionRate is the resolver for the dashboard_RetentionRate field.
-func (r *queryResolver) DashboardRetentionRate(ctx context.Context, year int) (*model.DashboardRetentionRate, error) {
+func (r *queryResolver) DashboardRetentionRate(ctx context.Context, period *model.DashboardPeriodInput) (*model.DashboardRetentionRate, error) {
 	panic(fmt.Errorf("not implemented: DashboardRetentionRate - dashboard_RetentionRate"))
 }
 
 // DashboardNewCustomers is the resolver for the dashboard_NewCustomers field.
-func (r *queryResolver) DashboardNewCustomers(ctx context.Context, year int) (*model.DashboardNewCustomers, error) {
+func (r *queryResolver) DashboardNewCustomers(ctx context.Context, period *model.DashboardPeriodInput) (*model.DashboardNewCustomers, error) {
 	panic(fmt.Errorf("not implemented: DashboardNewCustomers - dashboard_NewCustomers"))
 }
 

--- a/packages/server/comms-api/test/graph/resolver/opportunity.resolvers.go
+++ b/packages/server/comms-api/test/graph/resolver/opportunity.resolvers.go
@@ -12,6 +12,16 @@ import (
 	"github.com/openline-ai/openline-customer-os/packages/server/comms-api/test/graph/model"
 )
 
+// OpportunityUpdate is the resolver for the opportunityUpdate field.
+func (r *mutationResolver) OpportunityUpdate(ctx context.Context, input model.OpportunityUpdateInput) (*model.Opportunity, error) {
+	panic(fmt.Errorf("not implemented: OpportunityUpdate - opportunityUpdate"))
+}
+
+// OpportunityRenewalUpdate is the resolver for the opportunityRenewalUpdate field.
+func (r *mutationResolver) OpportunityRenewalUpdate(ctx context.Context, input model.OpportunityRenewalUpdateInput) (*model.Opportunity, error) {
+	panic(fmt.Errorf("not implemented: OpportunityRenewalUpdate - opportunityRenewalUpdate"))
+}
+
 // CreatedBy is the resolver for the createdBy field.
 func (r *opportunityResolver) CreatedBy(ctx context.Context, obj *model.Opportunity) (*model.User, error) {
 	panic(fmt.Errorf("not implemented: CreatedBy - createdBy"))

--- a/packages/server/comms-api/test/graph/resolver/organization.resolvers.go
+++ b/packages/server/comms-api/test/graph/resolver/organization.resolvers.go
@@ -118,26 +118,6 @@ func (r *mutationResolver) OrganizationUnsetOwner(ctx context.Context, organizat
 	panic(fmt.Errorf("not implemented: OrganizationUnsetOwner - organization_UnsetOwner"))
 }
 
-// OrganizationAddRelationship is the resolver for the organization_AddRelationship field.
-func (r *mutationResolver) OrganizationAddRelationship(ctx context.Context, organizationID string, relationship model.OrganizationRelationship) (*model.Organization, error) {
-	panic(fmt.Errorf("not implemented: OrganizationAddRelationship - organization_AddRelationship"))
-}
-
-// OrganizationRemoveRelationship is the resolver for the organization_RemoveRelationship field.
-func (r *mutationResolver) OrganizationRemoveRelationship(ctx context.Context, organizationID string, relationship model.OrganizationRelationship) (*model.Organization, error) {
-	panic(fmt.Errorf("not implemented: OrganizationRemoveRelationship - organization_RemoveRelationship"))
-}
-
-// OrganizationSetRelationshipStage is the resolver for the organization_SetRelationshipStage field.
-func (r *mutationResolver) OrganizationSetRelationshipStage(ctx context.Context, organizationID string, relationship model.OrganizationRelationship, stage string) (*model.Organization, error) {
-	panic(fmt.Errorf("not implemented: OrganizationSetRelationshipStage - organization_SetRelationshipStage"))
-}
-
-// OrganizationRemoveRelationshipStage is the resolver for the organization_RemoveRelationshipStage field.
-func (r *mutationResolver) OrganizationRemoveRelationshipStage(ctx context.Context, organizationID string, relationship model.OrganizationRelationship) (*model.Organization, error) {
-	panic(fmt.Errorf("not implemented: OrganizationRemoveRelationshipStage - organization_RemoveRelationshipStage"))
-}
-
 // Domains is the resolver for the domains field.
 func (r *organizationResolver) Domains(ctx context.Context, obj *model.Organization) ([]string, error) {
 	panic(fmt.Errorf("not implemented: Domains - domains"))
@@ -231,16 +211,6 @@ func (r *organizationResolver) TimelineEventsTotalCount(ctx context.Context, obj
 // Owner is the resolver for the owner field.
 func (r *organizationResolver) Owner(ctx context.Context, obj *model.Organization) (*model.User, error) {
 	panic(fmt.Errorf("not implemented: Owner - owner"))
-}
-
-// Relationships is the resolver for the relationships field.
-func (r *organizationResolver) Relationships(ctx context.Context, obj *model.Organization) ([]model.OrganizationRelationship, error) {
-	panic(fmt.Errorf("not implemented: Relationships - relationships"))
-}
-
-// RelationshipStages is the resolver for the relationshipStages field.
-func (r *organizationResolver) RelationshipStages(ctx context.Context, obj *model.Organization) ([]*model.OrganizationRelationshipStage, error) {
-	panic(fmt.Errorf("not implemented: RelationshipStages - relationshipStages"))
 }
 
 // ExternalLinks is the resolver for the externalLinks field.

--- a/packages/server/comms-api/test/graph/resolver/service_line_item.resolvers.go
+++ b/packages/server/comms-api/test/graph/resolver/service_line_item.resolvers.go
@@ -22,6 +22,16 @@ func (r *mutationResolver) ServiceLineItemUpdate(ctx context.Context, input mode
 	panic(fmt.Errorf("not implemented: ServiceLineItemUpdate - serviceLineItemUpdate"))
 }
 
+// ServiceLineItemDelete is the resolver for the serviceLineItem_Delete field.
+func (r *mutationResolver) ServiceLineItemDelete(ctx context.Context, id string) (*model.DeleteResponse, error) {
+	panic(fmt.Errorf("not implemented: ServiceLineItemDelete - serviceLineItem_Delete"))
+}
+
+// ServiceLineItemClose is the resolver for the serviceLineItem_Close field.
+func (r *mutationResolver) ServiceLineItemClose(ctx context.Context, input model.ServiceLineItemCloseInput) (string, error) {
+	panic(fmt.Errorf("not implemented: ServiceLineItemClose - serviceLineItem_Close"))
+}
+
 // ServiceLineItem is the resolver for the serviceLineItem field.
 func (r *queryResolver) ServiceLineItem(ctx context.Context, id string) (*model.ServiceLineItem, error) {
 	panic(fmt.Errorf("not implemented: ServiceLineItem - serviceLineItem"))

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -1298,57 +1298,55 @@ type OrgAccountDetails struct {
 }
 
 type Organization struct {
-	ID                            string                           `json:"id"`
-	CustomerOsID                  string                           `json:"customerOsId"`
-	ReferenceID                   *string                          `json:"referenceId,omitempty"`
-	CreatedAt                     time.Time                        `json:"createdAt"`
-	UpdatedAt                     time.Time                        `json:"updatedAt"`
-	Name                          string                           `json:"name"`
-	Description                   *string                          `json:"description,omitempty"`
-	Note                          *string                          `json:"note,omitempty"`
-	Domains                       []string                         `json:"domains"`
-	Website                       *string                          `json:"website,omitempty"`
-	Industry                      *string                          `json:"industry,omitempty"`
-	SubIndustry                   *string                          `json:"subIndustry,omitempty"`
-	IndustryGroup                 *string                          `json:"industryGroup,omitempty"`
-	TargetAudience                *string                          `json:"targetAudience,omitempty"`
-	ValueProposition              *string                          `json:"valueProposition,omitempty"`
-	IsPublic                      *bool                            `json:"isPublic,omitempty"`
-	IsCustomer                    *bool                            `json:"isCustomer,omitempty"`
-	Market                        *Market                          `json:"market,omitempty"`
-	Employees                     *int64                           `json:"employees,omitempty"`
-	LastFundingRound              *FundingRound                    `json:"lastFundingRound,omitempty"`
-	LastFundingAmount             *string                          `json:"lastFundingAmount,omitempty"`
-	Source                        DataSource                       `json:"source"`
-	SourceOfTruth                 DataSource                       `json:"sourceOfTruth"`
-	AppSource                     string                           `json:"appSource"`
-	Locations                     []*Location                      `json:"locations"`
-	Socials                       []*Social                        `json:"socials"`
-	Contacts                      *ContactsPage                    `json:"contacts"`
-	JobRoles                      []*JobRole                       `json:"jobRoles"`
-	Notes                         *NotePage                        `json:"notes"`
-	Tags                          []*Tag                           `json:"tags,omitempty"`
-	Contracts                     []*Contract                      `json:"contracts,omitempty"`
-	Emails                        []*Email                         `json:"emails"`
-	PhoneNumbers                  []*PhoneNumber                   `json:"phoneNumbers"`
-	Subsidiaries                  []*LinkedOrganization            `json:"subsidiaries"`
-	SubsidiaryOf                  []*LinkedOrganization            `json:"subsidiaryOf"`
-	SuggestedMergeTo              []*SuggestedMergeOrganization    `json:"suggestedMergeTo"`
-	CustomFields                  []*CustomField                   `json:"customFields"`
-	FieldSets                     []*FieldSet                      `json:"fieldSets"`
-	EntityTemplate                *EntityTemplate                  `json:"entityTemplate,omitempty"`
-	TimelineEvents                []TimelineEvent                  `json:"timelineEvents"`
-	TimelineEventsTotalCount      int64                            `json:"timelineEventsTotalCount"`
-	Owner                         *User                            `json:"owner,omitempty"`
-	Relationships                 []OrganizationRelationship       `json:"relationships"`
-	RelationshipStages            []*OrganizationRelationshipStage `json:"relationshipStages"`
-	ExternalLinks                 []*ExternalSystem                `json:"externalLinks"`
-	LastTouchPointAt              *time.Time                       `json:"lastTouchPointAt,omitempty"`
-	LastTouchPointType            *LastTouchpointType              `json:"lastTouchPointType,omitempty"`
-	LastTouchPointTimelineEventID *string                          `json:"lastTouchPointTimelineEventId,omitempty"`
-	LastTouchPointTimelineEvent   TimelineEvent                    `json:"lastTouchPointTimelineEvent,omitempty"`
-	IssueSummaryByStatus          []*IssueSummaryByStatus          `json:"issueSummaryByStatus"`
-	AccountDetails                *OrgAccountDetails               `json:"accountDetails,omitempty"`
+	ID                            string                        `json:"id"`
+	CustomerOsID                  string                        `json:"customerOsId"`
+	ReferenceID                   *string                       `json:"referenceId,omitempty"`
+	CreatedAt                     time.Time                     `json:"createdAt"`
+	UpdatedAt                     time.Time                     `json:"updatedAt"`
+	Name                          string                        `json:"name"`
+	Description                   *string                       `json:"description,omitempty"`
+	Note                          *string                       `json:"note,omitempty"`
+	Domains                       []string                      `json:"domains"`
+	Website                       *string                       `json:"website,omitempty"`
+	Industry                      *string                       `json:"industry,omitempty"`
+	SubIndustry                   *string                       `json:"subIndustry,omitempty"`
+	IndustryGroup                 *string                       `json:"industryGroup,omitempty"`
+	TargetAudience                *string                       `json:"targetAudience,omitempty"`
+	ValueProposition              *string                       `json:"valueProposition,omitempty"`
+	IsPublic                      *bool                         `json:"isPublic,omitempty"`
+	IsCustomer                    *bool                         `json:"isCustomer,omitempty"`
+	Market                        *Market                       `json:"market,omitempty"`
+	Employees                     *int64                        `json:"employees,omitempty"`
+	LastFundingRound              *FundingRound                 `json:"lastFundingRound,omitempty"`
+	LastFundingAmount             *string                       `json:"lastFundingAmount,omitempty"`
+	Source                        DataSource                    `json:"source"`
+	SourceOfTruth                 DataSource                    `json:"sourceOfTruth"`
+	AppSource                     string                        `json:"appSource"`
+	Locations                     []*Location                   `json:"locations"`
+	Socials                       []*Social                     `json:"socials"`
+	Contacts                      *ContactsPage                 `json:"contacts"`
+	JobRoles                      []*JobRole                    `json:"jobRoles"`
+	Notes                         *NotePage                     `json:"notes"`
+	Tags                          []*Tag                        `json:"tags,omitempty"`
+	Contracts                     []*Contract                   `json:"contracts,omitempty"`
+	Emails                        []*Email                      `json:"emails"`
+	PhoneNumbers                  []*PhoneNumber                `json:"phoneNumbers"`
+	Subsidiaries                  []*LinkedOrganization         `json:"subsidiaries"`
+	SubsidiaryOf                  []*LinkedOrganization         `json:"subsidiaryOf"`
+	SuggestedMergeTo              []*SuggestedMergeOrganization `json:"suggestedMergeTo"`
+	CustomFields                  []*CustomField                `json:"customFields"`
+	FieldSets                     []*FieldSet                   `json:"fieldSets"`
+	EntityTemplate                *EntityTemplate               `json:"entityTemplate,omitempty"`
+	TimelineEvents                []TimelineEvent               `json:"timelineEvents"`
+	TimelineEventsTotalCount      int64                         `json:"timelineEventsTotalCount"`
+	Owner                         *User                         `json:"owner,omitempty"`
+	ExternalLinks                 []*ExternalSystem             `json:"externalLinks"`
+	LastTouchPointAt              *time.Time                    `json:"lastTouchPointAt,omitempty"`
+	LastTouchPointType            *LastTouchpointType           `json:"lastTouchPointType,omitempty"`
+	LastTouchPointTimelineEventID *string                       `json:"lastTouchPointTimelineEventId,omitempty"`
+	LastTouchPointTimelineEvent   TimelineEvent                 `json:"lastTouchPointTimelineEvent,omitempty"`
+	IssueSummaryByStatus          []*IssueSummaryByStatus       `json:"issueSummaryByStatus"`
+	AccountDetails                *OrgAccountDetails            `json:"accountDetails,omitempty"`
 }
 
 func (Organization) IsNotedEntity() {}
@@ -1405,11 +1403,6 @@ func (OrganizationParticipant) IsInteractionEventParticipant() {}
 func (OrganizationParticipant) IsIssueParticipant() {}
 
 func (OrganizationParticipant) IsMeetingParticipant() {}
-
-type OrganizationRelationshipStage struct {
-	Relationship OrganizationRelationship `json:"relationship"`
-	Stage        *string                  `json:"stage,omitempty"`
-}
 
 type OrganizationUpdateInput struct {
 	ID          string  `json:"id"`
@@ -2946,121 +2939,6 @@ func (e *OpportunityRenewalLikelihood) UnmarshalGQL(v interface{}) error {
 }
 
 func (e OpportunityRenewalLikelihood) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-type OrganizationRelationship string
-
-const (
-	OrganizationRelationshipCustomer                         OrganizationRelationship = "CUSTOMER"
-	OrganizationRelationshipDistributor                      OrganizationRelationship = "DISTRIBUTOR"
-	OrganizationRelationshipPartner                          OrganizationRelationship = "PARTNER"
-	OrganizationRelationshipLicensingPartner                 OrganizationRelationship = "LICENSING_PARTNER"
-	OrganizationRelationshipFranchisee                       OrganizationRelationship = "FRANCHISEE"
-	OrganizationRelationshipFranchisor                       OrganizationRelationship = "FRANCHISOR"
-	OrganizationRelationshipAffiliate                        OrganizationRelationship = "AFFILIATE"
-	OrganizationRelationshipReseller                         OrganizationRelationship = "RESELLER"
-	OrganizationRelationshipInfluencerOrContentCreator       OrganizationRelationship = "INFLUENCER_OR_CONTENT_CREATOR"
-	OrganizationRelationshipMediaPartner                     OrganizationRelationship = "MEDIA_PARTNER"
-	OrganizationRelationshipInvestor                         OrganizationRelationship = "INVESTOR"
-	OrganizationRelationshipMergerOrAcquisitionTarget        OrganizationRelationship = "MERGER_OR_ACQUISITION_TARGET"
-	OrganizationRelationshipParentCompany                    OrganizationRelationship = "PARENT_COMPANY"
-	OrganizationRelationshipSubsidiary                       OrganizationRelationship = "SUBSIDIARY"
-	OrganizationRelationshipJointVenture                     OrganizationRelationship = "JOINT_VENTURE"
-	OrganizationRelationshipSponsor                          OrganizationRelationship = "SPONSOR"
-	OrganizationRelationshipSupplier                         OrganizationRelationship = "SUPPLIER"
-	OrganizationRelationshipVendor                           OrganizationRelationship = "VENDOR"
-	OrganizationRelationshipContractManufacturer             OrganizationRelationship = "CONTRACT_MANUFACTURER"
-	OrganizationRelationshipOriginalEquipmentManufacturer    OrganizationRelationship = "ORIGINAL_EQUIPMENT_MANUFACTURER"
-	OrganizationRelationshipOriginalDesignManufacturer       OrganizationRelationship = "ORIGINAL_DESIGN_MANUFACTURER"
-	OrganizationRelationshipPrivateLabelManufacturer         OrganizationRelationship = "PRIVATE_LABEL_MANUFACTURER"
-	OrganizationRelationshipLogisticsPartner                 OrganizationRelationship = "LOGISTICS_PARTNER"
-	OrganizationRelationshipConsultant                       OrganizationRelationship = "CONSULTANT"
-	OrganizationRelationshipServiceProvider                  OrganizationRelationship = "SERVICE_PROVIDER"
-	OrganizationRelationshipOutsourcingProvider              OrganizationRelationship = "OUTSOURCING_PROVIDER"
-	OrganizationRelationshipInsourcingPartner                OrganizationRelationship = "INSOURCING_PARTNER"
-	OrganizationRelationshipTechnologyProvider               OrganizationRelationship = "TECHNOLOGY_PROVIDER"
-	OrganizationRelationshipDataProvider                     OrganizationRelationship = "DATA_PROVIDER"
-	OrganizationRelationshipCertificationBody                OrganizationRelationship = "CERTIFICATION_BODY"
-	OrganizationRelationshipStandardsOrganization            OrganizationRelationship = "STANDARDS_ORGANIZATION"
-	OrganizationRelationshipIndustryAnalyst                  OrganizationRelationship = "INDUSTRY_ANALYST"
-	OrganizationRelationshipRealEstatePartner                OrganizationRelationship = "REAL_ESTATE_PARTNER"
-	OrganizationRelationshipTalentAcquisitionPartner         OrganizationRelationship = "TALENT_ACQUISITION_PARTNER"
-	OrganizationRelationshipProfessionalEmployerOrganization OrganizationRelationship = "PROFESSIONAL_EMPLOYER_ORGANIZATION"
-	OrganizationRelationshipResearchCollaborator             OrganizationRelationship = "RESEARCH_COLLABORATOR"
-	OrganizationRelationshipRegulatoryBody                   OrganizationRelationship = "REGULATORY_BODY"
-	OrganizationRelationshipTradeAssociationMember           OrganizationRelationship = "TRADE_ASSOCIATION_MEMBER"
-	OrganizationRelationshipCompetitor                       OrganizationRelationship = "COMPETITOR"
-)
-
-var AllOrganizationRelationship = []OrganizationRelationship{
-	OrganizationRelationshipCustomer,
-	OrganizationRelationshipDistributor,
-	OrganizationRelationshipPartner,
-	OrganizationRelationshipLicensingPartner,
-	OrganizationRelationshipFranchisee,
-	OrganizationRelationshipFranchisor,
-	OrganizationRelationshipAffiliate,
-	OrganizationRelationshipReseller,
-	OrganizationRelationshipInfluencerOrContentCreator,
-	OrganizationRelationshipMediaPartner,
-	OrganizationRelationshipInvestor,
-	OrganizationRelationshipMergerOrAcquisitionTarget,
-	OrganizationRelationshipParentCompany,
-	OrganizationRelationshipSubsidiary,
-	OrganizationRelationshipJointVenture,
-	OrganizationRelationshipSponsor,
-	OrganizationRelationshipSupplier,
-	OrganizationRelationshipVendor,
-	OrganizationRelationshipContractManufacturer,
-	OrganizationRelationshipOriginalEquipmentManufacturer,
-	OrganizationRelationshipOriginalDesignManufacturer,
-	OrganizationRelationshipPrivateLabelManufacturer,
-	OrganizationRelationshipLogisticsPartner,
-	OrganizationRelationshipConsultant,
-	OrganizationRelationshipServiceProvider,
-	OrganizationRelationshipOutsourcingProvider,
-	OrganizationRelationshipInsourcingPartner,
-	OrganizationRelationshipTechnologyProvider,
-	OrganizationRelationshipDataProvider,
-	OrganizationRelationshipCertificationBody,
-	OrganizationRelationshipStandardsOrganization,
-	OrganizationRelationshipIndustryAnalyst,
-	OrganizationRelationshipRealEstatePartner,
-	OrganizationRelationshipTalentAcquisitionPartner,
-	OrganizationRelationshipProfessionalEmployerOrganization,
-	OrganizationRelationshipResearchCollaborator,
-	OrganizationRelationshipRegulatoryBody,
-	OrganizationRelationshipTradeAssociationMember,
-	OrganizationRelationshipCompetitor,
-}
-
-func (e OrganizationRelationship) IsValid() bool {
-	switch e {
-	case OrganizationRelationshipCustomer, OrganizationRelationshipDistributor, OrganizationRelationshipPartner, OrganizationRelationshipLicensingPartner, OrganizationRelationshipFranchisee, OrganizationRelationshipFranchisor, OrganizationRelationshipAffiliate, OrganizationRelationshipReseller, OrganizationRelationshipInfluencerOrContentCreator, OrganizationRelationshipMediaPartner, OrganizationRelationshipInvestor, OrganizationRelationshipMergerOrAcquisitionTarget, OrganizationRelationshipParentCompany, OrganizationRelationshipSubsidiary, OrganizationRelationshipJointVenture, OrganizationRelationshipSponsor, OrganizationRelationshipSupplier, OrganizationRelationshipVendor, OrganizationRelationshipContractManufacturer, OrganizationRelationshipOriginalEquipmentManufacturer, OrganizationRelationshipOriginalDesignManufacturer, OrganizationRelationshipPrivateLabelManufacturer, OrganizationRelationshipLogisticsPartner, OrganizationRelationshipConsultant, OrganizationRelationshipServiceProvider, OrganizationRelationshipOutsourcingProvider, OrganizationRelationshipInsourcingPartner, OrganizationRelationshipTechnologyProvider, OrganizationRelationshipDataProvider, OrganizationRelationshipCertificationBody, OrganizationRelationshipStandardsOrganization, OrganizationRelationshipIndustryAnalyst, OrganizationRelationshipRealEstatePartner, OrganizationRelationshipTalentAcquisitionPartner, OrganizationRelationshipProfessionalEmployerOrganization, OrganizationRelationshipResearchCollaborator, OrganizationRelationshipRegulatoryBody, OrganizationRelationshipTradeAssociationMember, OrganizationRelationshipCompetitor:
-		return true
-	}
-	return false
-}
-
-func (e OrganizationRelationship) String() string {
-	return string(e)
-}
-
-func (e *OrganizationRelationship) UnmarshalGQL(v interface{}) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = OrganizationRelationship(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid OrganizationRelationship", str)
-	}
-	return nil
-}
-
-func (e OrganizationRelationship) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/packages/server/customer-os-api/graph/resolver/dashboard.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/dashboard.resolvers.go
@@ -6,8 +6,6 @@ package resolver
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/common"
@@ -246,26 +244,3 @@ func (r *Resolver) DashboardCustomerMap() generated.DashboardCustomerMapResolver
 }
 
 type dashboardCustomerMapResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
-func getPeriod(period *model.DashboardPeriodInput) (time.Time, time.Time, error) {
-	if period == nil {
-		now := time.Now().UTC()
-
-		//last 12 months including current month
-		startDate := now.AddDate(-1, 1, 0)
-		endDate := now
-
-		return startDate, endDate, nil
-	} else {
-		if period.Start.After(period.End) {
-			return time.Time{}, time.Time{}, fmt.Errorf("start date must be before end date")
-		}
-		return period.Start, period.End, nil
-	}
-}

--- a/packages/server/customer-os-api/graph/resolver/dashboard_helper.go
+++ b/packages/server/customer-os-api/graph/resolver/dashboard_helper.go
@@ -1,0 +1,25 @@
+package resolver
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/graph/model"
+)
+
+func getPeriod(period *model.DashboardPeriodInput) (time.Time, time.Time, error) {
+	if period == nil {
+		now := time.Now().UTC()
+
+		//last 12 months including current month
+		startDate := now.AddDate(-1, 1, 0)
+		endDate := now
+
+		return startDate, endDate, nil
+	} else {
+		if period.Start.After(period.End) {
+			return time.Time{}, time.Time{}, fmt.Errorf("start date must be before end date")
+		}
+		return period.Start, period.End, nil
+	}
+}

--- a/packages/server/customer-os-api/graph/resolver/issue.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/issue.resolvers.go
@@ -146,13 +146,3 @@ func (r *queryResolver) Issue(ctx context.Context, id string) (*model.Issue, err
 func (r *Resolver) Issue() generated.IssueResolver { return &issueResolver{r} }
 
 type issueResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
-func (r *issueResolver) MentionedByNotes(ctx context.Context, obj *model.Issue) ([]*model.Note, error) {
-	return nil, nil
-}

--- a/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
@@ -683,30 +683,6 @@ func (r *mutationResolver) OrganizationUnsetOwner(ctx context.Context, organizat
 	return mapper.MapEntityToOrganization(organizationEntity), nil
 }
 
-// OrganizationAddRelationship is the resolver for the organization_AddRelationship field.
-func (r *mutationResolver) OrganizationAddRelationship(ctx context.Context, organizationID string, relationship model.OrganizationRelationship) (*model.Organization, error) {
-	graphql.AddErrorf(ctx, "Not available")
-	return nil, nil
-}
-
-// OrganizationRemoveRelationship is the resolver for the organization_RemoveRelationship field.
-func (r *mutationResolver) OrganizationRemoveRelationship(ctx context.Context, organizationID string, relationship model.OrganizationRelationship) (*model.Organization, error) {
-	graphql.AddErrorf(ctx, "Not available")
-	return nil, nil
-}
-
-// OrganizationSetRelationshipStage is the resolver for the organization_SetRelationshipStage field.
-func (r *mutationResolver) OrganizationSetRelationshipStage(ctx context.Context, organizationID string, relationship model.OrganizationRelationship, stage string) (*model.Organization, error) {
-	graphql.AddErrorf(ctx, "Not available")
-	return nil, nil
-}
-
-// OrganizationRemoveRelationshipStage is the resolver for the organization_RemoveRelationshipStage field.
-func (r *mutationResolver) OrganizationRemoveRelationshipStage(ctx context.Context, organizationID string, relationship model.OrganizationRelationship) (*model.Organization, error) {
-	graphql.AddErrorf(ctx, "Not available")
-	return nil, nil
-}
-
 // Domains is the resolver for the domains field.
 func (r *organizationResolver) Domains(ctx context.Context, obj *model.Organization) ([]string, error) {
 	ctx = tracing.EnrichCtxWithSpanCtxForGraphQL(ctx, graphql.GetOperationContext(ctx))
@@ -993,18 +969,6 @@ func (r *organizationResolver) Owner(ctx context.Context, obj *model.Organizatio
 		return nil, nil
 	}
 	return mapper.MapEntityToUser(userEntityNillable), nil
-}
-
-// Relationships is the resolver for the relationships field.
-func (r *organizationResolver) Relationships(ctx context.Context, obj *model.Organization) ([]model.OrganizationRelationship, error) {
-	graphql.AddErrorf(ctx, "Not available")
-	return nil, nil
-}
-
-// RelationshipStages is the resolver for the relationshipStages field.
-func (r *organizationResolver) RelationshipStages(ctx context.Context, obj *model.Organization) ([]*model.OrganizationRelationshipStage, error) {
-	graphql.AddErrorf(ctx, "Not available")
-	return nil, nil
 }
 
 // ExternalLinks is the resolver for the externalLinks field.

--- a/packages/server/customer-os-api/graph/schemas/organization.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/organization.graphqls
@@ -26,10 +26,6 @@ extend type Mutation {
     organization_AddSocial(organizationId: ID!, input: SocialInput!): Social! @hasRole(roles: [ADMIN, USER]) @hasTenant
     organization_SetOwner(organizationId: ID!, userId: ID!): Organization! @hasRole(roles: [ADMIN, USER]) @hasTenant
     organization_UnsetOwner(organizationId: ID!): Organization! @hasRole(roles: [ADMIN, USER]) @hasTenant
-    organization_AddRelationship(organizationId: ID!, relationship: OrganizationRelationship!): Organization! @hasRole(roles: [ADMIN, USER]) @hasTenant @deprecated
-    organization_RemoveRelationship(organizationId: ID!, relationship: OrganizationRelationship!): Organization! @hasRole(roles: [ADMIN, USER]) @hasTenant @deprecated
-    organization_SetRelationshipStage(organizationId: ID!, relationship: OrganizationRelationship!, stage: String!): Organization! @hasRole(roles: [ADMIN, USER]) @hasTenant @deprecated
-    organization_RemoveRelationshipStage(organizationId: ID!, relationship: OrganizationRelationship!): Organization! @hasRole(roles: [ADMIN, USER]) @hasTenant @deprecated
 }
 
 type LinkedOrganization {
@@ -80,8 +76,6 @@ type Organization implements Node {
     timelineEvents(from: Time, size: Int!, timelineEventTypes: [TimelineEventType!]): [TimelineEvent!]! @goField(forceResolver: true)
     timelineEventsTotalCount(timelineEventTypes: [TimelineEventType!]): Int64! @goField(forceResolver: true)
     owner: User @goField(forceResolver: true)
-    relationships: [OrganizationRelationship!]! @goField(forceResolver: true) @deprecated
-    relationshipStages: [OrganizationRelationshipStage!]! @goField(forceResolver: true) @deprecated
     externalLinks: [ExternalSystem!]! @goField(forceResolver: true)
 
     lastTouchPointAt: Time
@@ -221,60 +215,6 @@ enum Market {
     B2B
     B2C
     MARKETPLACE
-}
-
-#Deprecated
-enum OrganizationRelationship {
-    CUSTOMER
-    DISTRIBUTOR
-    PARTNER
-    LICENSING_PARTNER
-    FRANCHISEE
-    FRANCHISOR
-    AFFILIATE
-    RESELLER
-    INFLUENCER_OR_CONTENT_CREATOR
-    MEDIA_PARTNER
-
-    INVESTOR
-    MERGER_OR_ACQUISITION_TARGET
-    PARENT_COMPANY
-    SUBSIDIARY
-    JOINT_VENTURE
-    SPONSOR
-
-    SUPPLIER
-    VENDOR
-    CONTRACT_MANUFACTURER
-    ORIGINAL_EQUIPMENT_MANUFACTURER
-    ORIGINAL_DESIGN_MANUFACTURER
-    PRIVATE_LABEL_MANUFACTURER
-    LOGISTICS_PARTNER
-
-    CONSULTANT
-    SERVICE_PROVIDER
-    OUTSOURCING_PROVIDER
-    INSOURCING_PARTNER
-    TECHNOLOGY_PROVIDER
-    DATA_PROVIDER
-    CERTIFICATION_BODY
-    STANDARDS_ORGANIZATION
-    INDUSTRY_ANALYST
-    REAL_ESTATE_PARTNER
-    TALENT_ACQUISITION_PARTNER
-    PROFESSIONAL_EMPLOYER_ORGANIZATION
-
-    RESEARCH_COLLABORATOR
-    REGULATORY_BODY
-    TRADE_ASSOCIATION_MEMBER
-
-    COMPETITOR
-}
-
-#Deprecated
-type OrganizationRelationshipStage {
-    relationship: OrganizationRelationship!
-    stage: String
 }
 
 enum FundingRound {


### PR DESCRIPTION
## Proposed changes
Cleanup graphql from deprecated queries and properties

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new period-based querying for dashboard metrics.
  - Added new mutation functions for updating and renewing opportunities.
  - Implemented new resolver functions for service line item management, including delete and close operations.

- **Refactor**
  - Restructured organization data model, removing deprecated relationship fields and types.
  - Centralized time period calculation logic in dashboard helper functions.
  - Simplified organization ownership logic with direct success response.

- **Bug Fixes**
  - Removed unused and deprecated resolver functions to streamline codebase and improve maintainability.

- **Documentation**
  - Updated GraphQL schema to reflect removal of deprecated organization relationship fields and enums.

- **Chores**
  - Cleaned up imports and unused code segments to enhance code clarity and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->