### PR TITLE
Do not set quantity to 0 for one time lines

### DIFF
--- a/packages/server/events-processing-platform/domain/service_line_item/aggregate/commands.go
+++ b/packages/server/events-processing-platform/domain/service_line_item/aggregate/commands.go
@@ -42,11 +42,6 @@ func (a *ServiceLineItemAggregate) createServiceLineItem(ctx context.Context, cm
 	span.SetTag(tracing.SpanTagAggregateId, a.GetID())
 	span.LogFields(log.Int64("aggregateVersion", a.GetVersion()), log.Object("command", cmd))
 
-	// If the service line item is one-time, set licenses to 0
-	if !cmd.DataFields.Billed.IsRecurrent() {
-		cmd.DataFields.Quantity = 0
-	}
-
 	// Adjust vat rate
 	if cmd.DataFields.VatRate < 0 {
 		cmd.DataFields.VatRate = 0

--- a/packages/server/events-processing-platform/domain/service_line_item/model/service_line_item.go
+++ b/packages/server/events-processing-platform/domain/service_line_item/model/service_line_item.go
@@ -13,7 +13,7 @@ type ServiceLineItem struct {
 	ContractId string             `json:"contractId"`
 	ParentId   string             `json:"parentId"`
 	Billed     string             `json:"billed"`
-	Quantity   int64              `json:"quantity"` // Relevant only for Subscription type
+	Quantity   int64              `json:"quantity"`
 	Price      float64            `json:"price"`
 	Name       string             `json:"name"`
 	Comments   string             `json:"comments,omitempty"`
@@ -30,7 +30,7 @@ type ServiceLineItem struct {
 // ServiceLineItemDataFields contains all the fields that may be used to create or update a service line item.
 type ServiceLineItemDataFields struct {
 	Billed     BilledType `json:"billed"`
-	Quantity   int64      `json:"quantity"` // Relevant only for Subscription type
+	Quantity   int64      `json:"quantity"`
 	Price      float64    `json:"price"`
 	Name       string     `json:"name"`
 	ContractId string     `json:"contractId"`


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed VAT rate calculation to handle negative values correctly.
	- Improved the handling of quantity for service line items, ensuring it's universally applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->