### PR TITLE
Revert "(COS-2087) Allow user to set payment methods on contract level"

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/BillingDetails.dto.ts
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/BillingDetails.dto.ts
@@ -11,11 +11,8 @@ export interface BillingDetailsForm {
   invoiceEmail?: string | null;
   addressLine1?: string | null;
   addressLine2?: string | null;
-  canPayWithCard?: boolean | null;
   organizationLegalName?: string | null;
   country?: SelectOption<string> | null;
-  canPayWithDirectDebit?: boolean | null;
-  canPayWithBankTransfer?: boolean | null;
   currency?: SelectOption<Currency> | null;
 }
 
@@ -29,26 +26,17 @@ export class BillingDetailsDto implements BillingDetailsForm {
   country?: SelectOption<string> | null;
   currency?: SelectOption<Currency> | null;
   contractUrl?: string | null;
-  canPayWithCard?: boolean | null;
-  canPayWithDirectDebit?: boolean | null;
-  canPayWithBankTransfer?: boolean | null;
 
   constructor(data?: Partial<GetContractQuery['contract']> | null) {
-    this.zip = data?.billingDetails?.postalCode ?? '';
-    this.locality = data?.billingDetails?.locality ?? '';
-    this.invoiceEmail = data?.billingDetails?.billingEmail ?? '';
-    this.addressLine1 = data?.billingDetails?.addressLine1 ?? '';
-    this.canPayWithCard = data?.billingDetails?.canPayWithCard;
-    this.canPayWithDirectDebit = data?.billingDetails?.canPayWithDirectDebit;
-    this.canPayWithBankTransfer = data?.billingDetails?.canPayWithBankTransfer;
-
-    this.country = countryOptions.find(
-      (i) => data?.billingDetails?.country === i.value,
-    );
+    this.zip = data?.zip ?? '';
+    this.locality = data?.locality ?? '';
+    this.invoiceEmail = data?.invoiceEmail ?? '';
+    this.addressLine1 = data?.addressLine1 ?? '';
+    this.country = countryOptions.find((i) => data?.country === i.value);
     this.currency = getCurrencyOptions().find(
       (i) => data?.currency === i.value,
     );
-    this.addressLine2 = data?.billingDetails?.addressLine2 ?? '';
+    this.addressLine2 = data?.addressLine2 ?? '';
     this.organizationLegalName = data?.organizationLegalName ?? '';
     this.contractUrl = data?.contractUrl ?? '';
   }
@@ -76,9 +64,6 @@ export class BillingDetailsDto implements BillingDetailsForm {
       currency: data?.currency?.value,
       addressLine2: data?.addressLine2,
       organizationLegalName: data?.organizationLegalName,
-      canPayWithCard: data?.canPayWithCard,
-      canPayWithDirectDebit: data?.canPayWithDirectDebit,
-      canPayWithBankTransfer: data?.canPayWithBankTransfer,
       patch: true,
     };
   }

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/ContractBillingDetailsForm.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/ContractBillingDetailsForm.tsx
@@ -2,13 +2,11 @@
 import React, { FC, useMemo } from 'react';
 
 import { Flex } from '@ui/layout/Flex';
-import { Text } from '@ui/typography/Text';
 import { FormInput } from '@ui/form/Input';
 import { ModalBody } from '@ui/overlay/Modal';
 import { FormUrlInput } from '@ui/form/UrlInput';
 import { FormSelect } from '@ui/form/SyncSelect';
 import { countryOptions } from '@shared/util/countryOptions';
