### PR TITLE
Alex/cos 2278 prevent cleaning org fields in update events

### DIFF
--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -13446,7 +13446,7 @@ input OrganizationUpdateInput {
     """
     Set to true when partial update is needed. Empty or missing fields will not be ignored.
     """
-    patch:              Boolean
+    patch:              Boolean @deprecated(reason: "all updates are patched now")
     name:               String
     description:        String
     notes:              String

--- a/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
@@ -249,73 +249,71 @@ func (r *mutationResolver) OrganizationUpdate(ctx context.Context, input model.O
 		}, nil
 	}
 	fieldsMask := []organizationpb.OrganizationMaskField{}
-	if input.Patch != nil && *input.Patch {
-		if utils.IfNotNilString(input.Name) != "" {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_NAME)
+	if utils.IfNotNilString(input.Name) != "" {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_NAME)
+	}
+	if input.ReferenceID != nil || input.CustomID != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_REFERENCE_ID)
+	}
+	if input.Description != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_DESCRIPTION)
+	}
+	if input.Website != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_WEBSITE)
+	}
+	if input.Industry != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_INDUSTRY)
+	}
+	if input.SubIndustry != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_SUB_INDUSTRY)
+	}
+	if input.IndustryGroup != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_INDUSTRY_GROUP)
+	}
+	if input.Market != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_MARKET)
+	}
+	if input.TargetAudience != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_TARGET_AUDIENCE)
+	}
+	if input.ValueProposition != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_VALUE_PROPOSITION)
+	}
+	if input.LastFundingAmount != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_LAST_FUNDING_AMOUNT)
+	}
+	if input.LastFundingRound != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_LAST_FUNDING_ROUND)
+	}
+	if input.YearFounded != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_YEAR_FOUNDED)
+	}
+	if input.Headquarters != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_HEADQUARTERS)
+	}
+	if input.LogoURL != nil || input.Logo != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_LOGO_URL)
+	}
+	if input.EmployeeGrowthRate != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_EMPLOYEE_GROWTH_RATE)
+	}
+	if input.Note != nil || input.Notes != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_NOTE)
+	}
+	if input.SlackChannelID != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_SLACK_CHANNEL_ID)
+	}
+	if len(fieldsMask) == 0 {
+		span.LogFields(log.String("result", "No fields to update"))
+		organizationEntity, err := r.Services.OrganizationService.GetById(ctx, input.ID)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			graphql.AddErrorf(ctx, "Failed to fetch organization details")
+			return &model.Organization{
+				ID: input.ID,
+			}, nil
 		}
-		if input.ReferenceID != nil || input.CustomID != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_REFERENCE_ID)
-		}
-		if input.Description != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_DESCRIPTION)
-		}
-		if input.Website != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_WEBSITE)
-		}
-		if input.Industry != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_INDUSTRY)
-		}
-		if input.SubIndustry != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_SUB_INDUSTRY)
-		}
-		if input.IndustryGroup != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_INDUSTRY_GROUP)
-		}
-		if input.Market != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_MARKET)
-		}
-		if input.TargetAudience != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_TARGET_AUDIENCE)
-		}
-		if input.ValueProposition != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_VALUE_PROPOSITION)
-		}
-		if input.LastFundingAmount != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_LAST_FUNDING_AMOUNT)
-		}
-		if input.LastFundingRound != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_LAST_FUNDING_ROUND)
-		}
-		if input.YearFounded != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_YEAR_FOUNDED)
-		}
-		if input.Headquarters != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_HEADQUARTERS)
-		}
-		if input.LogoURL != nil || input.Logo != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_LOGO_URL)
-		}
-		if input.EmployeeGrowthRate != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_EMPLOYEE_GROWTH_RATE)
-		}
-		if input.Note != nil || input.Notes != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_NOTE)
-		}
-		if input.SlackChannelID != nil {
-			fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_SLACK_CHANNEL_ID)
-		}
-		if len(fieldsMask) == 0 {
-			span.LogFields(log.String("result", "No fields to update"))
-			organizationEntity, err := r.Services.OrganizationService.GetById(ctx, input.ID)
-			if err != nil {
-				tracing.TraceErr(span, err)
-				graphql.AddErrorf(ctx, "Failed to fetch organization details")
-				return &model.Organization{
-					ID: input.ID,
-				}, nil
-			}
-			return mapper.MapEntityToOrganization(organizationEntity), nil
-		}
+		return mapper.MapEntityToOrganization(organizationEntity), nil
 	}
 
 	upsertOrganizationRequest := organizationpb.UpsertOrganizationGrpcRequest{

--- a/packages/server/customer-os-api/graph/resolver/organization.resolvers_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/organization.resolvers_it_test.go
@@ -1229,9 +1229,9 @@ func TestMutationResolver_OrganizationMerge_Properties(t *testing.T) {
 	defer tearDownTestCase(ctx)(t)
 	neo4jtest.CreateTenant(ctx, driver, tenantName)
 
-	parentOrgId := neo4jt.CreateOrganization(ctx, driver, tenantName, "main organization")
-	mergedOrgId1 := neo4jt.CreateOrganization(ctx, driver, tenantName, "to merge 1")
-	mergedOrgId2 := neo4jt.CreateOrganization(ctx, driver, tenantName, "to merge 2")
+	parentOrgId := neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{Name: "main organization"})
+	mergedOrgId1 := neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{Name: "to merge 1"})
+	mergedOrgId2 := neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{Name: "to merge 2"})
 
 	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
 

