### PR TITLE
Rename Tax -> VAT in invoice pdf

### DIFF
--- a/packages/server/events-processing-platform/subscriptions/invoice/pdf_template/index.html
+++ b/packages/server/events-processing-platform/subscriptions/invoice/pdf_template/index.html
@@ -220,7 +220,7 @@
                                 </div>
                                 {{if .InvoiceVat}}
                                 <div class="invoice-printed-column1 TextsmSemibold pr-0 {{if .InvoiceVat}}invoice-with-vat-column-size{{else}}{{end}}">
-                                    Tax
+                                    VAT
                                 </div>
                                 {{else}}
                                 {{end}}
@@ -272,7 +272,7 @@
                         {{if .InvoiceVat}}
                         <div class="invoice-subtotal-container">
                             <div class="invoice-title-4 TextsmRegular">
-                                Tax
+                                VAT
                             </div>
                             <div class="invoice-text-right TextsmRegular">
                                 {{.InvoiceCurrency}} {{.InvoiceVat}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated invoice template labels from "Tax" to "VAT" for clarity in billing documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->