### PR TITLE
[Notifications] - include email template in docker container

### DIFF
--- a/packages/server/events-processing-platform/Dockerfile
+++ b/packages/server/events-processing-platform/Dockerfile
@@ -49,6 +49,7 @@ FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5
 
 COPY --chown=65534:65534 --from=builder /go/bin/app .
 COPY --chown=65534:65534 --from=builder /workspace/build/events-processing-platform/.env .env
+COPY --chown=65534:65534 --from=builder /workspace/build/events-processing-platform/subscriptions/notifications/email_templates/ownership.single.mjml ./email_templates/ownership.single.mjml
 USER 65534
 
 ENTRYPOINT [ "./app" ]

--- a/packages/server/events-processing-platform/config/config.go
+++ b/packages/server/events-processing-platform/config/config.go
@@ -102,13 +102,14 @@ type ContractSubscription struct {
 }
 
 type NotificationsSubscription struct {
-	Enabled          bool   `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_ENABLED" envDefault:"true"`
-	GroupName        string `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_GROUP_NAME" envDefault:"notifications-v2" validate:"required"`
-	PoolSize         int    `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_POOL_SIZE" envDefault:"4" validate:"required,gte=0"`
-	BufferSizeClient uint32 `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_CLIENT_BUFFER_SIZE" envDefault:"10" validate:"required,gte=0"`
-	StartPosition    uint64 `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_START_POSITION" envDefault:"0"`
-	IgnoreEvents     bool   `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_IGNORE_EVENTS" envDefault:"true"`
-	RedirectUrl      string `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_REDIRECT_URL" envDefault:"https://app.openline.dev"`
+	Enabled           bool   `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_ENABLED" envDefault:"true"`
+	GroupName         string `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_GROUP_NAME" envDefault:"notifications-v2" validate:"required"`
+	PoolSize          int    `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_POOL_SIZE" envDefault:"4" validate:"required,gte=0"`
+	BufferSizeClient  uint32 `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_CLIENT_BUFFER_SIZE" envDefault:"10" validate:"required,gte=0"`
+	StartPosition     uint64 `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_START_POSITION" envDefault:"0"`
+	IgnoreEvents      bool   `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_IGNORE_EVENTS" envDefault:"true"`
+	RedirectUrl       string `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_REDIRECT_URL" envDefault:"https://app.openline.dev"`
+	EmailTemplatePath string `env:"EVENT_STORE_SUBSCRIPTIONS_NOTIFICATIONS_EMAIL_TEMPLATE_PATH" envDefault:"./email_templates"`
 }
 
 type Services struct {

--- a/packages/server/events-processing-platform/subscriptions/notifications/organization_event_handler.go
+++ b/packages/server/events-processing-platform/subscriptions/notifications/organization_event_handler.go
@@ -232,7 +232,14 @@ func (h *OrganizationEventHandler) notificationProviderSendInAppNotification(ctx
 }
 
 func (h *OrganizationEventHandler) parseOrgOwnerUpdateEmail(actor, target *entity.UserEntity, orgId, orgName string) (string, error) {
-	rawMjml, _ := os.ReadFile("./email_templates/ownership.single.mjml")
+	if _, err := os.Stat(h.cfg.Subscriptions.NotificationsSubscription.EmailTemplatePath); os.IsNotExist(err) {
+		return "", fmt.Errorf("(OrganizationEventHandler.parseOrgOwnerUpdateEmail) error: %s", err.Error())
+	}
+	emailPath := fmt.Sprintf("%s/ownership.single.mjml", h.cfg.Subscriptions.NotificationsSubscription.EmailTemplatePath)
+	if _, err := os.Stat(emailPath); err != nil {
+		return "", fmt.Errorf("(OrganizationEventHandler.parseOrgOwnerUpdateEmail) error: %s", err.Error())
+	}
+	rawMjml, _ := os.ReadFile(emailPath)
 	mjmlf := strings.Replace(string(rawMjml[:]), "{{userFirstName}}", target.FirstName, -1)
 	mjmlf = strings.Replace(mjmlf, "{{actorFirstName}}", actor.FirstName, -1)
 	mjmlf = strings.Replace(mjmlf, "{{actorLastName}}", actor.LastName, -1)

--- a/packages/server/events-processing-platform/subscriptions/notifications/organization_event_handler_test.go
+++ b/packages/server/events-processing-platform/subscriptions/notifications/organization_event_handler_test.go
@@ -69,7 +69,7 @@ func TestGraphOrganizationEventHandler_OnOrganizationUpdateOwner(t *testing.T) {
 		cfg: &config.Config{Services: config.Services{MJML: struct {
 			ApplicationId string "env:\"MJML_APPLICATION_ID,required\" envDefault:\"\""
 			SecretKey     string "env:\"MJML_SECRET_KEY,required\" envDefault:\"\""
-		}{ApplicationId: "", SecretKey: ""}}, Subscriptions: config.Subscriptions{NotificationsSubscription: config.NotificationsSubscription{RedirectUrl: "https://app.openline.dev"}}},
+		}{ApplicationId: "", SecretKey: ""}}, Subscriptions: config.Subscriptions{NotificationsSubscription: config.NotificationsSubscription{RedirectUrl: "https://app.openline.dev", EmailTemplatePath: "./email_templates"}}},
 	}
 
 	require.Equal(t, "", orgEventHandler.cfg.Services.MJML.ApplicationId)


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the Docker image build process to include a new email template file for enhanced event ownership communication.
- **Documentation**
	- Extended the `NotificationsSubscription` struct in `config.go` to include the `EmailTemplatePath` field.
- **Bug Fixes**
	- Enhanced handling of missing email templates in the `parseOrgOwnerUpdateEmail` function within the `OrganizationEventHandler`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->