### PR TITLE
add is null to filter operators

### DIFF
--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -12413,6 +12413,7 @@ enum ComparisonOperator {
     GTE
     IN
     BETWEEN
+    IS_NULL
 }`, BuiltIn: false},
 	{Name: "../schemas/interaction_event.graphqls", Input: `union InteractionEventParticipant = EmailParticipant | PhoneNumberParticipant | ContactParticipant | UserParticipant | OrganizationParticipant | JobRoleParticipant
 union InteractionSessionParticipant = EmailParticipant | PhoneNumberParticipant | ContactParticipant | UserParticipant

--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -12414,6 +12414,7 @@ enum ComparisonOperator {
     IN
     BETWEEN
     IS_NULL
+    IS_EMPTY
 }`, BuiltIn: false},
 	{Name: "../schemas/interaction_event.graphqls", Input: `union InteractionEventParticipant = EmailParticipant | PhoneNumberParticipant | ContactParticipant | UserParticipant | OrganizationParticipant | JobRoleParticipant
 union InteractionSessionParticipant = EmailParticipant | PhoneNumberParticipant | ContactParticipant | UserParticipant

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -2848,6 +2848,7 @@ const (
 	ComparisonOperatorIn         ComparisonOperator = "IN"
 	ComparisonOperatorBetween    ComparisonOperator = "BETWEEN"
 	ComparisonOperatorIsNull     ComparisonOperator = "IS_NULL"
+	ComparisonOperatorIsEmpty    ComparisonOperator = "IS_EMPTY"
 )
 
 var AllComparisonOperator = []ComparisonOperator{
@@ -2859,11 +2860,12 @@ var AllComparisonOperator = []ComparisonOperator{
 	ComparisonOperatorIn,
 	ComparisonOperatorBetween,
 	ComparisonOperatorIsNull,
+	ComparisonOperatorIsEmpty,
 }
 
 func (e ComparisonOperator) IsValid() bool {
 	switch e {
-	case ComparisonOperatorEq, ComparisonOperatorContains, ComparisonOperatorStartsWith, ComparisonOperatorLte, ComparisonOperatorGte, ComparisonOperatorIn, ComparisonOperatorBetween, ComparisonOperatorIsNull:
+	case ComparisonOperatorEq, ComparisonOperatorContains, ComparisonOperatorStartsWith, ComparisonOperatorLte, ComparisonOperatorGte, ComparisonOperatorIn, ComparisonOperatorBetween, ComparisonOperatorIsNull, ComparisonOperatorIsEmpty:
 		return true
 	}
 	return false

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -2847,6 +2847,7 @@ const (
 	ComparisonOperatorGte        ComparisonOperator = "GTE"
 	ComparisonOperatorIn         ComparisonOperator = "IN"
 	ComparisonOperatorBetween    ComparisonOperator = "BETWEEN"
+	ComparisonOperatorIsNull     ComparisonOperator = "IS_NULL"
 )
 
 var AllComparisonOperator = []ComparisonOperator{
@@ -2857,11 +2858,12 @@ var AllComparisonOperator = []ComparisonOperator{
 	ComparisonOperatorGte,
 	ComparisonOperatorIn,
 	ComparisonOperatorBetween,
+	ComparisonOperatorIsNull,
 }
 
 func (e ComparisonOperator) IsValid() bool {
 	switch e {
-	case ComparisonOperatorEq, ComparisonOperatorContains, ComparisonOperatorStartsWith, ComparisonOperatorLte, ComparisonOperatorGte, ComparisonOperatorIn, ComparisonOperatorBetween:
+	case ComparisonOperatorEq, ComparisonOperatorContains, ComparisonOperatorStartsWith, ComparisonOperatorLte, ComparisonOperatorGte, ComparisonOperatorIn, ComparisonOperatorBetween, ComparisonOperatorIsNull:
 		return true
 	}
 	return false

--- a/packages/server/customer-os-api/graph/resolver/test_queries/organization/get_organizations_filter_is_empty.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/organization/get_organizations_filter_is_empty.txt
@@ -1,0 +1,12 @@
+query GetOrganizations($page: Int!, $limit: Int!){
+  organizations(pagination: {page: $page, limit: $limit}
+            where:{filter: {property:"NAME" operation:IS_EMPTY value:""}}
+            sort:[{by: "NAME" direction:ASC }]) {
+    totalPages
+    totalElements
+    content {
+      id
+      name
+    }
+  }
+}

--- a/packages/server/customer-os-api/graph/schemas/filter.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/filter.graphqls
@@ -65,4 +65,5 @@ enum ComparisonOperator {
     GTE
     IN
     BETWEEN
+    IS_NULL
 }

--- a/packages/server/customer-os-api/graph/schemas/filter.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/filter.graphqls
@@ -66,4 +66,5 @@ enum ComparisonOperator {
     IN
     BETWEEN
     IS_NULL
+    IS_EMPTY
 }

--- a/packages/server/customer-os-api/service/filter_builder.go
+++ b/packages/server/customer-os-api/service/filter_builder.go
@@ -95,6 +95,9 @@ func comparisonOperatorToEnum(co model.ComparisonOperator) utils.ComparisonOpera
 		return utils.GTE
 	case model.ComparisonOperatorBetween:
 		return utils.BETWEEN
+	case model.ComparisonOperatorIsNull:
+		return utils.IS_NULL
+
 	default:
 		return utils.EQUALS
 	}

--- a/packages/server/customer-os-api/service/filter_builder.go
+++ b/packages/server/customer-os-api/service/filter_builder.go
@@ -97,7 +97,8 @@ func comparisonOperatorToEnum(co model.ComparisonOperator) utils.ComparisonOpera
 		return utils.BETWEEN
 	case model.ComparisonOperatorIsNull:
 		return utils.IS_NULL
-
+	case model.ComparisonOperatorIsEmpty:
+		return utils.IS_EMPTY
 	default:
 		return utils.EQUALS
 	}


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new comparison operators, `IS_NULL` and `IS_EMPTY`, for more flexible data filtering.
	- Added the ability to filter organizations by empty names in queries, enhancing data retrieval options.
- **Tests**
	- Implemented new tests to ensure the correct functionality of filtering organizations by empty names.
- **Documentation**
	- Updated GraphQL schema documentation to include the new `IS_NULL` and `IS_EMPTY` comparison operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->