### PR TITLE
[COS-1213] ARR breakdown - Cancellations

### DIFF
--- a/packages/server/customer-os-api/entity/dashboard/dashboard.go
+++ b/packages/server/customer-os-api/entity/dashboard/dashboard.go
@@ -38,13 +38,14 @@ type DashboardARRBreakdownData struct {
 	Months             []*DashboardARRBreakdownPerMonthData
 }
 type DashboardARRBreakdownPerMonthData struct {
+	Year            int
 	Month           int
-	NewlyContracted int
-	Renewals        int
-	Upsells         int
-	Downgrades      int
-	Cancellations   int
-	Churned         int
+	NewlyContracted float64
+	Renewals        float64
+	Upsells         float64
+	Downgrades      float64
+	Cancellations   float64
+	Churned         float64
 }
 
 type DashboardGrossRevenueRetentionData struct {

--- a/packages/server/customer-os-api/entity/service_line_item.go
+++ b/packages/server/customer-os-api/entity/service_line_item.go
@@ -9,6 +9,7 @@ type ServiceLineItemEntity struct {
 	UpdatedAt     time.Time
 	StartedAt     time.Time
 	EndedAt       *time.Time
+	IsCanceled    bool
 	Billed        BilledType
 	Price         float64
 	Quantity      int64

--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -271,6 +271,7 @@ type ComplexityRoot struct {
 		NewlyContracted func(childComplexity int) int
 		Renewals        func(childComplexity int) int
 		Upsells         func(childComplexity int) int
+		Year            func(childComplexity int) int
 	}
 
 	DashboardCustomerMap struct {
@@ -2454,6 +2455,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.DashboardARRBreakdownPerMonth.Upsells(childComplexity), true
+
+	case "DashboardARRBreakdownPerMonth.year":
+		if e.complexity.DashboardARRBreakdownPerMonth.Year == nil {
+			break
+		}
+
+		return e.complexity.DashboardARRBreakdownPerMonth.Year(childComplexity), true
 
 	case "DashboardCustomerMap.arr":
 		if e.complexity.DashboardCustomerMap.Arr == nil {
@@ -8605,13 +8613,14 @@ type DashboardARRBreakdown {
     perMonth: [DashboardARRBreakdownPerMonth]!
 }
 type DashboardARRBreakdownPerMonth {
+    year: Int!
     month: Int!
-    newlyContracted: Int!
-    renewals: Int!
-    upsells: Int!
-    downgrades: Int!
-    cancellations: Int!
-    churned: Int!
+    newlyContracted: Float!
+    renewals: Float!
+    upsells: Float!
+    downgrades: Float!
+    cancellations: Float!
+    churned: Float!
 }
 
 type DashboardRevenueAtRisk {
@@ -20606,6 +20615,8 @@ func (ec *executionContext) fieldContext_DashboardARRBreakdown_perMonth(ctx cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "year":
+				return ec.fieldContext_DashboardARRBreakdownPerMonth_year(ctx, field)
 			case "month":
 				return ec.fieldContext_DashboardARRBreakdownPerMonth_month(ctx, field)
 			case "newlyContracted":
@@ -20622,6 +20633,50 @@ func (ec *executionContext) fieldContext_DashboardARRBreakdown_perMonth(ctx cont
 				return ec.fieldContext_DashboardARRBreakdownPerMonth_churned(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type DashboardARRBreakdownPerMonth", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DashboardARRBreakdownPerMonth_year(ctx context.Context, field graphql.CollectedField, obj *model.DashboardARRBreakdownPerMonth) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DashboardARRBreakdownPerMonth_year(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Year, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_year(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DashboardARRBreakdownPerMonth",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -20697,9 +20752,9 @@ func (ec *executionContext) _DashboardARRBreakdownPerMonth_newlyContracted(ctx c
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(float64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_newlyContracted(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20709,7 +20764,7 @@ func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_newlyCont
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -20741,9 +20796,9 @@ func (ec *executionContext) _DashboardARRBreakdownPerMonth_renewals(ctx context.
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(float64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_renewals(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20753,7 +20808,7 @@ func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_renewals(
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -20785,9 +20840,9 @@ func (ec *executionContext) _DashboardARRBreakdownPerMonth_upsells(ctx context.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(float64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_upsells(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20797,7 +20852,7 @@ func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_upsells(c
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -20829,9 +20884,9 @@ func (ec *executionContext) _DashboardARRBreakdownPerMonth_downgrades(ctx contex
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(float64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_downgrades(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20841,7 +20896,7 @@ func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_downgrade
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -20873,9 +20928,9 @@ func (ec *executionContext) _DashboardARRBreakdownPerMonth_cancellations(ctx con
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(float64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_cancellations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20885,7 +20940,7 @@ func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_cancellat
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -20917,9 +20972,9 @@ func (ec *executionContext) _DashboardARRBreakdownPerMonth_churned(ctx context.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(float64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_churned(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20929,7 +20984,7 @@ func (ec *executionContext) fieldContext_DashboardARRBreakdownPerMonth_churned(c
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -68014,6 +68069,11 @@ func (ec *executionContext) _DashboardARRBreakdownPerMonth(ctx context.Context, 
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("DashboardARRBreakdownPerMonth")
+		case "year":
+			out.Values[i] = ec._DashboardARRBreakdownPerMonth_year(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "month":
 			out.Values[i] = ec._DashboardARRBreakdownPerMonth_month(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -521,13 +521,14 @@ type DashboardARRBreakdown struct {
 }
 
 type DashboardARRBreakdownPerMonth struct {
-	Month           int `json:"month"`
-	NewlyContracted int `json:"newlyContracted"`
-	Renewals        int `json:"renewals"`
-	Upsells         int `json:"upsells"`
-	Downgrades      int `json:"downgrades"`
-	Cancellations   int `json:"cancellations"`
-	Churned         int `json:"churned"`
+	Year            int     `json:"year"`
+	Month           int     `json:"month"`
+	NewlyContracted float64 `json:"newlyContracted"`
+	Renewals        float64 `json:"renewals"`
+	Upsells         float64 `json:"upsells"`
+	Downgrades      float64 `json:"downgrades"`
+	Cancellations   float64 `json:"cancellations"`
+	Churned         float64 `json:"churned"`
 }
 
 type DashboardCustomerMap struct {

--- a/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_arr_breakdown_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_arr_breakdown_it_test.go
@@ -1,0 +1,782 @@
+package resolver
+
+import (
+	"context"
+	"github.com/google/uuid"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/entity"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/graph/model"
+	neo4jt "github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/test/neo4j"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/utils/decode"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_No_Period_No_Data_In_DB(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+
+	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown_no_period",
+		map[string]interface{}{})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 12, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(0), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_InvalidPeriod(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+
+	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
+
+	response := callGraphQLExpectError(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2020-02-01T00:00:00.000Z",
+			"end":   "2020-01-01T00:00:00.000Z",
+		})
+
+	require.Contains(t, "Failed to get the data for period", response.Message)
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_PeriodIntervals(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+
+	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
+
+	assert_Dashboard_ARR_Breakdown_PeriodIntervals(t, "2020-01-01T00:00:00.000Z", "2020-01-31T00:00:00.000Z", 1)
+	assert_Dashboard_ARR_Breakdown_PeriodIntervals(t, "2020-01-01T00:00:00.000Z", "2020-01-01T00:00:00.000Z", 1)
+	assert_Dashboard_ARR_Breakdown_PeriodIntervals(t, "2020-01-01T00:00:00.000Z", "2020-02-01T00:00:00.000Z", 2)
+	assert_Dashboard_ARR_Breakdown_PeriodIntervals(t, "2020-01-01T00:00:00.000Z", "2020-02-28T00:00:00.000Z", 2)
+	assert_Dashboard_ARR_Breakdown_PeriodIntervals(t, "2020-01-01T00:00:00.000Z", "2029-12-01T00:00:00.000Z", 120)
+}
+
+func assert_Dashboard_ARR_Breakdown_PeriodIntervals(t *testing.T, start, end string, months int) {
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": start,
+			"end":   end,
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, months, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(0), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_Not_Canceled(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1StartedAt)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(0), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_Canceled_Before_Month(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
+	sli1EndedAt := time.Date(2023, 6, 30, 23, 59, 59, 999999999, time.UTC)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1StartedAt, sli1EndedAt)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(0), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_Started_Before_Canceled_End_Month(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
+	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1StartedAt, sli1EndedAt)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(2), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_Started_In_Month_Canceled_End_Month(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
+	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1StartedAt, sli1EndedAt)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(2), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_Canceled_Annually(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
+	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1StartedAt, sli1EndedAt)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(2), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_Canceled_Quarterly(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
+	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeQuarterly, 4, sli1StartedAt, sli1EndedAt)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(2), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_Canceled_Monthly(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
+	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeMonthly, 1, sli1StartedAt, sli1EndedAt)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(2), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_Started_In_Month_Canceled_Next_Month(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
+	sli1EndedAt := neo4jt.MiddleTimeOfMonth(2023, 8)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1StartedAt, sli1EndedAt)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(0), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_2_Versions_Started_Before_Not_Canceled(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
+	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 6)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+
+	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1StartedAt, sli1MiddleAt)
+	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1MiddleAt, sli1Id)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(0), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_2_Versions_Started_Before_Canceled_Before_Month(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
+	sli1MiddleAt := neo4jt.FirstTimeOfMonth(2023, 6)
+	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 6)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+
+	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1StartedAt, sli1MiddleAt)
+	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1MiddleAt, sli1EndedAt, sli1Id)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(0), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_2_Versions_Started_Before_Canceled_End_Month(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
+	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 6)
+	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+
+	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1StartedAt, sli1MiddleAt)
+	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1MiddleAt, sli1EndedAt, sli1Id)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(2), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_2_Versions_Started_In_Canceled_End_Month(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
+	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
+	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+
+	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1StartedAt, sli1MiddleAt)
+	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1MiddleAt, sli1EndedAt, sli1Id)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(2), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func TestQueryResolver_Dashboard_ARR_Breakdown_Cancellations_SLI_2_Versions_Started_In_Canceled_Next_Month(t *testing.T) {
+	ctx := context.TODO()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
+	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
+	sli1EndedAt := neo4jt.MiddleTimeOfMonth(2023, 8)
+	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+
+	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1StartedAt, sli1MiddleAt)
+	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, sli1MiddleAt, sli1EndedAt, sli1Id)
+
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
+		map[string]interface{}{
+			"start": "2023-07-01T00:00:00.000Z",
+			"end":   "2023-07-01T00:00:00.000Z",
+		})
+
+	var dashboardReport struct {
+		Dashboard_ARRBreakdown model.DashboardARRBreakdown
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.ArrBreakdown)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_ARRBreakdown.IncreasePercentage)
+	require.Equal(t, 1, len(dashboardReport.Dashboard_ARRBreakdown.PerMonth))
+
+	for _, month := range dashboardReport.Dashboard_ARRBreakdown.PerMonth {
+		require.Equal(t, 2023, month.Year)
+		require.Equal(t, 7, month.Month)
+		require.Equal(t, float64(0), month.NewlyContracted)
+		require.Equal(t, float64(0), month.Renewals)
+		require.Equal(t, float64(0), month.Upsells)
+		require.Equal(t, float64(0), month.Downgrades)
+		require.Equal(t, float64(0), month.Cancellations)
+		require.Equal(t, float64(0), month.Churned)
+	}
+}
+
+func insertARRBreakdownContractWithOpportunity(ctx context.Context, driver *neo4j.DriverWithContext, orgId string) string {
+	contractId := neo4jt.CreateContractForOrganization(ctx, driver, tenantName, orgId, entity.ContractEntity{})
+	opportunityId := neo4jt.CreateOpportunityForContract(ctx, driver, tenantName, contractId, entity.OpportunityEntity{})
+	neo4jt.ActiveRenewalOpportunityForContract(ctx, driver, tenantName, contractId, opportunityId)
+	return contractId
+}
+
+func insertARRBreakdownServiceLineItem(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, startedAt time.Time) string {
+	rand, _ := uuid.NewRandom()
+	id := rand.String()
+	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
+		ID:        id,
+		ParentID:  id,
+		Billed:    billedType,
+		Price:     price,
+		Quantity:  2,
+		StartedAt: startedAt,
+	})
+	return id
+}
+
+func insertARRBreakdownServiceLineItemEnded(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, startedAt, endedAt time.Time) string {
+	rand, _ := uuid.NewRandom()
+	id := rand.String()
+	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
+		ID:        id,
+		ParentID:  id,
+		Billed:    billedType,
+		Price:     price,
+		Quantity:  2,
+		StartedAt: startedAt,
+		EndedAt:   &endedAt,
+	})
+	return id
+}
+
+func insertARRBreakdownServiceLineItemCanceled(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, startedAt, endedAt time.Time) string {
+	rand, _ := uuid.NewRandom()
+	id := rand.String()
+	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
+		ID:         id,
+		ParentID:   id,
+		Billed:     billedType,
+		Price:      price,
+		Quantity:   2,
+		IsCanceled: true,
+		StartedAt:  startedAt,
+		EndedAt:    &endedAt,
+	})
+	return id
+}
+
+func insertARRBreakdownServiceLineItemWithParent(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, startedAt time.Time, parentId string) {
+	rand, _ := uuid.NewRandom()
+	id := rand.String()
+	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
+		ID:        id,
+		ParentID:  parentId,
+		Billed:    billedType,
+		Price:     price,
+		Quantity:  2,
+		StartedAt: startedAt,
+	})
+}
+
+func insertARRBreakdownServiceLineItemEndedWithParent(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, startedAt, endedAt time.Time, parentId string) {
+	rand, _ := uuid.NewRandom()
+	id := rand.String()
+	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
+		ID:        id,
+		ParentID:  parentId,
+		Billed:    billedType,
+		Price:     price,
+		Quantity:  2,
+		StartedAt: startedAt,
+		EndedAt:   &endedAt,
+	})
+}
+
+func insertARRBreakdownServiceLineItemCanceledWithParent(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, startedAt, endedAt time.Time, parentId string) {
+	rand, _ := uuid.NewRandom()
+	id := rand.String()
+	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
+		ID:         id,
+		ParentID:   parentId,
+		Billed:     billedType,
+		Price:      price,
+		Quantity:   2,
+		IsCanceled: true,
+		StartedAt:  startedAt,
+		EndedAt:    &endedAt,
+	})
+}

--- a/packages/server/customer-os-api/graph/resolver/test_queries/dashboard_view/dashboard_arr_breakdown.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/dashboard_view/dashboard_arr_breakdown.txt
@@ -1,0 +1,18 @@
+query GetDashboard_ARRBreakdown ($start: Time!, $end: Time!) {
+  dashboard_ARRBreakdown(
+      period: {start: $start, end: $end}
+    ) {
+    arrBreakdown
+    increasePercentage
+    perMonth {
+      year
+      month
+      newlyContracted
+      renewals
+      upsells
+      downgrades
+      cancellations
+      churned
+    }
+  }
+}

--- a/packages/server/customer-os-api/graph/resolver/test_queries/dashboard_view/dashboard_arr_breakdown_no_period.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/dashboard_view/dashboard_arr_breakdown_no_period.txt
@@ -1,0 +1,16 @@
+query GetDashboard_ARRBreakdown {
+  dashboard_ARRBreakdown {
+    arrBreakdown
+    increasePercentage
+    perMonth {
+      year
+      month
+      newlyContracted
+      renewals
+      upsells
+      downgrades
+      cancellations
+      churned
+    }
+  }
+}

--- a/packages/server/customer-os-api/graph/schemas/dashboard.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/dashboard.graphqls
@@ -53,13 +53,14 @@ type DashboardARRBreakdown {
     perMonth: [DashboardARRBreakdownPerMonth]!
 }
 type DashboardARRBreakdownPerMonth {
+    year: Int!
     month: Int!
-    newlyContracted: Int!
-    renewals: Int!
-    upsells: Int!
-    downgrades: Int!
-    cancellations: Int!
-    churned: Int!
+    newlyContracted: Float!
+    renewals: Float!
+    upsells: Float!
+    downgrades: Float!
+    cancellations: Float!
+    churned: Float!
 }
 
 type DashboardRevenueAtRisk {

--- a/packages/server/customer-os-api/mapper/dashboard_mapper.go
+++ b/packages/server/customer-os-api/mapper/dashboard_mapper.go
@@ -73,6 +73,7 @@ func MapDashboardARRBreakdownPerMonthData(months []*entityDashboard.DashboardARR
 	var result []*model.DashboardARRBreakdownPerMonth
 	for _, month := range months {
 		result = append(result, &model.DashboardARRBreakdownPerMonth{
+			Year:            month.Year,
 			Month:           month.Month,
 			NewlyContracted: month.NewlyContracted,
 			Renewals:        month.Renewals,

--- a/packages/server/customer-os-api/service/dashboard_service.go
+++ b/packages/server/customer-os-api/service/dashboard_service.go
@@ -224,21 +224,36 @@ func (s *dashboardService) GetDashboardARRBreakdownData(ctx context.Context, sta
 
 	response := entityDashboard.DashboardARRBreakdownData{}
 
-	response.ArrBreakdown = 1830990
-	response.IncreasePercentage = 2.3
+	response.ArrBreakdown = 0
+	response.IncreasePercentage = 0
 
-	min := 1
-	max := 50
-	for i := 1; i <= 12; i++ {
-		response.Months = append(response.Months, &entityDashboard.DashboardARRBreakdownPerMonthData{
-			Month:           i,
-			NewlyContracted: rand.Intn(max-min) + min,
-			Renewals:        rand.Intn(max-min) + min,
-			Upsells:         rand.Intn(max-min) + min,
-			Downgrades:      rand.Intn(max-min) + min,
-			Cancellations:   rand.Intn(max-min) + min,
-			Churned:         rand.Intn(max-min) + min,
-		})
+	data, err := s.repositories.DashboardRepository.GetDashboardARRBreakdownData(ctx, common.GetContext(ctx).Tenant, start, end)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, record := range data {
+		year, _ := record["year"].(int64)
+		month, _ := record["month"].(int64)
+		newlyContracted, _ := record["newlyContracted"].(float64)
+		renewals, _ := record["renewals"].(float64)
+		upsells, _ := record["upsells"].(float64)
+		downgrades, _ := record["downgrades"].(float64)
+		cancellations, _ := record["cancellations"].(float64)
+		churned, _ := record["churned"].(float64)
+
+		newData := &entityDashboard.DashboardARRBreakdownPerMonthData{
+			Year:            int(year),
+			Month:           int(month),
+			NewlyContracted: newlyContracted,
+			Renewals:        renewals,
+			Upsells:         upsells,
+			Downgrades:      downgrades,
+			Cancellations:   cancellations,
+			Churned:         churned,
+		}
+
+		response.Months = append(response.Months, newData)
 	}
 
 	return &response, nil

--- a/packages/server/customer-os-api/test/neo4j/neo4j_data_helper.go
+++ b/packages/server/customer-os-api/test/neo4j/neo4j_data_helper.go
@@ -1597,6 +1597,7 @@ func CreateServiceLineItemForContract(ctx context.Context, driver *neo4j.DriverW
 					sli.source=$source,
 					sli.sourceOfTruth=$sourceOfTruth,
 					sli.appSource=$appSource,
+					sli.isCanceled=$isCanceled,	
 					sli.billed=$billed,	
 					sli.quantity=$quantity,	
 					sli.price=$price,
@@ -1616,6 +1617,7 @@ func CreateServiceLineItemForContract(ctx context.Context, driver *neo4j.DriverW
 		"source":        serviceLineItem.Source,
 		"sourceOfTruth": serviceLineItem.SourceOfTruth,
 		"appSource":     serviceLineItem.AppSource,
+		"isCanceled":    serviceLineItem.IsCanceled,
 		"billed":        serviceLineItem.Billed,
 		"startedAt":     serviceLineItem.StartedAt,
 		"quantity":      serviceLineItem.Quantity,
@@ -1820,4 +1822,16 @@ func contains(slice []string, value string) bool {
 		}
 	}
 	return false
+}
+
+func FirstTimeOfMonth(year, month int) time.Time {
+	return time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)
+}
+
+func MiddleTimeOfMonth(year, month int) time.Time {
+	return FirstTimeOfMonth(year, month).AddDate(0, 0, 15)
+}
+
+func LastTimeOfMonth(year, month int) time.Time {
+	return FirstTimeOfMonth(year, month).AddDate(0, 1, 0).Add(-time.Nanosecond)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `Year` field for better tracking of ARR breakdown over months and years.
  - Added a new `IsCanceled` field to service line items to track cancellation status.
  - Implemented a new GraphQL query `GetDashboard_ARRBreakdown` for fetching detailed ARR breakdown data.

- **Enhancements**
  - Updated ARR breakdown metrics from integers to float64 for more precise calculations.
  - Enhanced the `DashboardRepository` with a new method to retrieve ARR breakdown data.
  - Improved the `dashboardService` to process actual data from the repository instead of dummy data.

- **Bug Fixes**
  - Fixed potential inaccuracies in ARR calculations by adjusting data types and adding relevant fields.

- **Tests**
  - Added comprehensive test suite for the `Dashboard_ARR_Breakdown` functionality to ensure reliability.

- **Documentation**
  - Updated GraphQL schema documentation to reflect new and modified fields in ARR breakdown types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->