### PR TITLE
[COS-945] - Dashboards tests unify

### DIFF
--- a/packages/server/customer-os-api/entity/dashboard/dashboard.go
+++ b/packages/server/customer-os-api/entity/dashboard/dashboard.go
@@ -21,6 +21,7 @@ type DashboardRetentionRateData struct {
 	Months             []*DashboardRetentionRatePerMonthData
 }
 type DashboardRetentionRatePerMonthData struct {
+	Year          int
 	Month         int
 	RenewCount    int
 	ChurnCount    int

--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -327,6 +327,7 @@ type ComplexityRoot struct {
 		ChurnCount func(childComplexity int) int
 		Month      func(childComplexity int) int
 		RenewCount func(childComplexity int) int
+		Year       func(childComplexity int) int
 	}
 
 	DashboardRevenueAtRisk struct {
@@ -2671,6 +2672,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.DashboardRetentionRatePerMonth.RenewCount(childComplexity), true
+
+	case "DashboardRetentionRatePerMonth.year":
+		if e.complexity.DashboardRetentionRatePerMonth.Year == nil {
+			break
+		}
+
+		return e.complexity.DashboardRetentionRatePerMonth.Year(childComplexity), true
 
 	case "DashboardRevenueAtRisk.atRisk":
 		if e.complexity.DashboardRevenueAtRisk.AtRisk == nil {
@@ -8718,6 +8726,7 @@ type DashboardRetentionRate {
     perMonth: [DashboardRetentionRatePerMonth]!
 }
 type DashboardRetentionRatePerMonth {
+    year: Int!
     month: Int!
     renewCount: Int!
     churnCount: Int!
@@ -22360,6 +22369,8 @@ func (ec *executionContext) fieldContext_DashboardRetentionRate_perMonth(ctx con
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "year":
+				return ec.fieldContext_DashboardRetentionRatePerMonth_year(ctx, field)
 			case "month":
 				return ec.fieldContext_DashboardRetentionRatePerMonth_month(ctx, field)
 			case "renewCount":
@@ -22368,6 +22379,50 @@ func (ec *executionContext) fieldContext_DashboardRetentionRate_perMonth(ctx con
 				return ec.fieldContext_DashboardRetentionRatePerMonth_churnCount(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type DashboardRetentionRatePerMonth", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DashboardRetentionRatePerMonth_year(ctx context.Context, field graphql.CollectedField, obj *model.DashboardRetentionRatePerMonth) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DashboardRetentionRatePerMonth_year(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Year, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DashboardRetentionRatePerMonth_year(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DashboardRetentionRatePerMonth",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -69490,6 +69545,11 @@ func (ec *executionContext) _DashboardRetentionRatePerMonth(ctx context.Context,
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("DashboardRetentionRatePerMonth")
+		case "year":
+			out.Values[i] = ec._DashboardRetentionRatePerMonth_year(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "month":
 			out.Values[i] = ec._DashboardRetentionRatePerMonth_month(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -586,6 +586,7 @@ type DashboardRetentionRate struct {
 }
 
 type DashboardRetentionRatePerMonth struct {
+	Year       int `json:"year"`
 	Month      int `json:"month"`
 	RenewCount int `json:"renewCount"`
 	ChurnCount int `json:"churnCount"`

--- a/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_arr_breakdown_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_arr_breakdown_it_test.go
@@ -2,8 +2,6 @@ package resolver
 
 import (
 	"context"
-	"github.com/google/uuid"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/entity"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/graph/model"
 	neo4jt "github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/test/neo4j"
@@ -114,8 +112,8 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_Not_Canceled(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -153,8 +151,8 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_Canceled_Before_Month(t *tes
 
 	sli1StartedAt := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
 	sli1EndedAt := time.Date(2023, 6, 30, 23, 59, 59, 999999999, time.UTC)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -192,8 +190,8 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_Started_Before_Canceled_End_
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -231,8 +229,8 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_Started_In_Month_Canceled_En
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -270,8 +268,8 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_Canceled_Annually(t *testing
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -309,8 +307,8 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_Canceled_Quarterly(t *testin
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 2, sli1StartedAt, sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 2, sli1StartedAt, sli1EndedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -348,8 +346,8 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_Canceled_Monthly(t *testing.
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt, sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt, sli1EndedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -387,8 +385,8 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_Not_Customer(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt, sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt, sli1EndedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -426,7 +424,7 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_No_Recurring_SLI(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
 
 	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
 		Price:      1,
@@ -472,8 +470,8 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_Started_In_Month_Canceled_Ne
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.MiddleTimeOfMonth(2023, 8)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -511,10 +509,10 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_2_Versions_Started_Before_No
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
 
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -553,10 +551,10 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_2_Versions_Started_Before_Ca
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1MiddleAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
 
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli1Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -595,10 +593,10 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_2_Versions_Started_Before_Ca
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
 
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli1Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -637,10 +635,10 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_2_Versions_Started_In_Cancel
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
 
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli1Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -680,13 +678,13 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_2_Contracts_1_Active_SLI_1_Cance
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
 
-	contract1Id := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
 
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemCanceledWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli1Id)
 
-	contract2Id := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -725,11 +723,11 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_2_Contracts_With_1_Canceled_SLI(
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 
-	contract1Id := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
 
-	contract2Id := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -768,10 +766,10 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_SLI_2_Versions_Started_In_Cancel
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.MiddleTimeOfMonth(2023, 8)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
 
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli1Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -808,10 +806,10 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Draft_Contract_In_Month(t *te
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus: entity.ContractStatusDraft,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -848,7 +846,7 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Live_Contract_In_Month_No_Rec
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
@@ -896,7 +894,7 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Ended_Contract_In_Month(t *te
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
@@ -946,11 +944,11 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Contract_Before_Month(t *test
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -987,11 +985,11 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Contract_Beginning_Of_Month(t
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1028,11 +1026,11 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Contract_End_Of_Month(t *test
 	})
 
 	sli1StartedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1069,11 +1067,11 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Contract_Not_Customer(t *test
 	})
 
 	sli1StartedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1110,7 +1108,7 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Contract_No_Recurring_SLI(t *
 	})
 
 	sli1StartedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
@@ -1155,11 +1153,11 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Contract_Next_Month(t *testin
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 8)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1197,13 +1195,13 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_1_Contract_1_SLI_2_Versions(t
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1240,11 +1238,11 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Contract_Annually(t *testing.
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1281,11 +1279,11 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Contract_Quarterly(t *testing
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 4, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 4, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1322,11 +1320,11 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_Contract_Monthly(t *testing.T
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1366,14 +1364,14 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_1_Contract_1_SLI_3_Versions(t
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1Middle2At := sli1MiddleAt.AddDate(0, 0, 1)
 
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemEndedWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Middle2At, sli1Id)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 36, 8, entity.BilledTypeAnnually, 12, 4, sli1MiddleAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemEndedWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Middle2At, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 36, 8, entity.BilledTypeAnnually, 12, 4, sli1MiddleAt, sli1Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1411,17 +1409,17 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_2_Contracts_1_SLI_1_Version(t
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 
-	contract1Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 24, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 24, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1460,21 +1458,21 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_2_Contracts_1_SLI_2_Versions(
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 
-	contract1Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
 
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 120, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli2Id)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 120, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1512,13 +1510,13 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_1_Contract_2_SLI(t *testing.T
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 120, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 120, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1557,16 +1555,16 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_1_Contract_2_SLI_2_Versions(t
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
 
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 120, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli2Id)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 120, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1606,21 +1604,21 @@ func Test_Dashboard_ARR_Breakdown_Newly_Contracted_1_Contract_1_Active_SLI_1_Con
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
 
-	contract1Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
 
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 120, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli2Id)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 120, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemCanceledWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1657,10 +1655,10 @@ func Test_Dashboard_ARR_Breakdown_Churned_Draft_Contract_In_Month(t *testing.T) 
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus: entity.ContractStatusDraft,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1697,11 +1695,11 @@ func Test_Dashboard_ARR_Breakdown_Churned_Live_Contract_In_Month(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1738,12 +1736,12 @@ func Test_Dashboard_ARR_Breakdown_Churned_Contract_In_Month(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1780,7 +1778,7 @@ func Test_Dashboard_ARR_Breakdown_Churned_Contract_In_Month_No_Recurring_SLI(t *
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
@@ -1826,12 +1824,12 @@ func Test_Dashboard_ARR_Breakdown_Churned_Contract_In_Month_Not_Customer(t *test
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1868,12 +1866,12 @@ func Test_Dashboard_ARR_Breakdown_Churned_Contract_Before_Month(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1910,12 +1908,12 @@ func Test_Dashboard_ARR_Breakdown_Churned_Contract_Beginning_Month(t *testing.T)
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1952,12 +1950,12 @@ func Test_Dashboard_ARR_Breakdown_Churned_Contract_End_Month(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -1994,12 +1992,12 @@ func Test_Dashboard_ARR_Breakdown_Churned_Contract_Next_Month(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 8)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2036,12 +2034,12 @@ func Test_Dashboard_ARR_Breakdown_Churned_Contract_Annually(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2078,12 +2076,12 @@ func Test_Dashboard_ARR_Breakdown_Churned_Contract_Quarterly(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 4, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 4, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2120,12 +2118,12 @@ func Test_Dashboard_ARR_Breakdown_Churned_Contract_Monthly(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2163,13 +2161,13 @@ func Test_Dashboard_ARR_Breakdown_Churned_1_Contract_1_SLI_2_Versions(t *testing
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2206,20 +2204,20 @@ func Test_Dashboard_ARR_Breakdown_Churned_2_Contracts_1_SLI_1_Version(t *testing
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contract1Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	sli2StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli2StartedAt,
 		EndedAt:          &sli2StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 24, 2, sli2StartedAt)
+	insertServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 24, 2, sli2StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2257,23 +2255,23 @@ func Test_Dashboard_ARR_Breakdown_Churned_2_Contracts_1_SLI_2_Versions(t *testin
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contract1Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1Id)
 
 	sli2StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli2MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli2StartedAt,
 		EndedAt:          &sli2StartedAt,
 	}, entity.OpportunityEntity{})
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 120, 2, sli2StartedAt, sli2MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli2Id)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 120, 2, sli2StartedAt, sli2MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2311,17 +2309,17 @@ func Test_Dashboard_ARR_Breakdown_Churned_1_Contract_2_SLI(t *testing.T) {
 
 	contractStartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &contractStartedAt,
 		EndedAt:          &contractStartedAt,
 	}, entity.OpportunityEntity{})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	sli2StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 2, sli2StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 2, sli2StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2359,7 +2357,7 @@ func Test_Dashboard_ARR_Breakdown_Churned_1_Contract_2_SLI_2_Versions(t *testing
 
 	contractStartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &contractStartedAt,
 		EndedAt:          &contractStartedAt,
@@ -2367,13 +2365,13 @@ func Test_Dashboard_ARR_Breakdown_Churned_1_Contract_2_SLI_2_Versions(t *testing
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1Id)
 
 	sli2StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli2MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 120, 2, sli2StartedAt, sli2MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli2Id)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 120, 2, sli2StartedAt, sli2MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2411,27 +2409,27 @@ func Test_Dashboard_ARR_Breakdown_Churned_2_Organizations_1_Contract_Each(t *tes
 
 	contractStartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 
-	contract1Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, org1Id, entity.ContractEntity{
+	contract1Id := insertContractWithOpportunity(ctx, driver, org1Id, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &contractStartedAt,
 		EndedAt:          &contractStartedAt,
 	}, entity.OpportunityEntity{})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	insertARRBreakdownServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	org2Id := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		IsCustomer: true,
 	})
 
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, org2Id, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, org2Id, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &contractStartedAt,
 		EndedAt:          &contractStartedAt,
 	}, entity.OpportunityEntity{})
 
 	sli2StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	insertARRBreakdownServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 24, 2, sli2StartedAt)
+	insertServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 24, 2, sli2StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2469,7 +2467,7 @@ func Test_Dashboard_ARR_Breakdown_Churned_1_Contract_2_SLI_1_Canceled(t *testing
 
 	contractStartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &contractStartedAt,
 		EndedAt:          &contractStartedAt,
@@ -2477,14 +2475,14 @@ func Test_Dashboard_ARR_Breakdown_Churned_1_Contract_2_SLI_1_Canceled(t *testing
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1Id)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1Id)
 
 	sli2StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli2MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli2EndedAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 120, 2, sli2StartedAt, sli2MiddleAt)
-	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli2EndedAt, sli2Id)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 120, 2, sli2StartedAt, sli2MiddleAt)
+	insertServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 240, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli2EndedAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2521,10 +2519,10 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Draft_Contract_No_Upsell_In_Month(t *t
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus: entity.ContractStatusDraft,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2562,11 +2560,11 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Draft_Contract_With_Upsell_In_Month(t 
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus: entity.ContractStatusDraft,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2603,11 +2601,11 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Live_Contract_No_Upsell_In_Month(t *te
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2645,15 +2643,15 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Live_Contract_With_Upsell_In_Month_Sho
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
 	// 96 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2692,15 +2690,15 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Live_Contract_With_Upsell_And_SLI_Canc
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
 	// 96 / year
-	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sliId)
+	insertServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2738,15 +2736,15 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Live_Contract_With_Downgrade_In_Month(
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2784,12 +2782,12 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Ended_Contract_No_Upsell_In_Month(t *t
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1EndedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2828,13 +2826,13 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Ended_Contract_With_Upsell_In_Month(t 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1EndedAt,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -2871,7 +2869,7 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Contract_No_Upsell_No_Recurring_SLI(t 
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
@@ -2917,7 +2915,7 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Contract_With_Upsell_No_Recurring_SLI(
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
@@ -2972,13 +2970,13 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Not_Customer(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3016,12 +3014,12 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Before_Month(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1MiddleAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3059,15 +3057,15 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Beginning_Month(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1MiddleAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
 	// 96 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3105,15 +3103,15 @@ func Test_Dashboard_ARR_Breakdown_Upsells_End_Month(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 96 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3151,12 +3149,12 @@ func Test_Dashboard_ARR_Breakdown_Upsells_Next_Month(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 8)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3194,15 +3192,15 @@ func Test_Dashboard_ARR_Breakdown_Upsells_2_SLI_Versions_Both_Annually(t *testin
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 96 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 24, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3240,15 +3238,15 @@ func Test_Dashboard_ARR_Breakdown_Upsells_2_SLI_Versions_1_Annually_1_Quarterly(
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 96 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 12, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 12, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3286,15 +3284,15 @@ func Test_Dashboard_ARR_Breakdown_Upsells_2_SLI_Versions_1_Annually_1_Monthly(t 
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 576 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3332,15 +3330,15 @@ func Test_Dashboard_ARR_Breakdown_Upsells_2_SLI_Versions_Both_Quarterly(t *testi
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 96 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 12, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 12, 2, sli1StartedAt, sli1EndAt)
 	//384 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 24, 4, entity.BilledTypeQuarterly, 12, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 24, 4, entity.BilledTypeQuarterly, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3378,15 +3376,15 @@ func Test_Dashboard_ARR_Breakdown_Upsells_2_SLI_Versions_1_Quarterly_1_Monthly(t
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 48 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 6, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 6, 2, sli1StartedAt, sli1EndAt)
 	// 288 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 12, 2, entity.BilledTypeQuarterly, 6, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 12, 2, entity.BilledTypeQuarterly, 6, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3424,15 +3422,15 @@ func Test_Dashboard_ARR_Breakdown_Upsells_2_SLI_Versions_Both_Monthly(t *testing
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 288 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 12, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 12, 2, sli1StartedAt, sli1EndAt)
 	// 1152 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 24, 4, entity.BilledTypeMonthly, 12, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 24, 4, entity.BilledTypeMonthly, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3470,11 +3468,11 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Draft_Contract_With_Downgrade_In_Mo
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus: entity.ContractStatusDraft,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3511,11 +3509,11 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Live_Contract_No_Downgrade_In_Month
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3553,15 +3551,15 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Live_Contract_With_Downgrade_In_Mon
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3600,15 +3598,15 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Live_Contract_With_Downgrade_And_SL
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sliId)
+	insertServiceLineItemCanceledWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1EndedAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3646,15 +3644,15 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Live_Contract_With_Upsell_In_Month(
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 12 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
 	// 24 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3692,12 +3690,12 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Ended_Contract_No_Downgrade_In_Mont
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1EndedAt,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3736,13 +3734,13 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Ended_Contract_With_Downgrade_In_Mo
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1EndedAt,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3779,7 +3777,7 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Contract_No_Downgrade_No_Recurring_
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
@@ -3825,7 +3823,7 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Contract_With_Downgrade_No_Recurrin
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
@@ -3880,13 +3878,13 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Not_Customer(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3924,12 +3922,12 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Before_Month(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1MiddleAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -3967,15 +3965,15 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Beginning_Month(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1MiddleAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4013,15 +4011,15 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_End_Month(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4059,12 +4057,12 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_Next_Month(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 8)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4102,15 +4100,15 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_2_SLI_Versions_Both_Annually(t *tes
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4148,15 +4146,15 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_2_SLI_Versions_1_Annually_1_Quarter
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 24 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 16 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 2, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 2, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4194,15 +4192,15 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_2_SLI_Versions_1_Annually_1_Monthly
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 32 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 16, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 16, 2, sli1StartedAt, sli1EndAt)
 	// 24 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, entity.BilledTypeAnnually, 16, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, entity.BilledTypeAnnually, 16, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4240,15 +4238,15 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_2_SLI_Versions_Both_Quarterly(t *te
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 96 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 12, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 12, 2, sli1StartedAt, sli1EndAt)
 	// 48 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 6, 2, entity.BilledTypeQuarterly, 12, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 6, 2, entity.BilledTypeQuarterly, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4286,15 +4284,15 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_2_SLI_Versions_1_Quarterly_1_Monthl
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 40 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 2, sli1StartedAt, sli1EndAt)
 	// 24 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, entity.BilledTypeQuarterly, 5, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, entity.BilledTypeQuarterly, 5, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4332,15 +4330,15 @@ func Test_Dashboard_ARR_Breakdown_Downgrades_2_SLI_Versions_Both_Monthly(t *test
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 
 	// 288 / year
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 12, 2, sli1StartedAt, sli1EndAt)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 12, 2, sli1StartedAt, sli1EndAt)
 	// 144 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 6, 2, entity.BilledTypeMonthly, 12, 2, sli1EndAt, sliId)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 6, 2, entity.BilledTypeMonthly, 12, 2, sli1EndAt, sliId)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4379,22 +4377,22 @@ func Test_Dashboard_ARR_Breakdown_1_Contract_With_Upsell_1_Contract_Without_Upse
 	//contract 1
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 48 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
 
 	//contract 2
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 12 / year
-	insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
+	insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4433,22 +4431,22 @@ func Test_Dashboard_ARR_Breakdown_1_Contract_With_Downgrade_1_Contract_Without_D
 	//contract 1
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
 
 	//contract 2
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 12 / year
-	insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
+	insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4487,24 +4485,24 @@ func Test_Dashboard_ARR_Breakdown_2_Contracts_With_Upsells(t *testing.T) {
 	//contract 1
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 48 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
 
 	//contract 2
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 12 / year
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
 	// 24 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 4, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 4, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4543,34 +4541,34 @@ func Test_Dashboard_ARR_Breakdown_2_Contracts_With_2_Upsells(t *testing.T) {
 	//contract 1
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contract1Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 48 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
 
 	// 12 / year
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
 	// 24 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 4, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
+	insertServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 4, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
 
 	//contract 2
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 240 / year
-	sli3Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 120, 2, sli1StartedAt, sli1EndAt)
+	sli3Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 120, 2, sli1StartedAt, sli1EndAt)
 	// 480 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 120, 4, entity.BilledTypeAnnually, 120, 2, sli1EndAt, sli3Id)
+	insertServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 120, 4, entity.BilledTypeAnnually, 120, 2, sli1EndAt, sli3Id)
 
 	// 120 / year
-	sli4Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 60, 2, sli1StartedAt, sli1EndAt)
+	sli4Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 60, 2, sli1StartedAt, sli1EndAt)
 	// 240 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 60, 4, entity.BilledTypeAnnually, 60, 2, sli1EndAt, sli4Id)
+	insertServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 60, 4, entity.BilledTypeAnnually, 60, 2, sli1EndAt, sli4Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4609,24 +4607,24 @@ func Test_Dashboard_ARR_Breakdown_2_Contracts_With_Downgrades(t *testing.T) {
 	//contract 1
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
 
 	//contract 2
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 12 / year
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
 	// 6 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 1, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 1, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4665,34 +4663,34 @@ func Test_Dashboard_ARR_Breakdown_2_Contracts_With_2_Downgrades(t *testing.T) {
 	//contract 1
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contract1Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
 
 	// 12 / year
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
 	// 6 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 1, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
+	insertServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 1, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
 
 	//contract 2
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 240 / year
-	sli3Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 120, 2, sli1StartedAt, sli1EndAt)
+	sli3Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 120, 2, sli1StartedAt, sli1EndAt)
 	// 120 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 60, 2, entity.BilledTypeAnnually, 120, 2, sli1EndAt, sli3Id)
+	insertServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 60, 2, entity.BilledTypeAnnually, 120, 2, sli1EndAt, sli3Id)
 
 	// 120 / year
-	sli4Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 60, 2, sli1StartedAt, sli1EndAt)
+	sli4Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 60, 2, sli1StartedAt, sli1EndAt)
 	// 60 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 60, 1, entity.BilledTypeAnnually, 60, 2, sli1EndAt, sli4Id)
+	insertServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 60, 1, entity.BilledTypeAnnually, 60, 2, sli1EndAt, sli4Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4730,27 +4728,27 @@ func Test_Dashboard_ARR_Breakdown_2_Organizations_1_Contract_With_Upsell_Each(t 
 	})
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, org1Id, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, org1Id, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 48 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 4, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
 
 	//contract 2
 	org2Id := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		IsCustomer: true,
 	})
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, org2Id, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, org2Id, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 12 / year
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
 	// 24 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 4, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 4, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4788,27 +4786,27 @@ func Test_Dashboard_ARR_Breakdown_2_Organizations_1_Contract_With_Downgrade_Each
 	})
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, org1Id, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, org1Id, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
 
 	//contract 2
 	org2Id := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		IsCustomer: true,
 	})
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, org2Id, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, org2Id, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 12 / year
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
 	// 6 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 1, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 1, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4846,27 +4844,27 @@ func Test_Dashboard_ARR_Breakdown_2_Contracts_With_Downgrade_Each(t *testing.T) 
 	})
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, org1Id, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, org1Id, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1EndAt, sli1Id)
 
 	//contract 2
 	org2Id := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		IsCustomer: true,
 	})
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, org2Id, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, org2Id, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 12 / year
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1EndAt)
 	// 6 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 1, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 1, entity.BilledTypeAnnually, 6, 2, sli1EndAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4904,24 +4902,24 @@ func Test_Dashboard_ARR_Breakdown_1_Organization_With_1_Contract_With_Downgrade_
 	})
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1MiddleAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contract1Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1MiddleAt)
 	// 12 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1MiddleAt, sli1Id)
 
 	//contract 2
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 12 / year
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1MiddleAt)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1MiddleAt)
 	// 24 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, entity.BilledTypeAnnually, 6, 2, sli1MiddleAt, sli2Id)
+	insertServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, entity.BilledTypeAnnually, 6, 2, sli1MiddleAt, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -4961,28 +4959,28 @@ func Test_Dashboard_ARR_Breakdown_1_Organization_With_1_Contract_With_Downgrade_
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1End1At := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1End2At := sli1End1At.Add(time.Hour * 24)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1End1At)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1End1At)
 	// 12 / year
-	insertARRBreakdownServiceLineItemEndedWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1End1At, sli1End2At, sli1Id)
+	insertServiceLineItemEndedWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1End1At, sli1End2At, sli1Id)
 	// 6 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 3, 2, entity.BilledTypeAnnually, 6, 2, sli1End2At, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 3, 2, entity.BilledTypeAnnually, 6, 2, sli1End2At, sli1Id)
 
 	//contract 2
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 12 / year
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1End1At)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1End1At)
 	// 24 / year
-	insertARRBreakdownServiceLineItemEndedWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 4, entity.BilledTypeAnnually, 6, 2, sli1End1At, sli1End2At, sli2Id)
+	insertServiceLineItemEndedWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 4, entity.BilledTypeAnnually, 6, 2, sli1End1At, sli1End2At, sli2Id)
 	// 36 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 6, entity.BilledTypeAnnually, 6, 4, sli1End2At, sli2Id)
