### PR TITLE
Fix slack webhook path

### DIFF
--- a/packages/server/customer-os-webhooks/route/slack.go
+++ b/packages/server/customer-os-webhooks/route/slack.go
@@ -19,8 +19,8 @@ import (
 )
 
 func AddSlackRoutes(ctx context.Context, route *gin.Engine, services *service.Services, log logger.Logger, cache *commoncaches.Cache) {
-	route.POST("/slack/channels",
-		handler.TracingEnhancer(ctx, "/slack/channels"),
+	route.POST("/sync/slack/channels",
+		handler.TracingEnhancer(ctx, "/sync/slack/channels"),
 		commonservice.ApiKeyCheckerHTTP(services.CommonServices.CommonRepositories.TenantApiKeyRepository, services.CommonServices.CommonRepositories.AppKeyRepository, commonservice.CUSTOMER_OS_WEBHOOKS, commonservice.WithCache(cache)),
 		syncSlackChannelsHandler(services, log))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the endpoint path for syncing Slack channels for improved clarity and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->