### PR TITLE
Alex/cos 2300 cannot set customer flag on organization

### DIFF
--- a/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
@@ -23,7 +23,7 @@ import (
 	neo4jentity "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
 	commonpb "github.com/openline-ai/openline-customer-os/packages/server/events-processing-proto/gen/proto/go/api/grpc/v1/common"
 	organizationpb "github.com/openline-ai/openline-customer-os/packages/server/events-processing-proto/gen/proto/go/api/grpc/v1/organization"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -302,6 +302,12 @@ func (r *mutationResolver) OrganizationUpdate(ctx context.Context, input model.O
 	}
 	if input.SlackChannelID != nil {
 		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_SLACK_CHANNEL_ID)
+	}
+	if input.Public != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_IS_PUBLIC)
+	}
+	if input.IsCustomer != nil {
+		fieldsMask = append(fieldsMask, organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_IS_CUSTOMER)
 	}
 	if len(fieldsMask) == 0 {
 		span.LogFields(log.String("result", "No fields to update"))

--- a/packages/server/customer-os-api/graph/resolver/organization.resolvers_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/organization.resolvers_it_test.go
@@ -1777,7 +1777,13 @@ func TestMutationResolver_OrganizationUpdate(t *testing.T) {
 			require.Equal(t, organizationId, request.Id)
 			require.Equal(t, tenantName, request.Tenant)
 			require.Equal(t, "slackChannelId", request.SlackChannelId)
-
+			require.Equal(t, true, request.IsCustomer)
+			require.Equal(t, true, request.IsPublic)
+			require.ElementsMatch(t, []organizationpb.OrganizationMaskField{
+				organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_SLACK_CHANNEL_ID,
+				organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_IS_CUSTOMER,
+				organizationpb.OrganizationMaskField_ORGANIZATION_PROPERTY_IS_PUBLIC,
+			}, request.FieldsMask)
 			calledUpdateOrganization = true
 
 			return &organizationpb.OrganizationIdGrpcResponse{
@@ -1790,8 +1796,9 @@ func TestMutationResolver_OrganizationUpdate(t *testing.T) {
 	rawResponse := callGraphQL(t, "organization/update_organization",
 		map[string]interface{}{"input": map[string]interface{}{
 			"id":             organizationId,
-			"patch":          true,
 			"slackChannelId": "slackChannelId",
+			"isCustomer":     true,
+			"public":         true,
 		},
 		})
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Enhanced organization update functionality to handle `Public` and `IsCustomer` settings.
- **Tests**
	- Improved testing for organization updates, including new assertions for `IsCustomer` and `IsPublic` fields.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->