+	insertServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 6, entity.BilledTypeAnnually, 6, 4, sli1End2At, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -5023,32 +5021,32 @@ func Test_Dashboard_ARR_Breakdown_1_Organization_With_1_Contract_With_Downgrade_
 	sli1End1At := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1End2At := sli1End1At.Add(time.Hour * 24)
 	sli1End3At := sli1End2At.Add(time.Hour * 24)
-	contract1Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 24 / year
-	sli1Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1End1At)
+	sli1Id := insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1End1At)
 	// 12 / year
-	insertARRBreakdownServiceLineItemEndedWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1End1At, sli1End2At, sli1Id)
+	insertServiceLineItemEndedWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 6, 2, entity.BilledTypeAnnually, 12, 2, sli1End1At, sli1End2At, sli1Id)
 	// 48 / year
-	insertARRBreakdownServiceLineItemEndedWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 24, 2, entity.BilledTypeAnnually, 6, 2, sli1End2At, sli1End3At, sli1Id)
+	insertServiceLineItemEndedWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 24, 2, entity.BilledTypeAnnually, 6, 2, sli1End2At, sli1End3At, sli1Id)
 	// 6 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 3, 2, entity.BilledTypeAnnually, 24, 2, sli1End3At, sli1Id)
+	insertServiceLineItemWithParent(ctx, driver, contract1Id, entity.BilledTypeAnnually, 3, 2, entity.BilledTypeAnnually, 24, 2, sli1End3At, sli1Id)
 
 	//contract 2