--- a/packages/server/customer-os-api/graph/schemas/organization.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/organization.graphqls
@@ -168,7 +168,7 @@ input OrganizationUpdateInput {
     """
     Set to true when partial update is needed. Empty or missing fields will not be ignored.
     """
-    patch:              Boolean
+    patch:              Boolean @deprecated(reason: "all updates are patched now")
     name:               String
     description:        String
     notes:              String

--- a/packages/server/events-processing-platform/domain/organization/events/organization_update.go
+++ b/packages/server/events-processing-platform/domain/organization/events/organization_update.go
@@ -95,89 +95,89 @@ func (e OrganizationUpdateEvent) shouldUpdateFieldIfNotIgnored(input string) boo
 }
 
 func (e OrganizationUpdateEvent) UpdateName() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.Name)) || utils.Contains(e.FieldsMask, model.FieldMaskName)
+	return (e.shouldUpdateFieldIfNotIgnored(e.Name)) || utils.Contains(e.FieldsMask, model.FieldMaskName)
 }
 
 func (e OrganizationUpdateEvent) UpdateHide() bool {
-	return len(e.FieldsMask) == 0 || utils.Contains(e.FieldsMask, model.FieldMaskHide)
+	return utils.Contains(e.FieldsMask, model.FieldMaskHide)
 }
 
 func (e OrganizationUpdateEvent) UpdateDescription() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.Description)) || utils.Contains(e.FieldsMask, model.FieldMaskDescription)
+	return (e.shouldUpdateFieldIfNotIgnored(e.Description)) || utils.Contains(e.FieldsMask, model.FieldMaskDescription)
 }
 
 func (e OrganizationUpdateEvent) UpdateWebsite() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.Website)) || utils.Contains(e.FieldsMask, model.FieldMaskWebsite)
+	return (e.shouldUpdateFieldIfNotIgnored(e.Website)) || utils.Contains(e.FieldsMask, model.FieldMaskWebsite)
 }
 
 func (e OrganizationUpdateEvent) UpdateIndustry() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.Industry)) || utils.Contains(e.FieldsMask, model.FieldMaskIndustry)
+	return (e.shouldUpdateFieldIfNotIgnored(e.Industry)) || utils.Contains(e.FieldsMask, model.FieldMaskIndustry)
 }
 
 func (e OrganizationUpdateEvent) UpdateSubIndustry() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.SubIndustry)) || utils.Contains(e.FieldsMask, model.FieldMaskSubIndustry)
+	return (e.shouldUpdateFieldIfNotIgnored(e.SubIndustry)) || utils.Contains(e.FieldsMask, model.FieldMaskSubIndustry)
 }
 
 func (e OrganizationUpdateEvent) UpdateIndustryGroup() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.IndustryGroup)) || utils.Contains(e.FieldsMask, model.FieldMaskIndustryGroup)
+	return (e.shouldUpdateFieldIfNotIgnored(e.IndustryGroup)) || utils.Contains(e.FieldsMask, model.FieldMaskIndustryGroup)
 }
 
 func (e OrganizationUpdateEvent) UpdateTargetAudience() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.TargetAudience)) || utils.Contains(e.FieldsMask, model.FieldMaskTargetAudience)
+	return (e.shouldUpdateFieldIfNotIgnored(e.TargetAudience)) || utils.Contains(e.FieldsMask, model.FieldMaskTargetAudience)
 }
 
 func (e OrganizationUpdateEvent) UpdateValueProposition() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.ValueProposition)) || utils.Contains(e.FieldsMask, model.FieldMaskValueProposition)
