### PR TITLE
Retry invoking event handler grpc in customer-os-webhooks

### DIFF
--- a/packages/server/customer-os-webhooks/constants/constants.go
+++ b/packages/server/customer-os-webhooks/constants/constants.go
@@ -6,12 +6,13 @@ const (
 	ServiceName                 = "CUSTOMER-OS-WEBHOOKS"
 	AppSourceCustomerOsWebhooks = "customer-os-webhooks"
 
-	ComponentService         = "service"
+	ComponentService = "service"
+	// Deprecated, all methods with this constants should be deprecated
 	ComponentNeo4jRepository = "neo4jRepository"
 
 	RequestMaxBodySizeCommon                      = 1 * 1024 * 1024   // 1 MB
 	RequestMaxBodySizeMessages                    = 10 * 1024 * 1024  // 10 MB
 	RequestMaxTimeout                             = 300 * time.Second // 5 minutes
 	MaxRetryCheckDataInNeo4jAfterEventRequest int = 10
-	TimeoutIntervalMs                             = 100
+	MaxRetryGrpcCallWhenUnavailable           int = 5
 )

--- a/packages/server/customer-os-webhooks/service/interaction_session_service.go
+++ b/packages/server/customer-os-webhooks/service/interaction_session_service.go
@@ -62,27 +62,29 @@ func (s *interactionSessionService) MergeInteractionSession(ctx context.Context,
 	}
 
 	ctx = tracing.InjectSpanContextIntoGrpcMetadata(ctx, span)