-	contract2Id := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
 	// 12 / year
-	sli2Id := insertARRBreakdownServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1End1At)
+	sli2Id := insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 2, sli1StartedAt, sli1End1At)
 	// 24 / year
-	insertARRBreakdownServiceLineItemEndedWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 4, entity.BilledTypeAnnually, 6, 2, sli1End1At, sli1End2At, sli2Id)
+	insertServiceLineItemEndedWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 4, entity.BilledTypeAnnually, 6, 2, sli1End1At, sli1End2At, sli2Id)
 	// 6 / year
-	insertARRBreakdownServiceLineItemEndedWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 1, entity.BilledTypeAnnually, 6, 4, sli1End2At, sli1End3At, sli2Id)
+	insertServiceLineItemEndedWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 1, entity.BilledTypeAnnually, 6, 4, sli1End2At, sli1End3At, sli2Id)
 	// 36 / year
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 6, entity.BilledTypeAnnually, 6, 1, sli1End3At, sli2Id)
+	insertServiceLineItemWithParent(ctx, driver, contract2Id, entity.BilledTypeAnnually, 6, 6, entity.BilledTypeAnnually, 6, 1, sli1End3At, sli2Id)
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",
 		map[string]interface{}{
@@ -5086,10 +5084,10 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Draft_Contract_Monthly_SLI(t *testing
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus: entity.ContractStatusDraft,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 12, 2, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5141,10 +5139,10 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Draft_Contract_Quarterly_SLI(t *testi
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus: entity.ContractStatusDraft,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 12, 2, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5196,10 +5194,10 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Draft_Contract_Annually_SLI(t *testin
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus: entity.ContractStatusDraft,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5251,7 +5249,7 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_In_Month_No_Recurring_S
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 	}, entity.OpportunityEntity{})
@@ -5315,8 +5313,8 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Not_Customer(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt, sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt, sli1EndedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5370,8 +5368,8 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Hidden_Organization(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertARRBreakdownContractWithOpportunity(ctx, driver, orgId)
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt, sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt, sli1EndedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5424,12 +5422,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Monthly_Renewal_1_SLI_M
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.FirstTimeOfMonth(2023, 10)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt, sli1EndedAt)
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt, sli1EndedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5469,13 +5467,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Ended_Contract_Monthly_Renewal_1_SLI_
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.FirstTimeOfMonth(2023, 10)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusEnded,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1EndedAt,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5514,12 +5512,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Monthly_Renewal_1_SLI_V
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5563,13 +5561,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Monthly_Renewal_1_SLI_V
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2023, 9)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 2, entity.BilledTypeMonthly, 5, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 2, entity.BilledTypeMonthly, 5, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5613,12 +5611,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Monthly_Renewal_1_SLI_Q
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.FirstTimeOfMonth(2024, 1)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt, sli1EndedAt)
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt, sli1EndedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5662,13 +5660,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Ended_Contract_Monthly_Renewal_1_SLI_
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.FirstTimeOfMonth(2024, 1)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1EndedAt,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5711,12 +5709,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Monthly_Renewal_1_SLI_V
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5760,13 +5758,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Monthly_Renewal_1_SLI_V
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 1)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, entity.BilledTypeQuarterly, 3, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, entity.BilledTypeQuarterly, 3, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5813,12 +5811,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Monthly_Renewal_1_SLI_A
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.FirstTimeOfMonth(2024, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt, sli1EndedAt)
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt, sli1EndedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5877,13 +5875,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Ended_Contract_Monthly_Renewal_1_SLI_
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.FirstTimeOfMonth(2024, 7)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		EndedAt:          &sli1EndedAt,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -5941,12 +5939,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Monthly_Renewal_1_SLI_V
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6005,13 +6003,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Monthly_Renewal_1_SLI_V
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleMonthlyRenewal,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 10, 1, entity.BilledTypeAnnually, 5, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 10, 1, entity.BilledTypeAnnually, 5, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6069,12 +6067,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Quarterly_Renewal_1_SLI
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleQuarterlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6118,13 +6116,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Quarterly_Renewal_1_SLI
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 1)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleQuarterlyRenewal,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 2, entity.BilledTypeMonthly, 5, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 2, entity.BilledTypeMonthly, 5, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6170,12 +6168,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Quarterly_Renewal_1_SLI
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleQuarterlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6219,13 +6217,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Quarterly_Renewal_1_SLI
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 1)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleQuarterlyRenewal,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, entity.BilledTypeQuarterly, 3, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, entity.BilledTypeQuarterly, 3, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6271,12 +6269,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Quarterly_Renewal_1_SLI
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleQuarterlyRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6335,13 +6333,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Quarterly_Renewal_1_SLI
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleQuarterlyRenewal,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 10, 1, entity.BilledTypeAnnually, 5, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 10, 1, entity.BilledTypeAnnually, 5, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6399,12 +6397,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Annual_Renewal_1_SLI_V1
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6451,13 +6449,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Annual_Renewal_1_SLI_V2
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 1)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 2, entity.BilledTypeMonthly, 5, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 2, entity.BilledTypeMonthly, 5, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6503,12 +6501,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Annual_Renewal_1_SLI_V1
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6555,13 +6553,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Annual_Renewal_1_SLI_V2
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 1)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, entity.BilledTypeQuarterly, 3, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, entity.BilledTypeQuarterly, 3, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6607,12 +6605,12 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Annual_Renewal_1_SLI_V1
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6671,13 +6669,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_Annual_Renewal_1_SLI_V2
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 10, 1, entity.BilledTypeAnnually, 5, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 10, 1, entity.BilledTypeAnnually, 5, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6735,13 +6733,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_1_Multi_Year_Renewal_1_
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](1),
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6799,13 +6797,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_2_Multi_Year_Renewal_1_
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](2),
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6864,14 +6862,14 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_1_Multi_Year_Renewal_1_
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 1)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](1),
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 2, entity.BilledTypeMonthly, 5, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 2, entity.BilledTypeMonthly, 5, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6930,14 +6928,14 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_2_Multi_Year_Renewal_1_
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 1)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](2),
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 2, entity.BilledTypeMonthly, 5, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeMonthly, 5, 2, entity.BilledTypeMonthly, 5, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -6995,13 +6993,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_1_Multi_Year_Renewal_1_
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](1),
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -7059,13 +7057,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_2_Multi_Year_Renewal_1_
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](2),
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -7124,14 +7122,14 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_1_Multi_Year_Renewal_1_
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 1)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](1),
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, entity.BilledTypeQuarterly, 3, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, entity.BilledTypeQuarterly, 3, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -7190,14 +7188,14 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_2_Multi_Year_Renewal_1_
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 1)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](1),
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, entity.BilledTypeQuarterly, 3, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeQuarterly, 5, 1, entity.BilledTypeQuarterly, 3, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -7255,13 +7253,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_1_Multi_Year_Renewal_1_
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](1),
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -7319,13 +7317,13 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_2_Multi_Year_Renewal_1_
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1StartedAt,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](2),
 	}, entity.OpportunityEntity{})
