### PR TITLE
[COS-1758][COS-1759] - org plan update make status detail optional

### DIFF
--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -12483,7 +12483,7 @@ input OrganizationPlanUpdateInput {
     id: ID!
     name: String
     retired: Boolean
-    statusDetails: StatusDetailsInput!
+    statusDetails: StatusDetailsInput
     organizationId: ID!
 }
 
@@ -82983,7 +82983,7 @@ func (ec *executionContext) unmarshalInputOrganizationPlanUpdateInput(ctx contex
 			it.Retired = data
 		case "statusDetails":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("statusDetails"))
-			data, err := ec.unmarshalNStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐStatusDetailsInput(ctx, v)
+			data, err := ec.unmarshalOStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐStatusDetailsInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -103756,6 +103756,14 @@ func (ec *executionContext) unmarshalOSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋo
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputSortBy(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐStatusDetailsInput(ctx context.Context, v interface{}) (*model.StatusDetailsInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputStatusDetailsInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -12509,12 +12509,12 @@ input OrganizationPlanMilestoneUpdateInput {
     id: ID!
     name: String
     order: Int64
-    dueDate: Time!
+    dueDate: Time
     updatedAt: Time!
     optional: Boolean
     retired: Boolean
-    items: [MilestoneItemInput!]!
-    statusDetails: StatusDetailsInput!
+    items: [MilestoneItemInput]
+    statusDetails: StatusDetailsInput
     organizationId: ID!
 }
 
@@ -82893,7 +82893,7 @@ func (ec *executionContext) unmarshalInputOrganizationPlanMilestoneUpdateInput(c
 			it.Order = data
 		case "dueDate":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dueDate"))
-			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -82921,14 +82921,14 @@ func (ec *executionContext) unmarshalInputOrganizationPlanMilestoneUpdateInput(c
 			it.Retired = data
 		case "items":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("items"))
-			data, err := ec.unmarshalNMilestoneItemInput2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInputᚄ(ctx, v)
+			data, err := ec.unmarshalOMilestoneItemInput2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.Items = data
 		case "statusDetails":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("statusDetails"))
-			data, err := ec.unmarshalNStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐStatusDetailsInput(ctx, v)
+			data, err := ec.unmarshalOStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐStatusDetailsInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -100911,28 +100911,6 @@ func (ec *executionContext) marshalNMilestoneItem2ᚖgithubᚗcomᚋopenlineᚑa
 	return ec._MilestoneItem(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNMilestoneItemInput2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInputᚄ(ctx context.Context, v interface{}) ([]*model.MilestoneItemInput, error) {
-	var vSlice []interface{}
-	if v != nil {
-		vSlice = graphql.CoerceList(v)
-	}
-	var err error
-	res := make([]*model.MilestoneItemInput, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNMilestoneItemInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInput(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) unmarshalNMilestoneItemInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInput(ctx context.Context, v interface{}) (*model.MilestoneItemInput, error) {
-	res, err := ec.unmarshalInputMilestoneItemInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
 func (ec *executionContext) marshalNNote2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐNote(ctx context.Context, sel ast.SelectionSet, v model.Note) graphql.Marshaler {
 	return ec._Note(ctx, sel, &v)
 }
@@ -101795,11 +101773,6 @@ func (ec *executionContext) marshalNStatusDetails2ᚖgithubᚗcomᚋopenlineᚑa
 		return graphql.Null
 	}
 	return ec._StatusDetails(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalNStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐStatusDetailsInput(ctx context.Context, v interface{}) (*model.StatusDetailsInput, error) {
-	res, err := ec.unmarshalInputStatusDetailsInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {
@@ -103507,6 +103480,34 @@ func (ec *executionContext) marshalOMeetingStatus2ᚖgithubᚗcomᚋopenlineᚑa
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) unmarshalOMilestoneItemInput2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInput(ctx context.Context, v interface{}) ([]*model.MilestoneItemInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.MilestoneItemInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOMilestoneItemInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalOMilestoneItemInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInput(ctx context.Context, v interface{}) (*model.MilestoneItemInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputMilestoneItemInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalONoteInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐNoteInput(ctx context.Context, v interface{}) (*model.NoteInput, error) {

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -1812,12 +1812,12 @@ type OrganizationPlanMilestoneUpdateInput struct {
 	ID                 string                `json:"id"`
 	Name               *string               `json:"name,omitempty"`
 	Order              *int64                `json:"order,omitempty"`
-	DueDate            time.Time             `json:"dueDate"`
+	DueDate            *time.Time            `json:"dueDate,omitempty"`
 	UpdatedAt          time.Time             `json:"updatedAt"`
 	Optional           *bool                 `json:"optional,omitempty"`
 	Retired            *bool                 `json:"retired,omitempty"`
-	Items              []*MilestoneItemInput `json:"items"`
-	StatusDetails      *StatusDetailsInput   `json:"statusDetails"`
+	Items              []*MilestoneItemInput `json:"items,omitempty"`
+	StatusDetails      *StatusDetailsInput   `json:"statusDetails,omitempty"`
 	OrganizationID     string                `json:"organizationId"`
 }
 

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -1825,7 +1825,7 @@ type OrganizationPlanUpdateInput struct {
 	ID             string              `json:"id"`
 	Name           *string             `json:"name,omitempty"`
 	Retired        *bool               `json:"retired,omitempty"`
-	StatusDetails  *StatusDetailsInput `json:"statusDetails"`
+	StatusDetails  *StatusDetailsInput `json:"statusDetails,omitempty"`
 	OrganizationID string              `json:"organizationId"`
 }
 

--- a/packages/server/customer-os-api/graph/resolver/organization_plan.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organization_plan.resolvers.go
@@ -151,7 +151,7 @@ func (r *mutationResolver) OrganizationPlanMilestoneUpdate(ctx context.Context, 
 	tracing.LogObjectAsJson(span, "input", input)
 
 	err := r.Services.OrganizationPlanService.UpdateOrganizationPlanMilestone(ctx, input.OrganizationID, input.OrganizationPlanID, input.ID, input.Name,
-		input.Order, &input.DueDate, input.Items, input.Optional, input.Retired, input.StatusDetails)
+		input.Order, input.DueDate, input.Items, input.Optional, input.Retired, input.StatusDetails)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		graphql.AddErrorf(ctx, "Failed to update organization plan milestone")
@@ -177,7 +177,7 @@ func (r *mutationResolver) OrganizationPlanMilestoneBulkUpdate(ctx context.Conte
 	var err error
 	for _, opms := range input {
 		err = r.Services.OrganizationPlanService.UpdateOrganizationPlanMilestone(ctx, opms.OrganizationID, opms.OrganizationPlanID, opms.ID, opms.Name,
-			opms.Order, &opms.DueDate, opms.Items, opms.Optional, opms.Retired, opms.StatusDetails)
+			opms.Order, opms.DueDate, opms.Items, opms.Optional, opms.Retired, opms.StatusDetails)
 		if err != nil {
 			tracing.TraceErr(span, err)
 			graphql.AddErrorf(ctx, "Failed to update org plan milestone")

--- a/packages/server/customer-os-api/graph/schemas/organization_plan.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/organization_plan.graphqls
@@ -100,12 +100,12 @@ input OrganizationPlanMilestoneUpdateInput {
     id: ID!
     name: String
     order: Int64
-    dueDate: Time!
+    dueDate: Time
     updatedAt: Time!
     optional: Boolean
     retired: Boolean
-    items: [MilestoneItemInput!]!
-    statusDetails: StatusDetailsInput!
+    items: [MilestoneItemInput]
+    statusDetails: StatusDetailsInput
     organizationId: ID!
 }
 

--- a/packages/server/customer-os-api/graph/schemas/organization_plan.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/organization_plan.graphqls
@@ -74,7 +74,7 @@ input OrganizationPlanUpdateInput {
     id: ID!
     name: String
     retired: Boolean
-    statusDetails: StatusDetailsInput!
+    statusDetails: StatusDetailsInput
     organizationId: ID!
 }
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Made several fields in organization plan updates optional for enhanced flexibility.
- **Bug Fixes**
	- Adjusted the handling of `DueDate` in organization plan milestones to correct logic errors.
- **Refactor**
	- Removed unnecessary `reflect` import for cleaner code.
	- Added new condition and function to improve handling of `statusDetails` in organization plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->