-	response, err := s.grpcClients.InteractionSessionClient.UpsertInteractionSession(ctx, &interactionsessionpb.UpsertInteractionSessionGrpcRequest{
-		Tenant: tenant,
-		Id:     interactionSessionId,
-		SourceFields: &commonpb.SourceFields{
-			Source:    externalSystem,
-			AppSource: utils.StringFirstNonEmpty(interactionSessionInput.AppSource, constants.AppSourceCustomerOsWebhooks),
-		},
-		ExternalSystemFields: &commonpb.ExternalSystemFields{
-			ExternalSystemId: externalSystem,
-			ExternalId:       interactionSessionInput.ExternalId,
-			ExternalUrl:      interactionSessionInput.ExternalUrl,
-			ExternalIdSecond: interactionSessionInput.ExternalIdSecond,
-			ExternalSource:   interactionSessionInput.ExternalSourceEntity,
-			SyncDate:         utils.ConvertTimeToTimestampPtr(&syncDate),
-		},
-		Identifier:  interactionSessionInput.Identifier,
-		Channel:     interactionSessionInput.Channel,
-		ChannelData: interactionSessionInput.ChannelData,
-		Status:      interactionSessionInput.Status,
-		Type:        interactionSessionInput.Type,
-		Name:        interactionSessionInput.Name,
+	response, err := CallEventsPlatformGRPCWithRetry[*interactionsessionpb.InteractionSessionIdGrpcResponse](func() (*interactionsessionpb.InteractionSessionIdGrpcResponse, error) {
+		return s.grpcClients.InteractionSessionClient.UpsertInteractionSession(ctx, &interactionsessionpb.UpsertInteractionSessionGrpcRequest{
+			Tenant: tenant,
+			Id:     interactionSessionId,
+			SourceFields: &commonpb.SourceFields{
+				Source:    externalSystem,
+				AppSource: utils.StringFirstNonEmpty(interactionSessionInput.AppSource, constants.AppSourceCustomerOsWebhooks),
+			},
+			ExternalSystemFields: &commonpb.ExternalSystemFields{
+				ExternalSystemId: externalSystem,
+				ExternalId:       interactionSessionInput.ExternalId,
+				ExternalUrl:      interactionSessionInput.ExternalUrl,
+				ExternalIdSecond: interactionSessionInput.ExternalIdSecond,
+				ExternalSource:   interactionSessionInput.ExternalSourceEntity,
+				SyncDate:         utils.ConvertTimeToTimestampPtr(&syncDate),
+			},
+			Identifier:  interactionSessionInput.Identifier,
+			Channel:     interactionSessionInput.Channel,
+			ChannelData: interactionSessionInput.ChannelData,
+			Status:      interactionSessionInput.Status,
+			Type:        interactionSessionInput.Type,
+			Name:        interactionSessionInput.Name,
+		})
 	})
 	if err != nil {
 		tracing.TraceErr(span, err)

--- a/packages/server/customer-os-webhooks/service/invoice_service.go
+++ b/packages/server/customer-os-webhooks/service/invoice_service.go
@@ -204,7 +204,9 @@ func (s *invoiceService) syncInvoice(ctx context.Context, syncMutex *sync.Mutex,
 		invoiceGrpcRequest.FieldsMask = fieldsMask
 
 		ctx = tracing.InjectSpanContextIntoGrpcMetadata(ctx, span)
-		_, err = s.grpcClients.InvoiceClient.UpdateInvoice(ctx, &invoiceGrpcRequest)
+		_, err = CallEventsPlatformGRPCWithRetry[*invoicepb.InvoiceIdResponse](func() (*invoicepb.InvoiceIdResponse, error) {
+			return s.grpcClients.InvoiceClient.UpdateInvoice(ctx, &invoiceGrpcRequest)
+		})
 		if err != nil {
 			failedSync = true
 			tracing.TraceErr(span, err, log.String("grpcMethod", "UpdateInvoice"))

--- a/packages/server/customer-os-webhooks/service/organization_service.go
+++ b/packages/server/customer-os-webhooks/service/organization_service.go
@@ -254,7 +254,7 @@ func (s *organizationService) syncOrganization(ctx context.Context, syncMutex *s
 
 		// Create or update organization
 		ctx = tracing.InjectSpanContextIntoGrpcMetadata(ctx, span)
-		_, err = s.grpcClients.OrganizationClient.UpsertOrganization(ctx, &organizationpb.UpsertOrganizationGrpcRequest{
+		upsertOrganizationGrpcRequest := organizationpb.UpsertOrganizationGrpcRequest{
 			Tenant:             tenant,
 			Id:                 organizationId,
 			LoggedInUserId:     "",
@@ -294,6 +294,9 @@ func (s *organizationService) syncOrganization(ctx context.Context, syncMutex *s
 				ExternalSource:   orgInput.ExternalSourceEntity,
 				SyncDate:         utils.ConvertTimeToTimestampPtr(&syncDate),
 			},
+		}
+		_, err = CallEventsPlatformGRPCWithRetry[*organizationpb.OrganizationIdGrpcResponse](func() (*organizationpb.OrganizationIdGrpcResponse, error) {
+			return s.grpcClients.OrganizationClient.UpsertOrganization(ctx, &upsertOrganizationGrpcRequest)
 		})
 		if err != nil {
 			failedSync = true
@@ -308,7 +311,7 @@ func (s *organizationService) syncOrganization(ctx context.Context, syncMutex *s
 				if organization != nil && findErr == nil {
 					break
 				}
-				time.Sleep(time.Duration(i*constants.TimeoutIntervalMs) * time.Millisecond)
+				time.Sleep(utils.BackOffExponentialDelay(i))
 			}
 		}
 	}
@@ -322,11 +325,13 @@ func (s *organizationService) syncOrganization(ctx context.Context, syncMutex *s
 				continue
 			}
 			if !domainInUse {
-				_, err = s.grpcClients.OrganizationClient.LinkDomainToOrganization(ctx, &organizationpb.LinkDomainToOrganizationGrpcRequest{
-					Tenant:         common.GetTenantFromContext(ctx),
-					OrganizationId: organizationId,
-					Domain:         domain,
-					AppSource:      appSource,
+				_, err = CallEventsPlatformGRPCWithRetry[*organizationpb.OrganizationIdGrpcResponse](func() (*organizationpb.OrganizationIdGrpcResponse, error) {
+					return s.grpcClients.OrganizationClient.LinkDomainToOrganization(ctx, &organizationpb.LinkDomainToOrganizationGrpcRequest{
+						Tenant:         common.GetTenantFromContext(ctx),
+						OrganizationId: organizationId,
+						Domain:         domain,
+						AppSource:      appSource,
+					})
 				})
 				if err != nil {
 					tracing.TraceErr(span, err, log.String("grpcFunction", "LinkDomainToOrganization"))
@@ -337,12 +342,14 @@ func (s *organizationService) syncOrganization(ctx context.Context, syncMutex *s
 	if !failedSync && orgInput.IsSubOrg() {
 		parentOrganizationId, _ := s.GetIdForReferencedOrganization(ctx, tenant, orgInput.ExternalSystem, orgInput.ParentOrganization.Organization)
 		if parentOrganizationId != "" {
-			_, err = s.grpcClients.OrganizationClient.AddParentOrganization(ctx, &organizationpb.AddParentOrganizationGrpcRequest{
-				Tenant:               common.GetTenantFromContext(ctx),
-				OrganizationId:       organizationId,
-				ParentOrganizationId: parentOrganizationId,
-				Type:                 orgInput.ParentOrganization.Type,
-				AppSource:            appSource,
+			_, err = CallEventsPlatformGRPCWithRetry[*organizationpb.OrganizationIdGrpcResponse](func() (*organizationpb.OrganizationIdGrpcResponse, error) {
+				return s.grpcClients.OrganizationClient.AddParentOrganization(ctx, &organizationpb.AddParentOrganizationGrpcRequest{
+					Tenant:               common.GetTenantFromContext(ctx),
+					OrganizationId:       organizationId,
+					ParentOrganizationId: parentOrganizationId,
+					Type:                 orgInput.ParentOrganization.Type,
+					AppSource:            appSource,
+				})
 			})
 			if err != nil {
 				failedSync = true
@@ -364,10 +371,12 @@ func (s *organizationService) syncOrganization(ctx context.Context, syncMutex *s
 			}
 			// Link email to organization
 			if emailId != "" {
-				_, err = s.grpcClients.OrganizationClient.LinkEmailToOrganization(ctx, &organizationpb.LinkEmailToOrganizationGrpcRequest{
-					Tenant:         common.GetTenantFromContext(ctx),
-					OrganizationId: organizationId,
-					EmailId:        emailId,
+				_, err = CallEventsPlatformGRPCWithRetry[*organizationpb.OrganizationIdGrpcResponse](func() (*organizationpb.OrganizationIdGrpcResponse, error) {
+					return s.grpcClients.OrganizationClient.LinkEmailToOrganization(ctx, &organizationpb.LinkEmailToOrganizationGrpcRequest{
+						Tenant:         common.GetTenantFromContext(ctx),
+						OrganizationId: organizationId,
+						EmailId:        emailId,
+					})
 				})
 				if err != nil {
 					tracing.TraceErr(span, err, log.String("grpcFunction", "LinkEmailToOrganization"))
@@ -390,12 +399,14 @@ func (s *organizationService) syncOrganization(ctx context.Context, syncMutex *s
 				}
 				// Link phone number to organization
 				if phoneNumberId != "" {
-					_, err = s.grpcClients.OrganizationClient.LinkPhoneNumberToOrganization(ctx, &organizationpb.LinkPhoneNumberToOrganizationGrpcRequest{
-						Tenant:         common.GetTenantFromContext(ctx),
-						OrganizationId: organizationId,
-						PhoneNumberId:  phoneNumberId,
-						Primary:        phoneNumberDtls.Primary,
-						Label:          phoneNumberDtls.Label,
+					_, err = CallEventsPlatformGRPCWithRetry[*organizationpb.OrganizationIdGrpcResponse](func() (*organizationpb.OrganizationIdGrpcResponse, error) {
+						return s.grpcClients.OrganizationClient.LinkPhoneNumberToOrganization(ctx, &organizationpb.LinkPhoneNumberToOrganizationGrpcRequest{
+							Tenant:         common.GetTenantFromContext(ctx),
+							OrganizationId: organizationId,
+							PhoneNumberId:  phoneNumberId,
+							Primary:        phoneNumberDtls.Primary,
+							Label:          phoneNumberDtls.Label,
+						})
 					})
 					if err != nil {
 						failedSync = true
@@ -429,10 +440,12 @@ func (s *organizationService) syncOrganization(ctx context.Context, syncMutex *s
 
 			// Link location to organization
 			if locationId != "" {
-				_, err = s.grpcClients.OrganizationClient.LinkLocationToOrganization(ctx, &organizationpb.LinkLocationToOrganizationGrpcRequest{
-					Tenant:         common.GetTenantFromContext(ctx),
-					OrganizationId: organizationId,
-					LocationId:     locationId,
+				_, err = CallEventsPlatformGRPCWithRetry(func() (*organizationpb.OrganizationIdGrpcResponse, error) {
+					return s.grpcClients.OrganizationClient.LinkLocationToOrganization(ctx, &organizationpb.LinkLocationToOrganizationGrpcRequest{
+						Tenant:         common.GetTenantFromContext(ctx),
+						OrganizationId: organizationId,
+						LocationId:     locationId,
+					})
 				})
 				if err != nil {
 					failedSync = true

--- a/packages/server/customer-os-webhooks/service/organization_service.go
+++ b/packages/server/customer-os-webhooks/service/organization_service.go
@@ -440,7 +440,7 @@ func (s *organizationService) syncOrganization(ctx context.Context, syncMutex *s
 
 			// Link location to organization
 			if locationId != "" {
-				_, err = CallEventsPlatformGRPCWithRetry(func() (*organizationpb.OrganizationIdGrpcResponse, error) {
+				_, err = CallEventsPlatformGRPCWithRetry[*organizationpb.OrganizationIdGrpcResponse](func() (*organizationpb.OrganizationIdGrpcResponse, error) {
 					return s.grpcClients.OrganizationClient.LinkLocationToOrganization(ctx, &organizationpb.LinkLocationToOrganizationGrpcRequest{
 						Tenant:         common.GetTenantFromContext(ctx),
 						OrganizationId: organizationId,

--- a/packages/server/customer-os-webhooks/service/utils.go
+++ b/packages/server/customer-os-webhooks/service/utils.go
@@ -16,7 +16,7 @@ func CallEventsPlatformGRPCWithRetry[T any](fn func() (T, error)) (T, error) {
 		if err == nil {
 			break
 		}
-		if grpcError, ok := status.FromError(err); ok && grpcError.Code() == codes.Unavailable {
+		if grpcError, ok := status.FromError(err); ok && (grpcError.Code() == codes.Unavailable || grpcError.Code() == codes.DeadlineExceeded) {
 			time.Sleep(utils.BackOffExponentialDelay(attempt))
 		} else {
 			break

--- a/packages/server/customer-os-webhooks/service/utils.go
+++ b/packages/server/customer-os-webhooks/service/utils.go
@@ -1,0 +1,26 @@
+package service
+
+import (
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-webhooks/constants"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"time"
+)
+
+func CallEventsPlatformGRPCWithRetry[T any](fn func() (T, error)) (T, error) {
+	var err error
+	var response T
+	for attempt := 1; attempt <= constants.MaxRetryGrpcCallWhenUnavailable; attempt++ {
+		response, err = fn()
+		if err == nil {
+			break
+		}
+		if grpcError, ok := status.FromError(err); ok && grpcError.Code() == codes.Unavailable {
+			time.Sleep(utils.BackOffExponentialDelay(attempt))
+		} else {
+			break
+		}
+	}
+	return response, err
+}


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a retry mechanism with exponential backoff delay for gRPC calls across various services, enhancing reliability in communication with the events platform.
- **Refactor**
	- Deprecated the `ComponentNeo4jRepository` constant and introduced `MaxRetryGrpcCallWhenUnavailable` for improved retry behavior control.
	- Centralized gRPC call retry logic into a new utility function, streamlining the process for multiple services (comments, contacts, emails, interaction events, interaction sessions, invoices, issues, locations, log entries, organizations, phone numbers, users).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->