-	insertARRBreakdownServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1StartedAt)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -7384,14 +7382,14 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_1_Multi_Year_Renewal_1_
 
 	sli1date := neo4jt.FirstTimeOfMonth(2022, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](1),
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 10, 1, entity.BilledTypeAnnually, 5, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 10, 1, entity.BilledTypeAnnually, 5, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -7450,14 +7448,14 @@ func Test_Dashboard_ARR_Breakdown_Renewals_Live_Contract_2_Multi_Year_Renewal_1_
 
 	sli1date := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli2date := neo4jt.FirstTimeOfMonth(2024, 6)
-	contractId := insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
 		ContractStatus:   entity.ContractStatusLive,
 		ServiceStartedAt: &sli1date,
 		RenewalCycle:     entity.RenewalCycleAnnualRenewal,
 		RenewalPeriods:   utils.Ptr[int64](2),
 	}, entity.OpportunityEntity{})
-	sliId := insertARRBreakdownServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1date, sli2date)
-	insertARRBreakdownServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 10, 1, entity.BilledTypeAnnually, 5, 1, sli2date, sliId)
+	sliId := insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 5, 1, sli1date, sli2date)
+	insertServiceLineItemWithParent(ctx, driver, contractId, entity.BilledTypeAnnually, 10, 1, entity.BilledTypeAnnually, 5, 1, sli2date, sliId)
 
 	format := "2006-01-02T15:04:05.000Z"
 	startTime := neo4jt.FirstTimeOfMonth(2023, 7)
