### PR TITLE
[Notifications] - if org has no name, set Unnamed Org on email

### DIFF
--- a/packages/server/events-processing-platform/subscriptions/notifications/organization_event_handler.go
+++ b/packages/server/events-processing-platform/subscriptions/notifications/organization_event_handler.go
@@ -267,7 +267,7 @@ func (h *OrganizationEventHandler) notificationProviderSendInAppNotification(ctx
 func (h *OrganizationEventHandler) parseOrgOwnerUpdateEmail(actor, target *neo4jentity.UserEntity, orgId, organizationName string) (string, error) {
 	orgName := organizationName
 	if organizationName == "" {
-		orgName = "Unnamed Organization"
+		orgName = "Unnamed"
 	}
 	if _, err := os.Stat(h.cfg.Subscriptions.NotificationsSubscription.EmailTemplatePath); os.IsNotExist(err) {
 		return "", fmt.Errorf("(OrganizationEventHandler.parseOrgOwnerUpdateEmail) error: %s", err.Error())

--- a/packages/server/events-processing-platform/subscriptions/notifications/organization_event_handler.go
+++ b/packages/server/events-processing-platform/subscriptions/notifications/organization_event_handler.go
@@ -264,7 +264,11 @@ func (h *OrganizationEventHandler) notificationProviderSendInAppNotification(ctx
 	return err
 }
 
-func (h *OrganizationEventHandler) parseOrgOwnerUpdateEmail(actor, target *neo4jentity.UserEntity, orgId, orgName string) (string, error) {
+func (h *OrganizationEventHandler) parseOrgOwnerUpdateEmail(actor, target *neo4jentity.UserEntity, orgId, organizationName string) (string, error) {
+	orgName := organizationName
+	if organizationName == "" {
+		orgName = "Unnamed Organization"
+	}
 	if _, err := os.Stat(h.cfg.Subscriptions.NotificationsSubscription.EmailTemplatePath); os.IsNotExist(err) {
 		return "", fmt.Errorf("(OrganizationEventHandler.parseOrgOwnerUpdateEmail) error: %s", err.Error())
 	}


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved email notifications by ensuring organization names are displayed correctly, using "Unnamed Organization" as a default when no name is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->