### PR TITLE
Add next invoicing to contract graphql

### DIFF
--- a/packages/server/customer-os-api-sdk/graph/generated/generated.go
+++ b/packages/server/customer-os-api-sdk/graph/generated/generated.go
@@ -139,6 +139,7 @@ type ComplexityRoot struct {
 		InvoiceNote            func(childComplexity int) int
 		InvoicingStarted       func(childComplexity int) int
 		Locality               func(childComplexity int) int
+		NextInvoicing          func(childComplexity int) int
 		OrganizationLegalName  func(childComplexity int) int
 		PostalCode             func(childComplexity int) int
 		Region                 func(childComplexity int) int
@@ -2272,6 +2273,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.BillingDetails.Locality(childComplexity), true
+
+	case "BillingDetails.nextInvoicing":
+		if e.complexity.BillingDetails.NextInvoicing == nil {
+			break
+		}
+
+		return e.complexity.BillingDetails.NextInvoicing(childComplexity), true
 
 	case "BillingDetails.organizationLegalName":
 		if e.complexity.BillingDetails.OrganizationLegalName == nil {
@@ -11565,6 +11573,7 @@ type BillingDetails {
     canPayWithCard:         Boolean
     canPayWithDirectDebit:  Boolean
     canPayWithBankTransfer: Boolean
+    nextInvoicing:          Time
 }
 
 input ContractInput {
@@ -20831,6 +20840,47 @@ func (ec *executionContext) fieldContext_BillingDetails_canPayWithBankTransfer(c
 	return fc, nil
 }
 
+func (ec *executionContext) _BillingDetails_nextInvoicing(ctx context.Context, field graphql.CollectedField, obj *model.BillingDetails) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BillingDetails_nextInvoicing(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NextInvoicing, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BillingDetails_nextInvoicing(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BillingDetails",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _BillingProfile_id(ctx context.Context, field graphql.CollectedField, obj *model.BillingProfile) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_BillingProfile_id(ctx, field)
 	if err != nil {
@@ -25008,6 +25058,8 @@ func (ec *executionContext) fieldContext_Contract_billingDetails(ctx context.Con
 				return ec.fieldContext_BillingDetails_canPayWithDirectDebit(ctx, field)
 			case "canPayWithBankTransfer":
 				return ec.fieldContext_BillingDetails_canPayWithBankTransfer(ctx, field)
+			case "nextInvoicing":
+				return ec.fieldContext_BillingDetails_nextInvoicing(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type BillingDetails", field.Name)
 		},
@@ -93432,6 +93484,8 @@ func (ec *executionContext) _BillingDetails(ctx context.Context, sel ast.Selecti
 			out.Values[i] = ec._BillingDetails_canPayWithDirectDebit(ctx, field, obj)
 		case "canPayWithBankTransfer":
 			out.Values[i] = ec._BillingDetails_canPayWithBankTransfer(ctx, field, obj)
+		case "nextInvoicing":
+			out.Values[i] = ec._BillingDetails_nextInvoicing(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/packages/server/customer-os-api-sdk/graph/model/models_gen.go
+++ b/packages/server/customer-os-api-sdk/graph/model/models_gen.go
@@ -178,6 +178,7 @@ type BillingDetails struct {
 	CanPayWithCard         *bool                 `json:"canPayWithCard,omitempty"`
 	CanPayWithDirectDebit  *bool                 `json:"canPayWithDirectDebit,omitempty"`
 	CanPayWithBankTransfer *bool                 `json:"canPayWithBankTransfer,omitempty"`
+	NextInvoicing          *time.Time            `json:"nextInvoicing,omitempty"`
 }
 
 type BillingDetailsInput struct {

--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -138,6 +138,7 @@ type ComplexityRoot struct {
 		InvoiceNote            func(childComplexity int) int
 		InvoicingStarted       func(childComplexity int) int
 		Locality               func(childComplexity int) int
+		NextInvoicing          func(childComplexity int) int
 		OrganizationLegalName  func(childComplexity int) int
 		PostalCode             func(childComplexity int) int
 		Region                 func(childComplexity int) int
@@ -2271,6 +2272,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.BillingDetails.Locality(childComplexity), true
+
+	case "BillingDetails.nextInvoicing":
+		if e.complexity.BillingDetails.NextInvoicing == nil {
+			break
+		}
+
+		return e.complexity.BillingDetails.NextInvoicing(childComplexity), true
 
 	case "BillingDetails.organizationLegalName":
 		if e.complexity.BillingDetails.OrganizationLegalName == nil {
@@ -11564,6 +11572,7 @@ type BillingDetails {
     canPayWithCard:         Boolean
     canPayWithDirectDebit:  Boolean
     canPayWithBankTransfer: Boolean
+    nextInvoicing:          Time
 }
 
 input ContractInput {
@@ -20830,6 +20839,47 @@ func (ec *executionContext) fieldContext_BillingDetails_canPayWithBankTransfer(c
 	return fc, nil
 }
 
+func (ec *executionContext) _BillingDetails_nextInvoicing(ctx context.Context, field graphql.CollectedField, obj *model.BillingDetails) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BillingDetails_nextInvoicing(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NextInvoicing, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BillingDetails_nextInvoicing(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BillingDetails",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _BillingProfile_id(ctx context.Context, field graphql.CollectedField, obj *model.BillingProfile) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_BillingProfile_id(ctx, field)
 	if err != nil {
@@ -25007,6 +25057,8 @@ func (ec *executionContext) fieldContext_Contract_billingDetails(ctx context.Con
 				return ec.fieldContext_BillingDetails_canPayWithDirectDebit(ctx, field)
 			case "canPayWithBankTransfer":
 				return ec.fieldContext_BillingDetails_canPayWithBankTransfer(ctx, field)
+			case "nextInvoicing":
+				return ec.fieldContext_BillingDetails_nextInvoicing(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type BillingDetails", field.Name)
 		},
@@ -93431,6 +93483,8 @@ func (ec *executionContext) _BillingDetails(ctx context.Context, sel ast.Selecti
 			out.Values[i] = ec._BillingDetails_canPayWithDirectDebit(ctx, field, obj)
 		case "canPayWithBankTransfer":
 			out.Values[i] = ec._BillingDetails_canPayWithBankTransfer(ctx, field, obj)
+		case "nextInvoicing":
+			out.Values[i] = ec._BillingDetails_nextInvoicing(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -176,6 +176,7 @@ type BillingDetails struct {
 	CanPayWithCard         *bool                 `json:"canPayWithCard,omitempty"`
 	CanPayWithDirectDebit  *bool                 `json:"canPayWithDirectDebit,omitempty"`
 	CanPayWithBankTransfer *bool                 `json:"canPayWithBankTransfer,omitempty"`
+	NextInvoicing          *time.Time            `json:"nextInvoicing,omitempty"`
 }
 
 type BillingDetailsInput struct {

--- a/packages/server/customer-os-api/graph/resolver/contract.resolvers_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/contract.resolvers_it_test.go
@@ -216,6 +216,7 @@ func TestQueryResolver_Contract_WithServiceLineItems(t *testing.T) {
 	defer tearDownTestCase(ctx)(t)
 
 	now := utils.Now()
+	tomorrow := now.Add(time.Duration(24) * time.Hour)
 	yesterday := now.Add(time.Duration(-24) * time.Hour)
 
 	neo4jtest.CreateTenant(ctx, driver, tenantName)
@@ -231,6 +232,7 @@ func TestQueryResolver_Contract_WithServiceLineItems(t *testing.T) {
 		InvoiceNote:            "invoice note",
 		BillingCycle:           neo4jenum.BillingCycleMonthlyBilling,
 		InvoicingStartDate:     &now,
+		NextInvoiceDate:        &tomorrow,
 		InvoicingEnabled:       true,
 		CanPayWithCard:         true,
 		CanPayWithDirectDebit:  true,
@@ -295,6 +297,8 @@ func TestQueryResolver_Contract_WithServiceLineItems(t *testing.T) {
 	require.True(t, *billingDetails.CanPayWithCard)
 	require.True(t, *billingDetails.CanPayWithDirectDebit)
 	require.True(t, *billingDetails.CanPayWithBankTransfer)
+	require.Equal(t, utils.StartOfDayInUTC(now), *billingDetails.InvoicingStarted)
+	require.Equal(t, utils.StartOfDayInUTC(tomorrow), *billingDetails.NextInvoicing)
 
 	require.Equal(t, 2, len(contract.ContractLineItems))
 

--- a/packages/server/customer-os-api/graph/resolver/test_queries/contract/get_contract_with_service_line_items.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/contract/get_contract_with_service_line_items.txt
@@ -6,6 +6,7 @@ query GetContract($contractId: ID!) {
     billingDetails {
         billingCycle
         invoicingStarted
+        nextInvoicing
         addressLine1
         addressLine2
         locality

--- a/packages/server/customer-os-api/graph/schemas/contract.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/contract.graphqls
@@ -67,6 +67,7 @@ type BillingDetails {
     canPayWithCard:         Boolean
     canPayWithDirectDebit:  Boolean
     canPayWithBankTransfer: Boolean
+    nextInvoicing:          Time
 }
 
 input ContractInput {

--- a/packages/server/customer-os-api/mapper/contract_mapper.go
+++ b/packages/server/customer-os-api/mapper/contract_mapper.go
@@ -23,6 +23,7 @@ func MapEntityToContract(entity *neo4jentity.ContractEntity) *model.Contract {
 		BillingDetails: &model.BillingDetails{
 			BillingCycle:           utils.ToPtr(MapContractBillingCycleToModel(entity.BillingCycle)),
 			InvoicingStarted:       entity.InvoicingStartDate,
+			NextInvoicing:          entity.NextInvoiceDate,
 			AddressLine1:           utils.ToPtr(entity.AddressLine1),
 			AddressLine2:           utils.ToPtr(entity.AddressLine2),
 			Locality:               utils.ToPtr(entity.Locality),


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new "Next Invoicing" date field to the billing details, allowing users to see the date of their next invoice.
- **Tests**
	- Updated tests to include checks for the new "Next Invoicing" field, ensuring accuracy against expected dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->