### PR TITLE
First service line item should start at the beginning of the day

### DIFF
--- a/packages/server/customer-os-common-module/utils/time_utils.go
+++ b/packages/server/customer-os-common-module/utils/time_utils.go
@@ -151,3 +151,7 @@ func LastTimeOfMonth(year, month int) time.Time {
 func LastDayOfMonth(year, month int) time.Time {
 	return FirstTimeOfMonth(year, month).AddDate(0, 1, 0).Add(-time.Hour * 24)
 }
+
+func StartOfDayInUTC(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/packages/server/events-processing-platform/domain/service_line_item/aggregate/commands.go
+++ b/packages/server/events-processing-platform/domain/service_line_item/aggregate/commands.go
@@ -57,6 +57,11 @@ func (a *ServiceLineItemAggregate) createServiceLineItem(ctx context.Context, cm
 		return err
 	}
 
+	// if this is parent service line item, set startedAt to start of day in UTC
+	if cmd.DataFields.ParentId == GetServiceLineItemObjectID(a.GetID(), a.Tenant) {
+		startedAtNotNil = utils.StartOfDayInUTC(startedAtNotNil)
+	}
+
 	createEvent, err := event.NewServiceLineItemCreateEvent(
 		a,
 		cmd.DataFields,

--- a/packages/server/events-processing-platform/domain/service_line_item/aggregate/utils.go
+++ b/packages/server/events-processing-platform/domain/service_line_item/aggregate/utils.go
@@ -2,8 +2,6 @@ package aggregate
 
 import (
 	"context"
-	"strings"
-
 	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/common/aggregate"
 	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/eventstore"
 	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/tracing"
@@ -14,13 +12,6 @@ import (
 // GetServiceLineItemObjectID generates the object ID for a service line item.
 func GetServiceLineItemObjectID(aggregateID string, tenant string) string {
 	return aggregate.GetAggregateObjectID(aggregateID, tenant, ServiceLineItemAggregateType)
-}
-
-// getServiceLineItemObjectUUID generates the UUID for a service line item when the tenant is not known.
-func getServiceLineItemObjectUUID(aggregateID string) string {
-	parts := strings.Split(aggregateID, "-")
-	fullUUID := parts[len(parts)-5] + "-" + parts[len(parts)-4] + "-" + parts[len(parts)-3] + "-" + parts[len(parts)-2] + "-" + parts[len(parts)-1]
-	return fullUUID
 }
 
 // LoadServiceLineItemAggregate loads the service line item aggregate from the event store.


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature to automatically adjust the start date of service line items to the beginning of the day in UTC.
- **Refactor**
	- Removed unused code related to generating UUIDs for service line items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->