### PR TITLE
[COS-2479][COS-2492] - Attach reminders correctly to user and org nodes

### DIFF
--- a/packages/server/customer-os-api/graph/resolver/reminders.resolvers_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/reminders.resolvers_it_test.go
@@ -30,6 +30,8 @@ func TestQueryResolver_Reminder(t *testing.T) {
 		AppSource:     "TEST APP SOURCE",
 		SourceOfTruth: neo4jentity.DataSourceOpenline,
 	})
+	neo4jtest.LinkReminderToUser(ctx, driver, tenantName, rid, uid)
+	neo4jtest.LinkReminderToOrganization(ctx, driver, tenantName, rid, orgId)
 
 	require.Equal(t, 1, neo4jtest.GetCountOfNodes(ctx, driver, "Reminder"))
 
@@ -54,7 +56,7 @@ func TestQueryResolver_RemindersForOrg(t *testing.T) {
 	now := utils.Now()
 	neo4jtest.CreateTenant(ctx, driver, tenantName)
 	orgId := neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{Name: "TEST ORG"})
-	uid := neo4jtest.CreateUser(ctx, driver, tenantName, neo4jentity.UserEntity{Name: "TEST USER"})
+	uid := neo4jtest.CreateUser(ctx, driver, tenantName, neo4jentity.UserEntity{Name: "TEST USER", FirstName: "TEST", LastName: "USER"})
 	rid := neo4jtest.CreateReminder(ctx, driver, tenantName, uid, orgId, now, neo4jentity.ReminderEntity{
 		Content:       "TEST CONTENT",
 		DueDate:       now,
@@ -63,6 +65,8 @@ func TestQueryResolver_RemindersForOrg(t *testing.T) {
 		AppSource:     "TEST APP SOURCE",
 		SourceOfTruth: neo4jentity.DataSourceOpenline,
 	})
+	neo4jtest.LinkReminderToUser(ctx, driver, tenantName, rid, uid)
+	neo4jtest.LinkReminderToOrganization(ctx, driver, tenantName, rid, orgId)
 
 	require.Equal(t, 1, neo4jtest.GetCountOfNodes(ctx, driver, "Reminder"))
 
@@ -79,6 +83,8 @@ func TestQueryResolver_RemindersForOrg(t *testing.T) {
 	require.Equal(t, now.Format("2006-01-02"), reminderStruct.RemindersForOrganization[0].DueDate.Format("2006-01-02"))
 	require.Equal(t, false, reminderStruct.RemindersForOrganization[0].Dismissed)
 	require.Equal(t, uid, reminderStruct.RemindersForOrganization[0].Owner.ID)
+	require.Equal(t, "TEST", reminderStruct.RemindersForOrganization[0].Owner.FirstName)
+
 }
 
 func TestMutationResolver_ReminderCreate(t *testing.T) {
@@ -86,7 +92,7 @@ func TestMutationResolver_ReminderCreate(t *testing.T) {
 	defer tearDownTestCase(ctx)(t)
 	neo4jtest.CreateTenant(ctx, driver, tenantName)
 	orgId := neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{Name: "TEST ORG"})
-	uid := neo4jtest.CreateUser(ctx, driver, tenantName, neo4jentity.UserEntity{Name: "TEST USER"})
+	uid := neo4jtest.CreateUser(ctx, driver, tenantName, neo4jentity.UserEntity{FirstName: "TEST", LastName: "USER"})
 	rid := uuid.New().String()
 	dueDate := utils.Now()
 	neo4jtest.CreateReminder(ctx, driver, tenantName, uid, orgId, utils.Now(), neo4jentity.ReminderEntity{
@@ -98,6 +104,8 @@ func TestMutationResolver_ReminderCreate(t *testing.T) {
 		AppSource:     "TEST APP SOURCE",
 		SourceOfTruth: neo4jentity.DataSourceOpenline,
 	})
+	neo4jtest.LinkReminderToUser(ctx, driver, tenantName, rid, uid)
+	neo4jtest.LinkReminderToOrganization(ctx, driver, tenantName, rid, orgId)
 
 	calledCreateReminder := false
 	reminderServiceCallbacks := events_platform.MockReminderServiceCallbacks{
@@ -135,6 +143,7 @@ func TestMutationResolver_ReminderCreate(t *testing.T) {
 	require.Equal(t, 1, neo4jtest.GetCountOfNodes(ctx, driver, "Reminder"))
 	require.Equal(t, "TEST CONTENT", reminderStruct.Reminder_Create.Content)
 	require.Equal(t, uid, reminderStruct.Reminder_Create.Owner.ID)
+	require.Equal(t, "TEST", reminderStruct.Reminder_Create.Owner.FirstName)
 }
 
 func TestMutationResolver_ReminderUpdate(t *testing.T) {
@@ -143,7 +152,7 @@ func TestMutationResolver_ReminderUpdate(t *testing.T) {
 	now := utils.Now()
 	neo4jtest.CreateTenant(ctx, driver, tenantName)
 	orgId := neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{Name: "TEST ORG"})
-	uid := neo4jtest.CreateUser(ctx, driver, tenantName, neo4jentity.UserEntity{Name: "TEST USER"})
+	uid := neo4jtest.CreateUser(ctx, driver, tenantName, neo4jentity.UserEntity{FirstName: "TEST", LastName: "USER"})
 	rid := neo4jtest.CreateReminder(ctx, driver, tenantName, uid, orgId, now, neo4jentity.ReminderEntity{
 		Content:       "TEST CONTENT",
 		DueDate:       now,
@@ -152,6 +161,9 @@ func TestMutationResolver_ReminderUpdate(t *testing.T) {
 		AppSource:     "TEST APP SOURCE",
 		SourceOfTruth: neo4jentity.DataSourceOpenline,
 	})
+	neo4jtest.LinkReminderToUser(ctx, driver, tenantName, rid, uid)
+	neo4jtest.LinkReminderToOrganization(ctx, driver, tenantName, rid, orgId)
+
 	dueDate := utils.Now()
 
 	require.Equal(t, 1, neo4jtest.GetCountOfNodes(ctx, driver, "Reminder"))
@@ -200,4 +212,5 @@ func TestMutationResolver_ReminderUpdate(t *testing.T) {
 	require.Equal(t, "UPDATED CONTENT", reminderStruct.Reminder_Update.Content)
 	require.Equal(t, true, reminderStruct.Reminder_Update.Dismissed)
 	require.Equal(t, uid, reminderStruct.Reminder_Update.Owner.ID)
+	require.Equal(t, "TEST", reminderStruct.Reminder_Update.Owner.FirstName)
 }

--- a/packages/server/customer-os-api/graph/resolver/resolvers_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/resolvers_it_test.go
@@ -5,6 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
+	"os"
+	"testing"
+
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
@@ -26,9 +30,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"gorm.io/gorm"
-	"log"
-	"os"
-	"testing"
 )
 
 var (

--- a/packages/server/customer-os-api/graph/resolver/test_queries/reminder/create_reminder.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/reminder/create_reminder.txt
@@ -12,6 +12,7 @@ reminder_Create(
         content
         owner {
             id
+            firstName
         }
   }
 }

--- a/packages/server/customer-os-api/graph/resolver/test_queries/reminder/update_reminder.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/reminder/update_reminder.txt
@@ -14,6 +14,7 @@ reminder_Update(
         dismissed
         owner {
             id
+            firstName
         }
   }
 }

--- a/packages/server/events-processing-platform-subscribers/subscriptions/graph/reminder_handler.go
+++ b/packages/server/events-processing-platform-subscribers/subscriptions/graph/reminder_handler.go
@@ -47,7 +47,20 @@ func (h *ReminderEventHandler) OnCreate(ctx context.Context, evt eventstore.Even
 	err := h.repositories.Neo4jRepositories.ReminderWriteRepository.CreateReminder(ctx, eventData.Tenant, reminderId, eventData.UserId, eventData.OrganizationId, eventData.Content, source, appSource, eventData.CreatedAt, eventData.DueDate)
 	if err != nil {
 		tracing.TraceErr(span, err)
-		h.log.Errorf("Error while saving reminder plan %s: %s", reminderId, err.Error())
+		h.log.Errorf("Error while saving reminder %s: %s", reminderId, err.Error())
+		return err
+	}
+	err = h.repositories.Neo4jRepositories.ReminderWriteRepository.LinkReminderToUser(ctx, eventData.Tenant, reminderId, eventData.UserId)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		h.log.Errorf("Error while linking reminder %s to user %s: %s", reminderId, eventData.UserId, err.Error())
+		return err
+	}
+
+	err = h.repositories.Neo4jRepositories.ReminderWriteRepository.LinkReminderToOrganization(ctx, eventData.Tenant, reminderId, eventData.OrganizationId)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		h.log.Errorf("Error while linking reminder %s to organization %s: %s", reminderId, eventData.OrganizationId, err.Error())
 		return err
 	}
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced reminders functionality to include links to both users and organizations.
	- Added `firstName` field to the `owner` object in reminder queries, improving personalization.

- **Refactor**
	- Improved code modularity in the Neo4j data handling for reminders by separating user and organization relationship creation.
	- Reorganized import statements for better code readability.

- **Tests**
	- Updated integration tests to reflect changes in reminders linking and the addition of user first names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->