-import { FormCheckbox } from '@ui/form/Checkbox/FormCheckbox';
 import { getCurrencyOptions } from '@shared/util/currencyOptions';
 
 interface SubscriptionServiceModalProps {
@@ -153,27 +151,6 @@ export const ContractBillingDetailsForm: FC<SubscriptionServiceModalProps> = ({
         formId={formId}
         options={currencyOptions ?? []}
       />
-
-      <Flex flexDirection='column' gap={2}>
-        <Text fontSize='sm' fontWeight='semibold' whiteSpace='nowrap'>
-          Customer can pay using...
-        </Text>
-        <FormCheckbox name='canPayWithCard' formId={formId} size='md'>
-          <Text fontSize='sm' whiteSpace='nowrap'>
-            Credit or Debit cards
-          </Text>
-        </FormCheckbox>
-        <FormCheckbox name='canPayWithDirectDebit' formId={formId} size='md'>
-          <Text fontSize='sm' whiteSpace='nowrap'>
-            Direct Debit
-          </Text>
-        </FormCheckbox>
-        <FormCheckbox name='canPayWithBankTransfer' formId={formId} size='md'>
-          <Text fontSize='sm' whiteSpace='nowrap'>
-            Bank Transfer
-          </Text>
-        </FormCheckbox>
-      </Flex>
     </ModalBody>
   );
 };

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/ContractBillingDetailsModal.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/ContractBillingDetailsModal.tsx
@@ -79,16 +79,7 @@ export const ContractBillingDetailsModal = ({
   const { data: tenantBillingProfile } = useTenantBillingProfilesQuery(client);
 
   const updateContract = useUpdateContractMutation(client, {
-    onMutate: ({
-      input: {
-        patch,
-        contractId,
-        canPayWithBankTransfer,
-        canPayWithDirectDebit,
-        canPayWithCard,
-        ...input
-      },
-    }) => {
+    onMutate: ({ input: { patch, contractId, ...input } }) => {
       queryClient.cancelQueries({ queryKey });
       queryClient.setQueryData<GetContractsQuery>(queryKey, (currentCache) => {
         return produce(currentCache, (draft) => {

--- a/packages/apps/spaces/app/organization/[id]/src/graphql/getContract.generated.ts
+++ b/packages/apps/spaces/app/organization/[id]/src/graphql/getContract.generated.ts
@@ -36,22 +36,13 @@ export type GetContractQuery = {
     contractUrl?: string | null;
     billingEnabled: boolean;
     organizationLegalName?: string | null;
+    addressLine1?: string | null;
+    addressLine2?: string | null;
+    locality?: string | null;
+    country?: string | null;
+    zip?: string | null;
+    invoiceEmail?: string | null;
     currency?: Types.Currency | null;
-    billingDetails?: {
-      __typename?: 'BillingDetails';
-      addressLine1?: string | null;
-      addressLine2?: string | null;
-      locality?: string | null;
-      region?: string | null;
-      invoicingStarted?: any | null;
-      country?: string | null;
-      postalCode?: string | null;
-      billingEmail?: string | null;
-      invoiceNote?: string | null;
-      canPayWithCard?: boolean | null;
-      canPayWithDirectDebit?: boolean | null;
-      canPayWithBankTransfer?: boolean | null;
-    } | null;
   };
 };
 
@@ -62,21 +53,13 @@ export const GetContractDocument = `
     contractUrl
     billingEnabled
     organizationLegalName
+    addressLine1
+    addressLine2
+    locality
+    country
+    zip
+    invoiceEmail
     currency
-    billingDetails {
-      addressLine1
-      addressLine2
-      locality
-      region
-      invoicingStarted
-      country
-      postalCode
-      billingEmail
-      invoiceNote
-      canPayWithCard
-      canPayWithDirectDebit
-      canPayWithBankTransfer
-    }
   }
 }
     `;

--- a/packages/apps/spaces/app/organization/[id]/src/graphql/getContract.graphql
+++ b/packages/apps/spaces/app/organization/[id]/src/graphql/getContract.graphql
@@ -4,20 +4,12 @@ query getContract($id: ID!) {
     contractUrl
     billingEnabled
     organizationLegalName
+    addressLine1
+    addressLine2
+    locality
+    country
+    zip
+    invoiceEmail
     currency
-    billingDetails {
-      addressLine1
-      addressLine2
-      locality
-      region
-      invoicingStarted
-      country
-      postalCode
-      billingEmail
-      invoiceNote
-      canPayWithCard
-      canPayWithDirectDebit
-      canPayWithBankTransfer
-    }
     }
   }

--- a/packages/apps/spaces/app/src/types/__generated__/graphql.types.ts
+++ b/packages/apps/spaces/app/src/types/__generated__/graphql.types.ts
@@ -1393,6 +1393,8 @@ export type Invoice = MetadataInterface & {
   due: Scalars['Time']['output'];
   internationalPaymentsBankInfo?: Maybe<Scalars['String']['output']>;
   invoiceLineItems: Array<InvoiceLine>;
+  /** @deprecated Use invoiceLineItems instead. */
+  invoiceLines: Array<InvoiceLine>;
   invoiceNumber: Scalars['String']['output'];
   invoicePeriodEnd: Scalars['Time']['output'];
   invoicePeriodStart: Scalars['Time']['output'];
@@ -1423,6 +1425,8 @@ export type InvoiceCustomer = {
 
 export type InvoiceLine = MetadataInterface & {
   __typename?: 'InvoiceLine';
+  /** @deprecated Use metadata instead. */
+  createdAt: Scalars['Time']['output'];
   description: Scalars['String']['output'];
   metadata: Metadata;
   price: Scalars['Float']['output'];


### PR DESCRIPTION
This reverts commit 24f435b1bb6799fadaf2d7b163b31bf9bfc87e93.

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated contract billing details interface to include new fields such as address lines, locality, country, zip, and invoice email for enhanced billing information accuracy.
- **Refactor**
	- Simplified payment method selection by removing options for credit/debit card, direct debit, and bank transfer from the contract billing details form.
	- Streamlined contract mutation function for better input handling.
- **Documentation**
	- Marked `invoiceLines` in the `Invoice` type and `createdAt` in the `InvoiceLine` type as deprecated, advising the use of `invoiceLineItems` and `metadata` respectively for future reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->