### PR TITLE
[COS-2382] - Expose cdn logo URL to global cache

### DIFF
--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -536,6 +536,7 @@ type ComplexityRoot struct {
 	}
 
 	GlobalCache struct {
+		CdnLogoURL           func(childComplexity int) int
 		ContractsExist       func(childComplexity int) int
 		GCliCache            func(childComplexity int) int
 		IsGoogleActive       func(childComplexity int) int
@@ -4195,6 +4196,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GCliItem.Type(childComplexity), true
+
+	case "GlobalCache.cdnLogoUrl":
+		if e.complexity.GlobalCache.CdnLogoURL == nil {
+			break
+		}
+
+		return e.complexity.GlobalCache.CdnLogoURL(childComplexity), true
 
 	case "GlobalCache.contractsExist":
 		if e.complexity.GlobalCache.ContractsExist == nil {
@@ -11270,6 +11278,8 @@ type GlobalCache {
     minARRForecastValue: Float!
     maxARRForecastValue: Float!
     contractsExist: Boolean!
+
+    cdnLogoUrl: String!
 }`, BuiltIn: false},
 	{Name: "../schemas/calendar.graphqls", Input: `"""
 Describes the relationship a Contact has with a Organization.
@@ -34468,6 +34478,50 @@ func (ec *executionContext) fieldContext_GlobalCache_contractsExist(ctx context.
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GlobalCache_cdnLogoUrl(ctx context.Context, field graphql.CollectedField, obj *model.GlobalCache) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GlobalCache_cdnLogoUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CdnLogoURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GlobalCache_cdnLogoUrl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GlobalCache",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -72577,6 +72631,8 @@ func (ec *executionContext) fieldContext_Query_global_Cache(ctx context.Context,
 				return ec.fieldContext_GlobalCache_maxARRForecastValue(ctx, field)
 			case "contractsExist":
 				return ec.fieldContext_GlobalCache_contractsExist(ctx, field)
+			case "cdnLogoUrl":
+				return ec.fieldContext_GlobalCache_cdnLogoUrl(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type GlobalCache", field.Name)
 		},
@@ -98264,6 +98320,11 @@ func (ec *executionContext) _GlobalCache(ctx context.Context, sel ast.SelectionS
 			}
 		case "contractsExist":
 			out.Values[i] = ec._GlobalCache_contractsExist(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "cdnLogoUrl":
+			out.Values[i] = ec._GlobalCache_cdnLogoUrl(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -992,6 +992,7 @@ type GlobalCache struct {
 	MinARRForecastValue  float64     `json:"minARRForecastValue"`
 	MaxARRForecastValue  float64     `json:"maxARRForecastValue"`
 	ContractsExist       bool        `json:"contractsExist"`
+	CdnLogoURL           string      `json:"cdnLogoUrl"`
 }
 
 type InteractionEvent struct {

--- a/packages/server/customer-os-api/graph/resolver/cache.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/cache.resolvers.go
@@ -93,5 +93,22 @@ func (r *queryResolver) GlobalCache(ctx context.Context) (*model.GlobalCache, er
 
 	response.ContractsExist = contractsExistForTenant
 
+	tenantSettings, err := r.Services.TenantService.GetTenantSettings(ctx)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		graphql.AddErrorf(ctx, "Failed GlobalCache - get tenant billing profiles")
+		return nil, nil
+	}
+
+	if tenantSettings != nil && tenantSettings.LogoRepositoryFileId != "" {
+		attachmentById, err := r.Services.AttachmentService.GetAttachmentById(ctx, tenantSettings.LogoRepositoryFileId)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			graphql.AddErrorf(ctx, "Failed GlobalCache - get tenant logo attachment by id")
+			return nil, nil
+		}
+		response.CdnLogoURL = attachmentById.CdnUrl
+	}
+
 	return response, nil
 }

--- a/packages/server/customer-os-api/graph/resolver/test_queries/cache/global_Cache.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/cache/global_Cache.txt
@@ -22,5 +22,6 @@ query global_Cache {
       }
     }
     contractsExist
+    cdnLogoUrl
   }
 }

--- a/packages/server/customer-os-api/graph/schemas/cache.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/cache.graphqls
@@ -11,4 +11,6 @@ type GlobalCache {
     minARRForecastValue: Float!
     maxARRForecastValue: Float!
     contractsExist: Boolean!
+
+    cdnLogoUrl: String!
 }

--- a/packages/server/customer-os-api/service/attachment_service.go
+++ b/packages/server/customer-os-api/service/attachment_service.go
@@ -124,7 +124,7 @@ func (s *attachmentService) GetAttachmentById(ctx context.Context, id string) (*
 func (s *attachmentService) MapDbNodeToAttachmentEntity(node dbtype.Node) *entity.AttachmentEntity {
 	props := utils.GetPropsFromNode(node)
 	createdAt := utils.GetTimePropOrEpochStart(props, "createdAt")
-	analysisEntity := entity.AttachmentEntity{
+	attachmentEntity := entity.AttachmentEntity{
 		Id:            utils.GetStringPropOrEmpty(props, "id"),
 		CreatedAt:     &createdAt,
 		FileName:      utils.GetStringPropOrEmpty(props, "fileName"),
@@ -136,7 +136,7 @@ func (s *attachmentService) MapDbNodeToAttachmentEntity(node dbtype.Node) *entit
 		Source:        neo4jentity.GetDataSource(utils.GetStringPropOrEmpty(props, "source")),
 		SourceOfTruth: neo4jentity.GetDataSource(utils.GetStringPropOrEmpty(props, "sourceOfTruth")),
 	}
-	return &analysisEntity
+	return &attachmentEntity
 }
 
 func (s *attachmentService) convertDbNodesToAttachments(records []*utils.DbNodeAndId) entity.AttachmentEntities {

--- a/packages/server/customer-os-api/test/neo4j/neo4j_data_helper.go
+++ b/packages/server/customer-os-api/test/neo4j/neo4j_data_helper.go
@@ -91,6 +91,7 @@ func CreateAttachment(ctx context.Context, driver *neo4j.DriverWithContext, tena
 		" a.createdAt=datetime({timezone: 'UTC'}), " +
 		" a.fileName=$fileName, " +
 		" a.mimeType=$mimeType, " +
+		" a.cdnUrl=$cdnUrl, " +
 		" a.basePath=$basePath, " +
 		" a.sourceOfTruth=$sourceOfTruth, " +
 		" a.appSource=$appSource " +
@@ -100,6 +101,7 @@ func CreateAttachment(ctx context.Context, driver *neo4j.DriverWithContext, tena
 		"id":            attachment.Id,
 		"fileName":      attachment.FileName,
 		"mimeType":      attachment.MimeType,
+		"cdnUrl":        attachment.CdnUrl,
 		"basePath":      attachment.BasePath,
 		"sourceOfTruth": attachment.SourceOfTruth,
 		"source":        attachment.Source,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new CDN Logo URL field to global cache settings, allowing for the display of tenant-specific logos.

- **Bug Fixes**
	- Fixed variable naming inconsistency in attachment mapping function.

- **Tests**
	- Enhanced global cache testing to include checks for the presence of a logo URL.

- **Documentation**
	- Updated GraphQL schema and queries to reflect the addition of the CDN Logo URL field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->