### PR TITLE
enhance organization with renewal summary

### DIFF
--- a/packages/server/customer-os-api/entity/organization.go
+++ b/packages/server/customer-os-api/entity/organization.go
@@ -53,10 +53,19 @@ type OrganizationEntity struct {
 	RenewalLikelihood RenewalLikelihood
 	RenewalForecast   RenewalForecast
 	BillingDetails    BillingDetails
+	RenewalSummary    RenewalSummary
 
 	InteractionEventParticipantDetails InteractionEventParticipantDetails
 
 	DataloaderKey string
+}
+
+type RenewalSummary struct {
+	ArrForecast            *float64
+	MaxArrForecast         *float64
+	NextRenewalAt          *time.Time
+	RenewalLikelihood      string
+	RenewalLikelihoodOrder *int64
 }
 
 type RenewalLikelihood struct {

--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -801,6 +801,7 @@ type ComplexityRoot struct {
 		BillingDetails    func(childComplexity int) int
 		RenewalForecast   func(childComplexity int) int
 		RenewalLikelihood func(childComplexity int) int
+		RenewalSummary    func(childComplexity int) int
 	}
 
 	Organization struct {
@@ -987,6 +988,13 @@ type ComplexityRoot struct {
 		UpdatedAt           func(childComplexity int) int
 		UpdatedBy           func(childComplexity int) int
 		UpdatedByID         func(childComplexity int) int
+	}
+
+	RenewalSummary struct {
+		ArrForecast       func(childComplexity int) int
+		MaxArrForecast    func(childComplexity int) int
+		NextRenewalDate   func(childComplexity int) int
+		RenewalLikelihood func(childComplexity int) int
 	}
 
 	Result struct {
@@ -6053,6 +6061,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OrgAccountDetails.RenewalLikelihood(childComplexity), true
 
+	case "OrgAccountDetails.renewalSummary":
+		if e.complexity.OrgAccountDetails.RenewalSummary == nil {
+			break
+		}
+
+		return e.complexity.OrgAccountDetails.RenewalSummary(childComplexity), true
+
 	case "Organization.accountDetails":
 		if e.complexity.Organization.AccountDetails == nil {
 			break
@@ -7328,6 +7343,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.RenewalLikelihood.UpdatedByID(childComplexity), true
+
+	case "RenewalSummary.arrForecast":
+		if e.complexity.RenewalSummary.ArrForecast == nil {
+			break
+		}
+
+		return e.complexity.RenewalSummary.ArrForecast(childComplexity), true
+
+	case "RenewalSummary.maxArrForecast":
+		if e.complexity.RenewalSummary.MaxArrForecast == nil {
+			break
+		}
+
+		return e.complexity.RenewalSummary.MaxArrForecast(childComplexity), true
+
+	case "RenewalSummary.nextRenewalDate":
+		if e.complexity.RenewalSummary.NextRenewalDate == nil {
+			break
+		}
+
+		return e.complexity.RenewalSummary.NextRenewalDate(childComplexity), true
+
+	case "RenewalSummary.renewalLikelihood":
+		if e.complexity.RenewalSummary.RenewalLikelihood == nil {
+			break
+		}
+
+		return e.complexity.RenewalSummary.RenewalLikelihood(childComplexity), true
 
 	case "Result.result":
 		if e.complexity.Result.Result == nil {
@@ -9857,9 +9900,10 @@ type Organization implements Node {
 }
 
 type OrgAccountDetails {
-    renewalLikelihood: RenewalLikelihood
-    renewalForecast: RenewalForecast
-    billingDetails: BillingDetails
+    renewalLikelihood: RenewalLikelihood @deprecated
+    renewalForecast: RenewalForecast @deprecated
+    billingDetails: BillingDetails @deprecated
+    renewalSummary: RenewalSummary
 }
 
 type RenewalLikelihood {
@@ -9880,6 +9924,13 @@ type RenewalForecast {
     updatedBy: User @goField(forceResolver: true)
     arr: Float
     maxArr: Float
+}
+
+type RenewalSummary {
+    arrForecast:       Float
+    maxArrForecast:    Float
+    renewalLikelihood: OpportunityRenewalLikelihood
+    nextRenewalDate:   Time
 }
 
 type BillingDetails {
@@ -48289,6 +48340,57 @@ func (ec *executionContext) fieldContext_OrgAccountDetails_billingDetails(ctx co
 	return fc, nil
 }
 
+func (ec *executionContext) _OrgAccountDetails_renewalSummary(ctx context.Context, field graphql.CollectedField, obj *model.OrgAccountDetails) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrgAccountDetails_renewalSummary(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RenewalSummary, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.RenewalSummary)
+	fc.Result = res
+	return ec.marshalORenewalSummary2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐRenewalSummary(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrgAccountDetails_renewalSummary(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrgAccountDetails",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "arrForecast":
+				return ec.fieldContext_RenewalSummary_arrForecast(ctx, field)
+			case "maxArrForecast":
+				return ec.fieldContext_RenewalSummary_maxArrForecast(ctx, field)
+			case "renewalLikelihood":
+				return ec.fieldContext_RenewalSummary_renewalLikelihood(ctx, field)
+			case "nextRenewalDate":
+				return ec.fieldContext_RenewalSummary_nextRenewalDate(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RenewalSummary", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Organization_id(ctx context.Context, field graphql.CollectedField, obj *model.Organization) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Organization_id(ctx, field)
 	if err != nil {
@@ -50780,6 +50882,8 @@ func (ec *executionContext) fieldContext_Organization_accountDetails(ctx context
 				return ec.fieldContext_OrgAccountDetails_renewalForecast(ctx, field)
 			case "billingDetails":
 				return ec.fieldContext_OrgAccountDetails_billingDetails(ctx, field)
+			case "renewalSummary":
+				return ec.fieldContext_OrgAccountDetails_renewalSummary(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type OrgAccountDetails", field.Name)
 		},
@@ -57848,6 +57952,170 @@ func (ec *executionContext) fieldContext_RenewalLikelihood_updatedBy(ctx context
 				return ec.fieldContext_User_appSource(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RenewalSummary_arrForecast(ctx context.Context, field graphql.CollectedField, obj *model.RenewalSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RenewalSummary_arrForecast(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ArrForecast, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RenewalSummary_arrForecast(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RenewalSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RenewalSummary_maxArrForecast(ctx context.Context, field graphql.CollectedField, obj *model.RenewalSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RenewalSummary_maxArrForecast(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MaxArrForecast, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RenewalSummary_maxArrForecast(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RenewalSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RenewalSummary_renewalLikelihood(ctx context.Context, field graphql.CollectedField, obj *model.RenewalSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RenewalSummary_renewalLikelihood(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RenewalLikelihood, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.OpportunityRenewalLikelihood)
+	fc.Result = res
+	return ec.marshalOOpportunityRenewalLikelihood2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOpportunityRenewalLikelihood(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RenewalSummary_renewalLikelihood(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RenewalSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type OpportunityRenewalLikelihood does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RenewalSummary_nextRenewalDate(ctx context.Context, field graphql.CollectedField, obj *model.RenewalSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RenewalSummary_nextRenewalDate(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NextRenewalDate, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RenewalSummary_nextRenewalDate(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RenewalSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -75331,6 +75599,8 @@ func (ec *executionContext) _OrgAccountDetails(ctx context.Context, sel ast.Sele
 			out.Values[i] = ec._OrgAccountDetails_renewalForecast(ctx, field, obj)
 		case "billingDetails":
 			out.Values[i] = ec._OrgAccountDetails_billingDetails(ctx, field, obj)
+		case "renewalSummary":
+			out.Values[i] = ec._OrgAccountDetails_renewalSummary(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -77936,6 +78206,48 @@ func (ec *executionContext) _RenewalLikelihood(ctx context.Context, sel ast.Sele
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var renewalSummaryImplementors = []string{"RenewalSummary"}
+
+func (ec *executionContext) _RenewalSummary(ctx context.Context, sel ast.SelectionSet, obj *model.RenewalSummary) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, renewalSummaryImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RenewalSummary")
+		case "arrForecast":
+			out.Values[i] = ec._RenewalSummary_arrForecast(ctx, field, obj)
+		case "maxArrForecast":
+			out.Values[i] = ec._RenewalSummary_maxArrForecast(ctx, field, obj)
+		case "renewalLikelihood":
+			out.Values[i] = ec._RenewalSummary_renewalLikelihood(ctx, field, obj)
+		case "nextRenewalDate":
+			out.Values[i] = ec._RenewalSummary_nextRenewalDate(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -83759,6 +84071,13 @@ func (ec *executionContext) marshalORenewalLikelihoodProbability2ᚖgithubᚗcom
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) marshalORenewalSummary2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐRenewalSummary(ctx context.Context, sel ast.SelectionSet, v *model.RenewalSummary) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._RenewalSummary(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOResult2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐResult(ctx context.Context, sel ast.SelectionSet, v *model.Result) graphql.Marshaler {

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -1295,6 +1295,7 @@ type OrgAccountDetails struct {
 	RenewalLikelihood *RenewalLikelihood `json:"renewalLikelihood,omitempty"`
 	RenewalForecast   *RenewalForecast   `json:"renewalForecast,omitempty"`
 	BillingDetails    *BillingDetails    `json:"billingDetails,omitempty"`
+	RenewalSummary    *RenewalSummary    `json:"renewalSummary,omitempty"`
 }
 
 type Organization struct {
@@ -1587,6 +1588,13 @@ type RenewalLikelihoodInput struct {
 	ID          string                        `json:"id"`
 	Probability *RenewalLikelihoodProbability `json:"probability,omitempty"`
 	Comment     *string                       `json:"comment,omitempty"`
+}
+
+type RenewalSummary struct {
+	ArrForecast       *float64                      `json:"arrForecast,omitempty"`
+	MaxArrForecast    *float64                      `json:"maxArrForecast,omitempty"`
+	RenewalLikelihood *OpportunityRenewalLikelihood `json:"renewalLikelihood,omitempty"`
+	NextRenewalDate   *time.Time                    `json:"nextRenewalDate,omitempty"`
 }
 
 // Describes the success or failure of the GraphQL call.

--- a/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_it_test.go
@@ -468,9 +468,8 @@ func TestQueryResolver_Sort_Organizations_ByForecastAmount(t *testing.T) {
 
 	organizationId1 := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		Name: "org1",
-		RenewalForecast: entity.RenewalForecast{
-			Amount: utils.ToPtr[float64](200),
-			Arr:    utils.ToPtr[float64](200),
+		RenewalSummary: entity.RenewalSummary{
+			ArrForecast: utils.ToPtr[float64](200),
 		},
 	})
 	organizationId2 := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
@@ -478,16 +477,14 @@ func TestQueryResolver_Sort_Organizations_ByForecastAmount(t *testing.T) {
 	})
 	organizationId3 := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		Name: "org3",
-		RenewalForecast: entity.RenewalForecast{
-			Amount: utils.ToPtr[float64](100.5),
-			Arr:    utils.ToPtr[float64](100.5),
+		RenewalSummary: entity.RenewalSummary{
+			ArrForecast: utils.ToPtr[float64](100.5),
 		},
 	})
 	organizationId4 := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		Name: "org4",
-		RenewalForecast: entity.RenewalForecast{
-			Amount: utils.ToPtr[float64](300),
-			Arr:    utils.ToPtr[float64](300),
+		RenewalSummary: entity.RenewalSummary{
+			ArrForecast: utils.ToPtr[float64](300),
 		},
 	})
 

--- a/packages/server/customer-os-api/graph/resolver/test_queries/organization/get_organization_with_account_details.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/organization/get_organization_with_account_details.txt
@@ -23,6 +23,12 @@ query GetOrganizationById($organizationId: ID!){
             renewalCycle
             renewalCycleStart
         }
+        renewalSummary {
+            arrForecast
+            maxArrForecast
+            renewalLikelihood
+            nextRenewalDate
+        }
     }
   }
 }

--- a/packages/server/customer-os-api/graph/schemas/organization.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/organization.graphqls
@@ -89,9 +89,10 @@ type Organization implements Node {
 }
 
 type OrgAccountDetails {
-    renewalLikelihood: RenewalLikelihood
-    renewalForecast: RenewalForecast
-    billingDetails: BillingDetails
+    renewalLikelihood: RenewalLikelihood @deprecated
+    renewalForecast: RenewalForecast @deprecated
+    billingDetails: BillingDetails @deprecated
+    renewalSummary: RenewalSummary
 }
 
 type RenewalLikelihood {
@@ -112,6 +113,13 @@ type RenewalForecast {
     updatedBy: User @goField(forceResolver: true)
     arr: Float
     maxArr: Float
+}
+
+type RenewalSummary {
+    arrForecast:       Float
+    maxArrForecast:    Float
+    renewalLikelihood: OpportunityRenewalLikelihood
+    nextRenewalDate:   Time
 }
 
 type BillingDetails {

--- a/packages/server/customer-os-api/mapper/opportunity_renewal_likelihood_mapper.go
+++ b/packages/server/customer-os-api/mapper/opportunity_renewal_likelihood_mapper.go
@@ -22,3 +22,18 @@ func MapOpportunityRenewalLikelihoodFromModel(input model.OpportunityRenewalLike
 func MapOpportunityRenewalLikelihoodToModel(input entity.OpportunityRenewalLikelihood) model.OpportunityRenewalLikelihood {
 	return opportunityRenewalLikelihoodByValue[input]
 }
+
+func MapOpportunityRenewalLikelihoodToModelPtr(input string) *model.OpportunityRenewalLikelihood {
+	switch input {
+	case string(entity.OpportunityRenewalLikelihoodHigh):
+		return utils.Ptr(model.OpportunityRenewalLikelihoodHighRenewal)
+	case string(entity.OpportunityRenewalLikelihoodMedium):
+		return utils.Ptr(model.OpportunityRenewalLikelihoodMediumRenewal)
+	case string(entity.OpportunityRenewalLikelihoodLow):
+		return utils.Ptr(model.OpportunityRenewalLikelihoodLowRenewal)
+	case string(entity.OpportunityRenewalLikelihoodZero):
+		return utils.Ptr(model.OpportunityRenewalLikelihoodZeroRenewal)
+	default:
+		return nil
+	}
+}

--- a/packages/server/customer-os-api/mapper/organization_mapper.go
+++ b/packages/server/customer-os-api/mapper/organization_mapper.go
@@ -61,6 +61,12 @@ func MapEntityToOrganization(entity *entity.OrganizationEntity) *model.Organizat
 				RenewalCycleStart: entity.BillingDetails.RenewalCycleStart,
 				RenewalCycleNext:  entity.BillingDetails.RenewalCycleNext,
 			},
+			RenewalSummary: &model.RenewalSummary{
+				ArrForecast:       entity.RenewalSummary.ArrForecast,
+				MaxArrForecast:    entity.RenewalSummary.MaxArrForecast,
+				NextRenewalDate:   entity.RenewalSummary.NextRenewalAt,
+				RenewalLikelihood: MapOpportunityRenewalLikelihoodToModelPtr(entity.RenewalSummary.RenewalLikelihood),
+			},
 		},
 	}
 }

--- a/packages/server/customer-os-api/service/custom_field_service.go
+++ b/packages/server/customer-os-api/service/custom_field_service.go
@@ -290,7 +290,7 @@ func (s *customFieldService) mapDbNodeToCustomFieldEntity(node dbtype.Node) *ent
 		Value: model.AnyTypeValue{
 			Str:   utils.GetStringPropOrNil(props, entity.CustomFieldTextProperty.String()),
 			Time:  utils.GetTimePropOrNil(props, entity.CustomFieldTimeProperty.String()),
-			Int:   utils.GetIntPropOrNil(props, entity.CustomFieldIntProperty.String()),
+			Int:   utils.GetInt64PropOrNil(props, entity.CustomFieldIntProperty.String()),
 			Float: utils.GetFloatPropOrNil(props, entity.CustomFieldFloatProperty.String()),
 			Bool:  utils.GetBoolPropOrNil(props, entity.CustomFieldBoolProperty.String()),
 		},

--- a/packages/server/customer-os-api/service/custom_field_template_service.go
+++ b/packages/server/customer-os-api/service/custom_field_template_service.go
@@ -105,9 +105,9 @@ func (s *customFieldTemplateService) mapDbNodeToCustomFieldTemplate(dbNode dbtyp
 		Order:     utils.GetIntPropOrMinusOne(props, "order"),
 		Mandatory: utils.GetBoolPropOrFalse(props, "mandatory"),
 		Type:      utils.GetStringPropOrEmpty(props, "type"),
-		Length:    utils.GetIntPropOrNil(props, "length"),
-		Min:       utils.GetIntPropOrNil(props, "min"),
-		Max:       utils.GetIntPropOrNil(props, "max"),
+		Length:    utils.GetInt64PropOrNil(props, "length"),
+		Min:       utils.GetInt64PropOrNil(props, "min"),
+		Max:       utils.GetInt64PropOrNil(props, "max"),
 		CreatedAt: utils.GetTimePropOrEpochStart(props, "createdAt"),
 		UpdatedAt: utils.GetTimePropOrEpochStart(props, "updatedAt"),
 	}

--- a/packages/server/customer-os-api/service/organization_service.go
+++ b/packages/server/customer-os-api/service/organization_service.go
@@ -866,6 +866,13 @@ func (s *organizationService) mapDbNodeToOrganizationEntity(node dbtype.Node) *e
 			RenewalCycleStart: utils.GetTimePropOrNil(props, "billingDetailsRenewalCycleStart"),
 			RenewalCycleNext:  utils.GetTimePropOrNil(props, "billingDetailsRenewalCycleNext"),
 		},
+		RenewalSummary: entity.RenewalSummary{
+			ArrForecast:            utils.GetFloatPropOrNil(props, "renewalForecastArr"),
+			MaxArrForecast:         utils.GetFloatPropOrNil(props, "renewalForecastMaxArr"),
+			NextRenewalAt:          utils.GetTimePropOrNil(props, "derivedNextRenewalAt"),
+			RenewalLikelihood:      utils.GetStringPropOrEmpty(props, "derivedRenewalLikelihood"),
+			RenewalLikelihoodOrder: utils.GetInt64PropOrNil(props, "derivedRenewalLikelihoodOrder"),
+		},
 	}
 	return &output
 }

--- a/packages/server/customer-os-api/test/neo4j/neo4j_data_helper.go
+++ b/packages/server/customer-os-api/test/neo4j/neo4j_data_helper.go
@@ -795,13 +795,16 @@ func CreateOrg(ctx context.Context, driver *neo4j.DriverWithContext, tenant stri
 							org.renewalForecastComment=$renewalForecastComment,
 							org.renewalForecastUpdatedAt=$renewalForecastUpdatedAt,
 							org.renewalForecastUpdatedBy=$renewalForecastUpdatedBy,
-							org.renewalForecastArr=$renewalForecastArr,
-							org.renewalForecastMaxArr=$renewalForecastMaxArr,
 							org.billingDetailsAmount=$billingDetailsAmount,
 							org.billingDetailsFrequency=$billingDetailsFrequency,
 							org.billingDetailsRenewalCycle=$billingDetailsRenewalCycle,
 							org.billingDetailsRenewalCycleStart=$billingDetailsRenewalCycleStart,
-							org.billingDetailsRenewalCycleNext=$billingDetailsRenewalCycleNext
+							org.billingDetailsRenewalCycleNext=$billingDetailsRenewalCycleNext,
+							org.renewalForecastArr=$renewalForecastArr,
+							org.renewalForecastMaxArr=$renewalForecastMaxArr,
+							org.derivedNextRenewalAt=$derivedNextRenewalAt,
+							org.derivedRenewalLikelihood=$derivedRenewalLikelihood,
+							org.derivedRenewalLikelihoodOrder=$derivedRenewalLikelihoodOrder
 							`, tenant)
 	ExecuteWriteQuery(ctx, driver, query, map[string]any{
 		"id":                              organizationId.String(),
@@ -831,8 +834,6 @@ func CreateOrg(ctx context.Context, driver *neo4j.DriverWithContext, tenant stri
 		"renewalLikelihoodUpdatedAt":      utils.TimePtrFirstNonNilNillableAsAny(organization.RenewalLikelihood.UpdatedAt),
 		"renewalForecast":                 organization.RenewalForecast.Amount,
 		"renewalForecastPotential":        organization.RenewalForecast.PotentialAmount,
-		"renewalForecastArr":              organization.RenewalForecast.Arr,
-		"renewalForecastMaxArr":           organization.RenewalForecast.MaxArr,
 		"renewalForecastComment":          organization.RenewalForecast.Comment,
 		"renewalForecastUpdatedBy":        organization.RenewalForecast.UpdatedById,
 		"renewalForecastUpdatedAt":        utils.TimePtrFirstNonNilNillableAsAny(organization.RenewalForecast.UpdatedAt),
@@ -841,8 +842,12 @@ func CreateOrg(ctx context.Context, driver *neo4j.DriverWithContext, tenant stri
 		"billingDetailsRenewalCycle":      organization.BillingDetails.RenewalCycle,
 		"billingDetailsRenewalCycleStart": utils.TimePtrFirstNonNilNillableAsAny(utils.ToDatePtr(organization.BillingDetails.RenewalCycleStart)),
 		"billingDetailsRenewalCycleNext":  utils.TimePtrFirstNonNilNillableAsAny(utils.ToDatePtr(organization.BillingDetails.RenewalCycleNext)),
-
-		"now": utils.Now(),
+		"renewalForecastArr":              organization.RenewalSummary.ArrForecast,
+		"renewalForecastMaxArr":           organization.RenewalSummary.MaxArrForecast,
+		"derivedNextRenewalAt":            utils.TimePtrFirstNonNilNillableAsAny(organization.RenewalSummary.NextRenewalAt),
+		"derivedRenewalLikelihood":        organization.RenewalSummary.RenewalLikelihood,
+		"derivedRenewalLikelihoodOrder":   organization.RenewalSummary.RenewalLikelihoodOrder,
+		"now":                             utils.Now(),
 	})
 	return organizationId.String()
 }

--- a/packages/server/customer-os-common-module/utils/core_utils.go
+++ b/packages/server/customer-os-common-module/utils/core_utils.go
@@ -24,6 +24,10 @@ func ToPtr[T any](obj T) *T {
 	return &obj
 }
 
+func Ptr[T any](obj T) *T {
+	return &obj
+}
+
 func StringPtr(str string) *string {
 	return &str
 }

--- a/packages/server/customer-os-common-module/utils/neo4j_utils.go
+++ b/packages/server/customer-os-common-module/utils/neo4j_utils.go
@@ -436,7 +436,7 @@ func GetInt64PropOrZero(props map[string]any, key string) int64 {
 	return 0
 }
 
-func GetIntPropOrNil(props map[string]any, key string) *int64 {
+func GetInt64PropOrNil(props map[string]any, key string) *int64 {
 	if props[key] != nil {
 		i := props[key].(int64)
 		return &i

--- a/packages/server/events-processing-platform/domain/organization/aggregate/aggregate.go
+++ b/packages/server/events-processing-platform/domain/organization/aggregate/aggregate.go
@@ -68,6 +68,7 @@ func (a *OrganizationAggregate) When(event eventstore.Event) error {
 		events.OrganizationRequestNextCycleDateV1,
 		events.OrganizationRefreshLastTouchpointV1,
 		events.OrganizationRefreshArrV1,
+		events.OrganizationRefreshRenewalSummaryV1,
 		events.OrganizationRequestScrapeByWebsiteV1:
 		return nil
 	default:

--- a/packages/server/events-processing-platform/domain/organization/aggregate/commands.go
+++ b/packages/server/events-processing-platform/domain/organization/aggregate/commands.go
@@ -46,6 +46,8 @@ func (a *OrganizationAggregate) HandleCommand(ctx context.Context, cmd eventstor
 		return a.refreshLastTouchpoint(ctx, c)
 	case *command.RefreshArrCommand:
 		return a.refreshArr(ctx, c)
+	case *command.RefreshRenewalSummaryCommand:
+		return a.refreshRenewalSummary(ctx, c)
 	case *command.UpsertCustomFieldCommand:
 		return a.upsertCustomField(ctx, c)
 	case *command.LinkEmailCommand:
@@ -461,7 +463,11 @@ func (a *OrganizationAggregate) refreshLastTouchpoint(ctx context.Context, cmd *
 		return errors.Wrap(err, "NewOrganizationRefreshLastTouchpointEvent")
 	}
 
-	aggregate.EnrichEventWithMetadata(&event, &span, a.Tenant, cmd.LoggedInUserId)
+	aggregate.EnrichEventWithMetadataExtended(&event, span, aggregate.EventMetadata{
+		Tenant: a.GetTenant(),
+		UserId: cmd.LoggedInUserId,
+		App:    cmd.AppSource,
+	})
 
 	return a.Apply(event)
 }
@@ -474,6 +480,28 @@ func (a *OrganizationAggregate) refreshArr(ctx context.Context, cmd *command.Ref
 	span.LogFields(log.Int64("aggregateVersion", a.GetVersion()), log.Object("command", cmd))
 
 	event, err := events.NewOrganizationRefreshArrEvent(a)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return errors.Wrap(err, "NewOrganizationRefreshArrEvent")
+	}
+
+	aggregate.EnrichEventWithMetadataExtended(&event, span, aggregate.EventMetadata{
+		Tenant: a.GetTenant(),
+		UserId: cmd.LoggedInUserId,
+		App:    cmd.AppSource,
+	})
+
+	return a.Apply(event)
+}
+
+func (a *OrganizationAggregate) refreshRenewalSummary(ctx context.Context, cmd *command.RefreshRenewalSummaryCommand) error {
+	span, _ := opentracing.StartSpanFromContext(ctx, "OrganizationAggregate.refreshRenewalSummary")
+	defer span.Finish()
+	span.SetTag(tracing.SpanTagTenant, a.GetTenant())
+	span.SetTag(tracing.SpanTagAggregateId, a.GetID())
+	span.LogFields(log.Int64("aggregateVersion", a.GetVersion()), log.Object("command", cmd))
+
+	event, err := events.NewOrganizationRefreshRenewalSummaryEvent(a)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return errors.Wrap(err, "NewOrganizationRefreshArrEvent")

--- a/packages/server/events-processing-platform/domain/organization/command/refresh_renewal_summary_command.go
+++ b/packages/server/events-processing-platform/domain/organization/command/refresh_renewal_summary_command.go
@@ -1,0 +1,13 @@
+package command
+
+import "github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/eventstore"
+
+type RefreshRenewalSummaryCommand struct {
+	eventstore.BaseCommand
+}
+
+func NewRefreshRenewalSummaryCommand(tenant, orgId, userId, appSource string) *RefreshRenewalSummaryCommand {
+	return &RefreshRenewalSummaryCommand{
+		BaseCommand: eventstore.NewBaseCommand(orgId, tenant, userId).WithAppSource(appSource),
+	}
+}

--- a/packages/server/events-processing-platform/domain/organization/command_handler/command_handlers.go
+++ b/packages/server/events-processing-platform/domain/organization/command_handler/command_handlers.go
@@ -28,6 +28,7 @@ type CommandHandlers struct {
 	AddParentCommand               AddParentCommandHandler
 	RemoveParentCommand            RemoveParentCommandHandler
 	RefreshArr                     RefreshArrCommandHandler
+	RefreshRenewalSummary          RefreshRenewalSummaryCommandHandler
 }
 
 func NewCommandHandlers(log logger.Logger, cfg *config.Config, es eventstore.AggregateStore, repositories *repository.Repositories) *CommandHandlers {
@@ -51,5 +52,6 @@ func NewCommandHandlers(log logger.Logger, cfg *config.Config, es eventstore.Agg
 		AddParentCommand:               NewAddParentCommandHandler(log, es),
 		RemoveParentCommand:            NewRemoveParentCommandHandler(log, es),
 		RefreshArr:                     NewRefreshArrCommandHandler(log, es, cfg.Utils),
+		RefreshRenewalSummary:          NewRefreshRenewalSummaryCommandHandler(log, es, cfg.Utils),
 	}
 }

--- a/packages/server/events-processing-platform/domain/organization/command_handler/refresh_renewal_summary.go
+++ b/packages/server/events-processing-platform/domain/organization/command_handler/refresh_renewal_summary.go
@@ -1,0 +1,73 @@
+package command_handler
+
+import (
+	"context"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/config"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/organization/aggregate"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/organization/command"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/eventstore"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/logger"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/tracing"
+	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/validator"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"github.com/pkg/errors"
+	"time"
+)
+
+type RefreshRenewalSummaryCommandHandler interface {
+	Handle(ctx context.Context, command *command.RefreshRenewalSummaryCommand) error
+}
+
+type refreshRenewalSummaryCommandHandler struct {
+	log logger.Logger
+	es  eventstore.AggregateStore
+	cfg config.Utils
+}
+
+func NewRefreshRenewalSummaryCommandHandler(log logger.Logger, es eventstore.AggregateStore, cfg config.Utils) RefreshRenewalSummaryCommandHandler {
+	return &refreshRenewalSummaryCommandHandler{log: log, es: es, cfg: cfg}
+}
+
+func (h *refreshRenewalSummaryCommandHandler) Handle(ctx context.Context, cmd *command.RefreshRenewalSummaryCommand) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "RefreshRenewalSummaryCommandHandler.Handle")
+	defer span.Finish()
+	tracing.SetCommandHandlerSpanTags(ctx, span, cmd.Tenant, cmd.LoggedInUserId)
+	span.LogFields(log.Object("command", cmd))
+
+	validationError, done := validator.Validate(cmd, span)
+	if done {
+		return validationError
+	}
+
+	for attempt := 0; attempt == 0 || attempt < h.cfg.RetriesOnOptimisticLockException; attempt++ {
+		organizationAggregate, err := aggregate.LoadOrganizationAggregate(ctx, h.es, cmd.Tenant, cmd.ObjectID)
+		if err != nil {
+			return err
+		}
+		if err = organizationAggregate.HandleCommand(ctx, cmd); err != nil {
+			return err
+		}
+
+		err = h.es.Save(ctx, organizationAggregate)
+		if err == nil {
+			return nil // Save successful
+		}
+
+		if eventstore.IsEventStoreErrorCodeWrongExpectedVersion(err) {
+			// Handle concurrency error
+			span.LogFields(log.Int("retryAttempt", attempt+1))
+			time.Sleep(utils.BackOffExponentialDelay(attempt)) // backoffDelay is a function that increases the delay with each attempt
+			continue                                           // Retry
+		} else {
+			// Some other error occurred
+			tracing.TraceErr(span, err)
+			return err
+		}
+	}
+
+	err := errors.New("reached maximum number of retries")
+	tracing.TraceErr(span, err)
+	return err
+}

--- a/packages/server/events-processing-platform/domain/organization/events/events.go
+++ b/packages/server/events-processing-platform/domain/organization/events/events.go
@@ -32,6 +32,7 @@ const (
 	OrganizationAddParentV1               = "V1_ORGANIZATION_ADD_PARENT"
 	OrganizationRemoveParentV1            = "V1_ORGANIZATION_REMOVE_PARENT"
 	OrganizationRefreshArrV1              = "V1_ORGANIZATION_REFRESH_ARR"
+	OrganizationRefreshRenewalSummaryV1   = "V1_ORGANIZATION_REFRESH_RENEWAL_SUMMARY"
 )
 
 type OrganizationCreateEvent struct {
@@ -548,6 +549,26 @@ func NewOrganizationRefreshArrEvent(aggregate eventstore.Aggregate) (eventstore.
 	event := eventstore.NewBaseEvent(aggregate, OrganizationRefreshArrV1)
 	if err := event.SetJsonData(&eventData); err != nil {
 		return eventstore.Event{}, errors.Wrap(err, "error setting json data for OrganizationRefreshArrEvent")
+	}
+	return event, nil
+}
+
+type OrganizationRefreshRenewalSummaryEvent struct {
+	Tenant string `json:"tenant" validate:"required"`
+}
+
+func NewOrganizationRefreshRenewalSummaryEvent(aggregate eventstore.Aggregate) (eventstore.Event, error) {
+	eventData := OrganizationRefreshRenewalSummaryEvent{
+		Tenant: aggregate.GetTenant(),
+	}
+
+	if err := validator.GetValidator().Struct(eventData); err != nil {
+		return eventstore.Event{}, errors.Wrap(err, "failed to validate OrganizationRefreshRenewalSummaryEvent")
+	}
+
+	event := eventstore.NewBaseEvent(aggregate, OrganizationRefreshRenewalSummaryV1)
+	if err := event.SetJsonData(&eventData); err != nil {
+		return eventstore.Event{}, errors.Wrap(err, "error setting json data for OrganizationRefreshRenewalSummaryEvent")
 	}
 	return event, nil
 }

--- a/packages/server/events-processing-platform/graph_db/data_mapper.go
+++ b/packages/server/events-processing-platform/graph_db/data_mapper.go
@@ -51,8 +51,6 @@ func MapDbNodeToOrganizationEntity(node dbtype.Node) *entity.OrganizationEntity 
 			Comment:         utils.GetStringPropOrNil(props, "renewalForecastComment"),
 			UpdatedBy:       utils.GetStringPropOrEmpty(props, "renewalForecastUpdatedBy"),
 			UpdatedAt:       utils.GetTimePropOrNil(props, "renewalForecastUpdatedAt"),
-			Arr:             utils.GetFloatPropOrNil(props, "renewalForecastArr"),
-			MaxArr:          utils.GetFloatPropOrNil(props, "renewalForecastMaxArr"),
 		},
 		BillingDetails: entity.BillingDetails{
 			Amount:            utils.GetFloatPropOrNil(props, "billingDetailsAmount"),
@@ -60,6 +58,13 @@ func MapDbNodeToOrganizationEntity(node dbtype.Node) *entity.OrganizationEntity 
 			RenewalCycle:      utils.GetStringPropOrEmpty(props, "billingDetailsRenewalCycle"),
 			RenewalCycleStart: utils.GetTimePropOrNil(props, "billingDetailsRenewalCycleStart"),
 			RenewalCycleNext:  utils.GetTimePropOrNil(props, "billingDetailsRenewalCycleNext"),
+		},
+		RenewalSummary: entity.RenewalSummary{
+			ArrForecast:            utils.GetFloatPropOrNil(props, "renewalForecastArr"),
+			MaxArrForecast:         utils.GetFloatPropOrNil(props, "renewalForecastMaxArr"),
+			RenewalLikelihood:      utils.GetStringPropOrEmpty(props, "derivedRenewalLikelihood"),
+			RenewalLikelihoodOrder: utils.GetInt64PropOrNil(props, "derivedRenewalLikelihoodOrder"),
+			NextRenewalAt:          utils.GetTimePropOrNil(props, "derivedNextRenewalAt"),
 		},
 	}
 	return &output

--- a/packages/server/events-processing-platform/graph_db/entity/organization.go
+++ b/packages/server/events-processing-platform/graph_db/entity/organization.go
@@ -52,12 +52,14 @@ type OrganizationEntity struct {
 	RenewalLikelihood RenewalLikelihood
 	RenewalForecast   RenewalForecast
 	BillingDetails    BillingDetails
+	RenewalSummary    RenewalSummary
 
 	InteractionEventParticipantDetails InteractionEventParticipantDetails
 
 	DataloaderKey string
 }
 
+// Deprecated
 type RenewalLikelihood struct {
 	RenewalLikelihood         string
 	PreviousRenewalLikelihood string
@@ -83,14 +85,26 @@ func (r RenewalLikelihood) String() string {
 	return output
 }
 
+// Deprecated
 type RenewalForecast struct {
-	Amount          *float64
+	//deprecated
+	Amount *float64
+	//deprecated
 	PotentialAmount *float64
-	Comment         *string
-	UpdatedAt       *time.Time
-	UpdatedBy       string
-	Arr             *float64
-	MaxArr          *float64
+	//deprecated
+	Comment *string
+	//deprecated
+	UpdatedAt *time.Time
+	//deprecated
+	UpdatedBy string
+}
+
+type RenewalSummary struct {
+	ArrForecast            *float64
+	MaxArrForecast         *float64
+	NextRenewalAt          *time.Time
+	RenewalLikelihood      string
+	RenewalLikelihoodOrder *int64
 }
 
 func (r RenewalForecast) String() string {
@@ -119,6 +133,7 @@ func (r RenewalForecast) String() string {
 	return output
 }
 
+// Deprecated
 type BillingDetails struct {
 	Amount            *float64
 	Frequency         string
@@ -162,12 +177,6 @@ func (OrganizationEntity) NotedEntityLabel() string {
 func (OrganizationEntity) IsInteractionEventParticipant() {}
 
 func (OrganizationEntity) ParticipantLabel() string {
-	return NodeLabel_Organization
-}
-
-func (OrganizationEntity) IsMeetingParticipant() {}
-
-func (OrganizationEntity) MeetingParticipantLabel() string {
 	return NodeLabel_Organization
 }
 

--- a/packages/server/events-processing-platform/subscriptions/graph/graph_subscriber.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/graph_subscriber.go
@@ -215,6 +215,8 @@ func (s *GraphSubscriber) When(ctx context.Context, evt eventstore.Event) error 
 		return s.organizationEventHandler.OnRefreshLastTouchpoint(ctx, evt)
 	case orgevents.OrganizationRefreshArrV1:
 		return s.organizationEventHandler.OnRefreshArr(ctx, evt)
+	case orgevents.OrganizationRefreshRenewalSummaryV1:
+		return s.organizationEventHandler.OnRefreshRenewalSummary(ctx, evt)
 	case orgevents.OrganizationUpsertCustomFieldV1:
 		return s.organizationEventHandler.OnUpsertCustomField(ctx, evt)
 	case orgevents.OrganizationAddParentV1:

--- a/packages/server/events-processing-platform/subscriptions/graph/opportunity_event_handler_it_test.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/opportunity_event_handler_it_test.go
@@ -401,14 +401,21 @@ func TestOpportunityEventHandler_OnUpdateRenewal_AmountAndRenewalChangedByUser(t
 	for _, value := range eventsMap {
 		eventList = value
 	}
-	require.Equal(t, 1, len(eventList))
+	require.Equal(t, 2, len(eventList))
 
 	generatedEvent1 := eventList[0]
-	require.Equal(t, organizationEvents.OrganizationRefreshArrV1, generatedEvent1.EventType)
-	var eventData1 organizationEvents.OrganizationRefreshArrEvent
+	require.Equal(t, organizationEvents.OrganizationRefreshRenewalSummaryV1, generatedEvent1.EventType)
+	var eventData1 organizationEvents.OrganizationRefreshRenewalSummaryEvent
 	err = generatedEvent1.GetJsonData(&eventData1)
 	require.Nil(t, err)
 	require.Equal(t, tenantName, eventData1.Tenant)
+
+	generatedEvent2 := eventList[1]
+	require.Equal(t, organizationEvents.OrganizationRefreshArrV1, generatedEvent2.EventType)
+	var eventData2 organizationEvents.OrganizationRefreshArrEvent
+	err = generatedEvent1.GetJsonData(&eventData2)
+	require.Nil(t, err)
+	require.Equal(t, tenantName, eventData2.Tenant)
 }
 
 func TestOpportunityEventHandler_OnUpdateRenewal_OnlyCommentsChangedByUser_DoNotUpdatePreviousUpdatedByUser(t *testing.T) {

--- a/packages/server/events-processing-platform/subscriptions/graph/organization_event_handlers.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/organization_event_handlers.go
@@ -646,6 +646,77 @@ func (h *OrganizationEventHandler) OnRefreshArr(ctx context.Context, evt eventst
 	return nil
 }
 
+func (h *OrganizationEventHandler) OnRefreshRenewalSummary(ctx context.Context, evt eventstore.Event) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationEventHandler.OnRefreshRenewalSummary")
+	defer span.Finish()
+	setCommonSpanTagsAndLogFields(span, evt)
+
+	var eventData events.OrganizationRefreshArrEvent
+	if err := evt.GetJsonData(&eventData); err != nil {
+		tracing.TraceErr(span, err)
+		return errors.Wrap(err, "evt.GetJsonData")
+	}
+
+	organizationId := aggregate.GetOrganizationObjectID(evt.AggregateID, eventData.Tenant)
+
+	opportunityDbNodes, err := h.repositories.OpportunityRepository.GetOpenRenewalOpportunitiesForOrganization(ctx, eventData.Tenant, organizationId)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		h.log.Errorf("Failed to get open renewal opportunities for organization %s: %s", organizationId, err.Error())
+		return nil
+	}
+	var nextRenewalDate *time.Time
+	var lowestRenewalLikelihood *string
+	var renewalLikelihoodOrder int64
+	if len(opportunityDbNodes) > 0 {
+		opportunities := make([]entity.OpportunityEntity, len(opportunityDbNodes))
+		for _, opportunityDbNode := range opportunityDbNodes {
+			opportunities = append(opportunities, *graph_db.MapDbNodeToOpportunityEntity(opportunityDbNode))
+		}
+		for _, opportunity := range opportunities {
+			if opportunity.RenewalDetails.RenewedAt != nil {
+				if nextRenewalDate == nil || opportunity.RenewalDetails.RenewedAt.Before(*nextRenewalDate) {
+					nextRenewalDate = opportunity.RenewalDetails.RenewedAt
+				}
+			}
+			if opportunity.RenewalDetails.RenewalLikelihood != "" {
+				order := getOrderForRenewalLikelihood(opportunity.RenewalDetails.RenewalLikelihood)
+				if renewalLikelihoodOrder == 0 || renewalLikelihoodOrder > order {
+					renewalLikelihoodOrder = order
+					lowestRenewalLikelihood = utils.ToPtr(opportunity.RenewalDetails.RenewalLikelihood)
+				}
+			}
+		}
+	}
+
+	renewalLikelihoodOrderPtr := utils.ToPtr[int64](renewalLikelihoodOrder)
+	if renewalLikelihoodOrder == 0 {
+		renewalLikelihoodOrderPtr = nil
+	}
+
+	if err := h.repositories.OrganizationRepository.UpdateRenewalSummary(ctx, eventData.Tenant, organizationId, lowestRenewalLikelihood, renewalLikelihoodOrderPtr, nextRenewalDate); err != nil {
+		tracing.TraceErr(span, err)
+		h.log.Errorf("Failed to update arr for tenant %s, organization %s: %s", eventData.Tenant, organizationId, err.Error())
+	}
+
+	return nil
+}
+
+func getOrderForRenewalLikelihood(likelihood string) int64 {
+	switch likelihood {
+	case "HIGH":
+		return 40
+	case "MEDIUM":
+		return 30
+	case "LOW":
+		return 20
+	case "ZERO":
+		return 10
+	default:
+		return 0
+	}
+}
+
 func (h *OrganizationEventHandler) OnUpsertCustomField(ctx context.Context, evt eventstore.Event) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationEventHandler.OnUpsertCustomField")
 	defer span.Finish()

--- a/packages/server/events-processing-platform/subscriptions/graph/organization_event_handlers_it_test.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/organization_event_handlers_it_test.go
@@ -797,8 +797,84 @@ func TestGraphOrganizationEventHandler_OnRefreshArr(t *testing.T) {
 	// verify organization
 	organization := graph_db.MapDbNodeToOrganizationEntity(*orgDbNode)
 	require.Equal(t, orgId, organization.ID)
-	require.Equal(t, float64(1110), *organization.RenewalForecast.Arr)
-	require.Equal(t, float64(2220), *organization.RenewalForecast.MaxArr)
+	require.Equal(t, float64(1110), *organization.RenewalSummary.ArrForecast)
+	require.Equal(t, float64(2220), *organization.RenewalSummary.MaxArrForecast)
+
+	// Check no events were generated
+	eventsMap := aggregateStore.GetEventMap()
+	require.Equal(t, 0, len(eventsMap))
+}
+
+func TestGraphOrganizationEventHandler_OnRefreshRenewalSummary(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx, testDatabase)(t)
+
+	aggregateStore := eventstore.NewTestAggregateStore()
+
+	tomorrow := utils.Now().Add(time.Duration(24) * time.Hour)
+	afterTomorrow := utils.Now().Add(time.Duration(48) * time.Hour)
+
+	// prepare neo4j data
+	neo4jt.CreateTenant(ctx, testDatabase.Driver, tenantName)
+	orgId := neo4jt.CreateOrganization(ctx, testDatabase.Driver, tenantName, entity.OrganizationEntity{})
+	contractId1 := neo4jt.CreateContractForOrganization(ctx, testDatabase.Driver, tenantName, orgId, entity.ContractEntity{})
+	contractId2 := neo4jt.CreateContractForOrganization(ctx, testDatabase.Driver, tenantName, orgId, entity.ContractEntity{})
+	opportunityIdRenewal1_1 := neo4jt.CreateOpportunity(ctx, testDatabase.Driver, tenantName, entity.OpportunityEntity{
+		RenewalDetails: entity.RenewalDetails{
+			RenewedAt:         &tomorrow,
+			RenewalLikelihood: "HIGH",
+		},
+		InternalType:  string(opportunitymodel.OpportunityInternalTypeStringRenewal),
+		InternalStage: string(opportunitymodel.OpportunityInternalStageStringOpen),
+	})
+	opportunityIdRenewal2_1 := neo4jt.CreateOpportunity(ctx, testDatabase.Driver, tenantName, entity.OpportunityEntity{
+		RenewalDetails: entity.RenewalDetails{
+			RenewedAt:         &afterTomorrow,
+			RenewalLikelihood: "LOW",
+		},
+		InternalType:  string(opportunitymodel.OpportunityInternalTypeStringRenewal),
+		InternalStage: string(opportunitymodel.OpportunityInternalStageStringOpen),
+	})
+	opportunityIdRenewal2_2 := neo4jt.CreateOpportunity(ctx, testDatabase.Driver, tenantName, entity.OpportunityEntity{
+		RenewalDetails: entity.RenewalDetails{
+			RenewedAt:         &afterTomorrow,
+			RenewalLikelihood: "ZERO",
+		},
+		InternalType:  string(opportunitymodel.OpportunityInternalTypeStringRenewal),
+		InternalStage: string(opportunitymodel.OpportunityInternalStageStringClosedWon),
+	})
+	opportunityIdNbo2_3 := neo4jt.CreateOpportunity(ctx, testDatabase.Driver, tenantName, entity.OpportunityEntity{
+		InternalType: string(opportunitymodel.OpportunityInternalTypeStringNBO),
+	})
+	neo4jt.LinkContractWithOpportunity(ctx, testDatabase.Driver, contractId1, opportunityIdRenewal1_1, true)
+	neo4jt.LinkContractWithOpportunity(ctx, testDatabase.Driver, contractId2, opportunityIdRenewal2_1, true)
+	neo4jt.LinkContractWithOpportunity(ctx, testDatabase.Driver, contractId2, opportunityIdRenewal2_2, true)
+	neo4jt.LinkContractWithOpportunity(ctx, testDatabase.Driver, contractId2, opportunityIdNbo2_3, false)
+	neo4jt.AssertNeo4jNodeCount(ctx, t, testDatabase.Driver, map[string]int{"Organization": 1, "Contract": 2, "Opportunity": 4})
+
+	// prepare event handler
+	orgEventHandler := &OrganizationEventHandler{
+		repositories:         testDatabase.Repositories,
+		organizationCommands: command_handler.NewCommandHandlers(testLogger, &config.Config{}, aggregateStore, testDatabase.Repositories),
+	}
+	orgAggregate := aggregate.NewOrganizationAggregateWithTenantAndID(tenantName, orgId)
+	event, err := events.NewOrganizationRefreshRenewalSummaryEvent(orgAggregate)
+	require.Nil(t, err)
+
+	// EXECUTE
+	err = orgEventHandler.OnRefreshRenewalSummary(context.Background(), event)
+	require.Nil(t, err)
+
+	orgDbNode, err := neo4jt.GetNodeById(ctx, testDatabase.Driver, "Organization", orgId)
+	require.Nil(t, err)
+	require.NotNil(t, orgDbNode)
+
+	// verify organization
+	organization := graph_db.MapDbNodeToOrganizationEntity(*orgDbNode)
+	require.Equal(t, orgId, organization.ID)
+	require.Equal(t, int64(20), *organization.RenewalSummary.RenewalLikelihoodOrder)
+	require.Equal(t, "LOW", organization.RenewalSummary.RenewalLikelihood)
+	require.Equal(t, tomorrow, *organization.RenewalSummary.NextRenewalAt)
 
 	// Check no events were generated
 	eventsMap := aggregateStore.GetEventMap()

--- a/packages/server/events-processing-platform/subscriptions/organization/organization_subscriber.go
+++ b/packages/server/events-processing-platform/subscriptions/organization/organization_subscriber.go
@@ -125,28 +125,7 @@ func (s *OrganizationSubscriber) When(ctx context.Context, evt eventstore.Event)
 		return s.organizationEventHandler.OnRenewalForecastRequested(ctx, evt)
 	case orgevts.OrganizationRequestNextCycleDateV1:
 		return s.organizationEventHandler.OnNextCycleDateRequested(ctx, evt)
-	case
-		orgevts.OrganizationLinkDomainV1,
-		orgevts.OrganizationRequestScrapeByWebsiteV1,
-		orgevts.OrganizationPhoneNumberLinkV1,
-		orgevts.OrganizationEmailLinkV1,
-		orgevts.OrganizationLocationLinkV1,
-		orgevts.OrganizationAddSocialV1,
-		orgevts.OrganizationUpdateRenewalLikelihoodV1,
-		orgevts.OrganizationUpdateRenewalForecastV1,
-		orgevts.OrganizationUpdateBillingDetailsV1,
-		orgevts.OrganizationRefreshLastTouchpointV1,
-		orgevts.OrganizationHideV1,
-		orgevts.OrganizationShowV1,
-		orgevts.OrganizationAddParentV1,
-		orgevts.OrganizationRemoveParentV1,
-		orgevts.OrganizationUpsertCustomFieldV1:
-		return nil
-
 	default:
-		s.log.Warnf("(OrganizationSubscriber) Unknown EventType: {%s}", evt.EventType)
-		err := eventstore.ErrInvalidEventType
-		err.EventType = evt.GetEventType()
-		return err
+		return nil
 	}
 }

--- a/packages/server/events-processing-platform/subscriptions/organization/organization_webscrape_subscriber.go
+++ b/packages/server/events-processing-platform/subscriptions/organization/organization_webscrape_subscriber.go
@@ -121,7 +121,6 @@ func (s *OrganizationWebscrapeSubscriber) When(ctx context.Context, evt eventsto
 		return s.organizationEventHandler.WebscrapeOrganizationByDomain(ctx, evt)
 	case orgevts.OrganizationRequestScrapeByWebsiteV1:
 		return s.organizationEventHandler.WebscrapeOrganizationByWebsite(ctx, evt)
-
 	default:
 		return nil
 	}


### PR DESCRIPTION

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `RenewalSummary` feature for organizations, providing a comprehensive view of renewal forecasts and likelihoods.
  - Added the ability to fetch and display renewal summaries in the user interface.

- **Enhancements**
  - Improved the accuracy of renewal date predictions and forecast amounts.
  - Enhanced the opportunity renewal process with additional data points for better decision-making.

- **Bug Fixes**
  - Corrected the handling of integer properties in custom fields to support larger values.

- **Deprecated**
  - Marked certain fields related to renewal likelihood and billing details as deprecated in favor of the new `RenewalSummary`.

- **Refactor**
  - Streamlined the process of updating renewal summaries within the organization repository.
  - Optimized event handling for organization renewal summary refreshes.

- **Tests**
  - Expanded test coverage to include new functionality and ensure the accuracy of renewal summaries.

- **Documentation**
  - Updated GraphQL schema documentation to reflect the addition of `RenewalSummary` fields.

- **Chores**
  - Cleaned up unused code and improved codebase maintainability.

- **Revert**
  - No reverts in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->