### PR TITLE
[COS-1794] - do not create retired milestones for plan

### DIFF
--- a/packages/server/customer-os-api/graph/resolver/organization_plan.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organization_plan.resolvers.go
@@ -42,6 +42,9 @@ func (r *mutationResolver) OrganizationPlanCreate(ctx context.Context, input mod
 	}
 	// create organization plan milestones based on each master plan milestone
 	for _, masterPlanMilestoneEntity := range *masterPlanMilestonesEntities {
+		if masterPlanMilestoneEntity.Retired {
+			continue
+		}
 		msDueDate := time.Now().UTC().Add(time.Hour * time.Duration(masterPlanMilestoneEntity.DurationHours))
 		_, err := r.Services.OrganizationPlanService.CreateOrganizationPlanMilestone(
 			ctx,


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the creation process for organization plan milestones to skip any that are marked as retired, ensuring only active milestones are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->