### PR TITLE
(fix|COS-1138): Deactivate the Likelihood selection control when Likelihood is ZERO (info modal)

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalARRCard.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalARRCard.tsx
@@ -6,6 +6,7 @@ import { FeaturedIcon } from '@ui/media/Icon';
 import { Heading } from '@ui/typography/Heading';
 import { DateTimeUtils } from '@spaces/utils/date';
 import { Card, CardHeader } from '@ui/presentation/Card';
+import { InfoDialog } from '@ui/overlay/AlertDialog/InfoDialog';
 import { ClockFastForward } from '@ui/media/icons/ClockFastForward';
 import { formatCurrency } from '@spaces/utils/getFormattedCurrencyNumber';
 import {
@@ -51,6 +52,8 @@ export const RenewalARRCard = ({
   const formattedAmount = formatCurrency(hasEnded ? 0 : opportunity.amount);
 
   const hasRewenewChanged = formattedMaxAmount !== formattedAmount;
+  const hasRenewalLikelihoodZero =
+    opportunity?.renewalLikelihood === OpportunityRenewalLikelihood.ZeroRenewal;
 
   return (
     <>
@@ -61,7 +64,7 @@ export const RenewalARRCard = ({
         my={2}
         size='lg'
         variant='outline'
-        cursor='pointer'
+        cursor={hasEnded ? 'default' : 'pointer'}
         border='1px solid'
         borderColor='gray.200'
         position='relative'
@@ -159,14 +162,30 @@ export const RenewalARRCard = ({
           </Flex>
         </CardHeader>
       </Card>
-      <RenewalDetailsModal
-        isOpen={modal.isOpen && isLocalOpen}
-        onClose={() => {
-          modal.onClose();
-          setIsLocalOpen(false);
-        }}
-        data={opportunity}
-      />
+
+      {hasRenewalLikelihoodZero ? (
+        <InfoDialog
+          isOpen={modal.isOpen && isLocalOpen}
+          onClose={modal.onClose}
+          onConfirm={modal.onClose}
+          confirmButtonLabel='Got it'
+          label='This contract ends soon'
+        >
+          <Text fontSize='sm' fontWeight='normal' mt={1}>
+            The renewal likelihood has been downgraded to Zero because the
+            contract is set to end within the current renewal cycle.
+          </Text>
+        </InfoDialog>
+      ) : (
+        <RenewalDetailsModal
+          isOpen={modal.isOpen && isLocalOpen}
+          onClose={() => {
+            modal.onClose();
+            setIsLocalOpen(false);
+          }}
+          data={opportunity}
+        />
+      )}
     </>
   );
 };

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalDetailsModal.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalDetailsModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useParams } from 'next/navigation';
-import { useRef, useMemo, useState, useEffect } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 import { produce } from 'immer';
 import { useQueryClient } from '@tanstack/react-query';
@@ -11,7 +11,6 @@ import { Flex } from '@ui/layout/Flex';
 import { Text } from '@ui/typography/Text';
 import { FeaturedIcon } from '@ui/media/Icon';
 import { Heading } from '@ui/typography/Heading';
-import { FormSelect } from '@ui/form/SyncSelect';
 import { toastError } from '@ui/presentation/Toast';
 import { Button, ButtonGroup } from '@ui/form/Button';
 import { AutoresizeTextarea } from '@ui/form/Textarea';
@@ -20,7 +19,6 @@ import { CurrencyDollar } from '@ui/media/icons/CurrencyDollar';
 import { getGraphQLClient } from '@shared/util/getGraphQLClient';
 import { ClockFastForward } from '@ui/media/icons/ClockFastForward';
 import { Opportunity, OpportunityRenewalLikelihood } from '@graphql/types';
-import { useGetUsersQuery } from '@organizations/graphql/getUsers.generated';
 import {
   GetContractsQuery,
   useGetContractsQuery,
@@ -54,31 +52,31 @@ export const RenewalDetailsModal = ({
   const orgId = useParams()?.id as string;
   const client = getGraphQLClient();
   const queryClient = useQueryClient();
-  const formId = `renewal-details-form-${data.id}`;
+  // const formId = `renewal-details-form-${data.id}`;
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [likelihood, setLikelihood] = useState<
     OpportunityRenewalLikelihood | undefined | null
   >((data?.renewalLikelihood as OpportunityRenewalLikelihood) ?? null);
   const [amount, setAmount] = useState<string>(data?.amount?.toString() || '');
   const [reason, setReason] = useState<string>(data?.comments || '');
-  const [owner, setOwner] = useState<null | { value: string; label: string }>(
-    null,
-  );
-  const { data: usersData } = useGetUsersQuery(client, {
-    pagination: {
-      limit: 50,
-      page: 1,
-    },
-  });
-
-  const options = useMemo(() => {
-    return usersData?.users?.content
-      ?.filter((e) => Boolean(e.firstName) || Boolean(e.lastName))
-      ?.map((o) => ({
-        value: o.id,
-        label: `${o.firstName} ${o.lastName}`.trim(),
-      }));
-  }, [usersData?.users?.content?.length]);
+  // const [owner, setOwner] = useState<null | { value: string; label: string }>(
+  //   null,
+  // );
+  // const { data: usersData } = useGetUsersQuery(client, {
+  //   pagination: {
+  //     limit: 50,
+  //     page: 1,
+  //   },
+  // });
+  //
+  // const options = useMemo(() => {
+  //   return usersData?.users?.content
+  //     ?.filter((e) => Boolean(e.firstName) || Boolean(e.lastName))
+  //     ?.map((o) => ({
+  //       value: o.id,
+  //       label: `${o.firstName} ${o.lastName}`.trim(),
+  //     }));
+  // }, [usersData?.users?.content?.length]);
 
   const getContractsQueryKey = useGetContractsQuery.getKey({
     id: orgId,
@@ -191,20 +189,21 @@ export const RenewalDetailsModal = ({
           </Heading>
         </ModalHeader>
         <ModalBody as={Flex} flexDir='column' pb='0' gap={4}>
-          <FormSelect
-            formId={formId}
-            name='arrForecast'
-            isClearable
-            isDisabled
-            value={owner}
-            isLoading={false}
-            placeholder='Owner'
-            backspaceRemovesValue
-            onChange={setOwner}
-            options={options}
-            label='Owner'
-            isLabelVisible
-          />
+          {/*todo uncomment when BE is ready*/}
+          {/*<FormSelect*/}
+          {/*  formId={formId}*/}
+          {/*  name='arrForecast'*/}
+          {/*  isClearable*/}
+          {/*  isDisabled*/}
+          {/*  value={owner}*/}
+          {/*  isLoading={false}*/}
+          {/*  placeholder='Owner'*/}
+          {/*  backspaceRemovesValue*/}
+          {/*  onChange={setOwner}*/}
+          {/*  options={options}*/}
+          {/*  label='Owner'*/}
+          {/*  isLabelVisible*/}
+          {/*/>*/}
 
           <div>
             <Text


### PR DESCRIPTION
## Changes
This commit modifies the behaviour and content of the RenewalARRCard component and its related RenewalDetailsModal component.

On RenewalARRCard, a new InfoDialog component is introduced when an opportunity's renewalLikelihood property is ZeroRenewal. This presents the user with more specific information regarding why the likelihood has been downgraded, enhancing user understanding.

On RenewalDetailsModal, the FormSelect component, which previously displayed the 'Owner', has been commented out as it awaits backend completion. This ensures that no incorrect information is visible to the user.


What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an `InfoDialog` to inform users when a contract's renewal likelihood is downgraded to zero.

- **Enhancements**
  - Improved conditional rendering logic to display relevant information based on contract renewal status.

- **Refactor**
  - Streamlined import statements and removed unused components and hooks to simplify component structure.

- **Documentation**
  - Added code comments to highlight areas for future development or attention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->