### PR TITLE
fix: make relationship inputs read-only for given tenants

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
@@ -53,6 +53,9 @@ export const AboutPanel = () => {
   const showParentRelationshipSelector = useFeatureIsOn(
     'show-parent-relationship-selector',
   );
+  const parentRelationshipReadOnly = useFeatureIsOn(
+    'parent-relationship-selector-read-only',
+  );
   const { updateOrganization, addSocial, invalidateQuery } =
     useAboutPanelMethods({ id });
 
@@ -219,6 +222,7 @@ export const AboutPanel = () => {
           showParentRelationshipSelector && (
             <ParentOrgInput
               id={id}
+              isReadOnly={parentRelationshipReadOnly}
               parentOrg={
                 data?.organization?.subsidiaryOf?.[0]?.organization?.id
                   ? {
@@ -333,6 +337,7 @@ export const AboutPanel = () => {
             showParentRelationshipSelector && (
               <Branches
                 id={id}
+                isReadOnly={parentRelationshipReadOnly}
                 branches={
                   (data?.organization
                     ?.subsidiaries as Organization['subsidiaries']) ?? []

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AboutPanel/branches/Branches.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AboutPanel/branches/Branches.tsx
@@ -27,10 +27,15 @@ import {
 
 interface BranchesProps {
   id: string;
+  isReadOnly?: boolean;
   branches?: Organization['subsidiaries'];
 }
 
-export const Branches: React.FC<BranchesProps> = ({ id, branches = [] }) => {
+export const Branches: React.FC<BranchesProps> = ({
+  id,
+  isReadOnly,
+  branches = [],
+}) => {
   const client = getGraphQLClient();
   const queryClient = useQueryClient();
   const { push } = useRouter();
@@ -192,13 +197,15 @@ export const Branches: React.FC<BranchesProps> = ({ id, branches = [] }) => {
         pb={4}
       >
         <Heading fontSize={'md'}>Branches</Heading>
-        <IconButton
-          size='xs'
-          variant='ghost'
-          aria-label='Add'
-          onClick={handleCreateOrganization}
-          icon={<Plus boxSize='4' />}
-        />
+        {!isReadOnly && (
+          <IconButton
+            size='xs'
+            variant='ghost'
+            aria-label='Add'
+            onClick={handleCreateOrganization}
+            icon={<Plus boxSize='4' />}
+          />
+        )}
       </CardHeader>
       <CardBody as={VStack} pt={0} gap={2} alignItems='baseline'>
         {branches.map(({ organization }) =>

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AboutPanel/branches/ParentOrgInput.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AboutPanel/branches/ParentOrgInput.tsx
@@ -22,12 +22,14 @@ import {
 
 interface ParentOrgInputProps {
   id: string;
+  isReadOnly?: boolean;
   parentOrg: { label: string; value: string } | null;
 }
 
 export const ParentOrgInput: React.FC<ParentOrgInputProps> = ({
-  parentOrg,
   id,
+  parentOrg,
+  isReadOnly,
 }) => {
   const client = getGraphQLClient();
   const queryClient = useQueryClient();
@@ -203,6 +205,7 @@ export const ParentOrgInput: React.FC<ParentOrgInputProps> = ({
   return (
     <Select
       isClearable
+      isReadOnly={isReadOnly}
       value={parentOrg || ''}
       onChange={(e) => {
         if (!e && parentOrg) {

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
@@ -90,7 +90,7 @@ export const ContractCard = ({
       toastError(
         `${
           invalidDate
-            ? 'The contract end date needs to be after the service start date'
+            ? 'The contract must end after the service start or signing date'
             : 'Failed to update contract'
         }`,
         `update-contract-error-${error}`,

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalARRCard.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalARRCard.tsx
@@ -11,6 +11,7 @@ import { ClockFastForward } from '@ui/media/icons/ClockFastForward';
 import { formatCurrency } from '@spaces/utils/getFormattedCurrencyNumber';
 import {
   Opportunity,
+  InternalStage,
   ContractRenewalCycle,
   OpportunityRenewalLikelihood,
 } from '@graphql/types';
@@ -69,6 +70,7 @@ export const RenewalARRCard = ({
         borderColor='gray.200'
         position='relative'
         onClick={() => {
+          if (opportunity?.internalStage === InternalStage.ClosedLost) return;
           modal.onOpen();
           setIsLocalOpen(true);
         }}

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalDetailsModal.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalDetailsModal.tsx
@@ -146,14 +146,17 @@ export const RenewalDetailsModal = ({
       }));
   }, [usersData?.users?.content?.length]);
 
+  const defaultValues = {
+    renewalLikelihood: data?.renewalLikelihood,
+    amount: data?.amount?.toString(),
+    reason: data?.comments,
+    owner: options?.find((o) => o.value === data?.owner?.id),
+  };
+
   const { state, handleSubmit } = useForm({
     formId,
-    defaultValues: {
-      renewalLikelihood: data?.renewalLikelihood,
-      amount: data?.amount?.toString(),
-      reason: data?.comments,
-      owner: options?.find((o) => o.value === data?.owner?.id),
-    },
+    defaultValues,
+    debug: true,
     onSubmit: async ({ amount, owner, reason, renewalLikelihood }) => {
       updateOpportunityMutation.mutate({
         input: {
@@ -206,6 +209,7 @@ export const RenewalDetailsModal = ({
             isClearable
             name='owner'
             label='Owner'
+            isLabelVisible
             formId={formId}
             isLoading={false}
             options={options}

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalDetailsModal.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalDetailsModal.tsx
@@ -156,7 +156,6 @@ export const RenewalDetailsModal = ({
   const { state, handleSubmit } = useForm({
     formId,
     defaultValues,
-    debug: true,
     onSubmit: async ({ amount, owner, reason, renewalLikelihood }) => {
       updateOpportunityMutation.mutate({
         input: {

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Notes/Notes.dto.ts
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Notes/Notes.dto.ts
@@ -25,7 +25,6 @@ export class NotesDTO implements NotesForm {
     return {
       id: data.id,
       note: data.note,
-      name: '',
       patch: true,
     } as UpdateOrganizationMutationVariables['input'];
   }

--- a/packages/apps/spaces/yarn.lock
+++ b/packages/apps/spaces/yarn.lock
@@ -14464,9 +14464,9 @@ react-hook-form@7.47.0:
   integrity sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==
 
 react-inverted-form@^1.2.11:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/react-inverted-form/-/react-inverted-form-1.2.11.tgz#51962e1f27149d11d332c16c419c1b2a82dc8a5d"
-  integrity sha512-Z1jRSmyIOil6qUm6BMsNFzEwjXVfcFG+KWcNvAzfsbcDXMTDIRRdfYPie4xPRtwxvoVxr2Ykzkbm4Ih3p9fSAA==
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/react-inverted-form/-/react-inverted-form-1.2.12.tgz#ac3ab883dad71f759bb5761cba964fa11e09506a"
+  integrity sha512-kbSRm7Te+/UTgS7zVJUiLYJ12MVSCWBF8JSkf9VO3Lawbb4Iks3riunBqW6CUZxCFoXsb5/DwsREClQb/+NTVg==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a read-only mode for the parent relationship selector based on a feature flag.
  - Added conditional rendering of the "Add" button in the Branches component, allowing it to be read-only.

- **Enhancements**
  - Updated error message logic in the ContractCard for improved clarity on contract end date validation.
  - Implemented a more structured approach to form default values in the RenewalDetailsModal.

- **Refactor**
  - Reorganized props in the ParentOrgInput component for better readability and maintenance.
  - Removed the `name` property from the `NotesDTO` to align with updated data handling practices.

- **Documentation**
  - Enhanced user-facing error messages to provide more specific contract-related information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->