@@ -7517,111 +7515,4 @@ func assertRenewalsMonthData(t *testing.T, dashboardReport *model.DashboardARRBr
 	require.Equal(t, year, dashboardReport.PerMonth[index].Year)
 	require.Equal(t, month, dashboardReport.PerMonth[index].Month)
 	require.Equal(t, expectedRenewals, dashboardReport.PerMonth[index].Renewals)
-}
-
-func insertARRBreakdownContractWithOpportunity(ctx context.Context, driver *neo4j.DriverWithContext, orgId string) string {
-	return insertARRBreakdownContractWithOpportunityExtended(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
-}
-
-func insertARRBreakdownContractWithOpportunityExtended(ctx context.Context, driver *neo4j.DriverWithContext, orgId string, contract entity.ContractEntity, opportunity entity.OpportunityEntity) string {
-	contractId := neo4jt.CreateContractForOrganization(ctx, driver, tenantName, orgId, contract)
-	opportunityId := neo4jt.CreateOpportunityForContract(ctx, driver, tenantName, contractId, opportunity)
-	neo4jt.ActiveRenewalOpportunityForContract(ctx, driver, tenantName, contractId, opportunityId)
-	return contractId
-}
-
-func insertARRBreakdownServiceLineItem(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, quantity int64, startedAt time.Time) string {
-	rand, _ := uuid.NewRandom()
-	id := rand.String()
-	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
-		ID:        id,
-		ParentID:  id,
-		Billed:    billedType,
-		Price:     price,
-		Quantity:  quantity,
-		StartedAt: startedAt,
-	})
-	return id
-}
-
-func insertARRBreakdownServiceLineItemEnded(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, quantity int64, startedAt, endedAt time.Time) string {
-	rand, _ := uuid.NewRandom()
-	id := rand.String()
-	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
-		ID:        id,
-		ParentID:  id,
-		Billed:    billedType,
-		Price:     price,
-		Quantity:  quantity,
-		StartedAt: startedAt,
-		EndedAt:   &endedAt,
-	})
-	return id
-}
-
-func insertARRBreakdownServiceLineItemCanceled(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, quantity int64, startedAt, endedAt time.Time) string {
-	rand, _ := uuid.NewRandom()
-	id := rand.String()
-	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
-		ID:         id,
-		ParentID:   id,
-		Billed:     billedType,
-		Price:      price,
-		Quantity:   quantity,
-		IsCanceled: true,
-		StartedAt:  startedAt,
-		EndedAt:    &endedAt,
-	})
-	return id
-}
-
-func insertARRBreakdownServiceLineItemWithParent(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, quantity int64, previousBilledType entity.BilledType, previousPrice float64, previousQuantity int64, startedAt time.Time, parentId string) {
-	rand, _ := uuid.NewRandom()
-	id := rand.String()
-	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
-		ID:               id,
-		ParentID:         parentId,
-		Billed:           billedType,
-		Price:            price,
-		Quantity:         quantity,
-		PreviousBilled:   previousBilledType,
-		PreviousPrice:    previousPrice,
-		PreviousQuantity: previousQuantity,
-		StartedAt:        startedAt,
-	})
-}
-
-func insertARRBreakdownServiceLineItemEndedWithParent(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, quantity int64, previousBilledType entity.BilledType, previousPrice float64, previousQuantity int64, startedAt, endedAt time.Time, parentId string) {
-	rand, _ := uuid.NewRandom()
-	id := rand.String()
-	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
-		ID:               id,
-		ParentID:         parentId,
-		Billed:           billedType,
-		Price:            price,
-		Quantity:         quantity,
-		PreviousBilled:   previousBilledType,
-		PreviousPrice:    previousPrice,
-		PreviousQuantity: previousQuantity,
-		StartedAt:        startedAt,
-		EndedAt:          &endedAt,
-	})
-}
-
-func insertARRBreakdownServiceLineItemCanceledWithParent(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, quantity int64, previousBilledType entity.BilledType, previousPrice float64, previousQuantity int64, startedAt, endedAt time.Time, parentId string) {
-	rand, _ := uuid.NewRandom()
-	id := rand.String()
-	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
-		ID:               id,
-		ParentID:         parentId,
-		Billed:           billedType,
-		Price:            price,
-		Quantity:         quantity,
-		PreviousBilled:   previousBilledType,
-		PreviousPrice:    previousPrice,
-		PreviousQuantity: previousQuantity,
-		IsCanceled:       true,
-		StartedAt:        startedAt,
-		EndedAt:          &endedAt,
-	})
 }

--- a/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_mrr_per_customer_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_mrr_per_customer_it_test.go
@@ -2,7 +2,6 @@ package resolver
 
 import (
 	"context"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/entity"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/graph/model"
 	neo4jt "github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/test/neo4j"
@@ -98,8 +97,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_InMonth_HiddenOrganization
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2024, 7)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -142,8 +141,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_InMonth_ProspectOrganizati
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -187,8 +186,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_InMonth_Hidden_Organizatio
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -232,8 +231,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_Canceled(t *testing.T) {
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.FirstTimeOfMonth(2023, 9)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, &sli1StartedAt, &sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemCanceled(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -275,8 +274,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_BeforeMonth(t *testing.T) 
 	})
 
 	sli1StartedAt := neo4jt.LastTimeOfMonth(2023, 6)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -319,8 +318,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_AfterMonth(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 8)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -362,10 +361,10 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_AtBeginningOfMonth(t *test
 		IsCustomer: true,
 	})
 
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
 
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -408,8 +407,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_AtEndOfMonth(t *testing.T)
 	})
 
 	sli1StartedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -453,8 +452,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_InMonth_EndedImmediately(t
 	})
 
 	sli1StartedAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1StartedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -499,8 +498,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_InMonth_EndedAtEndOfMonth(
 
 	sli1StartedAt := neo4jt.MiddleTimeOfMonth(2023, 7)
 	sli1EndedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItemEnded(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -543,8 +542,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_Yearly(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -587,8 +586,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_Quarterly(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1StartedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeQuarterly, 3, 1, sli1StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -631,8 +630,8 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_SLI_Monthly(t *testing.T) {
 	})
 
 	sli1StartedAt := neo4jt.LastTimeOfMonth(2023, 7)
-	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt)
+	contractId := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contractId, entity.BilledTypeMonthly, 1, 2, sli1StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -676,12 +675,12 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_2_SLI_SameMonth_SameOrganizati
 	})
 
 	sli1StartedAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contract1Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	contract2ServiceStartedAt := neo4jt.MiddleTimeOfMonth(2023, 7).Add(10 * 24 * time.Hour)
-	contract2Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, contract2ServiceStartedAt)
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, contract2ServiceStartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -723,17 +722,16 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_2_SLI_SameMonth_DifferentOrgan
 	orgId1 := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		IsCustomer: true,
 	})
+	sli1StartedAt := neo4jt.MiddleTimeOfMonth(2023, 7)
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId1, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+
 	orgId2 := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		IsCustomer: true,
 	})
-
-	sli1StartedAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contract1Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId1)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
-
 	contract2ServiceStartedAt := neo4jt.MiddleTimeOfMonth(2023, 7).Add(10 * 24 * time.Hour)
-	contract2Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId2)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, contract2ServiceStartedAt)
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId2, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, contract2ServiceStartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 2})
@@ -777,12 +775,12 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_2_SLI_DifferentMonths_SameOrga
 	})
 
 	sli1StartedAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	contract1Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
 
 	contract2ServiceStartedAt := neo4jt.MiddleTimeOfMonth(2023, 9)
-	contract2Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, contract2ServiceStartedAt)
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
+	insertServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, contract2ServiceStartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -824,17 +822,16 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_2_SLI_DifferentMonths_Differen
 	orgId1 := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		IsCustomer: true,
 	})
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId1, entity.ContractEntity{}, entity.OpportunityEntity{})
+	sli1StartedAt := neo4jt.MiddleTimeOfMonth(2023, 7)
+	insertServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+
 	orgId2 := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		IsCustomer: true,
 	})
-
-	contract1Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId1)
-	sli1StartedAt := neo4jt.MiddleTimeOfMonth(2023, 7)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
-
-	contract2Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId2)
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId2, entity.ContractEntity{}, entity.OpportunityEntity{})
 	sli2StartedAt := neo4jt.MiddleTimeOfMonth(2023, 8)
-	insertMRRPerCustomerServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, sli2StartedAt)
+	insertServiceLineItem(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, sli2StartedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 2})
@@ -873,19 +870,19 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_2_SLI_SameOrganization_Overlap
 
 	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
 
