### PR TITLE
[COS-1785][COS-1786] - Propagate status update from milestone items up to org plan status

### DIFF
--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -788,12 +788,6 @@ type ComplexityRoot struct {
 		TotalPages    func(childComplexity int) int
 	}
 
-	MilestoneItem struct {
-		Status    func(childComplexity int) int
-		Text      func(childComplexity int) int
-		UpdatedAt func(childComplexity int) int
-	}
-
 	Mutation struct {
 		AnalysisCreate                          func(childComplexity int, analysis model.AnalysisInput) int
 		AttachmentCreate                        func(childComplexity int, input model.AttachmentInput) int
@@ -1111,6 +1105,12 @@ type ComplexityRoot struct {
 		SourceOfTruth func(childComplexity int) int
 		StatusDetails func(childComplexity int) int
 		UpdatedAt     func(childComplexity int) int
+	}
+
+	OrganizationPlanMilestoneItem struct {
+		Status    func(childComplexity int) int
+		Text      func(childComplexity int) int
+		UpdatedAt func(childComplexity int) int
 	}
 
 	PageView struct {
@@ -5446,27 +5446,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.MeetingsPage.TotalPages(childComplexity), true
 
-	case "MilestoneItem.status":
-		if e.complexity.MilestoneItem.Status == nil {
-			break
-		}
-
-		return e.complexity.MilestoneItem.Status(childComplexity), true
-
-	case "MilestoneItem.text":
-		if e.complexity.MilestoneItem.Text == nil {
-			break
-		}
-
-		return e.complexity.MilestoneItem.Text(childComplexity), true
-
-	case "MilestoneItem.updatedAt":
-		if e.complexity.MilestoneItem.UpdatedAt == nil {
-			break
-		}
-
-		return e.complexity.MilestoneItem.UpdatedAt(childComplexity), true
-
 	case "Mutation.analysis_Create":
 		if e.complexity.Mutation.AnalysisCreate == nil {
 			break
@@ -8279,6 +8258,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OrganizationPlanMilestone.UpdatedAt(childComplexity), true
 
+	case "OrganizationPlanMilestoneItem.status":
+		if e.complexity.OrganizationPlanMilestoneItem.Status == nil {
+			break
+		}
+
+		return e.complexity.OrganizationPlanMilestoneItem.Status(childComplexity), true
+
+	case "OrganizationPlanMilestoneItem.text":
+		if e.complexity.OrganizationPlanMilestoneItem.Text == nil {
+			break
+		}
+
+		return e.complexity.OrganizationPlanMilestoneItem.Text(childComplexity), true
+
+	case "OrganizationPlanMilestoneItem.updatedAt":
+		if e.complexity.OrganizationPlanMilestoneItem.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.OrganizationPlanMilestoneItem.UpdatedAt(childComplexity), true
+
 	case "PageView.appSource":
 		if e.complexity.PageView.AppSource == nil {
 			break
@@ -10178,7 +10178,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputMeetingInput,
 		ec.unmarshalInputMeetingParticipantInput,
 		ec.unmarshalInputMeetingUpdateInput,
-		ec.unmarshalInputMilestoneItemInput,
 		ec.unmarshalInputNoteInput,
 		ec.unmarshalInputNoteUpdateInput,
 		ec.unmarshalInputOnboardingStatusInput,
@@ -10187,8 +10186,11 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputOrganizationInput,
 		ec.unmarshalInputOrganizationPlanInput,
 		ec.unmarshalInputOrganizationPlanMilestoneInput,
+		ec.unmarshalInputOrganizationPlanMilestoneItemInput,
 		ec.unmarshalInputOrganizationPlanMilestoneReorderInput,
+		ec.unmarshalInputOrganizationPlanMilestoneStatusDetailsInput,
 		ec.unmarshalInputOrganizationPlanMilestoneUpdateInput,
+		ec.unmarshalInputOrganizationPlanStatusDetailsInput,
 		ec.unmarshalInputOrganizationPlanUpdateInput,
 		ec.unmarshalInputOrganizationUpdateInput,
 		ec.unmarshalInputPagination,
@@ -10204,7 +10206,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputSocialInput,
 		ec.unmarshalInputSocialUpdateInput,
 		ec.unmarshalInputSortBy,
-		ec.unmarshalInputStatusDetailsInput,
 		ec.unmarshalInputTagIdOrNameInput,
 		ec.unmarshalInputTagInput,
 		ec.unmarshalInputTagUpdateInput,
@@ -12710,10 +12711,37 @@ type OrganizationPlanMilestone implements SourceFields & Node {
     order:              Int64!
     dueDate:            Time!
     optional:           Boolean!
-    items:              [MilestoneItem!]!
+    items:              [OrganizationPlanMilestoneItem!]!
     retired:            Boolean!
     statusDetails:      StatusDetails!
     adhoc:              Boolean!
+}
+
+enum OnboardingPlanStatus {
+    NOT_STARTED
+    ON_TRACK
+    LATE
+    DONE
+    NOT_STARTED_LATE
+    DONE_LATE
+}
+
+enum OnboardingPlanMilestoneStatus {
+    NOT_STARTED
+    STARTED
+    DONE
+    NOT_STARTED_LATE
+    STARTED_LATE
+    DONE_LATE
+}
+
+enum OnboardingPlanMilestoneItemStatus {
+    NOT_DONE
+    SKIPPED
+    DONE
+    NOT_DONE_LATE
+    SKIPPED_LATE
+    DONE_LATE
 }
 
 type StatusDetails {
@@ -12722,14 +12750,20 @@ type StatusDetails {
     text: String!
 }
 
-type MilestoneItem {
-    status: String!
+input OrganizationPlanStatusDetailsInput {
+    status: OnboardingPlanStatus!
     updatedAt: Time!
     text: String!
 }
 
-input StatusDetailsInput {
-    status: String!
+input OrganizationPlanMilestoneStatusDetailsInput {
+    status: OnboardingPlanMilestoneStatus!
+    updatedAt: Time!
+    text: String!
+}
+
+type OrganizationPlanMilestoneItem {
+    status: OnboardingPlanMilestoneItemStatus!
     updatedAt: Time!
     text: String!
 }
@@ -12744,7 +12778,7 @@ input OrganizationPlanUpdateInput {
     id: ID!
     name: String
     retired: Boolean
-    statusDetails: StatusDetailsInput
+    statusDetails: OrganizationPlanStatusDetailsInput
     organizationId: ID!
 }
 
@@ -12760,8 +12794,8 @@ input OrganizationPlanMilestoneInput {
     adhoc: Boolean!
 }
 
-input MilestoneItemInput {
-    status: String!
+input OrganizationPlanMilestoneItemInput {
+    status: OnboardingPlanMilestoneItemStatus!
     updatedAt: Time!
     text: String!
 }
@@ -12775,8 +12809,8 @@ input OrganizationPlanMilestoneUpdateInput {
     updatedAt: Time!
     optional: Boolean
     retired: Boolean
-    items: [MilestoneItemInput]
-    statusDetails: StatusDetailsInput
+    items: [OrganizationPlanMilestoneItemInput]
+    statusDetails: OrganizationPlanMilestoneStatusDetailsInput
     organizationId: ID!
     adhoc: Boolean
 }
@@ -42598,138 +42632,6 @@ func (ec *executionContext) fieldContext_MeetingsPage_totalElements(ctx context.
 	return fc, nil
 }
 
-func (ec *executionContext) _MilestoneItem_status(ctx context.Context, field graphql.CollectedField, obj *model.MilestoneItem) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_MilestoneItem_status(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Status, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_MilestoneItem_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "MilestoneItem",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _MilestoneItem_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.MilestoneItem) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_MilestoneItem_updatedAt(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.UpdatedAt, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(time.Time)
-	fc.Result = res
-	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_MilestoneItem_updatedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "MilestoneItem",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Time does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _MilestoneItem_text(ctx context.Context, field graphql.CollectedField, obj *model.MilestoneItem) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_MilestoneItem_text(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Text, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_MilestoneItem_text(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "MilestoneItem",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Mutation_analysis_Create(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_analysis_Create(ctx, field)
 	if err != nil {
@@ -65125,9 +65027,9 @@ func (ec *executionContext) _OrganizationPlanMilestone_items(ctx context.Context
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.MilestoneItem)
+	res := resTmp.([]*model.OrganizationPlanMilestoneItem)
 	fc.Result = res
-	return ec.marshalNMilestoneItem2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemᚄ(ctx, field.Selections, res)
+	return ec.marshalNOrganizationPlanMilestoneItem2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneItemᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_OrganizationPlanMilestone_items(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -65139,13 +65041,13 @@ func (ec *executionContext) fieldContext_OrganizationPlanMilestone_items(ctx con
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "status":
-				return ec.fieldContext_MilestoneItem_status(ctx, field)
+				return ec.fieldContext_OrganizationPlanMilestoneItem_status(ctx, field)
 			case "updatedAt":
-				return ec.fieldContext_MilestoneItem_updatedAt(ctx, field)
+				return ec.fieldContext_OrganizationPlanMilestoneItem_updatedAt(ctx, field)
 			case "text":
-				return ec.fieldContext_MilestoneItem_text(ctx, field)
+				return ec.fieldContext_OrganizationPlanMilestoneItem_text(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type MilestoneItem", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type OrganizationPlanMilestoneItem", field.Name)
 		},
 	}
 	return fc, nil
@@ -65286,6 +65188,138 @@ func (ec *executionContext) fieldContext_OrganizationPlanMilestone_adhoc(ctx con
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrganizationPlanMilestoneItem_status(ctx context.Context, field graphql.CollectedField, obj *model.OrganizationPlanMilestoneItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrganizationPlanMilestoneItem_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.OnboardingPlanMilestoneItemStatus)
+	fc.Result = res
+	return ec.marshalNOnboardingPlanMilestoneItemStatus2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOnboardingPlanMilestoneItemStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrganizationPlanMilestoneItem_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrganizationPlanMilestoneItem",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type OnboardingPlanMilestoneItemStatus does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrganizationPlanMilestoneItem_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.OrganizationPlanMilestoneItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrganizationPlanMilestoneItem_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrganizationPlanMilestoneItem_updatedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrganizationPlanMilestoneItem",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OrganizationPlanMilestoneItem_text(ctx context.Context, field graphql.CollectedField, obj *model.OrganizationPlanMilestoneItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OrganizationPlanMilestoneItem_text(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Text, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OrganizationPlanMilestoneItem_text(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OrganizationPlanMilestoneItem",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -83953,47 +83987,6 @@ func (ec *executionContext) unmarshalInputMeetingUpdateInput(ctx context.Context
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputMilestoneItemInput(ctx context.Context, obj interface{}) (model.MilestoneItemInput, error) {
-	var it model.MilestoneItemInput
-	asMap := map[string]interface{}{}
-	for k, v := range obj.(map[string]interface{}) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"status", "updatedAt", "text"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "status":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Status = data
-		case "updatedAt":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("updatedAt"))
-			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.UpdatedAt = data
-		case "text":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("text"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Text = data
-		}
-	}
-
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputNoteInput(ctx context.Context, obj interface{}) (model.NoteInput, error) {
 	var it model.NoteInput
 	asMap := map[string]interface{}{}
@@ -84567,6 +84560,47 @@ func (ec *executionContext) unmarshalInputOrganizationPlanMilestoneInput(ctx con
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputOrganizationPlanMilestoneItemInput(ctx context.Context, obj interface{}) (model.OrganizationPlanMilestoneItemInput, error) {
+	var it model.OrganizationPlanMilestoneItemInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"status", "updatedAt", "text"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "status":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
+			data, err := ec.unmarshalNOnboardingPlanMilestoneItemStatus2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOnboardingPlanMilestoneItemStatus(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Status = data
+		case "updatedAt":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("updatedAt"))
+			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UpdatedAt = data
+		case "text":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("text"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Text = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputOrganizationPlanMilestoneReorderInput(ctx context.Context, obj interface{}) (model.OrganizationPlanMilestoneReorderInput, error) {
 	var it model.OrganizationPlanMilestoneReorderInput
 	asMap := map[string]interface{}{}
@@ -84602,6 +84636,47 @@ func (ec *executionContext) unmarshalInputOrganizationPlanMilestoneReorderInput(
 				return it, err
 			}
 			it.OrderedIds = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputOrganizationPlanMilestoneStatusDetailsInput(ctx context.Context, obj interface{}) (model.OrganizationPlanMilestoneStatusDetailsInput, error) {
+	var it model.OrganizationPlanMilestoneStatusDetailsInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"status", "updatedAt", "text"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "status":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
+			data, err := ec.unmarshalNOnboardingPlanMilestoneStatus2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOnboardingPlanMilestoneStatus(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Status = data
+		case "updatedAt":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("updatedAt"))
+			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UpdatedAt = data
+		case "text":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("text"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Text = data
 		}
 	}
 
@@ -84680,14 +84755,14 @@ func (ec *executionContext) unmarshalInputOrganizationPlanMilestoneUpdateInput(c
 			it.Retired = data
 		case "items":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("items"))
-			data, err := ec.unmarshalOMilestoneItemInput2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInput(ctx, v)
+			data, err := ec.unmarshalOOrganizationPlanMilestoneItemInput2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneItemInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.Items = data
 		case "statusDetails":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("statusDetails"))
-			data, err := ec.unmarshalOStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐStatusDetailsInput(ctx, v)
+			data, err := ec.unmarshalOOrganizationPlanMilestoneStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneStatusDetailsInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -84706,6 +84781,47 @@ func (ec *executionContext) unmarshalInputOrganizationPlanMilestoneUpdateInput(c
 				return it, err
 			}
 			it.Adhoc = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputOrganizationPlanStatusDetailsInput(ctx context.Context, obj interface{}) (model.OrganizationPlanStatusDetailsInput, error) {
+	var it model.OrganizationPlanStatusDetailsInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"status", "updatedAt", "text"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "status":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
+			data, err := ec.unmarshalNOnboardingPlanStatus2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOnboardingPlanStatus(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Status = data
+		case "updatedAt":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("updatedAt"))
+			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UpdatedAt = data
+		case "text":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("text"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Text = data
 		}
 	}
 
@@ -84749,7 +84865,7 @@ func (ec *executionContext) unmarshalInputOrganizationPlanUpdateInput(ctx contex
 			it.Retired = data
 		case "statusDetails":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("statusDetails"))
-			data, err := ec.unmarshalOStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐStatusDetailsInput(ctx, v)
+			data, err := ec.unmarshalOOrganizationPlanStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanStatusDetailsInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -85601,47 +85717,6 @@ func (ec *executionContext) unmarshalInputSortBy(ctx context.Context, obj interf
 				return it, err
 			}
 			it.CaseSensitive = data
-		}
-	}
-
-	return it, nil
-}
-
-func (ec *executionContext) unmarshalInputStatusDetailsInput(ctx context.Context, obj interface{}) (model.StatusDetailsInput, error) {
-	var it model.StatusDetailsInput
-	asMap := map[string]interface{}{}
-	for k, v := range obj.(map[string]interface{}) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"status", "updatedAt", "text"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "status":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Status = data
-		case "updatedAt":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("updatedAt"))
-			data, err := ec.unmarshalNTime2timeᚐTime(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.UpdatedAt = data
-		case "text":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("text"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Text = data
 		}
 	}
 
@@ -93557,55 +93632,6 @@ func (ec *executionContext) _MeetingsPage(ctx context.Context, sel ast.Selection
 	return out
 }
 
-var milestoneItemImplementors = []string{"MilestoneItem"}
-
-func (ec *executionContext) _MilestoneItem(ctx context.Context, sel ast.SelectionSet, obj *model.MilestoneItem) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, milestoneItemImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	deferred := make(map[string]*graphql.FieldSet)
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("MilestoneItem")
-		case "status":
-			out.Values[i] = ec._MilestoneItem_status(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "updatedAt":
-			out.Values[i] = ec._MilestoneItem_updatedAt(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "text":
-			out.Values[i] = ec._MilestoneItem_text(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch(ctx)
-	if out.Invalids > 0 {
-		return graphql.Null
-	}
-
-	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
-
-	for label, dfs := range deferred {
-		ec.processDeferredGroup(graphql.DeferredGroup{
-			Label:    label,
-			Path:     graphql.GetPath(ctx),
-			FieldSet: dfs,
-			Context:  ctx,
-		})
-	}
-
-	return out
-}
-
 var mutationImplementors = []string{"Mutation"}
 
 func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet) graphql.Marshaler {
@@ -96497,6 +96523,55 @@ func (ec *executionContext) _OrganizationPlanMilestone(ctx context.Context, sel 
 			}
 		case "adhoc":
 			out.Values[i] = ec._OrganizationPlanMilestone_adhoc(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var organizationPlanMilestoneItemImplementors = []string{"OrganizationPlanMilestoneItem"}
+
+func (ec *executionContext) _OrganizationPlanMilestoneItem(ctx context.Context, sel ast.SelectionSet, obj *model.OrganizationPlanMilestoneItem) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, organizationPlanMilestoneItemImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("OrganizationPlanMilestoneItem")
+		case "status":
+			out.Values[i] = ec._OrganizationPlanMilestoneItem_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updatedAt":
+			out.Values[i] = ec._OrganizationPlanMilestoneItem_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "text":
+			out.Values[i] = ec._OrganizationPlanMilestoneItem_text(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -102939,60 +103014,6 @@ func (ec *executionContext) marshalNMeetingsPage2ᚖgithubᚗcomᚋopenlineᚑai
 	return ec._MeetingsPage(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNMilestoneItem2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.MilestoneItem) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNMilestoneItem2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItem(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
-func (ec *executionContext) marshalNMilestoneItem2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItem(ctx context.Context, sel ast.SelectionSet, v *model.MilestoneItem) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._MilestoneItem(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalNNote2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐNote(ctx context.Context, sel ast.SelectionSet, v model.Note) graphql.Marshaler {
 	return ec._Note(ctx, sel, &v)
 }
@@ -103127,6 +103148,36 @@ func (ec *executionContext) marshalNNotedEntity2ᚕgithubᚗcomᚋopenlineᚑai�
 	}
 
 	return ret
+}
+
+func (ec *executionContext) unmarshalNOnboardingPlanMilestoneItemStatus2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOnboardingPlanMilestoneItemStatus(ctx context.Context, v interface{}) (model.OnboardingPlanMilestoneItemStatus, error) {
+	var res model.OnboardingPlanMilestoneItemStatus
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNOnboardingPlanMilestoneItemStatus2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOnboardingPlanMilestoneItemStatus(ctx context.Context, sel ast.SelectionSet, v model.OnboardingPlanMilestoneItemStatus) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalNOnboardingPlanMilestoneStatus2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOnboardingPlanMilestoneStatus(ctx context.Context, v interface{}) (model.OnboardingPlanMilestoneStatus, error) {
+	var res model.OnboardingPlanMilestoneStatus
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNOnboardingPlanMilestoneStatus2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOnboardingPlanMilestoneStatus(ctx context.Context, sel ast.SelectionSet, v model.OnboardingPlanMilestoneStatus) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalNOnboardingPlanStatus2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOnboardingPlanStatus(ctx context.Context, v interface{}) (model.OnboardingPlanStatus, error) {
+	var res model.OnboardingPlanStatus
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNOnboardingPlanStatus2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOnboardingPlanStatus(ctx context.Context, sel ast.SelectionSet, v model.OnboardingPlanStatus) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNOnboardingStatus2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOnboardingStatus(ctx context.Context, v interface{}) (model.OnboardingStatus, error) {
@@ -103379,6 +103430,60 @@ func (ec *executionContext) marshalNOrganizationPlanMilestone2ᚖgithubᚗcomᚋ
 func (ec *executionContext) unmarshalNOrganizationPlanMilestoneInput2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneInput(ctx context.Context, v interface{}) (model.OrganizationPlanMilestoneInput, error) {
 	res, err := ec.unmarshalInputOrganizationPlanMilestoneInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNOrganizationPlanMilestoneItem2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneItemᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.OrganizationPlanMilestoneItem) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNOrganizationPlanMilestoneItem2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneItem(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNOrganizationPlanMilestoneItem2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneItem(ctx context.Context, sel ast.SelectionSet, v *model.OrganizationPlanMilestoneItem) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._OrganizationPlanMilestoneItem(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNOrganizationPlanMilestoneReorderInput2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneReorderInput(ctx context.Context, v interface{}) (model.OrganizationPlanMilestoneReorderInput, error) {
@@ -105578,34 +105683,6 @@ func (ec *executionContext) marshalOMeetingStatus2ᚖgithubᚗcomᚋopenlineᚑa
 	return v
 }
 
-func (ec *executionContext) unmarshalOMilestoneItemInput2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInput(ctx context.Context, v interface{}) ([]*model.MilestoneItemInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	var vSlice []interface{}
-	if v != nil {
-		vSlice = graphql.CoerceList(v)
-	}
-	var err error
-	res := make([]*model.MilestoneItemInput, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOMilestoneItemInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInput(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) unmarshalOMilestoneItemInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐMilestoneItemInput(ctx context.Context, v interface{}) (*model.MilestoneItemInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputMilestoneItemInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
 func (ec *executionContext) unmarshalONoteInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐNoteInput(ctx context.Context, v interface{}) (*model.NoteInput, error) {
 	if v == nil {
 		return nil, nil
@@ -105718,6 +105795,50 @@ func (ec *executionContext) marshalOOrganizationPage2ᚖgithubᚗcomᚋopenline�
 		return graphql.Null
 	}
 	return ec._OrganizationPage(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOOrganizationPlanMilestoneItemInput2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneItemInput(ctx context.Context, v interface{}) ([]*model.OrganizationPlanMilestoneItemInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.OrganizationPlanMilestoneItemInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOOrganizationPlanMilestoneItemInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneItemInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalOOrganizationPlanMilestoneItemInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneItemInput(ctx context.Context, v interface{}) (*model.OrganizationPlanMilestoneItemInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputOrganizationPlanMilestoneItemInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOOrganizationPlanMilestoneStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanMilestoneStatusDetailsInput(ctx context.Context, v interface{}) (*model.OrganizationPlanMilestoneStatusDetailsInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputOrganizationPlanMilestoneStatusDetailsInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOOrganizationPlanStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐOrganizationPlanStatusDetailsInput(ctx context.Context, v interface{}) (*model.OrganizationPlanStatusDetailsInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputOrganizationPlanStatusDetailsInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOPagination2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐPagination(ctx context.Context, v interface{}) (*model.Pagination, error) {
@@ -105853,14 +105974,6 @@ func (ec *executionContext) unmarshalOSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋo
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputSortBy(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) unmarshalOStatusDetailsInput2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐStatusDetailsInput(ctx context.Context, v interface{}) (*model.StatusDetailsInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputStatusDetailsInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -1520,18 +1520,6 @@ func (this MeetingsPage) GetTotalPages() int { return this.TotalPages }
 // **Required.**
 func (this MeetingsPage) GetTotalElements() int64 { return this.TotalElements }
 
-type MilestoneItem struct {
-	Status    string    `json:"status"`
-	UpdatedAt time.Time `json:"updatedAt"`
-	Text      string    `json:"text"`
-}
-
-type MilestoneItemInput struct {
-	Status    string    `json:"status"`
-	UpdatedAt time.Time `json:"updatedAt"`
-	Text      string    `json:"text"`
-}
-
 type Mutation struct {
 }
 
@@ -1794,20 +1782,20 @@ type OrganizationPlanInput struct {
 }
 
 type OrganizationPlanMilestone struct {
-	ID            string           `json:"id"`
-	CreatedAt     time.Time        `json:"createdAt"`
-	UpdatedAt     time.Time        `json:"updatedAt"`
-	Name          string           `json:"name"`
-	Source        DataSource       `json:"source"`
-	SourceOfTruth DataSource       `json:"sourceOfTruth"`
-	AppSource     string           `json:"appSource"`
-	Order         int64            `json:"order"`
-	DueDate       time.Time        `json:"dueDate"`
-	Optional      bool             `json:"optional"`
-	Items         []*MilestoneItem `json:"items"`
-	Retired       bool             `json:"retired"`
-	StatusDetails *StatusDetails   `json:"statusDetails"`
-	Adhoc         bool             `json:"adhoc"`
+	ID            string                           `json:"id"`
+	CreatedAt     time.Time                        `json:"createdAt"`
+	UpdatedAt     time.Time                        `json:"updatedAt"`
+	Name          string                           `json:"name"`
+	Source        DataSource                       `json:"source"`
+	SourceOfTruth DataSource                       `json:"sourceOfTruth"`
+	AppSource     string                           `json:"appSource"`
+	Order         int64                            `json:"order"`
+	DueDate       time.Time                        `json:"dueDate"`
+	Optional      bool                             `json:"optional"`
+	Items         []*OrganizationPlanMilestoneItem `json:"items"`
+	Retired       bool                             `json:"retired"`
+	StatusDetails *StatusDetails                   `json:"statusDetails"`
+	Adhoc         bool                             `json:"adhoc"`
 }
 
 func (OrganizationPlanMilestone) IsSourceFields()                   {}
@@ -1830,33 +1818,57 @@ type OrganizationPlanMilestoneInput struct {
 	Adhoc              bool      `json:"adhoc"`
 }
 
+type OrganizationPlanMilestoneItem struct {
+	Status    OnboardingPlanMilestoneItemStatus `json:"status"`
+	UpdatedAt time.Time                         `json:"updatedAt"`
+	Text      string                            `json:"text"`
+}
+
+type OrganizationPlanMilestoneItemInput struct {
+	Status    OnboardingPlanMilestoneItemStatus `json:"status"`
+	UpdatedAt time.Time                         `json:"updatedAt"`
+	Text      string                            `json:"text"`
+}
+
 type OrganizationPlanMilestoneReorderInput struct {
 	OrganizationPlanID string   `json:"organizationPlanId"`
 	OrganizationID     string   `json:"organizationId"`
 	OrderedIds         []string `json:"orderedIds"`
 }
 
+type OrganizationPlanMilestoneStatusDetailsInput struct {
+	Status    OnboardingPlanMilestoneStatus `json:"status"`
+	UpdatedAt time.Time                     `json:"updatedAt"`
+	Text      string                        `json:"text"`
+}
+
 type OrganizationPlanMilestoneUpdateInput struct {
-	OrganizationPlanID string                `json:"organizationPlanId"`
-	ID                 string                `json:"id"`
-	Name               *string               `json:"name,omitempty"`
-	Order              *int64                `json:"order,omitempty"`
-	DueDate            *time.Time            `json:"dueDate,omitempty"`
-	UpdatedAt          time.Time             `json:"updatedAt"`
-	Optional           *bool                 `json:"optional,omitempty"`
-	Retired            *bool                 `json:"retired,omitempty"`
-	Items              []*MilestoneItemInput `json:"items,omitempty"`
-	StatusDetails      *StatusDetailsInput   `json:"statusDetails,omitempty"`
-	OrganizationID     string                `json:"organizationId"`
-	Adhoc              *bool                 `json:"adhoc,omitempty"`
+	OrganizationPlanID string                                       `json:"organizationPlanId"`
+	ID                 string                                       `json:"id"`
+	Name               *string                                      `json:"name,omitempty"`
+	Order              *int64                                       `json:"order,omitempty"`
+	DueDate            *time.Time                                   `json:"dueDate,omitempty"`
+	UpdatedAt          time.Time                                    `json:"updatedAt"`
+	Optional           *bool                                        `json:"optional,omitempty"`
+	Retired            *bool                                        `json:"retired,omitempty"`
+	Items              []*OrganizationPlanMilestoneItemInput        `json:"items,omitempty"`
+	StatusDetails      *OrganizationPlanMilestoneStatusDetailsInput `json:"statusDetails,omitempty"`
+	OrganizationID     string                                       `json:"organizationId"`
+	Adhoc              *bool                                        `json:"adhoc,omitempty"`
+}
+
+type OrganizationPlanStatusDetailsInput struct {
+	Status    OnboardingPlanStatus `json:"status"`
+	UpdatedAt time.Time            `json:"updatedAt"`
+	Text      string               `json:"text"`
 }
 
 type OrganizationPlanUpdateInput struct {
-	ID             string              `json:"id"`
-	Name           *string             `json:"name,omitempty"`
-	Retired        *bool               `json:"retired,omitempty"`
-	StatusDetails  *StatusDetailsInput `json:"statusDetails,omitempty"`
-	OrganizationID string              `json:"organizationId"`
+	ID             string                              `json:"id"`
+	Name           *string                             `json:"name,omitempty"`
+	Retired        *bool                               `json:"retired,omitempty"`
+	StatusDetails  *OrganizationPlanStatusDetailsInput `json:"statusDetails,omitempty"`
+	OrganizationID string                              `json:"organizationId"`
 }
 
 type OrganizationUpdateInput struct {
@@ -2169,12 +2181,6 @@ type State struct {
 }
 
 type StatusDetails struct {
-	Status    string    `json:"status"`
-	UpdatedAt time.Time `json:"updatedAt"`
-	Text      string    `json:"text"`
-}
-
-type StatusDetailsInput struct {
 	Status    string    `json:"status"`
 	UpdatedAt time.Time `json:"updatedAt"`
 	Text      string    `json:"text"`
@@ -3736,6 +3742,153 @@ func (e *MeetingStatus) UnmarshalGQL(v interface{}) error {
 }
 
 func (e MeetingStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type OnboardingPlanMilestoneItemStatus string
+
+const (
+	OnboardingPlanMilestoneItemStatusNotDone     OnboardingPlanMilestoneItemStatus = "NOT_DONE"
+	OnboardingPlanMilestoneItemStatusSkipped     OnboardingPlanMilestoneItemStatus = "SKIPPED"
+	OnboardingPlanMilestoneItemStatusDone        OnboardingPlanMilestoneItemStatus = "DONE"
+	OnboardingPlanMilestoneItemStatusNotDoneLate OnboardingPlanMilestoneItemStatus = "NOT_DONE_LATE"
+	OnboardingPlanMilestoneItemStatusSkippedLate OnboardingPlanMilestoneItemStatus = "SKIPPED_LATE"
+	OnboardingPlanMilestoneItemStatusDoneLate    OnboardingPlanMilestoneItemStatus = "DONE_LATE"
+)
+
+var AllOnboardingPlanMilestoneItemStatus = []OnboardingPlanMilestoneItemStatus{
+	OnboardingPlanMilestoneItemStatusNotDone,
+	OnboardingPlanMilestoneItemStatusSkipped,
+	OnboardingPlanMilestoneItemStatusDone,
+	OnboardingPlanMilestoneItemStatusNotDoneLate,
+	OnboardingPlanMilestoneItemStatusSkippedLate,
+	OnboardingPlanMilestoneItemStatusDoneLate,
+}
+
+func (e OnboardingPlanMilestoneItemStatus) IsValid() bool {
+	switch e {
+	case OnboardingPlanMilestoneItemStatusNotDone, OnboardingPlanMilestoneItemStatusSkipped, OnboardingPlanMilestoneItemStatusDone, OnboardingPlanMilestoneItemStatusNotDoneLate, OnboardingPlanMilestoneItemStatusSkippedLate, OnboardingPlanMilestoneItemStatusDoneLate:
+		return true
+	}
+	return false
+}
+
+func (e OnboardingPlanMilestoneItemStatus) String() string {
+	return string(e)
+}
+
+func (e *OnboardingPlanMilestoneItemStatus) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = OnboardingPlanMilestoneItemStatus(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid OnboardingPlanMilestoneItemStatus", str)
+	}
+	return nil
+}
+
+func (e OnboardingPlanMilestoneItemStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type OnboardingPlanMilestoneStatus string
+
+const (
+	OnboardingPlanMilestoneStatusNotStarted     OnboardingPlanMilestoneStatus = "NOT_STARTED"
+	OnboardingPlanMilestoneStatusStarted        OnboardingPlanMilestoneStatus = "STARTED"
+	OnboardingPlanMilestoneStatusDone           OnboardingPlanMilestoneStatus = "DONE"
+	OnboardingPlanMilestoneStatusNotStartedLate OnboardingPlanMilestoneStatus = "NOT_STARTED_LATE"
+	OnboardingPlanMilestoneStatusStartedLate    OnboardingPlanMilestoneStatus = "STARTED_LATE"
+	OnboardingPlanMilestoneStatusDoneLate       OnboardingPlanMilestoneStatus = "DONE_LATE"
+)
+
+var AllOnboardingPlanMilestoneStatus = []OnboardingPlanMilestoneStatus{
+	OnboardingPlanMilestoneStatusNotStarted,
+	OnboardingPlanMilestoneStatusStarted,
+	OnboardingPlanMilestoneStatusDone,
+	OnboardingPlanMilestoneStatusNotStartedLate,
+	OnboardingPlanMilestoneStatusStartedLate,
+	OnboardingPlanMilestoneStatusDoneLate,
+}
+
+func (e OnboardingPlanMilestoneStatus) IsValid() bool {
+	switch e {
+	case OnboardingPlanMilestoneStatusNotStarted, OnboardingPlanMilestoneStatusStarted, OnboardingPlanMilestoneStatusDone, OnboardingPlanMilestoneStatusNotStartedLate, OnboardingPlanMilestoneStatusStartedLate, OnboardingPlanMilestoneStatusDoneLate:
+		return true
+	}
+	return false
+}
+
+func (e OnboardingPlanMilestoneStatus) String() string {
+	return string(e)
+}
+
+func (e *OnboardingPlanMilestoneStatus) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = OnboardingPlanMilestoneStatus(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid OnboardingPlanMilestoneStatus", str)
+	}
+	return nil
+}
+
+func (e OnboardingPlanMilestoneStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type OnboardingPlanStatus string
+
+const (
+	OnboardingPlanStatusNotStarted     OnboardingPlanStatus = "NOT_STARTED"
+	OnboardingPlanStatusOnTrack        OnboardingPlanStatus = "ON_TRACK"
+	OnboardingPlanStatusLate           OnboardingPlanStatus = "LATE"
+	OnboardingPlanStatusDone           OnboardingPlanStatus = "DONE"
+	OnboardingPlanStatusNotStartedLate OnboardingPlanStatus = "NOT_STARTED_LATE"
+	OnboardingPlanStatusDoneLate       OnboardingPlanStatus = "DONE_LATE"
+)
+
+var AllOnboardingPlanStatus = []OnboardingPlanStatus{
+	OnboardingPlanStatusNotStarted,
+	OnboardingPlanStatusOnTrack,
+	OnboardingPlanStatusLate,
+	OnboardingPlanStatusDone,
+	OnboardingPlanStatusNotStartedLate,
+	OnboardingPlanStatusDoneLate,
+}
+
+func (e OnboardingPlanStatus) IsValid() bool {
+	switch e {
+	case OnboardingPlanStatusNotStarted, OnboardingPlanStatusOnTrack, OnboardingPlanStatusLate, OnboardingPlanStatusDone, OnboardingPlanStatusNotStartedLate, OnboardingPlanStatusDoneLate:
+		return true
+	}
+	return false
+}
+
+func (e OnboardingPlanStatus) String() string {
+	return string(e)
+}
+
+func (e *OnboardingPlanStatus) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = OnboardingPlanStatus(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid OnboardingPlanStatus", str)
+	}
+	return nil
+}
+
+func (e OnboardingPlanStatus) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/packages/server/customer-os-api/graph/resolver/organization_plan.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organization_plan.resolvers.go
@@ -311,7 +311,9 @@ func (r *queryResolver) OrganizationPlan(ctx context.Context, id string) (*model
 		graphql.AddErrorf(ctx, "Org plan with id %s not found", id)
 		return nil, nil
 	}
-	return mapper.MapEntityToOrganizationPlan(orgPlanEntity), nil
+	op := mapper.MapEntityToOrganizationPlan(orgPlanEntity)
+
+	return op, nil
 }
 
 // OrganizationPlansForOrganization is the resolver for the organizationPlansForOrganization field.

--- a/packages/server/customer-os-api/graph/schemas/organization_plan.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/organization_plan.graphqls
@@ -41,10 +41,37 @@ type OrganizationPlanMilestone implements SourceFields & Node {
     order:              Int64!
     dueDate:            Time!
     optional:           Boolean!
-    items:              [MilestoneItem!]!
+    items:              [OrganizationPlanMilestoneItem!]!
     retired:            Boolean!
     statusDetails:      StatusDetails!
     adhoc:              Boolean!
+}
+
+enum OnboardingPlanStatus {
+    NOT_STARTED
+    ON_TRACK
+    LATE
+    DONE
+    NOT_STARTED_LATE
+    DONE_LATE
+}
+
+enum OnboardingPlanMilestoneStatus {
+    NOT_STARTED
+    STARTED
+    DONE
+    NOT_STARTED_LATE
+    STARTED_LATE
+    DONE_LATE
+}
+
+enum OnboardingPlanMilestoneItemStatus {
+    NOT_DONE
+    SKIPPED
+    DONE
+    NOT_DONE_LATE
+    SKIPPED_LATE
+    DONE_LATE
 }
 
 type StatusDetails {
@@ -53,14 +80,20 @@ type StatusDetails {
     text: String!
 }
 
-type MilestoneItem {
-    status: String!
+input OrganizationPlanStatusDetailsInput {
+    status: OnboardingPlanStatus!
     updatedAt: Time!
     text: String!
 }
 
-input StatusDetailsInput {
-    status: String!
+input OrganizationPlanMilestoneStatusDetailsInput {
+    status: OnboardingPlanMilestoneStatus!
+    updatedAt: Time!
+    text: String!
+}
+
+type OrganizationPlanMilestoneItem {
+    status: OnboardingPlanMilestoneItemStatus!
     updatedAt: Time!
     text: String!
 }
@@ -75,7 +108,7 @@ input OrganizationPlanUpdateInput {
     id: ID!
     name: String
     retired: Boolean
-    statusDetails: StatusDetailsInput
+    statusDetails: OrganizationPlanStatusDetailsInput
     organizationId: ID!
 }
 
@@ -91,8 +124,8 @@ input OrganizationPlanMilestoneInput {
     adhoc: Boolean!
 }
 
-input MilestoneItemInput {
-    status: String!
+input OrganizationPlanMilestoneItemInput {
+    status: OnboardingPlanMilestoneItemStatus!
     updatedAt: Time!
     text: String!
 }
@@ -106,8 +139,8 @@ input OrganizationPlanMilestoneUpdateInput {
     updatedAt: Time!
     optional: Boolean
     retired: Boolean
-    items: [MilestoneItemInput]
-    statusDetails: StatusDetailsInput
+    items: [OrganizationPlanMilestoneItemInput]
+    statusDetails: OrganizationPlanMilestoneStatusDetailsInput
     organizationId: ID!
     adhoc: Boolean
 }

--- a/packages/server/customer-os-api/mapper/organization_plan_mapper.go
+++ b/packages/server/customer-os-api/mapper/organization_plan_mapper.go
@@ -63,20 +63,35 @@ func MapEntitiesToOrganizationPlanMilestones(entities *neo4jentity.OrganizationP
 	return models
 }
 
-func MapEntityToOrganizationPlanMilestoneItems(entities []neo4jentity.OrganizationPlanMilestoneItem) []*model.MilestoneItem {
-	var models []*model.MilestoneItem
+func MapEntityToOrganizationPlanMilestoneItems(entities []neo4jentity.OrganizationPlanMilestoneItem) []*model.OrganizationPlanMilestoneItem {
+	var models []*model.OrganizationPlanMilestoneItem
 	for _, entity := range entities {
 		models = append(models, MapEntityToOrganizationPlanMilestoneItem(&entity))
 	}
 	return models
 }
 
-func MapEntityToOrganizationPlanMilestoneItem(entity *neo4jentity.OrganizationPlanMilestoneItem) *model.MilestoneItem {
+func MapEntityToOrganizationPlanMilestoneItem(entity *neo4jentity.OrganizationPlanMilestoneItem) *model.OrganizationPlanMilestoneItem {
 	if entity == nil {
 		return nil
 	}
-	return &model.MilestoneItem{
-		Status:    entity.Status,
+	status := model.OnboardingPlanMilestoneItemStatusNotDone
+	switch entity.Status {
+	case model.OnboardingPlanMilestoneItemStatusNotDone.String():
+		status = model.OnboardingPlanMilestoneItemStatusNotDone
+	case model.OnboardingPlanMilestoneItemStatusDone.String():
+		status = model.OnboardingPlanMilestoneItemStatusDone
+	case model.OnboardingPlanMilestoneItemStatusSkipped.String():
+		status = model.OnboardingPlanMilestoneItemStatusSkipped
+	case model.OnboardingPlanMilestoneItemStatusNotDoneLate.String():
+		status = model.OnboardingPlanMilestoneItemStatusNotDoneLate
+	case model.OnboardingPlanMilestoneItemStatusSkippedLate.String():
+		status = model.OnboardingPlanMilestoneItemStatusSkippedLate
+	case model.OnboardingPlanMilestoneItemStatusDoneLate.String():
+		status = model.OnboardingPlanMilestoneItemStatusDoneLate
+	}
+	return &model.OrganizationPlanMilestoneItem{
+		Status:    status,
 		UpdatedAt: entity.UpdatedAt,
 		Text:      entity.Text,
 	}

--- a/packages/server/events-processing-platform/domain/organization_plan/model/org_plan_status.go
+++ b/packages/server/events-processing-platform/domain/organization_plan/model/org_plan_status.go
@@ -4,9 +4,12 @@ type OrganizationPlanStatusString string
 
 const (
 	OrganizationPlanStatusNotStarted OrganizationPlanStatusString = "NOT_STARTED"
-	OrganizationPlanStatusOnTrack    OrganizationPlanStatusString = "ON_TRACK"
-	OrganizationPlanStatusLate       OrganizationPlanStatusString = "LATE"
+	OrganizationPlanStatusOnTrack    OrganizationPlanStatusString = "ON_TRACK" // ~ started, on time
+	OrganizationPlanStatusLate       OrganizationPlanStatusString = "LATE"     // ~ started, late
 	OrganizationPlanStatusDone       OrganizationPlanStatusString = "DONE"
+	// timeline related
+	OrganizationPlanStatusNotStartedLate OrganizationPlanStatusString = "NOT_STARTED_LATE"
+	OrganizationPlanStatusDoneLate       OrganizationPlanStatusString = "DONE_LATE"
 )
 
 type OrganizationPlanStatus int32
@@ -16,6 +19,9 @@ const (
 	OnTrack
 	Late
 	Done
+	// timeline related
+	NotStartedLate
+	DoneLate
 )
 
 func (os OrganizationPlanStatus) String() string {
@@ -28,6 +34,10 @@ func (os OrganizationPlanStatus) String() string {
 		return string(OrganizationPlanStatusLate)
 	case Done:
 		return string(OrganizationPlanStatusDone)
+	case NotStartedLate:
+		return string(OrganizationPlanStatusNotStartedLate)
+	case DoneLate:
+		return string(OrganizationPlanStatusDoneLate)
 	default:
 		return string(OrganizationPlanStatusNotStarted)
 	}

--- a/packages/server/events-processing-platform/domain/organization_plan/model/org_plan_status.go
+++ b/packages/server/events-processing-platform/domain/organization_plan/model/org_plan_status.go
@@ -41,6 +41,10 @@ const (
 	OrganizationPlanMilestoneStatusNotStarted OrganizationPlanMilestoneStatusString = "NOT_STARTED"
 	OrganizationPlanMilestoneStatusStarted    OrganizationPlanMilestoneStatusString = "STARTED"
 	OrganizationPlanMilestoneStatusDone       OrganizationPlanMilestoneStatusString = "DONE"
+	// timeline related
+	OrganizationPlanMilestoneStatusNotStartedLate OrganizationPlanMilestoneStatusString = "NOT_STARTED_LATE"
+	OrganizationPlanMilestoneStatusStartedLate    OrganizationPlanMilestoneStatusString = "STARTED_LATE"
+	OrganizationPlanMilestoneStatusDoneLate       OrganizationPlanMilestoneStatusString = "DONE_LATE"
 )
 
 type OrganizationPlanMilestoneStatus int32
@@ -49,6 +53,10 @@ const (
 	MilestoneNotStarted OrganizationPlanMilestoneStatus = iota
 	MilestoneStarted
 	MilestoneDone
+	// timeline related
+	MilestoneNotStartedLate
+	MilestoneStartedLate
+	MilestoneDoneLate
 )
 
 func (os OrganizationPlanMilestoneStatus) String() string {
@@ -59,6 +67,12 @@ func (os OrganizationPlanMilestoneStatus) String() string {
 		return string(OrganizationPlanMilestoneStatusStarted)
 	case MilestoneDone:
 		return string(OrganizationPlanMilestoneStatusDone)
+	case MilestoneNotStartedLate:
+		return string(OrganizationPlanMilestoneStatusNotStartedLate)
+	case MilestoneStartedLate:
+		return string(OrganizationPlanMilestoneStatusStartedLate)
+	case MilestoneDoneLate:
+		return string(OrganizationPlanMilestoneStatusDoneLate)
 	default:
 		return string(OrganizationPlanMilestoneStatusNotStarted)
 	}
@@ -72,6 +86,10 @@ const (
 	OrganizationPlanMilestoneTaskStatusNotDone OrganizationPlanMilestoneTaskStatusString = "NOT_DONE"
 	OrganizationPlanMilestoneTaskStatusSkipped OrganizationPlanMilestoneTaskStatusString = "SKIPPED"
 	OrganizationPlanMilestoneTaskStatusDone    OrganizationPlanMilestoneTaskStatusString = "DONE"
+	// timeline related
+	OrganizationPlanMilestoneTaskStatusNotDoneLate OrganizationPlanMilestoneTaskStatusString = "NOT_DONE_LATE"
+	OrganizationPlanMilestoneTaskStatusSkippedLate OrganizationPlanMilestoneTaskStatusString = "SKIPPED_LATE"
+	OrganizationPlanMilestoneTaskStatusDoneLate    OrganizationPlanMilestoneTaskStatusString = "DONE_LATE"
 )
 
 type OrganizationPlanMilestoneTaskStatus int32
@@ -80,6 +98,10 @@ const (
 	TaskNotDone OrganizationPlanMilestoneTaskStatus = iota
 	TaskSkipped
 	TaskDone
+	// timeline related
+	TaskNotDoneLate
+	TaskSkippedLate
+	TaskDoneLate
 )
 
 func (os OrganizationPlanMilestoneTaskStatus) String() string {
@@ -90,6 +112,12 @@ func (os OrganizationPlanMilestoneTaskStatus) String() string {
 		return string(OrganizationPlanMilestoneTaskStatusSkipped)
 	case TaskDone:
 		return string(OrganizationPlanMilestoneStatusDone)
+	case TaskNotDoneLate:
+		return string(OrganizationPlanMilestoneTaskStatusNotDoneLate)
+	case TaskSkippedLate:
+		return string(OrganizationPlanMilestoneTaskStatusSkippedLate)
+	case TaskDoneLate:
+		return string(OrganizationPlanMilestoneTaskStatusDoneLate)
 	default:
 		return string(OrganizationPlanMilestoneTaskStatusNotDone)
 	}

--- a/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
+	neo4jmapper "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/mapper"
 	neo4jrepository "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/repository"
 	event "github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/organization_plan/events"
 	"github.com/openline-ai/openline-customer-os/packages/server/events-processing-platform/domain/organization_plan/model"
@@ -266,25 +267,6 @@ func (h *OrganizationPlanEventHandler) OnReorderMilestones(ctx context.Context, 
 	return nil
 }
 
-//	func convertMasterPlanMilestonesToOrganizationPlanMilestones(masterPlanMilestonesNodes []*dbtype.Node, createdAt time.Time) []entity.OrganizationPlanMilestoneEntity {
-//		organizationPlanMilestones := make([]entity.OrganizationPlanMilestoneEntity, len(masterPlanMilestonesNodes))
-//		for i, masterPlanMilestoneNode := range masterPlanMilestonesNodes {
-//			mpMilestone := neo4jmapper.MapDbNodeToMasterPlanMilestoneEntity(masterPlanMilestoneNode)
-//			organizationPlanMilestones[i] = entity.OrganizationPlanMilestoneEntity{
-//				Id:            uuid.New().String(),
-//				Name:          mpMilestone.Name,
-//				Order:         mpMilestone.Order,
-//				DueDate:       createdAt.Add(time.Duration(mpMilestone.DurationHours) * time.Hour),
-//				Items:         convertItemsStrToObject(mpMilestone.Items),
-//				Optional:      mpMilestone.Optional,
-//				CreatedAt:     createdAt,
-//				UpdatedAt:     createdAt,
-//				StatusDetails: entity.OrganizationPlanMilestoneStatusDetails{Status: model.MilestoneNotStarted.String(), UpdatedAt: createdAt, Comments: ""},
-//				Adhoc:         false,
-//			}
-//		}
-//		return organizationPlanMilestones
-//	}
 func (h *OrganizationPlanEventHandler) propagateStatusUpdatesFromMilestone(ctx context.Context, data neo4jrepository.OrganizationPlanMilestoneUpdateFields, tenant, opid string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationPlanEventHandler.propagateStatusUpdatesFromMilestone")
 	defer span.Finish()

--- a/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler.go
@@ -382,17 +382,17 @@ func checkAllItemStatusesAreDoneOrSkipped(items []model.OrganizationPlanMileston
 	return true
 }
 
-func convertMilestonesToOrganizationPlanMilestones(masterPlanMilestonesNodes []*dbtype.Node, createdAt time.Time) []entity.OrganizationPlanMilestoneEntity {
-	organizationPlanMilestones := make([]entity.OrganizationPlanMilestoneEntity, len(masterPlanMilestonesNodes))
-	for i, masterPlanMilestoneNode := range masterPlanMilestonesNodes {
-		mpMilestone := neo4jmapper.MapDbNodeToMasterPlanMilestoneEntity(masterPlanMilestoneNode)
+func convertMilestonesToOrganizationPlanMilestones(opMilestonesNodes []*dbtype.Node, createdAt time.Time) []entity.OrganizationPlanMilestoneEntity {
+	organizationPlanMilestones := make([]entity.OrganizationPlanMilestoneEntity, len(opMilestonesNodes))
+	for i, opMilestoneNode := range opMilestonesNodes {
+		milestone := neo4jmapper.MapDbNodeToOrganizationPlanMilestoneEntity(opMilestoneNode)
 		organizationPlanMilestones[i] = entity.OrganizationPlanMilestoneEntity{
 			Id:            uuid.New().String(),
-			Name:          mpMilestone.Name,
-			Order:         mpMilestone.Order,
-			DueDate:       createdAt.Add(time.Duration(mpMilestone.DurationHours) * time.Hour),
-			Items:         convertItemsStrToObject(mpMilestone.Items),
-			Optional:      mpMilestone.Optional,
+			Name:          milestone.Name,
+			Order:         milestone.Order,
+			DueDate:       createdAt.Add(time.Duration(milestone.DurationHours) * time.Hour),
+			Items:         convertItemsStrToObject(milestone.Items),
+			Optional:      milestone.Optional,
 			CreatedAt:     createdAt,
 			UpdatedAt:     createdAt,
 			StatusDetails: entity.OrganizationPlanMilestoneStatusDetails{Status: model.MilestoneNotStarted.String(), UpdatedAt: createdAt, Comments: ""},

--- a/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler_it_test.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler_it_test.go
@@ -606,8 +606,9 @@ func TestOrganizationPlanEventHandler_OnUpdateMilestoneLate(t *testing.T) {
 		10,
 		[]model.OrganizationPlanMilestoneItem{{Text: "item1", Status: model.TaskDone.String(), UpdatedAt: lateUpdateTime}, {Text: "item2Change", Status: model.TaskNotDone.String(), UpdatedAt: lateUpdateTime}},
 		[]string{event.FieldMaskName, event.FieldMaskOptional, event.FieldMaskItems, event.FieldMaskOrder, event.FieldMaskStatusDetails},
-		true,
-		true,
+		true,  // optional
+		false, // adhoc
+		true,  // retired
 		lateUpdateTime,
 		timeNow.Add(time.Hour*24), // due date
 		model.OrganizationPlanDetails{
@@ -732,8 +733,9 @@ func TestOrganizationPlanEventHandler_OnUpdateMilestoneAllDoneLate(t *testing.T)
 		10,
 		[]model.OrganizationPlanMilestoneItem{{Text: "item1", Status: model.TaskDone.String(), UpdatedAt: lateUpdateTime}, {Text: "item2Change", Status: model.TaskDoneLate.String(), UpdatedAt: lateUpdateTime}},
 		[]string{event.FieldMaskName, event.FieldMaskOptional, event.FieldMaskItems, event.FieldMaskOrder, event.FieldMaskStatusDetails},
-		true,
-		true,
+		true,  // optional
+		false, // adhoc
+		true,  // retired
 		lateUpdateTime,
 		timeNow.Add(time.Hour*24), // due date
 		model.OrganizationPlanDetails{

--- a/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler_it_test.go
+++ b/packages/server/events-processing-platform/subscriptions/graph/organization_plan_event_handler_it_test.go
@@ -366,7 +366,7 @@ func TestOrganizationPlanEventHandler_OnUpdateMilestone(t *testing.T) {
 		updateTime,
 		timeNow.Add(time.Hour*48), // due date
 		model.OrganizationPlanDetails{
-			Status:    model.MilestoneStarted.String(),
+			Status:    model.MilestoneNotStarted.String(),
 			Comments:  "comments",
 			UpdatedAt: updateTime,
 		},
@@ -394,8 +394,8 @@ func TestOrganizationPlanEventHandler_OnUpdateMilestone(t *testing.T) {
 	require.Equal(t, int64(10), milestone.Order)
 	require.Equal(t, timeNow.Add(time.Hour*48), milestone.DueDate)
 	require.Equal(t, true, milestone.Optional)
-	require.Equal(t, false, milestone.Retired) // mask not passed so we ignore this field update
-	require.Equal(t, model.MilestoneStarted.String(), milestone.StatusDetails.Status)
+	require.Equal(t, false, milestone.Retired)                                        // mask not passed so we ignore this field update
+	require.Equal(t, model.MilestoneStarted.String(), milestone.StatusDetails.Status) // automatic update
 	require.Equal(t, "comments", milestone.StatusDetails.Comments)
 	require.Equal(t, updateTime, milestone.StatusDetails.UpdatedAt)
 	for i, item := range milestone.Items {
@@ -407,6 +407,10 @@ func TestOrganizationPlanEventHandler_OnUpdateMilestone(t *testing.T) {
 			require.Equal(t, "item2Change", item.Text)
 		}
 	}
+	organizationPlanDbNode, err := neo4jtest.GetNodeById(ctx, testDatabase.Driver, neo4jutil.NodeLabelOrganizationPlan, opid)
+	require.Nil(t, err)
+	op := neo4jmapper.MapDbNodeToOrganizationPlanEntity(organizationPlanDbNode)
+	require.Equal(t, model.OnTrack.String(), op.StatusDetails.Status) // automatic update
 }
 
 func TestOrganizationPlanEventHandler_OnReorderMilestones(t *testing.T) {
@@ -513,10 +517,265 @@ func TestOrganizationPlanEventHandler_OnReorderMilestones(t *testing.T) {
 	require.NotNil(t, orgPlanMilestoneDbNode1)
 	milestone1 := neo4jmapper.MapDbNodeToOrganizationPlanMilestoneEntity(orgPlanMilestoneDbNode1)
 	require.Equal(t, int64(1), milestone1.Order)
+	require.Equal(t, model.MilestoneNotStarted.String(), milestone1.StatusDetails.Status) // don't update status automatically
 
 	orgPlanMilestoneDbNode2, err := neo4jtest.GetNodeById(ctx, testDatabase.Driver, neo4jutil.NodeLabelOrganizationPlanMilestone, milestoneId2)
 	require.Nil(t, err)
 	require.NotNil(t, orgPlanMilestoneDbNode2)
 	milestone2 := neo4jmapper.MapDbNodeToOrganizationPlanMilestoneEntity(orgPlanMilestoneDbNode2)
 	require.Equal(t, int64(0), milestone2.Order)
+	require.Equal(t, model.MilestoneNotStarted.String(), milestone2.StatusDetails.Status) // don't update status automatically
+
+	organizationPlanDbNode, err := neo4jtest.GetNodeById(ctx, testDatabase.Driver, neo4jutil.NodeLabelOrganizationPlan, opid)
+	require.Nil(t, err)
+	op := neo4jmapper.MapDbNodeToOrganizationPlanEntity(organizationPlanDbNode)
+	require.Equal(t, model.NotStarted.String(), op.StatusDetails.Status) // no automatic update
+}
+
+func TestOrganizationPlanEventHandler_OnUpdateMilestoneLate(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx, testDatabase)(t)
+
+	// prepare neo4j data
+	neo4jtest.CreateTenant(ctx, testDatabase.Driver, tenantName)
+	timeNow := utils.Now()
+	mpid := neo4jtest.CreateMasterPlan(ctx, testDatabase.Driver, tenantName, neo4jentity.MasterPlanEntity{
+		Source:        neo4jentity.DataSource(constants.SourceOpenline),
+		AppSource:     constants.AppSourceEventProcessingPlatform,
+		Name:          "master plan name",
+		SourceOfTruth: neo4jentity.DataSource(constants.SourceOpenline),
+		CreatedAt:     timeNow,
+		UpdatedAt:     timeNow,
+		Retired:       false,
+	})
+	orgId := neo4jtest.CreateOrganization(ctx, testDatabase.Driver, tenantName, neo4jentity.OrganizationEntity{Name: "test org"})
+	opid := neo4jtest.CreateOrganizationPlan(ctx, testDatabase.Driver, tenantName, mpid, orgId, neo4jentity.OrganizationPlanEntity{
+		Source:        neo4jentity.DataSource(constants.SourceOpenline),
+		AppSource:     constants.AppSourceEventProcessingPlatform,
+		Name:          "org plan name",
+		SourceOfTruth: neo4jentity.DataSource(constants.SourceOpenline),
+		CreatedAt:     timeNow,
+		UpdatedAt:     timeNow,
+		Retired:       false,
+		StatusDetails: neo4jentity.OrganizationPlanStatusDetails{
+			Status:    model.NotStarted.String(),
+			Comments:  "",
+			UpdatedAt: timeNow,
+		},
+	})
+
+	milestoneId := neo4jtest.CreateOrganizationPlanMilestone(ctx, testDatabase.Driver, tenantName, opid, neo4jentity.OrganizationPlanMilestoneEntity{
+		Source:        neo4jentity.DataSource(constants.SourceOpenline),
+		AppSource:     constants.AppSourceEventProcessingPlatform,
+		Name:          "milestone name",
+		SourceOfTruth: neo4jentity.DataSource(constants.SourceOpenline),
+		CreatedAt:     timeNow,
+		UpdatedAt:     timeNow,
+		Retired:       false,
+		Order:         0,
+		DueDate:       timeNow.Add(time.Hour * 24),
+		Items:         []neo4jentity.OrganizationPlanMilestoneItem{{Text: "item1", Status: model.TaskNotDone.String(), UpdatedAt: timeNow}, {Text: "item2", Status: model.TaskNotDone.String(), UpdatedAt: timeNow}},
+		Optional:      false,
+		StatusDetails: neo4jentity.OrganizationPlanMilestoneStatusDetails{
+			Status:    model.MilestoneNotStarted.String(),
+			Comments:  "",
+			UpdatedAt: timeNow,
+		},
+	})
+
+	neo4jtest.AssertNeo4jNodeCount(ctx, t, testDatabase.Driver, map[string]int{
+		neo4jutil.NodeLabelOrganizationPlan:                             1,
+		neo4jutil.NodeLabelOrganizationPlanMilestone:                    1,
+		neo4jutil.NodeLabelOrganizationPlanMilestone + "_" + tenantName: 1,
+	})
+
+	// Prepare the event handler
+	orgPlanEventHandler := &OrganizationPlanEventHandler{
+		log:          testLogger,
+		repositories: testDatabase.Repositories,
+	}
+
+	// Create an MasterPlanMilestoneCreateEvent
+	orgAggregate := aggregate.NewOrganizationAggregateWithTenantAndID(tenantName, orgId)
+	lateUpdateTime := timeNow.Add(time.Hour * 48)
+	updateEvent, err := event.NewOrganizationPlanMilestoneUpdateEvent(
+		orgAggregate,
+		opid,
+		milestoneId,
+		"new name",
+		10,
+		[]model.OrganizationPlanMilestoneItem{{Text: "item1", Status: model.TaskDone.String(), UpdatedAt: lateUpdateTime}, {Text: "item2Change", Status: model.TaskNotDone.String(), UpdatedAt: lateUpdateTime}},
+		[]string{event.FieldMaskName, event.FieldMaskOptional, event.FieldMaskItems, event.FieldMaskOrder, event.FieldMaskStatusDetails},
+		true,
+		true,
+		lateUpdateTime,
+		timeNow.Add(time.Hour*24), // due date
+		model.OrganizationPlanDetails{
+			Status:    model.MilestoneNotStarted.String(),
+			Comments:  "comments",
+			UpdatedAt: lateUpdateTime,
+		},
+	)
+	require.Nil(t, err)
+
+	// EXECUTE
+	err = orgPlanEventHandler.OnUpdateMilestone(context.Background(), updateEvent)
+	require.Nil(t, err)
+
+	// verify nodes and relationships
+	neo4jtest.AssertNeo4jNodeCount(ctx, t, testDatabase.Driver, map[string]int{
+		neo4jutil.NodeLabelOrganizationPlan:          1,
+		neo4jutil.NodeLabelOrganizationPlanMilestone: 1})
+
+	// verify master plan milestone node
+	orgPlanMilestoneDbNode, err := neo4jtest.GetNodeById(ctx, testDatabase.Driver, neo4jutil.NodeLabelOrganizationPlanMilestone, milestoneId)
+	require.Nil(t, err)
+	require.NotNil(t, orgPlanMilestoneDbNode)
+
+	milestone := neo4jmapper.MapDbNodeToOrganizationPlanMilestoneEntity(orgPlanMilestoneDbNode)
+	require.Equal(t, milestoneId, milestone.Id)
+	require.Equal(t, lateUpdateTime, milestone.UpdatedAt)
+	require.Equal(t, "new name", milestone.Name)
+	require.Equal(t, int64(10), milestone.Order)
+	require.Equal(t, timeNow.Add(time.Hour*24), milestone.DueDate) // no due date update
+	require.Equal(t, true, milestone.Optional)
+	require.Equal(t, false, milestone.Retired)                                            // mask not passed so we ignore this field update
+	require.Equal(t, model.MilestoneStartedLate.String(), milestone.StatusDetails.Status) // automatic update
+	require.Equal(t, "comments", milestone.StatusDetails.Comments)
+	require.Equal(t, lateUpdateTime, milestone.StatusDetails.UpdatedAt)
+	for i, item := range milestone.Items {
+		if i == 0 {
+			require.Equal(t, model.TaskDone.String(), item.Status)
+			require.Equal(t, "item1", item.Text)
+		} else {
+			require.Equal(t, model.TaskNotDone.String(), item.Status)
+			require.Equal(t, "item2Change", item.Text)
+		}
+	}
+	organizationPlanDbNode, err := neo4jtest.GetNodeById(ctx, testDatabase.Driver, neo4jutil.NodeLabelOrganizationPlan, opid)
+	require.Nil(t, err)
+	op := neo4jmapper.MapDbNodeToOrganizationPlanEntity(organizationPlanDbNode)
+	require.Equal(t, model.Late.String(), op.StatusDetails.Status) // automatic update
+}
+
+func TestOrganizationPlanEventHandler_OnUpdateMilestoneAllDoneLate(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx, testDatabase)(t)
+
+	// prepare neo4j data
+	neo4jtest.CreateTenant(ctx, testDatabase.Driver, tenantName)
+	timeNow := utils.Now()
+	mpid := neo4jtest.CreateMasterPlan(ctx, testDatabase.Driver, tenantName, neo4jentity.MasterPlanEntity{
+		Source:        neo4jentity.DataSource(constants.SourceOpenline),
+		AppSource:     constants.AppSourceEventProcessingPlatform,
+		Name:          "master plan name",
+		SourceOfTruth: neo4jentity.DataSource(constants.SourceOpenline),
+		CreatedAt:     timeNow,
+		UpdatedAt:     timeNow,
+		Retired:       false,
+	})
+	orgId := neo4jtest.CreateOrganization(ctx, testDatabase.Driver, tenantName, neo4jentity.OrganizationEntity{Name: "test org"})
+	opid := neo4jtest.CreateOrganizationPlan(ctx, testDatabase.Driver, tenantName, mpid, orgId, neo4jentity.OrganizationPlanEntity{
+		Source:        neo4jentity.DataSource(constants.SourceOpenline),
+		AppSource:     constants.AppSourceEventProcessingPlatform,
+		Name:          "org plan name",
+		SourceOfTruth: neo4jentity.DataSource(constants.SourceOpenline),
+		CreatedAt:     timeNow,
+		UpdatedAt:     timeNow,
+		Retired:       false,
+		StatusDetails: neo4jentity.OrganizationPlanStatusDetails{
+			Status:    model.NotStarted.String(),
+			Comments:  "",
+			UpdatedAt: timeNow,
+		},
+	})
+
+	milestoneId := neo4jtest.CreateOrganizationPlanMilestone(ctx, testDatabase.Driver, tenantName, opid, neo4jentity.OrganizationPlanMilestoneEntity{
+		Source:        neo4jentity.DataSource(constants.SourceOpenline),
+		AppSource:     constants.AppSourceEventProcessingPlatform,
+		Name:          "milestone name",
+		SourceOfTruth: neo4jentity.DataSource(constants.SourceOpenline),
+		CreatedAt:     timeNow,
+		UpdatedAt:     timeNow,
+		Retired:       false,
+		Order:         0,
+		DueDate:       timeNow.Add(time.Hour * 24),
+		Items:         []neo4jentity.OrganizationPlanMilestoneItem{{Text: "item1", Status: model.TaskNotDone.String(), UpdatedAt: timeNow}, {Text: "item2", Status: model.TaskNotDone.String(), UpdatedAt: timeNow}},
+		Optional:      false,
+		StatusDetails: neo4jentity.OrganizationPlanMilestoneStatusDetails{
+			Status:    model.MilestoneNotStarted.String(),
+			Comments:  "",
+			UpdatedAt: timeNow,
+		},
+	})
+
+	neo4jtest.AssertNeo4jNodeCount(ctx, t, testDatabase.Driver, map[string]int{
+		neo4jutil.NodeLabelOrganizationPlan:                             1,
+		neo4jutil.NodeLabelOrganizationPlanMilestone:                    1,
+		neo4jutil.NodeLabelOrganizationPlanMilestone + "_" + tenantName: 1,
+	})
+
+	// Prepare the event handler
+	orgPlanEventHandler := &OrganizationPlanEventHandler{
+		log:          testLogger,
+		repositories: testDatabase.Repositories,
+	}
+
+	// Create an MasterPlanMilestoneCreateEvent
+	orgAggregate := aggregate.NewOrganizationAggregateWithTenantAndID(tenantName, orgId)
+	lateUpdateTime := timeNow.Add(time.Hour * 48)
+	updateEvent, err := event.NewOrganizationPlanMilestoneUpdateEvent(
+		orgAggregate,
+		opid,
+		milestoneId,
+		"new name",
+		10,
+		[]model.OrganizationPlanMilestoneItem{{Text: "item1", Status: model.TaskDone.String(), UpdatedAt: lateUpdateTime}, {Text: "item2Change", Status: model.TaskDoneLate.String(), UpdatedAt: lateUpdateTime}},
+		[]string{event.FieldMaskName, event.FieldMaskOptional, event.FieldMaskItems, event.FieldMaskOrder, event.FieldMaskStatusDetails},
+		true,
+		true,
+		lateUpdateTime,
+		timeNow.Add(time.Hour*24), // due date
+		model.OrganizationPlanDetails{
+			Status:    model.MilestoneNotStarted.String(),
+			Comments:  "comments",
+			UpdatedAt: lateUpdateTime,
+		},
+	)
+	require.Nil(t, err)
+
+	// EXECUTE
+	err = orgPlanEventHandler.OnUpdateMilestone(context.Background(), updateEvent)
+	require.Nil(t, err)
+
+	// verify nodes and relationships
+	neo4jtest.AssertNeo4jNodeCount(ctx, t, testDatabase.Driver, map[string]int{
+		neo4jutil.NodeLabelOrganizationPlan:          1,
+		neo4jutil.NodeLabelOrganizationPlanMilestone: 1})
+
+	// verify master plan milestone node
+	orgPlanMilestoneDbNode, err := neo4jtest.GetNodeById(ctx, testDatabase.Driver, neo4jutil.NodeLabelOrganizationPlanMilestone, milestoneId)
+	require.Nil(t, err)
+	require.NotNil(t, orgPlanMilestoneDbNode)
+
+	milestone := neo4jmapper.MapDbNodeToOrganizationPlanMilestoneEntity(orgPlanMilestoneDbNode)
+	require.Equal(t, milestoneId, milestone.Id)
+	require.Equal(t, lateUpdateTime, milestone.UpdatedAt)
+
+	require.Equal(t, model.MilestoneDoneLate.String(), milestone.StatusDetails.Status) // automatic update
+	require.Equal(t, "comments", milestone.StatusDetails.Comments)
+	require.Equal(t, lateUpdateTime, milestone.StatusDetails.UpdatedAt)
+	for i, item := range milestone.Items {
+		if i == 0 {
+			require.Equal(t, model.TaskDone.String(), item.Status)
+			require.Equal(t, "item1", item.Text)
+		} else {
+			require.Equal(t, model.TaskDoneLate.String(), item.Status)
+			require.Equal(t, "item2Change", item.Text)
+		}
+	}
+	organizationPlanDbNode, err := neo4jtest.GetNodeById(ctx, testDatabase.Driver, neo4jutil.NodeLabelOrganizationPlan, opid)
+	require.Nil(t, err)
+	op := neo4jmapper.MapDbNodeToOrganizationPlanEntity(organizationPlanDbNode)
+	require.Equal(t, model.DoneLate.String(), op.StatusDetails.Status) // automatic update
 }


### PR DESCRIPTION
## Proposed changes

# Do not merge before Matt's demo tomorrow

This change enables upon milestone status updates or milestone items updates to calculate and propagate status updates throughout org plans. 

This also adds enums for graphql schema matching the possible statuses.

Plus tests.

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced types and enums for organization plan milestones, including status details and update capabilities.
	- Added functionality to retrieve milestone due dates and milestones for specific organization plans.
	- Implemented new logic for propagating status updates from milestones to the overall organization plan.
- **Refactor**
	- Updated organization plan and milestone update functions to use new input types for better clarity and functionality.
	- Refined status descriptors for organization plans and milestones to provide more detailed status information.
- **Bug Fixes**
	- Fixed an issue where milestone due dates and status updates were not properly handled and propagated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->