### PR TITLE
(fix|COS-1156): The 'timeAgo' method in DateTimeUtils has been updated to provide a simple 'today' & (fix|COS-1135): Update label on ContractCard

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
@@ -324,7 +324,7 @@ export const ContractCard = ({
               calendarIconHidden
             />
             <FormSelect
-              label='Contract renews'
+              label='Renewal cycle'
               placeholder='Renewal cycle'
               isLabelVisible
               name='renewalCycle'

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalARRCard.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalARRCard.tsx
@@ -111,11 +111,9 @@ export const RenewalARRCard = ({
 
                 {!hasEnded && opportunity.renewedAt && startedAt && (
                   <Text color='gray.500' ml={1} fontSize='sm'>
-                    {DateTimeUtils.isToday(opportunity.renewedAt)
-                      ? 'today'
-                      : DateTimeUtils.timeAgo(opportunity.renewedAt, {
-                          addSuffix: true,
-                        })}
+                    {DateTimeUtils.timeAgo(opportunity.renewedAt, {
+                      addSuffix: true,
+                    })}
                   </Text>
                 )}
               </Flex>

--- a/packages/apps/spaces/utils/date.ts
+++ b/packages/apps/spaces/utils/date.ts
@@ -51,6 +51,11 @@ export class DateTimeUtils {
     date: string | number,
     options?: { addSuffix?: boolean; includeSeconds?: boolean },
   ): string {
+    const isToday = this.isToday(this.getDate(date).toISOString());
+    if (isToday) {
+      return 'today';
+    }
+
     return formatDistanceToNow(this.getDate(date), options);
   }
 


### PR DESCRIPTION
if the input date is the current date, thereby enhancing readability for users. This change also resulted in refactoring of the usage of this function in RenewalARRCard component. Previously, 'isToday' check was done explicitly in this component, but with this change, the check has been encapsulated within the function call itself.

(fix|COS-1135): Update label on ContractCard

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the time elapsed display logic for renewed opportunities to always show the duration since renewal, regardless of whether it occurred today.

- **Refactor**
  - Enhanced `DateTimeUtils` to return 'today' when the input date is the current date, improving date-related user interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->