-	orgId1 := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		IsCustomer: true,
 	})
 
-	contract1Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId1)
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
 	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
 	sli1EndedAt := neo4jt.FirstTimeOfMonth(2023, 9)
-	insertMRRPerCustomerServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
+	insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
 
-	contract2Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId1)
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{}, entity.OpportunityEntity{})
 	sli2StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli2EndedAt := neo4jt.FirstTimeOfMonth(2023, 10)
-	insertMRRPerCustomerServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, sli2StartedAt, sli2EndedAt)
+	insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, sli2StartedAt, sli2EndedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -928,19 +925,19 @@ func TestQueryResolver_Dashboard_MRR_Per_Customer_2_SLI_DifferentOrganization_Ov
 	orgId1 := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		IsCustomer: true,
 	})
+
+	contract1Id := insertContractWithOpportunity(ctx, driver, orgId1, entity.ContractEntity{}, entity.OpportunityEntity{})
+	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
+	sli1EndedAt := neo4jt.FirstTimeOfMonth(2023, 9)
+	insertServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
+
 	orgId2 := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
 		IsCustomer: true,
 	})
-
-	contract1Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId1)
-	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 6)
-	sli1EndedAt := neo4jt.FirstTimeOfMonth(2023, 9)
-	insertMRRPerCustomerServiceLineItemEnded(ctx, driver, contract1Id, entity.BilledTypeAnnually, 12, 2, sli1StartedAt, sli1EndedAt)
-
-	contract2Id := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId2)
+	contract2Id := insertContractWithOpportunity(ctx, driver, orgId2, entity.ContractEntity{}, entity.OpportunityEntity{})
 	sli2StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
 	sli2EndedAt := neo4jt.FirstTimeOfMonth(2023, 10)
-	insertMRRPerCustomerServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, sli2StartedAt, sli2EndedAt)
+	insertServiceLineItemEnded(ctx, driver, contract2Id, entity.BilledTypeAnnually, 12, 2, sli2StartedAt, sli2EndedAt)
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 2})
@@ -986,41 +983,4 @@ func assertMRRMonthData(t *testing.T, dashboardReport *model.DashboardMRRPerCust
 	require.Equal(t, year, dashboardReport.PerMonth[index].Year)
 	require.Equal(t, month, dashboardReport.PerMonth[index].Month)
 	require.Equal(t, expected, dashboardReport.PerMonth[index].Value)
-}
-
-func insertMRRPerCustomerContractWithOpportunity(ctx context.Context, driver *neo4j.DriverWithContext, orgId string) string {
-	contractId := neo4jt.CreateContractForOrganization(ctx, driver, tenantName, orgId, entity.ContractEntity{})
-	opportunityId := neo4jt.CreateOpportunityForContract(ctx, driver, tenantName, contractId, entity.OpportunityEntity{})
-	neo4jt.ActiveRenewalOpportunityForContract(ctx, driver, tenantName, contractId, opportunityId)
-	return contractId
-}
-
-func insertMRRPerCustomerServiceLineItem(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, quantity int64, startedAt time.Time) {
-	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
-		Billed:    billedType,
-		Price:     price,
-		Quantity:  quantity,
-		StartedAt: startedAt,
-	})
-}
-
-func insertMRRPerCustomerServiceLineItemEnded(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, quantity int64, startedAt, endedAt time.Time) {
-	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
-		Billed:    billedType,
-		Price:     price,
-		Quantity:  quantity,
-		StartedAt: startedAt,
-		EndedAt:   &endedAt,
-	})
-}
-
-func insertMRRPerCustomerServiceLineItemCanceled(ctx context.Context, driver *neo4j.DriverWithContext, contractId string, billedType entity.BilledType, price float64, quantity int64, startedAt, endedAt *time.Time) {
-	neo4jt.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, entity.ServiceLineItemEntity{
-		IsCanceled: true,
-		Billed:     billedType,
-		Price:      price,
-		Quantity:   quantity,
-		StartedAt:  *startedAt,
-		EndedAt:    endedAt,
-	})
 }

