### PR TITLE
[COS-1731] - add query for org plans for org and pass org id on create

### DIFF
--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -1180,7 +1180,7 @@ type ComplexityRoot struct {
 		OrganizationDistinctOwners            func(childComplexity int) int
 		OrganizationPlan                      func(childComplexity int, id string) int
 		OrganizationPlans                     func(childComplexity int, retired *bool) int
-		OrganizationPlansForOrg               func(childComplexity int, organizationID string) int
+		OrganizationPlansForOrganization      func(childComplexity int, organizationID string) int
 		Organizations                         func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) int
 		PhoneNumber                           func(childComplexity int, id string) int
 		PlayerByAuthIDProvider                func(childComplexity int, authID string, provider string) int
@@ -1746,7 +1746,7 @@ type QueryResolver interface {
 	Organization(ctx context.Context, id string) (*model.Organization, error)
 	OrganizationDistinctOwners(ctx context.Context) ([]*model.User, error)
 	OrganizationPlan(ctx context.Context, id string) (*model.OrganizationPlan, error)
-	OrganizationPlansForOrg(ctx context.Context, organizationID string) ([]*model.OrganizationPlan, error)
+	OrganizationPlansForOrganization(ctx context.Context, organizationID string) ([]*model.OrganizationPlan, error)
 	OrganizationPlans(ctx context.Context, retired *bool) ([]*model.OrganizationPlan, error)
 	PhoneNumber(ctx context.Context, id string) (*model.PhoneNumber, error)
 	PlayerByAuthIDProvider(ctx context.Context, authID string, provider string) (*model.Player, error)
@@ -8791,17 +8791,17 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.OrganizationPlans(childComplexity, args["retired"].(*bool)), true
 
-	case "Query.organizationPlansForOrg":
-		if e.complexity.Query.OrganizationPlansForOrg == nil {
+	case "Query.organizationPlansForOrganization":
+		if e.complexity.Query.OrganizationPlansForOrganization == nil {
 			break
 		}
 
-		args, err := ec.field_Query_organizationPlansForOrg_args(context.TODO(), rawArgs)
+		args, err := ec.field_Query_organizationPlansForOrganization_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
-		return e.complexity.Query.OrganizationPlansForOrg(childComplexity, args["organizationId"].(string)), true
+		return e.complexity.Query.OrganizationPlansForOrganization(childComplexity, args["organizationId"].(string)), true
 
 	case "Query.organizations":
 		if e.complexity.Query.Organizations == nil {
@@ -12367,7 +12367,7 @@ enum LastTouchpointType {
 
 extend type Query {
     organizationPlan(id: ID!): OrganizationPlan! @hasRole(roles: [ADMIN, USER]) @hasTenant
-    organizationPlansForOrg(organizationId: ID!): [OrganizationPlan!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
+    organizationPlansForOrganization(organizationId: ID!): [OrganizationPlan!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
     organizationPlans(retired: Boolean): [OrganizationPlan!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
 }
 
@@ -17112,7 +17112,7 @@ func (ec *executionContext) field_Query_organizationPlan_args(ctx context.Contex
 	return args, nil
 }
 
-func (ec *executionContext) field_Query_organizationPlansForOrg_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Query_organizationPlansForOrganization_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 string
@@ -68945,8 +68945,8 @@ func (ec *executionContext) fieldContext_Query_organizationPlan(ctx context.Cont
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_organizationPlansForOrg(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_organizationPlansForOrg(ctx, field)
+func (ec *executionContext) _Query_organizationPlansForOrganization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_organizationPlansForOrganization(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -68960,7 +68960,7 @@ func (ec *executionContext) _Query_organizationPlansForOrg(ctx context.Context, 
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Query().OrganizationPlansForOrg(rctx, fc.Args["organizationId"].(string))
+			return ec.resolvers.Query().OrganizationPlansForOrganization(rctx, fc.Args["organizationId"].(string))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			roles, err := ec.unmarshalNRole2ᚕgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐRoleᚄ(ctx, []interface{}{"ADMIN", "USER"})
@@ -69006,7 +69006,7 @@ func (ec *executionContext) _Query_organizationPlansForOrg(ctx context.Context, 
 	return ec.marshalNOrganizationPlan2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_organizationPlansForOrg(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_organizationPlansForOrganization(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -69047,7 +69047,7 @@ func (ec *executionContext) fieldContext_Query_organizationPlansForOrg(ctx conte
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_organizationPlansForOrg_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Query_organizationPlansForOrganization_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -95118,7 +95118,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "organizationPlansForOrg":
+		case "organizationPlansForOrganization":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -95127,7 +95127,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_organizationPlansForOrg(ctx, field)
+				res = ec._Query_organizationPlansForOrganization(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -1180,6 +1180,7 @@ type ComplexityRoot struct {
 		OrganizationDistinctOwners            func(childComplexity int) int
 		OrganizationPlan                      func(childComplexity int, id string) int
 		OrganizationPlans                     func(childComplexity int, retired *bool) int
+		OrganizationPlansForOrg               func(childComplexity int, organizationID string) int
 		Organizations                         func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) int
 		PhoneNumber                           func(childComplexity int, id string) int
 		PlayerByAuthIDProvider                func(childComplexity int, authID string, provider string) int
@@ -1745,6 +1746,7 @@ type QueryResolver interface {
 	Organization(ctx context.Context, id string) (*model.Organization, error)
 	OrganizationDistinctOwners(ctx context.Context) ([]*model.User, error)
 	OrganizationPlan(ctx context.Context, id string) (*model.OrganizationPlan, error)
+	OrganizationPlansForOrg(ctx context.Context, organizationID string) ([]*model.OrganizationPlan, error)
 	OrganizationPlans(ctx context.Context, retired *bool) ([]*model.OrganizationPlan, error)
 	PhoneNumber(ctx context.Context, id string) (*model.PhoneNumber, error)
 	PlayerByAuthIDProvider(ctx context.Context, authID string, provider string) (*model.Player, error)
@@ -8789,6 +8791,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.OrganizationPlans(childComplexity, args["retired"].(*bool)), true
 
+	case "Query.organizationPlansForOrg":
+		if e.complexity.Query.OrganizationPlansForOrg == nil {
+			break
+		}
+
+		args, err := ec.field_Query_organizationPlansForOrg_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.OrganizationPlansForOrg(childComplexity, args["organizationId"].(string)), true
+
 	case "Query.organizations":
 		if e.complexity.Query.Organizations == nil {
 			break
@@ -12353,6 +12367,7 @@ enum LastTouchpointType {
 
 extend type Query {
     organizationPlan(id: ID!): OrganizationPlan! @hasRole(roles: [ADMIN, USER]) @hasTenant
+    organizationPlansForOrg(organizationId: ID!): [OrganizationPlan!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
     organizationPlans(retired: Boolean): [OrganizationPlan!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
 }
 
@@ -12407,6 +12422,7 @@ input StatusDetailsInput {
 input OrganizationPlanInput {
     name: String
     masterPlanId: String
+    organizationId: ID!
 }
 
 input OrganizationPlanUpdateInput {
@@ -17093,6 +17109,21 @@ func (ec *executionContext) field_Query_organizationPlan_args(ctx context.Contex
 		}
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_organizationPlansForOrg_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["organizationId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("organizationId"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["organizationId"] = arg0
 	return args, nil
 }
 
@@ -68914,6 +68945,115 @@ func (ec *executionContext) fieldContext_Query_organizationPlan(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_organizationPlansForOrg(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_organizationPlansForOrg(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Query().OrganizationPlansForOrg(rctx, fc.Args["organizationId"].(string))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			roles, err := ec.unmarshalNRole2ᚕgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐRoleᚄ(ctx, []interface{}{"ADMIN", "USER"})
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.HasRole == nil {
+				return nil, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, roles)
+		}
+		directive2 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.HasTenant == nil {
+				return nil, errors.New("directive hasTenant is not implemented")
+			}
+			return ec.directives.HasTenant(ctx, nil, directive1)
+		}
+
+		tmp, err := directive2(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.([]*model.OrganizationPlan); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be []*github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/graph/model.OrganizationPlan`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.OrganizationPlan)
+	fc.Result = res
+	return ec.marshalNOrganizationPlan2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_organizationPlansForOrg(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_OrganizationPlan_id(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_OrganizationPlan_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_OrganizationPlan_updatedAt(ctx, field)
+			case "name":
+				return ec.fieldContext_OrganizationPlan_name(ctx, field)
+			case "source":
+				return ec.fieldContext_OrganizationPlan_source(ctx, field)
+			case "sourceOfTruth":
+				return ec.fieldContext_OrganizationPlan_sourceOfTruth(ctx, field)
+			case "appSource":
+				return ec.fieldContext_OrganizationPlan_appSource(ctx, field)
+			case "retired":
+				return ec.fieldContext_OrganizationPlan_retired(ctx, field)
+			case "milestones":
+				return ec.fieldContext_OrganizationPlan_milestones(ctx, field)
+			case "retiredMilestones":
+				return ec.fieldContext_OrganizationPlan_retiredMilestones(ctx, field)
+			case "statusDetails":
+				return ec.fieldContext_OrganizationPlan_statusDetails(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OrganizationPlan", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_organizationPlansForOrg_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_organizationPlans(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_organizationPlans(ctx, field)
 	if err != nil {
@@ -82025,7 +82165,7 @@ func (ec *executionContext) unmarshalInputOrganizationPlanInput(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "masterPlanId"}
+	fieldsInOrder := [...]string{"name", "masterPlanId", "organizationId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -82046,6 +82186,13 @@ func (ec *executionContext) unmarshalInputOrganizationPlanInput(ctx context.Cont
 				return it, err
 			}
 			it.MasterPlanID = data
+		case "organizationId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("organizationId"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrganizationID = data
 		}
 	}
 
@@ -94959,6 +95106,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_organizationPlan(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "organizationPlansForOrg":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_organizationPlansForOrg(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -1760,8 +1760,9 @@ func (this OrganizationPlan) GetAppSource() string         { return this.AppSour
 func (OrganizationPlan) IsNode() {}
 
 type OrganizationPlanInput struct {
-	Name         *string `json:"name,omitempty"`
-	MasterPlanID *string `json:"masterPlanId,omitempty"`
+	Name           *string `json:"name,omitempty"`
+	MasterPlanID   *string `json:"masterPlanId,omitempty"`
+	OrganizationID string  `json:"organizationId"`
 }
 
 type OrganizationPlanMilestone struct {

--- a/packages/server/customer-os-api/graph/resolver/organization_plan.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organization_plan.resolvers.go
@@ -301,9 +301,9 @@ func (r *queryResolver) OrganizationPlan(ctx context.Context, id string) (*model
 	return mapper.MapEntityToOrganizationPlan(orgPlanEntity), nil
 }
 
-// OrganizationPlansForOrg is the resolver for the organizationPlansForOrg field.
-func (r *queryResolver) OrganizationPlansForOrg(ctx context.Context, organizationID string) ([]*model.OrganizationPlan, error) {
-	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.OrganizationPlansForOrg", graphql.GetOperationContext(ctx))
+// OrganizationPlansForOrganization is the resolver for the organizationPlansForOrganization field.
+func (r *queryResolver) OrganizationPlansForOrganization(ctx context.Context, organizationID string) ([]*model.OrganizationPlan, error) {
+	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.OrganizationPlansForOrganization", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)
 	span.SetTag(tracing.SpanTagEntityId, organizationID)

--- a/packages/server/customer-os-api/graph/resolver/organization_plan.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organization_plan.resolvers.go
@@ -27,7 +27,7 @@ func (r *mutationResolver) OrganizationPlanCreate(ctx context.Context, input mod
 	tracing.SetDefaultResolverSpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", input)
 	// Create empty organization plan
-	orgPlanId, err := r.Services.OrganizationPlanService.CreateOrganizationPlan(ctx, utils.IfNotNilString(input.Name), *input.MasterPlanID)
+	orgPlanId, err := r.Services.OrganizationPlanService.CreateOrganizationPlan(ctx, utils.IfNotNilString(input.Name), *input.MasterPlanID, input.OrganizationID)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		graphql.AddErrorf(ctx, "Failed to create organization plan")
@@ -301,6 +301,22 @@ func (r *queryResolver) OrganizationPlan(ctx context.Context, id string) (*model
 	return mapper.MapEntityToOrganizationPlan(orgPlanEntity), nil
 }
 
+// OrganizationPlansForOrg is the resolver for the organizationPlansForOrg field.
+func (r *queryResolver) OrganizationPlansForOrg(ctx context.Context, organizationID string) ([]*model.OrganizationPlan, error) {
+	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.OrganizationPlansForOrg", graphql.GetOperationContext(ctx))
+	defer span.Finish()
+	tracing.SetDefaultResolverSpanTags(ctx, span)
+	span.SetTag(tracing.SpanTagEntityId, organizationID)
+
+	orgPlanEntities, err := r.Services.OrganizationPlanService.GetOrganizationPlansForOrganization(ctx, organizationID)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		graphql.AddErrorf(ctx, "Failed to get Org plans for organization %s", organizationID)
+		return nil, nil
+	}
+	return mapper.MapEntitiesToOrganizationPlans(orgPlanEntities), nil
+}
+
 // OrganizationPlans is the resolver for the organizationPlans field.
 func (r *queryResolver) OrganizationPlans(ctx context.Context, retired *bool) ([]*model.OrganizationPlan, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.OrganizationPlans", graphql.GetOperationContext(ctx))
@@ -310,7 +326,7 @@ func (r *queryResolver) OrganizationPlans(ctx context.Context, retired *bool) ([
 	orgPlanEntities, err := r.Services.OrganizationPlanService.GetOrganizationPlans(ctx, retired)
 	if err != nil {
 		tracing.TraceErr(span, err)
-		graphql.AddErrorf(ctx, "Failed to get Master plans")
+		graphql.AddErrorf(ctx, "Failed to get Organization plans")
 		return nil, nil
 	}
 	return mapper.MapEntitiesToOrganizationPlans(orgPlanEntities), nil

--- a/packages/server/customer-os-api/graph/schemas/organization_plan.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/organization_plan.graphqls
@@ -11,7 +11,7 @@ extend type Mutation {
 
 extend type Query {
     organizationPlan(id: ID!): OrganizationPlan! @hasRole(roles: [ADMIN, USER]) @hasTenant
-    organizationPlansForOrg(organizationId: ID!): [OrganizationPlan!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
+    organizationPlansForOrganization(organizationId: ID!): [OrganizationPlan!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
     organizationPlans(retired: Boolean): [OrganizationPlan!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
 }
 

--- a/packages/server/customer-os-api/graph/schemas/organization_plan.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/organization_plan.graphqls
@@ -11,6 +11,7 @@ extend type Mutation {
 
 extend type Query {
     organizationPlan(id: ID!): OrganizationPlan! @hasRole(roles: [ADMIN, USER]) @hasTenant
+    organizationPlansForOrg(organizationId: ID!): [OrganizationPlan!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
     organizationPlans(retired: Boolean): [OrganizationPlan!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
 }
 
@@ -65,6 +66,7 @@ input StatusDetailsInput {
 input OrganizationPlanInput {
     name: String
     masterPlanId: String
+    organizationId: ID!
 }
 
 input OrganizationPlanUpdateInput {

--- a/packages/server/events-processing-platform/domain/organization_plan/event_handler/create_org_plan_handler.go
+++ b/packages/server/events-processing-platform/domain/organization_plan/event_handler/create_org_plan_handler.go
@@ -50,7 +50,7 @@ func (h *createOrganizationPlanHandler) Handle(ctx context.Context, baseRequest 
 
 	createdAtNotNil := utils.IfNotNilTimeWithDefault(request.CreatedAt, utils.Now())
 
-	createEvent, err := event.NewOrganizationPlanCreateEvent(organizationAggregate, baseRequest.ObjectID, request.MasterPlanId, request.Name, baseRequest.SourceFields, createdAtNotNil)
+	createEvent, err := event.NewOrganizationPlanCreateEvent(organizationAggregate, baseRequest.ObjectID, request.MasterPlanId, request.OrgId, request.Name, baseRequest.SourceFields, createdAtNotNil)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return errors.Wrap(err, "NewOrganizationPlanCreateEvent")

--- a/packages/server/events-processing-platform/domain/organization_plan/events/org_plan_create.go
+++ b/packages/server/events-processing-platform/domain/organization_plan/events/org_plan_create.go
@@ -16,9 +16,10 @@ type OrganizationPlanCreateEvent struct {
 	SourceFields       commonmodel.Source `json:"sourceFields"`
 	OrganizationPlanId string             `json:"organizationPlanId"`
 	MasterPlanId       string             `json:"masterPlanId"`
+	OrganizationId     string             `json:"organizationId"`
 }
 
-func NewOrganizationPlanCreateEvent(aggregate eventstore.Aggregate, organizationPlanId, masterPlanId, name string, sourceFields commonmodel.Source, createdAt time.Time) (eventstore.Event, error) {
+func NewOrganizationPlanCreateEvent(aggregate eventstore.Aggregate, organizationPlanId, masterPlanId, organizationId, name string, sourceFields commonmodel.Source, createdAt time.Time) (eventstore.Event, error) {
 	eventData := OrganizationPlanCreateEvent{
 		Tenant:             aggregate.GetTenant(),
 		Name:               name,
@@ -26,6 +27,7 @@ func NewOrganizationPlanCreateEvent(aggregate eventstore.Aggregate, organization
 		SourceFields:       sourceFields,
 		OrganizationPlanId: organizationPlanId,
 		MasterPlanId:       masterPlanId,
+		OrganizationId:     organizationId,
 	}
 
 	if err := validator.GetValidator().Struct(eventData); err != nil {

--- a/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/mapper"
 	neo4jrepository "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/repository"
-	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/organization/aggregate"
 	event "github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/organization_plan/events"
 	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/organization_plan/model"
 	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/eventstore"
@@ -44,7 +43,7 @@ func (h *OrganizationPlanEventHandler) OnCreate(ctx context.Context, evt eventst
 		return errors.Wrap(err, "evt.GetJsonData")
 	}
 
-	organizationId := aggregate.GetOrganizationObjectID(evt.GetAggregateID(), eventData.Tenant)
+	organizationId := eventData.OrganizationId
 	masterPlanId := eventData.MasterPlanId
 	span.SetTag(tracing.SpanTagEntityId, eventData.OrganizationPlanId)
 

--- a/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler_it_test.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler_it_test.go
@@ -68,6 +68,7 @@ func TestOrganizationPlanEventHandler_OnCreate(t *testing.T) {
 		orgAggregate,
 		orgPlanId,
 		mpid,
+		orgId,
 		"org plan name",
 		commonmodel.Source{
 			Source:    constants.SourceOpenline,


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to specify an organization ID when creating an organization plan.
	- Introduced a new query to fetch organization plans for a specific organization.

- **Enhancements**
	- Updated error messaging for clarity in organization plan operations.

- **Bug Fixes**
	- Corrected event handling logic to use the new organization ID field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->