+	return (e.shouldUpdateFieldIfNotIgnored(e.ValueProposition)) || utils.Contains(e.FieldsMask, model.FieldMaskValueProposition)
 }
 
 func (e OrganizationUpdateEvent) UpdateIsPublic() bool {
-	return len(e.FieldsMask) == 0 || utils.Contains(e.FieldsMask, model.FieldMaskIsPublic)
+	return utils.Contains(e.FieldsMask, model.FieldMaskIsPublic)
 }
 
 func (e OrganizationUpdateEvent) UpdateIsCustomer() bool {
-	return len(e.FieldsMask) == 0 || utils.Contains(e.FieldsMask, model.FieldMaskIsCustomer)
+	return utils.Contains(e.FieldsMask, model.FieldMaskIsCustomer)
 }
 
 func (e OrganizationUpdateEvent) UpdateEmployees() bool {
-	return len(e.FieldsMask) == 0 || utils.Contains(e.FieldsMask, model.FieldMaskEmployees)
+	return utils.Contains(e.FieldsMask, model.FieldMaskEmployees)
 }
 
 func (e OrganizationUpdateEvent) UpdateMarket() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.Market)) || utils.Contains(e.FieldsMask, model.FieldMaskMarket)
+	return (e.shouldUpdateFieldIfNotIgnored(e.Market)) || utils.Contains(e.FieldsMask, model.FieldMaskMarket)
 }
 
 func (e OrganizationUpdateEvent) UpdateLastFundingRound() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.LastFundingRound)) || utils.Contains(e.FieldsMask, model.FieldMaskLastFundingRound)
+	return (e.shouldUpdateFieldIfNotIgnored(e.LastFundingRound)) || utils.Contains(e.FieldsMask, model.FieldMaskLastFundingRound)
 }
 
 func (e OrganizationUpdateEvent) UpdateLastFundingAmount() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.LastFundingAmount)) || utils.Contains(e.FieldsMask, model.FieldMaskLastFundingAmount)
+	return (e.shouldUpdateFieldIfNotIgnored(e.LastFundingAmount)) || utils.Contains(e.FieldsMask, model.FieldMaskLastFundingAmount)
 }
 
 func (e OrganizationUpdateEvent) UpdateReferenceId() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.ReferenceId)) || utils.Contains(e.FieldsMask, model.FieldMaskReferenceId)
+	return (e.shouldUpdateFieldIfNotIgnored(e.ReferenceId)) || utils.Contains(e.FieldsMask, model.FieldMaskReferenceId)
 }
 
 func (e OrganizationUpdateEvent) UpdateNote() bool {
-	return (len(e.FieldsMask) == 0 && e.shouldUpdateFieldIfNotIgnored(e.Note)) || utils.Contains(e.FieldsMask, model.FieldMaskNote)
+	return (e.shouldUpdateFieldIfNotIgnored(e.Note)) || utils.Contains(e.FieldsMask, model.FieldMaskNote)
 }
 
 func (e OrganizationUpdateEvent) UpdateYearFounded() bool {
-	return len(e.FieldsMask) == 0 || utils.Contains(e.FieldsMask, model.FieldMaskYearFounded)
+	return utils.Contains(e.FieldsMask, model.FieldMaskYearFounded)
 }
 
 func (e OrganizationUpdateEvent) UpdateHeadquarters() bool {
-	return len(e.FieldsMask) == 0 || utils.Contains(e.FieldsMask, model.FieldMaskHeadquarters)
+	return utils.Contains(e.FieldsMask, model.FieldMaskHeadquarters)
 }
 
 func (e OrganizationUpdateEvent) UpdateEmployeeGrowthRate() bool {
-	return len(e.FieldsMask) == 0 || utils.Contains(e.FieldsMask, model.FieldMaskEmployeeGrowthRate)
+	return utils.Contains(e.FieldsMask, model.FieldMaskEmployeeGrowthRate)
 }
 
 func (e OrganizationUpdateEvent) UpdateSlackChannelId() bool {
-	return len(e.FieldsMask) == 0 || utils.Contains(e.FieldsMask, model.FieldMaskSlackChannelId)
+	return utils.Contains(e.FieldsMask, model.FieldMaskSlackChannelId)
 }
 
 func (e OrganizationUpdateEvent) UpdateLogoUrl() bool {
-	return len(e.FieldsMask) == 0 || utils.Contains(e.FieldsMask, model.FieldMaskLogoUrl)
+	return utils.Contains(e.FieldsMask, model.FieldMaskLogoUrl)
 }


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the efficiency and clarity of organization field updates in the backend.
	- Improved the structure and maintainability of organization creation in integration tests.
- **Documentation**
	- Deprecated the `patch` field in the `OrganizationUpdateInput` GraphQL input type, indicating a shift towards a more streamlined update approach.
- **Chores**
	- Simplified the logic in the `OrganizationUpdateEvent` methods for more straightforward organization entity updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->