--- a/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_retention_rate_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_retention_rate_it_test.go
@@ -1,0 +1,280 @@
+package resolver
+
+import (
+	"context"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/graph/model"
+	neo4jt "github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/test/neo4j"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/utils/decode"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+//func TestQueryResolver_Dashboard_Retention_Rate_No_Period_No_Data_In_DB(t *testing.T) {
+//	ctx := context.Background()
+//	defer tearDownTestCase(ctx)(t)
+//	neo4jt.CreateTenant(ctx, driver, tenantName)
+//
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
+//
+//	rawResponse := callGraphQL(t, "dashboard_view/dashboard_retention_rate_no_period",
+//		map[string]interface{}{})
+//
+//	var dashboardReport struct {
+//		Dashboard_RetentionRate model.DashboardRetentionRate
+//	}
+//
+//	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+//	require.Nil(t, err)
+//
+//	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.RetentionRate)
+//	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.IncreasePercentage)
+//	require.Equal(t, 12, len(dashboardReport.Dashboard_RetentionRate.PerMonth))
+//
+//	for _, month := range dashboardReport.Dashboard_RetentionRate.PerMonth {
+//		require.Equal(t, float64(0), month.RenewCount)
+//		require.Equal(t, float64(0), month.ChurnCount)
+//	}
+//}
+
+func TestQueryResolver_Dashboard_Retention_Rate_InvalidPeriod(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+	neo4jt.CreateTenant(ctx, driver, tenantName)
+
+	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
+
+	response := callGraphQLExpectError(t, "dashboard_view/dashboard_retention_rate",
+		map[string]interface{}{
+			"start": "2020-02-01T00:00:00.000Z",
+			"end":   "2020-01-01T00:00:00.000Z",
+		})
+
+	require.Contains(t, "Failed to get the data for period", response.Message)
+}
+
+//func TestQueryResolver_Dashboard_Retention_Rate_PeriodIntervals(t *testing.T) {
+//	ctx := context.Background()
+//	defer tearDownTestCase(ctx)(t)
+//	neo4jt.CreateTenant(ctx, driver, tenantName)
+//
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
+//
+//	assert_Dashboard_Retention_Rate_PeriodIntervals(t, "2020-01-01T00:00:00.000Z", "2020-01-31T00:00:00.000Z", 1)
+//	assert_Dashboard_Retention_Rate_PeriodIntervals(t, "2020-01-01T00:00:00.000Z", "2020-01-01T00:00:00.000Z", 1)
+//	assert_Dashboard_Retention_Rate_PeriodIntervals(t, "2020-01-01T00:00:00.000Z", "2020-02-01T00:00:00.000Z", 2)
+//	assert_Dashboard_Retention_Rate_PeriodIntervals(t, "2020-01-01T00:00:00.000Z", "2020-02-28T00:00:00.000Z", 2)
+//	assert_Dashboard_Retention_Rate_PeriodIntervals(t, "2020-01-01T00:00:00.000Z", "2029-12-01T00:00:00.000Z", 120)
+//}
+
+func assert_Dashboard_Retention_Rate_PeriodIntervals(t *testing.T, start, end string, months int) {
+	rawResponse := callGraphQL(t, "dashboard_view/dashboard_retention_rate",
+		map[string]interface{}{
+			"start": start,
+			"end":   end,
+		})
+
+	var dashboardReport struct {
+		Dashboard_RetentionRate model.DashboardRetentionRate
+	}
+
+	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+	require.Nil(t, err)
+
+	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.RetentionRate)
+	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.IncreasePercentage)
+	require.Equal(t, months, len(dashboardReport.Dashboard_RetentionRate.PerMonth))
+}
+
+//
+//func TestQueryResolver_Dashboard_Retention_Rate_Hidden_Organization(t *testing.T) {
+//	ctx := context.Background()
+//	defer tearDownTestCase(ctx)(t)
+//	neo4jt.CreateTenant(ctx, driver, tenantName)
+//	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+//
+//	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+//		Hide: true,
+//	})
+//
+//	sli1StartedAt := neo4jt.FirstTimeOfMonth(2024, 7)
+//	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
+//	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+//
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Contract": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Opportunity": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"ServiceLineItem": 1})
+//
+//	rawResponse := callGraphQL(t, "dashboard_view/dashboard_retention_rate",
+//		map[string]interface{}{
+//			"start": "2023-07-01T00:00:00.000Z",
+//			"end":   "2023-07-01T00:00:00.000Z",
+//		})
+//
+//	var dashboardReport struct {
+//		Dashboard_RetentionRate model.DashboardRetentionRate
+//	}
+//
+//	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+//	require.Nil(t, err)
+//
+//	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.RetentionRate)
+//	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.IncreasePercentage)
+//	require.Equal(t, 1, len(dashboardReport.Dashboard_RetentionRate.PerMonth))
+//
+//	for _, month := range dashboardReport.Dashboard_RetentionRate.PerMonth {
+//		require.Equal(t, 2023, month.Year)
+//		require.Equal(t, 7, month.Month)
+//		require.Equal(t, float64(0), month.RenewCount)
+//		require.Equal(t, float64(0), month.ChurnCount)
+//	}
+//}
+//
+//func TestQueryResolver_Dashboard_Retention_Rate_Prospect_Organization(t *testing.T) {
+//	ctx := context.Background()
+//	defer tearDownTestCase(ctx)(t)
+//	neo4jt.CreateTenant(ctx, driver, tenantName)
+//	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+//
+//	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+//		IsCustomer: false,
+//	})
+//
+//	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
+//	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
+//	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+//
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Contract": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Opportunity": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"ServiceLineItem": 1})
+//
+//	rawResponse := callGraphQL(t, "dashboard_view/dashboard_retention_rate",
+//		map[string]interface{}{
+//			"start": "2023-07-01T00:00:00.000Z",
+//			"end":   "2023-07-01T00:00:00.000Z",
+//		})
+//
+//	var dashboardReport struct {
+//		Dashboard_RetentionRate model.DashboardRetentionRate
+//	}
+//
+//	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+//	require.Nil(t, err)
+//
+//	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.RetentionRate)
+//	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.IncreasePercentage)
+//	require.Equal(t, 1, len(dashboardReport.Dashboard_RetentionRate.PerMonth))
+//
+//	for _, month := range dashboardReport.Dashboard_RetentionRate.PerMonth {
+//		require.Equal(t, 2023, month.Year)
+//		require.Equal(t, 7, month.Month)
+//		require.Equal(t, float64(0), month.RenewCount)
+//		require.Equal(t, float64(0), month.ChurnCount)
+//	}
+//}
+//
+//func TestQueryResolver_Dashboard_Retention_Rate_Not_A_Customer(t *testing.T) {
+//	ctx := context.Background()
+//	defer tearDownTestCase(ctx)(t)
+//	neo4jt.CreateTenant(ctx, driver, tenantName)
+//	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+//
+//	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+//		IsCustomer: true,
+//		Hide:       true,
+//	})
+//
+//	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
+//	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
+//	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+//
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Contract": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Opportunity": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"ServiceLineItem": 1})
+//
+//	rawResponse := callGraphQL(t, "dashboard_view/dashboard_retention_rate",
+//		map[string]interface{}{
+//			"start": "2023-07-01T00:00:00.000Z",
+//			"end":   "2023-07-01T00:00:00.000Z",
+//		})
+//
+//	var dashboardReport struct {
+//		Dashboard_RetentionRate model.DashboardRetentionRate
+//	}
+//
+//	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+//	require.Nil(t, err)
+//
+//	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.RetentionRate)
+//	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.IncreasePercentage)
+//	require.Equal(t, 1, len(dashboardReport.Dashboard_RetentionRate.PerMonth))
+//
+//	for _, month := range dashboardReport.Dashboard_RetentionRate.PerMonth {
+//		require.Equal(t, 2023, month.Year)
+//		require.Equal(t, 7, month.Month)
+//		require.Equal(t, float64(0), month.RenewCount)
+//		require.Equal(t, float64(0), month.ChurnCount)
+//	}
+//}
+//
+//func TestQueryResolver_Dashboard_Retention_Renewals_1_Contract_1_SLI_V1(t *testing.T) {
+//	ctx := context.Background()
+//	defer tearDownTestCase(ctx)(t)
+//	neo4jt.CreateTenant(ctx, driver, tenantName)
+//	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
+//
+//	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+//		IsCustomer: true,
+//		Hide:       true,
+//	})
+//
+//	sli1StartedAt := neo4jt.FirstTimeOfMonth(2023, 7)
+//	contractId := insertMRRPerCustomerContractWithOpportunity(ctx, driver, orgId)
+//	insertMRRPerCustomerServiceLineItem(ctx, driver, contractId, entity.BilledTypeAnnually, 12, 2, sli1StartedAt)
+//
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Contract": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Opportunity": 1})
+//	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"ServiceLineItem": 1})
+//
+//	rawResponse := callGraphQL(t, "dashboard_view/dashboard_retention_rate",
+//		map[string]interface{}{
+//			"start": "2023-07-01T00:00:00.000Z",
+//			"end":   "2023-07-01T00:00:00.000Z",
+//		})
+//
+//	var dashboardReport struct {
+//		Dashboard_RetentionRate model.DashboardRetentionRate
+//	}
+//
+//	err := decode.Decode(rawResponse.Data.(map[string]any), &dashboardReport)
+//	require.Nil(t, err)
+//
+//	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.RetentionRate)
+//	require.Equal(t, float64(0), dashboardReport.Dashboard_RetentionRate.IncreasePercentage)
+//	require.Equal(t, 1, len(dashboardReport.Dashboard_RetentionRate.PerMonth))
+//
+//	assertRetentionRateMonthData(t, &dashboardReport.Dashboard_RetentionRate, 2023, 7, 2, 0)
+//}
+
+func assertRetentionRateMonthData(t *testing.T, dashboardReport *model.DashboardRetentionRate, year, month int, renewExpected, churnExpected int64) {
+	// Find the index corresponding to the given year and month in the PerMonth slice
+	var index int
+	for i, data := range dashboardReport.PerMonth {
+		if data.Year == year && data.Month == month {
+			index = i
+			break
+		}
+	}
+
+	require.Equal(t, year, dashboardReport.PerMonth[index].Year)
+	require.Equal(t, month, dashboardReport.PerMonth[index].Month)
+	require.Equal(t, renewExpected, dashboardReport.PerMonth[index].RenewCount)
+	require.Equal(t, churnExpected, dashboardReport.PerMonth[index].ChurnCount)
+}

--- a/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_revenue_at_risk_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_revenue_at_risk_it_test.go
@@ -202,7 +202,17 @@ func TestQueryResolver_Dashboard_Revenue_At_Risk_One_Organization_With_1_Live_Re
 	neo4jt.CreateTenant(ctx, driver, tenantName)
 	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
 
-	insert1OrganizationWith1ContractWithOpportunity(ctx, driver, entity.OpportunityRenewalLikelihoodHigh)
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{})
+
+	contract1ServiceStartedAt := neo4jt.FirstTimeOfMonth(2023, 8)
+	insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
+		ServiceStartedAt: &contract1ServiceStartedAt,
+		ContractStatus:   entity.ContractStatusLive,
+	}, entity.OpportunityEntity{
+		MaxAmount:         10,
+		InternalType:      entity.InternalTypeRenewal,
+		RenewalLikelihood: entity.OpportunityRenewalLikelihoodHigh,
+	})
 
 	assertFor1Organization(ctx, t, driver, float64(10), float64(0))
 }
@@ -213,7 +223,19 @@ func TestQueryResolver_Dashboard_Revenue_At_Risk_One_Organization_With_1_Live_Re
 	neo4jt.CreateTenant(ctx, driver, tenantName)
 	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
 
-	insert1OrganizationWith1ContractWithOpportunity(ctx, driver, entity.OpportunityRenewalLikelihoodMedium)
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	contract1ServiceStartedAt := neo4jt.FirstTimeOfMonth(2023, 8)
+	insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
+		ServiceStartedAt: &contract1ServiceStartedAt,
+		ContractStatus:   entity.ContractStatusLive,
+	}, entity.OpportunityEntity{
+		MaxAmount:         10,
+		InternalType:      entity.InternalTypeRenewal,
+		RenewalLikelihood: entity.OpportunityRenewalLikelihoodMedium,
+	})
 
 	assertFor1Organization(ctx, t, driver, float64(0), float64(10))
 }
@@ -224,7 +246,19 @@ func TestQueryResolver_Dashboard_Revenue_At_Risk_One_Organization_With_1_Live_Re
 	neo4jt.CreateTenant(ctx, driver, tenantName)
 	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
 
-	insert1OrganizationWith1ContractWithOpportunity(ctx, driver, entity.OpportunityRenewalLikelihoodLow)
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	contract1ServiceStartedAt := neo4jt.FirstTimeOfMonth(2023, 8)
+	insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
+		ServiceStartedAt: &contract1ServiceStartedAt,
+		ContractStatus:   entity.ContractStatusLive,
+	}, entity.OpportunityEntity{
+		MaxAmount:         10,
+		InternalType:      entity.InternalTypeRenewal,
+		RenewalLikelihood: entity.OpportunityRenewalLikelihoodLow,
+	})
 
 	assertFor1Organization(ctx, t, driver, float64(0), float64(10))
 }
@@ -235,7 +269,19 @@ func TestQueryResolver_Dashboard_Revenue_At_Risk_One_Organization_With_1_Live_Co
 	neo4jt.CreateTenant(ctx, driver, tenantName)
 	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
 
-	insert1OrganizationWith1ContractWithOpportunity(ctx, driver, entity.OpportunityRenewalLikelihoodZero)
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	contract1ServiceStartedAt := neo4jt.FirstTimeOfMonth(2023, 8)
+	insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
+		ServiceStartedAt: &contract1ServiceStartedAt,
+		ContractStatus:   entity.ContractStatusLive,
+	}, entity.OpportunityEntity{
+		MaxAmount:         10,
+		InternalType:      entity.InternalTypeRenewal,
+		RenewalLikelihood: entity.OpportunityRenewalLikelihoodZero,
+	})
 
 	assertFor1Organization(ctx, t, driver, float64(0), float64(10))
 }
@@ -246,10 +292,28 @@ func TestQueryResolver_Dashboard_Revenue_At_Risk_One_Organization_With_1_High_1_
 	neo4jt.CreateTenant(ctx, driver, tenantName)
 	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
 
-	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{})
+	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
 
-	insertContractWithOpportunity(ctx, driver, orgId, entity.OpportunityRenewalLikelihoodHigh)
-	insertContractWithOpportunity(ctx, driver, orgId, entity.OpportunityRenewalLikelihoodMedium)
+	contractServiceStartedAt := neo4jt.FirstTimeOfMonth(2023, 8)
+	insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
+		ServiceStartedAt: &contractServiceStartedAt,
+		ContractStatus:   entity.ContractStatusLive,
+	}, entity.OpportunityEntity{
+		MaxAmount:         10,
+		InternalType:      entity.InternalTypeRenewal,
+		RenewalLikelihood: entity.OpportunityRenewalLikelihoodHigh,
+	})
+
+	insertContractWithOpportunity(ctx, driver, orgId, entity.ContractEntity{
+		ServiceStartedAt: &contractServiceStartedAt,
+		ContractStatus:   entity.ContractStatusLive,
+	}, entity.OpportunityEntity{
+		MaxAmount:         10,
+		InternalType:      entity.InternalTypeRenewal,
+		RenewalLikelihood: entity.OpportunityRenewalLikelihoodMedium,
+	})
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 1})
@@ -279,8 +343,32 @@ func TestQueryResolver_Dashboard_Revenue_At_Risk_2_Organizations_With_1_High_1_A
 	neo4jt.CreateTenant(ctx, driver, tenantName)
 	neo4jt.CreateDefaultUserWithId(ctx, driver, tenantName, testUserId)
 
-	insert1OrganizationWith1ContractWithOpportunity(ctx, driver, entity.OpportunityRenewalLikelihoodHigh)
-	insert1OrganizationWith1ContractWithOpportunity(ctx, driver, entity.OpportunityRenewalLikelihoodMedium)
+	org1Id := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	contractServiceStartedAt := neo4jt.FirstTimeOfMonth(2023, 8)
+	insertContractWithOpportunity(ctx, driver, org1Id, entity.ContractEntity{
+		ServiceStartedAt: &contractServiceStartedAt,
+		ContractStatus:   entity.ContractStatusLive,
+	}, entity.OpportunityEntity{
+		MaxAmount:         10,
+		InternalType:      entity.InternalTypeRenewal,
+		RenewalLikelihood: entity.OpportunityRenewalLikelihoodHigh,
+	})
+
+	org2Id := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{
+		IsCustomer: true,
+	})
+
+	insertContractWithOpportunity(ctx, driver, org2Id, entity.ContractEntity{
+		ServiceStartedAt: &contractServiceStartedAt,
+		ContractStatus:   entity.ContractStatusLive,
+	}, entity.OpportunityEntity{
+		MaxAmount:         10,
+		InternalType:      entity.InternalTypeRenewal,
+		RenewalLikelihood: entity.OpportunityRenewalLikelihoodMedium,
+	})
 
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Tenant": 1})
 	assertNeo4jNodeCount(ctx, t, driver, map[string]int{"Organization": 2})
@@ -302,29 +390,6 @@ func TestQueryResolver_Dashboard_Revenue_At_Risk_2_Organizations_With_1_High_1_A
 
 	require.Equal(t, float64(10), dashboardReport.Dashboard_RevenueAtRisk.HighConfidence)
 	require.Equal(t, float64(10), dashboardReport.Dashboard_RevenueAtRisk.AtRisk)
-}
-
-func insert1OrganizationWith1ContractWithOpportunity(ctx context.Context, driver *neo4j.DriverWithContext, renewalLikelihood entity.OpportunityRenewalLikelihood) {
-	orgId := neo4jt.CreateOrg(ctx, driver, tenantName, entity.OrganizationEntity{})
-
-	insertContractWithOpportunity(ctx, driver, orgId, renewalLikelihood)
-}
-
-func insertContractWithOpportunity(ctx context.Context, driver *neo4j.DriverWithContext, orgId string, renewalLikelihood entity.OpportunityRenewalLikelihood) {
-	contract1ServiceStartedAt := time.Date(2023, 8, 1, 0, 0, 0, 0, time.UTC)
-	contractId := neo4jt.CreateContractForOrganization(ctx, driver, tenantName, orgId, entity.ContractEntity{
-		ServiceStartedAt: &contract1ServiceStartedAt,
-		ContractStatus:   entity.ContractStatusLive,
-	})
-	opportunityId := neo4jt.CreateOpportunityForContract(ctx, driver, tenantName, contractId, entity.OpportunityEntity{
-		Name:              "opportunity 1",
-		CreatedAt:         contract1ServiceStartedAt,
-		UpdatedAt:         contract1ServiceStartedAt,
-		MaxAmount:         10,
-		InternalType:      entity.InternalTypeRenewal,
-		RenewalLikelihood: renewalLikelihood,
-	})
-	neo4jt.ActiveRenewalOpportunityForContract(ctx, driver, tenantName, contractId, opportunityId)
 }
 
 func assertFor1Organization(ctx context.Context, t *testing.T, driver *neo4j.DriverWithContext, expectedHighConfidence float64, expectedAtRisk float64) {

--- a/packages/server/customer-os-api/graph/resolver/test_queries/dashboard_view/dashboard_retention_rate.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/dashboard_view/dashboard_retention_rate.txt
@@ -1,0 +1,14 @@
+query GetDashboard_RetentionRate ($start: Time!, $end: Time!) {
+  dashboard_RetentionRate(
+       period: {start: $start, end: $end}
+     ) {
+    retentionRate
+    increasePercentage
+    perMonth {
+      year
+      month
+      renewCount
+      churnCount
+    }
+  }
+}

--- a/packages/server/customer-os-api/graph/resolver/test_queries/dashboard_view/dashboard_retention_rate_no_period.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/dashboard_view/dashboard_retention_rate_no_period.txt
@@ -1,0 +1,12 @@
+query GetDashboard_RetentionRate {
+  dashboard_RetentionRate {
+    retentionRate
+    increasePercentage
+    perMonth {
+      year
+      month
+      renewCount
+      churnCount
+    }
+  }
+}

--- a/packages/server/customer-os-api/graph/schemas/dashboard.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/dashboard.graphqls
@@ -74,6 +74,7 @@ type DashboardRetentionRate {
     perMonth: [DashboardRetentionRatePerMonth]!
 }
 type DashboardRetentionRatePerMonth {
+    year: Int!
     month: Int!
     renewCount: Int!
     churnCount: Int!

--- a/packages/server/customer-os-api/mapper/dashboard_mapper.go
+++ b/packages/server/customer-os-api/mapper/dashboard_mapper.go
@@ -41,6 +41,7 @@ func MapDashboardRetentionRatePerMonthData(months []*entityDashboard.DashboardRe
 	var result []*model.DashboardRetentionRatePerMonth
 	for _, month := range months {
 		result = append(result, &model.DashboardRetentionRatePerMonth{
+			Year:       month.Year,
 			Month:      month.Month,
 			RenewCount: month.RenewCount,
 			ChurnCount: month.ChurnCount,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new 'Year' field to the dashboard, enhancing the Retention Rate data with annual insights.

- **Enhancements**
  - Improved dashboard GraphQL queries to support retrieval of year-specific retention rate data.

- **Refactor**
  - Streamlined test setup for revenue at risk calculations, ensuring more robust data handling.
  - Generalized functions for inserting contract-related test data to improve reusability.

- **Tests**
  - Added and refined integration tests for dashboard resolvers to validate the retention rate calculations.

- **Documentation**
  - Updated GraphQL schema documentation to reflect new 'year' field in retention rate data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->