### PR TITLE
(fix|COS-2543): Add state field if country is USA, make sendInvoices from field read only, add ability to enable payment by check

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/BillingDetails.dto.ts
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/BillingDetails.dto.ts
@@ -6,6 +6,7 @@ import { GetContractQuery } from '@organization/src/graphql/getContract.generate
 
 export interface BillingDetailsForm {
   zip?: string | null;
+  region?: string | null;
   locality?: string | null;
   payOnline?: boolean | null;
   contractUrl?: string | null;
@@ -28,6 +29,7 @@ export class BillingDetailsDto implements BillingDetailsForm {
   addressLine1?: string | null;
   addressLine2?: string | null;
   organizationLegalName?: string | null;
+  region?: string | null;
   country?: SelectOption<string> | null;
   currency?: SelectOption<Currency> | null;
   contractUrl?: string | null;
@@ -57,6 +59,7 @@ export class BillingDetailsDto implements BillingDetailsForm {
     this.contractUrl = data?.contractUrl ?? '';
     this.payOnline = data?.billingDetails?.payOnline;
     this.payAutomatically = data?.billingDetails?.payAutomatically;
+    this.region = data?.billingDetails?.region;
   }
 
   static toForm(
@@ -89,6 +92,11 @@ export class BillingDetailsDto implements BillingDetailsForm {
         payOnline: data?.payOnline,
         payAutomatically: data?.payAutomatically,
         canPayWithBankTransfer: data?.canPayWithBankTransfer,
+        canPayWithCard: data?.canPayWithCard,
+        region: data?.region,
+        locality: data?.locality,
+        country: data?.country?.value ?? '',
+        postalCode: data?.zip,
       },
       patch: true,
     };

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/ContractBillingDetailsForm.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/ContractBillingDetailsForm.tsx
@@ -15,6 +15,7 @@ import { FormUrlInput } from '@ui/form/UrlInput';
 import { FormSelect } from '@ui/form/SyncSelect';
 import { InfoCircle } from '@ui/media/icons/InfoCircle';
 import { FormSwitch } from '@ui/form/Switch/FromSwitch';
+import { SelectOption } from '@shared/types/SelectOptions';
 import { countryOptions } from '@shared/util/countryOptions';
 import { FormCheckbox } from '@ui/form/Checkbox/FormCheckbox';
 import { getGraphQLClient } from '@shared/util/getGraphQLClient';
@@ -31,6 +32,8 @@ interface SubscriptionServiceModalProps {
   currency?: string;
   isEmailValid: boolean;
   organizationName: string;
+  country?: SelectOption<string> | null;
+
   tenantBillingProfile?: TenantBillingProfile | null;
   bankAccounts: Array<BankAccount> | null | undefined;
   onSetIsBillingDetailsHovered: (newState: boolean) => void;
@@ -46,6 +49,7 @@ export const ContractBillingDetailsForm: FC<SubscriptionServiceModalProps> = ({
   tenantBillingProfile,
   organizationName,
   bankAccounts,
+  country,
 }) => {
   const client = getGraphQLClient();
   const { data: tenantSettingsData } = useTenantSettingsQuery(client);
@@ -132,12 +136,23 @@ export const ContractBillingDetailsForm: FC<SubscriptionServiceModalProps> = ({
         onMouseEnter={() => onSetIsBillingDetailsHovered(true)}
         onMouseLeave={() => onSetIsBillingDetailsHovered(false)}
       >
+        <FormSelect
+          label='Country'
+          placeholder='Country'
+          name='country'
+          formId={formId}
+          isLabelVisible
+          options={countryOptions}
+          onFocus={() => onSetIsBillingDetailsFocused(true)}
+          onBlur={() => onSetIsBillingDetailsFocused(false)}
+        />
         <FormInput
           label='Billing address'
           isLabelVisible
           labelProps={{
             fontSize: 'sm',
             mb: 0,
+            mt: 2,
             fontWeight: 'semibold',
           }}
           formId={formId}
@@ -158,6 +173,16 @@ export const ContractBillingDetailsForm: FC<SubscriptionServiceModalProps> = ({
           onBlur={() => onSetIsBillingDetailsFocused(false)}
           autoComplete='off'
         />
+        {country?.value === 'US' && (
+          <FormInput
+            label='State'
+            name='region'
+            placeholder='State'
+            formId={formId}
+            onFocus={() => onSetIsBillingDetailsFocused(true)}
+            onBlur={() => onSetIsBillingDetailsFocused(false)}
+          />
+        )}
         <Flex>
           <FormInput
             label='City'
@@ -180,15 +205,6 @@ export const ContractBillingDetailsForm: FC<SubscriptionServiceModalProps> = ({
             autoComplete='off'
           />
         </Flex>
-        <FormSelect
-          label='Country'
-          placeholder='Country'
-          name='country'
-          formId={formId}
-          options={countryOptions}
-          onFocus={() => onSetIsBillingDetailsFocused(true)}
-          onBlur={() => onSetIsBillingDetailsFocused(false)}
-        />
       </Flex>
 
       {tenantSettingsData?.tenantSettings?.billingEnabled && (

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/ContractBillingDetailsModal.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/ContractBillingDetailsModal.tsx
@@ -238,17 +238,22 @@ export const ContractBillingDetailsModal = ({
                     tenantBillingProfile?.tenantBillingProfiles?.[0]?.country,
                 )?.label
               : '',
-            email: '',
+            email:
+              tenantBillingProfile?.tenantBillingProfiles?.[0]
+                ?.sendInvoicesFrom,
             name: tenantBillingProfile?.tenantBillingProfiles?.[0]?.legalName,
+            region:
+              tenantBillingProfile?.tenantBillingProfiles?.[0]?.region ?? '',
           }
         : {
             addressLine1: '29 Maple Lane',
             addressLine2: 'Springfield, Haven County',
             locality: 'San Francisco',
             zip: '89302',
-            country: 'United States',
+            country: 'United States of America',
             email: 'invoices@acme.com',
             name: 'Acme Corp.',
+            region: 'California',
           },
     }),
     [tenantBillingProfile?.tenantBillingProfiles?.[0]],
@@ -335,6 +340,7 @@ export const ContractBillingDetailsModal = ({
               onSetIsBillingDetailsHovered={setIsBillingDetailsHovered}
               onSetIsBillingDetailsFocused={setIsBillingDetailsFocused}
               bankAccounts={bankAccountsData?.bankAccounts as BankAccount[]}
+              country={state?.values?.country}
             />
             <ModalFooter p='6'>
               <Button variant='outline' w='full' onClick={onClose}>
@@ -368,6 +374,7 @@ export const ContractBillingDetailsModal = ({
                   country: state?.values?.country?.label ?? '',
                   email: state.values.invoiceEmail ?? '',
                   name: state.values?.organizationLegalName ?? '',
+                  region: state.values?.region ?? '',
                 }}
                 {...invoicePreviewStaticData}
                 canPayWithBankTransfer={
@@ -375,6 +382,7 @@ export const ContractBillingDetailsModal = ({
                     ?.canPayWithBankTransfer &&
                   state.values.canPayWithBankTransfer
                 }
+                check={tenantBillingProfile?.tenantBillingProfiles?.[0]?.check}
                 availableBankAccount={
                   bankAccountsData?.bankAccounts?.find(
                     (e) => e.currency === state?.values?.currency?.value,

--- a/packages/apps/spaces/app/organization/[id]/src/graphql/getContract.generated.ts
+++ b/packages/apps/spaces/app/organization/[id]/src/graphql/getContract.generated.ts
@@ -83,6 +83,7 @@ export const GetContractDocument = `
       payAutomatically
       payOnline
       invoicingStarted
+      region
     }
   }
 }

--- a/packages/apps/spaces/app/organization/[id]/src/graphql/getContract.graphql
+++ b/packages/apps/spaces/app/organization/[id]/src/graphql/getContract.graphql
@@ -22,6 +22,7 @@ query getContract($id: ID!) {
       payAutomatically
       payOnline
       invoicingStarted
+      region
 
     }
   }

--- a/packages/apps/spaces/app/organization/[id]/src/graphql/getContracts.generated.ts
+++ b/packages/apps/spaces/app/organization/[id]/src/graphql/getContracts.generated.ts
@@ -76,6 +76,7 @@ export type GetContractsQuery = {
         organizationLegalName?: string | null;
         billingCycle?: Types.ContractBillingCycle | null;
         invoicingStarted?: any | null;
+        region?: string | null;
       } | null;
       opportunities?: Array<{
         __typename?: 'Opportunity';
@@ -170,6 +171,7 @@ export const GetContractsDocument = `
         organizationLegalName
         billingCycle
         invoicingStarted
+        region
       }
       opportunities {
         id

--- a/packages/apps/spaces/app/organization/[id]/src/graphql/getContracts.graphql
+++ b/packages/apps/spaces/app/organization/[id]/src/graphql/getContracts.graphql
@@ -40,6 +40,7 @@ query getContracts($id: ID!) {
                 organizationLegalName
                 billingCycle
                 invoicingStarted
+                region
             }
             opportunities {
                 id

--- a/packages/apps/spaces/app/settings/src/components/Tabs/panels/BillingPanel/TenantBillingProfile.dto.ts
+++ b/packages/apps/spaces/app/settings/src/components/Tabs/panels/BillingPanel/TenantBillingProfile.dto.ts
@@ -6,6 +6,8 @@ import { getCurrencyOptions } from '@shared/util/currencyOptions';
 export interface TenantBillingDetails {
   zip?: string | null;
   phone?: string | null;
+  check?: boolean | null;
+  region?: string | null;
   locality?: string | null;
   legalName?: string | null;
   vatNumber?: string | null;
@@ -31,13 +33,13 @@ export class TenantBillingDetailsDto implements TenantBillingDetails {
   country?: SelectOption<string> | null;
   zip?: string | null;
   legalName?: string | null;
-  domesticPaymentsBankInfo?: string | null;
-  internationalPaymentsBankInfo?: string | null;
   canPayWithBankTransfer;
   canPayWithPigeon;
   sendInvoicesFrom;
   sendInvoicesBcc;
   vatNumber;
+  check?: boolean | null;
+  region?: string | null;
 
   constructor(
     data?: (TenantBillingProfile & { baseCurrency?: string | null }) | null,
@@ -52,9 +54,11 @@ export class TenantBillingDetailsDto implements TenantBillingDetails {
     this.legalName = data?.legalName;
     this.canPayWithBankTransfer = data?.canPayWithBankTransfer;
     this.canPayWithPigeon = data?.canPayWithPigeon;
-    this.sendInvoicesFrom = data?.sendInvoicesFrom?.split('@')[0] ?? '';
+    this.sendInvoicesFrom = data?.sendInvoicesFrom ?? '';
     this.sendInvoicesBcc = data?.sendInvoicesBcc ?? '';
     this.vatNumber = data?.vatNumber;
+    this.check = data?.check;
+    this.region = data?.region;
     this.baseCurrency = getCurrencyOptions().find(
       (i) => data?.baseCurrency === i.value,
     );

--- a/packages/apps/spaces/app/settings/src/components/Tabs/panels/BillingPanel/components/TenantBillingDetailsForm.tsx
+++ b/packages/apps/spaces/app/settings/src/components/Tabs/panels/BillingPanel/components/TenantBillingDetailsForm.tsx
@@ -6,13 +6,17 @@ import { LogoUploader } from '@settings/components/LogoUploadComponent/LogoUploa
 import { VatInput } from '@settings/components/Tabs/panels/BillingPanel/components/VatInput';
 import { PaymentMethods } from '@settings/components/Tabs/panels/BillingPanel/components/PaymentMethods';
 
+import { Box } from '@ui/layout/Box';
 import { Flex } from '@ui/layout/Flex';
 import { Text } from '@ui/typography/Text';
 import { CardBody } from '@ui/layout/Card';
+import { FormInput } from '@ui/form/Input';
 import { FormSelect } from '@ui/form/SyncSelect';
 import { Divider } from '@ui/presentation/Divider';
+import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
+import { FormSwitch } from '@ui/form/Switch/FromSwitch';
+import { SelectOption } from '@shared/types/SelectOptions';
 import { countryOptions } from '@shared/util/countryOptions';
-import { FormInput, FormResizableInput } from '@ui/form/Input';
 import { getCurrencyOptions } from '@shared/util/currencyOptions';
 
 export const TenantBillingPanelDetailsForm = ({
@@ -20,9 +24,15 @@ export const TenantBillingPanelDetailsForm = ({
   setIsInvoiceProviderFocused,
   formId,
   organizationName,
+  check,
+  sendInvoicesFrom,
+  country,
 }: {
   formId: string;
+  check?: boolean | null;
+  sendInvoicesFrom?: string;
   organizationName?: string | null;
+  country?: SelectOption<string> | null;
   setIsInvoiceProviderFocused: (newState: boolean) => void;
   setIsInvoiceProviderDetailsHovered: (newState: boolean) => void;
 }) => {
@@ -63,6 +73,14 @@ export const TenantBillingPanelDetailsForm = ({
         onMouseEnter={() => setIsInvoiceProviderDetailsHovered(true)}
         onMouseLeave={() => setIsInvoiceProviderDetailsHovered(false)}
       >
+        <FormSelect
+          name='country'
+          placeholder='Country'
+          label='Country'
+          isLabelVisible
+          formId={formId}
+          options={countryOptions}
+        />
         <FormInput
           autoComplete='off'
           label='Billing address'
@@ -71,6 +89,7 @@ export const TenantBillingPanelDetailsForm = ({
           labelProps={{
             fontSize: 'sm',
             mb: 0,
+            mt: 2,
             fontWeight: 'semibold',
           }}
           name='addressLine1'
@@ -87,6 +106,25 @@ export const TenantBillingPanelDetailsForm = ({
           onFocus={() => setIsInvoiceProviderFocused(true)}
           onBlur={() => setIsInvoiceProviderFocused(false)}
         />
+        <FormInput
+          autoComplete='off'
+          label='Billing address line 2'
+          name='addressLine2'
+          placeholder='Address line 2'
+          formId={formId}
+          onFocus={() => setIsInvoiceProviderFocused(true)}
+          onBlur={() => setIsInvoiceProviderFocused(false)}
+        />
+        {country?.value === 'US' && (
+          <FormInput
+            label='State'
+            name='region'
+            placeholder='State'
+            formId={formId}
+            onFocus={() => setIsInvoiceProviderFocused(true)}
+            onBlur={() => setIsInvoiceProviderFocused(false)}
+          />
+        )}
 
         <Flex gap={2}>
           <FormInput
@@ -108,12 +146,7 @@ export const TenantBillingPanelDetailsForm = ({
             onBlur={() => setIsInvoiceProviderFocused(false)}
           />
         </Flex>
-        <FormSelect
-          name='country'
-          placeholder='Country'
-          formId={formId}
-          options={countryOptions}
-        />
+
         <VatInput
           formId={formId}
           name='vatNumber'
@@ -140,23 +173,27 @@ export const TenantBillingPanelDetailsForm = ({
           <Divider background='gray.200' />
         </Flex>
 
-        <FormResizableInput
-          formId={formId}
-          autoComplete='off'
-          label='From'
-          labelProps={{
-            fontSize: 'sm',
-            mb: 0,
-            mt: 4,
-            fontWeight: 'semibold',
-          }}
-          fontWeight='medium'
-          isLabelVisible
-          name='sendInvoicesFrom'
-          placeholder=''
-          rightElement={'@invoices.customeros.ai'}
-          onFocus={() => setIsInvoiceProviderFocused(true)}
-        />
+        {sendInvoicesFrom && (
+          <Tooltip label='This email is configured by CustomerOs'>
+            <FormInput
+              formId={formId}
+              autoComplete='off'
+              cursor='not-allowed'
+              label='From'
+              labelProps={{
+                fontSize: 'sm',
+                mb: 0,
+                mt: 4,
+                fontWeight: 'semibold',
+              }}
+              isLabelVisible
+              isReadOnly
+              name='sendInvoicesFrom'
+              placeholder=''
+              onFocus={() => setIsInvoiceProviderFocused(true)}
+            />
+          </Tooltip>
+        )}
 
         <FormInput
           autoComplete='off'
@@ -176,6 +213,21 @@ export const TenantBillingPanelDetailsForm = ({
         />
       </Flex>
       <PaymentMethods formId={formId} organizationName={organizationName} />
+      <Box>
+        <FormSwitch
+          size='sm'
+          name='check'
+          formId={formId}
+          label='Checks'
+          fontWeight='semibold'
+          labelProps={{
+            fontSize: 'sm',
+            fontWeight: 'semibold',
+            margin: 0,
+          }}
+        />
+        {check && <Text>Want to pay by check? Contact {sendInvoicesFrom}</Text>}
+      </Box>
     </CardBody>
   );
 };

--- a/packages/apps/spaces/app/settings/src/components/Tabs/panels/BillingPanel/utils.ts
+++ b/packages/apps/spaces/app/settings/src/components/Tabs/panels/BillingPanel/utils.ts
@@ -1,23 +1,3 @@
-export const validateEmailLocalPart = (data: string): undefined | string => {
-  const value = data.split(' ').join('');
-
-  if (value) {
-    if (value.startsWith('.') || value.endsWith('.')) {
-      return 'The email address cannot start or end with a dot.';
-    }
-
-    const regex = /^[A-Z0-9_!#$%&'*+/=?`{|}~^.-]+$/i;
-    if (value.includes('..')) {
-      return 'The email address cannot contain consecutive dots.';
-    }
-    if (!regex.test(value)) {
-      return 'The email address cannot contain consecutive dots.';
-    }
-  }
-
-  return undefined;
-};
-
 export const validateEmail = (value: string): undefined | string => {
   if (value) {
     if (value.startsWith('.') || value.endsWith('.')) {

--- a/packages/apps/spaces/app/settings/src/graphql/getTenantBillingProfile.generated.ts
+++ b/packages/apps/spaces/app/settings/src/graphql/getTenantBillingProfile.generated.ts
@@ -44,6 +44,8 @@ export type TenantBillingProfileQuery = {
     sendInvoicesFrom: string;
     canPayWithBankTransfer: boolean;
     canPayWithPigeon: boolean;
+    check: boolean;
+    region: string;
   };
 };
 
@@ -62,6 +64,8 @@ export const TenantBillingProfileDocument = `
     sendInvoicesFrom
     canPayWithBankTransfer
     canPayWithPigeon
+    check
+    region
   }
 }
     `;

--- a/packages/apps/spaces/app/settings/src/graphql/getTenantBillingProfile.graphql
+++ b/packages/apps/spaces/app/settings/src/graphql/getTenantBillingProfile.graphql
@@ -12,5 +12,7 @@ query TenantBillingProfile($id: ID!) {
         sendInvoicesFrom
         canPayWithBankTransfer
         canPayWithPigeon
+        check
+        region
     }
 }

--- a/packages/apps/spaces/app/settings/src/graphql/getTenantBillingProfiles.generated.ts
+++ b/packages/apps/spaces/app/settings/src/graphql/getTenantBillingProfiles.generated.ts
@@ -45,6 +45,8 @@ export type TenantBillingProfilesQuery = {
     sendInvoicesBcc: string;
     canPayWithPigeon: boolean;
     canPayWithBankTransfer: boolean;
+    check: boolean;
+    region: string;
   }>;
 };
 
@@ -64,6 +66,8 @@ export const TenantBillingProfilesDocument = `
     sendInvoicesBcc
     canPayWithPigeon
     canPayWithBankTransfer
+    check
+    region
   }
 }
     `;

--- a/packages/apps/spaces/app/settings/src/graphql/getTenantBillingProfiles.graphql
+++ b/packages/apps/spaces/app/settings/src/graphql/getTenantBillingProfiles.graphql
@@ -13,5 +13,7 @@ query TenantBillingProfiles {
         sendInvoicesBcc
         canPayWithPigeon
         canPayWithBankTransfer
+        check
+        region
     }
 }

--- a/packages/apps/spaces/app/src/components/Invoice/Invoice.tsx
+++ b/packages/apps/spaces/app/src/components/Invoice/Invoice.tsx
@@ -24,6 +24,7 @@ type Address = {
   zip: string;
   email: string;
   name?: string;
+  region: string;
   country?: string;
   locality: string;
   vatNumber?: string;
@@ -44,6 +45,7 @@ type InvoiceProps = {
   amountDue?: number;
   note?: string | null;
   invoiceNumber: string;
+  check?: boolean | null;
   isBilledToFocused?: boolean;
   isInvoiceProviderFocused?: boolean;
   canPayWithBankTransfer?: boolean | null;
@@ -69,6 +71,7 @@ export function Invoice({
   currency = 'USD',
   canPayWithBankTransfer,
   availableBankAccount,
+  check,
 }: InvoiceProps) {
   const isInvoiceMetaSectionBlurred =
     isBilledToFocused || isInvoiceProviderFocused;
@@ -136,6 +139,7 @@ export function Invoice({
               addressLine1={billedTo?.addressLine1}
               addressLine2={billedTo?.addressLine2}
               vatNumber={billedTo?.vatNumber}
+              region={billedTo?.region}
             />
             <InvoicePartySection
               title='From'
@@ -149,6 +153,7 @@ export function Invoice({
               addressLine1={from?.addressLine1}
               addressLine2={from?.addressLine2}
               vatNumber={from?.vatNumber}
+              region={from?.region}
             />
           </Flex>
         </Flex>
@@ -177,6 +182,14 @@ export function Invoice({
             availableBankAccount={availableBankAccount}
             currency={currency}
           />
+        )}
+        {check && (
+          <Text fontSize='xs' color='gray.500' my={2}>
+            Want to pay by check? Contact{' '}
+            <Link href={`mailto:${from.email}`} textDecoration='underline'>
+              {from.email}
+            </Link>
+          </Text>
         )}
         <Flex
           alignItems='center'

--- a/packages/apps/spaces/app/src/components/Invoice/InvoicePreviewModal.tsx
+++ b/packages/apps/spaces/app/src/components/Invoice/InvoicePreviewModal.tsx
@@ -33,6 +33,7 @@ const extractAddressData = (invoiceData: InvoiceCustomer | InvoiceProvider) => {
     locality: invoiceData?.addressLocality ?? '',
     addressLine1: invoiceData?.addressLine1 ?? '',
     addressLine2: invoiceData?.addressLine2 ?? '',
+    region: invoiceData?.addressRegion ?? '',
   };
 };
 

--- a/packages/apps/spaces/app/src/components/Invoice/components/InvoicePartySection.tsx
+++ b/packages/apps/spaces/app/src/components/Invoice/components/InvoicePartySection.tsx
@@ -10,6 +10,7 @@ type InvoiceHeaderProps = {
   title: string;
   name?: string;
   email?: string;
+  region?: string;
   country?: string;
   locality?: string;
   vatNumber?: string;
@@ -30,65 +31,85 @@ export const InvoicePartySection: FC<InvoiceHeaderProps> = ({
   addressLine1 = '',
   addressLine2 = '',
   vatNumber = '',
+  region = '',
   title,
-}) => (
-  <Flex
-    flexDir='column'
-    flex={1}
-    w={170}
-    py={2}
-    px={3}
-    borderTop='1px solid'
-    borderRight={title === 'From' ? 'none' : '1px solid'}
-    borderBottom='1px solid'
-    borderColor={'gray.300'}
-    filter={isBlurred ? 'blur(2px)' : 'none'}
-    transition='filter 0.25s ease-in-out'
-    position='relative'
-    sx={{
-      '&:after': {
-        content: '""',
-        bg: 'transparent',
-        border: '2px solid',
-        position: 'absolute',
-        top: 0,
-        bottom: 0,
-        left: 0,
-        right: title === 'From' ? -4 : 0,
-        opacity: isFocused ? 1 : 0,
-        transition: 'opacity 0.25s ease-in-out',
-      },
-    }}
-  >
-    <Text fontWeight='semibold' mb={1} fontSize='sm'>
-      {title}
-    </Text>
-    <Text fontSize='sm' fontWeight='medium' mb={1} lineHeight={1.2}>
-      {name}
-    </Text>
-    {/*{vatNumber && (*/}
-    {/*  <Text fontSize='xs' mb={1} lineHeight={1.2}>*/}
-    {/*    VAT number: {vatNumber}*/}
-    {/*  </Text>*/}
-    {/*)}*/}
+}) => {
+  const isUSA = country === 'United States of America';
 
-    <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
-      {addressLine1}
-      <Text as='span' display='block' lineHeight={1.2}>
-        {addressLine2}
+  return (
+    <Flex
+      flexDir='column'
+      flex={1}
+      w={170}
+      py={2}
+      px={3}
+      borderTop='1px solid'
+      borderRight={title === 'From' ? 'none' : '1px solid'}
+      borderBottom='1px solid'
+      borderColor={'gray.300'}
+      filter={isBlurred ? 'blur(2px)' : 'none'}
+      transition='filter 0.25s ease-in-out'
+      position='relative'
+      sx={{
+        '&:after': {
+          content: '""',
+          bg: 'transparent',
+          border: '2px solid',
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: title === 'From' ? -4 : 0,
+          opacity: isFocused ? 1 : 0,
+          transition: 'opacity 0.25s ease-in-out',
+        },
+      }}
+    >
+      <Text fontWeight='semibold' mb={1} fontSize='sm'>
+        {title}
       </Text>
-    </Text>
-    <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
-      {locality}
-      {locality && zip && ', '} {zip}
-    </Text>
-    <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
-      {country}
-    </Text>
-    {email && (
+      <Text fontSize='sm' fontWeight='medium' mb={1} lineHeight={1.2}>
+        {name}
+      </Text>
+      {/*{vatNumber && (*/}
+      {/*  <Text fontSize='xs' mb={1} lineHeight={1.2}>*/}
+      {/*    VAT number: {vatNumber}*/}
+      {/*  </Text>*/}
+      {/*)}*/}
+
       <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
-        {email}
+        {addressLine1}
+        <Text as='span' display='block' lineHeight={1.2}>
+          {addressLine2}
+        </Text>
       </Text>
-    )}
-  </Flex>
-);
+
+      {isUSA && (
+        <>
+          <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
+            {locality}
+          </Text>
+          <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
+            {region}
+            {region && zip && ', '} {zip}
+          </Text>
+        </>
+      )}
+      {!isUSA && (
+        <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
+          {locality}
+          {locality && zip && ', '} {zip}
+        </Text>
+      )}
+
+      <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
+        {country}
+      </Text>
+      {email && (
+        <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
+          {email}
+        </Text>
+      )}
+    </Flex>
+  );
+};

--- a/packages/apps/spaces/app/src/components/RootSidenav/RootSidenav.tsx
+++ b/packages/apps/spaces/app/src/components/RootSidenav/RootSidenav.tsx
@@ -110,18 +110,14 @@ export const RootSidenav = () => {
 
   return (
     <div className='px-2 pt-2.5 pb-4 h-full w-12.5 bg-white flex flex-col border-r border-gray-200'>
-      <div
-        className='mb-2 ml-3 cursor-pointer flex justify-flex-start overflow-hidden relative'
-        tabIndex={0}
-        role='button'
-      >
+      <div className='mb-2 ml-3 cursor-pointer flex justify-flex-start overflow-hidden relative'>
         {!isLoading ? (
           <Image
             src={cdnLogoUrl ?? logoCustomerOs}
             alt='CustomerOS'
             width={136}
             height={30}
-            className='pointer-events-none transition-opacity-250 ease-in-out'
+            className='pointer-events-none transition-opacity-250 ease-in-out max-h-8 w-auto'
           />
         ) : (
           <Skeleton className='w-full h-8 mr-2' />

--- a/packages/apps/spaces/app/src/types/__generated__/graphql.types.ts
+++ b/packages/apps/spaces/app/src/types/__generated__/graphql.types.ts
@@ -179,6 +179,7 @@ export type BillingDetails = {
   canPayWithBankTransfer?: Maybe<Scalars['Boolean']['output']>;
   canPayWithCard?: Maybe<Scalars['Boolean']['output']>;
   canPayWithDirectDebit?: Maybe<Scalars['Boolean']['output']>;
+  check?: Maybe<Scalars['Boolean']['output']>;
   country?: Maybe<Scalars['String']['output']>;
   invoiceNote?: Maybe<Scalars['String']['output']>;
   invoicingStarted?: Maybe<Scalars['Time']['output']>;
@@ -199,6 +200,7 @@ export type BillingDetailsInput = {
   canPayWithBankTransfer?: InputMaybe<Scalars['Boolean']['input']>;
   canPayWithCard?: InputMaybe<Scalars['Boolean']['input']>;
   canPayWithDirectDebit?: InputMaybe<Scalars['Boolean']['input']>;
+  check?: InputMaybe<Scalars['Boolean']['input']>;
   country?: InputMaybe<Scalars['String']['input']>;
   invoiceNote?: InputMaybe<Scalars['String']['input']>;
   invoicingStarted?: InputMaybe<Scalars['Time']['input']>;
@@ -4174,6 +4176,7 @@ export type TenantBillingProfile = Node &
     /** @deprecated Not used */
     canPayWithDirectDebitSEPA?: Maybe<Scalars['Boolean']['output']>;
     canPayWithPigeon: Scalars['Boolean']['output'];
+    check: Scalars['Boolean']['output'];
     country: Scalars['String']['output'];
     createdAt: Scalars['Time']['output'];
     /** @deprecated Not used */
@@ -4183,7 +4186,6 @@ export type TenantBillingProfile = Node &
     id: Scalars['ID']['output'];
     /** @deprecated Not used */
     internationalPaymentsBankInfo?: Maybe<Scalars['String']['output']>;
-    invoiceNote: Scalars['String']['output'];
     legalName: Scalars['String']['output'];
     locality: Scalars['String']['output'];
     phone: Scalars['String']['output'];
@@ -4207,11 +4209,11 @@ export type TenantBillingProfileInput = {
   canPayWithDirectDebitBacs?: InputMaybe<Scalars['Boolean']['input']>;
   canPayWithDirectDebitSEPA?: InputMaybe<Scalars['Boolean']['input']>;
   canPayWithPigeon: Scalars['Boolean']['input'];
+  check: Scalars['Boolean']['input'];
   country?: InputMaybe<Scalars['String']['input']>;
   domesticPaymentsBankInfo?: InputMaybe<Scalars['String']['input']>;
   email?: InputMaybe<Scalars['String']['input']>;
   internationalPaymentsBankInfo?: InputMaybe<Scalars['String']['input']>;
-  invoiceNote?: InputMaybe<Scalars['String']['input']>;
   legalName?: InputMaybe<Scalars['String']['input']>;
   locality?: InputMaybe<Scalars['String']['input']>;
   phone?: InputMaybe<Scalars['String']['input']>;
@@ -4232,12 +4234,12 @@ export type TenantBillingProfileUpdateInput = {
   canPayWithDirectDebitBacs?: InputMaybe<Scalars['Boolean']['input']>;
   canPayWithDirectDebitSEPA?: InputMaybe<Scalars['Boolean']['input']>;
   canPayWithPigeon?: InputMaybe<Scalars['Boolean']['input']>;
+  check?: InputMaybe<Scalars['Boolean']['input']>;
   country?: InputMaybe<Scalars['String']['input']>;
   domesticPaymentsBankInfo?: InputMaybe<Scalars['String']['input']>;
   email?: InputMaybe<Scalars['String']['input']>;
   id: Scalars['ID']['input'];
   internationalPaymentsBankInfo?: InputMaybe<Scalars['String']['input']>;
-  invoiceNote?: InputMaybe<Scalars['String']['input']>;
   legalName?: InputMaybe<Scalars['String']['input']>;
   locality?: InputMaybe<Scalars['String']['input']>;
   patch?: InputMaybe<Scalars['Boolean']['input']>;

--- a/packages/apps/spaces/scripts/codegen-graphql.ts
+++ b/packages/apps/spaces/scripts/codegen-graphql.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import dotenv from 'dotenv';
 
 dotenv.config({
-  path: path.join(__dirname, '../', '.env.development'),
+  path: path.join(__dirname, '../', '.env.production'),
 });
 
 const config: CodegenConfig = {
@@ -14,7 +14,7 @@ const config: CodegenConfig = {
       [`${process.env.CUSTOMER_OS_API_PATH}/query`]: {
         headers: {
           'X-Openline-API-KEY': process.env.CUSTOMER_OS_API_KEY as string,
-          'X-Openline-USERNAME': 'customerostestuser@gmail.com',
+          'X-Openline-USERNAME': 'edi@openline.ai',
         },
       },
     },

--- a/packages/apps/spaces/ui/form/Switch/FromSwitch.tsx
+++ b/packages/apps/spaces/ui/form/Switch/FromSwitch.tsx
@@ -65,9 +65,9 @@ export const FormSwitch = forwardRef(
       >
         {isLabelVisible ? (
           <FormLabel
-            {...labelProps}
             fontWeight='medium'
             color={props.isDisabled ? 'gray.500' : 'gray.700'}
+            {...labelProps}
           >
             {label}
           </FormLabel>

--- a/packages/apps/spaces/yarn.lock
+++ b/packages/apps/spaces/yarn.lock
@@ -2504,6 +2504,13 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
   integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
 
+"@fragaria/address-formatter@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fragaria/address-formatter/-/address-formatter-5.3.0.tgz#a054eab7da00ab656ac506bcaf44d5901eee0b32"
+  integrity sha512-XyPVrogFcn9at13gq+5Q4NPNgPxfwukWa0Gl2Jpoa5sFuIcT7mb327GBeb2cDevzZTJ3RG8jnFv0NfZCl/YTyg==
+  dependencies:
+    mustache "^4.0.0"
+
 "@graphql-codegen/add@^3.2.1":
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/add/-/add-3.2.3.tgz#f1ecee085987e7c21841edc4b1fd48877c663e1a"
@@ -4671,7 +4678,6 @@
   integrity sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==
   dependencies:
     "@babel/runtime" "^7.13.10"
-
 
 "@radix-ui/react-use-rect@1.0.1":
   version "1.0.1"
@@ -13972,6 +13978,11 @@ multishift@^2.0.8:
     compute-scroll-into-view "^1.0.20"
     tiny-warning "^1.0.3"
     w3c-keyname "^2.2.7"
+
+mustache@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
 mute-stream@0.0.8:
   version "0.0.8"


### PR DESCRIPTION



## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added regional fields (`region` and `country`) across various billing and invoice components to enhance location-specific billing details.
    - Introduced a new payment option (`check`) for more flexible payment processing.
    - Enhanced country selection with a dynamic form input for state selection based on the country, specifically for the US.
- **Bug Fixes**
    - Consolidated email validation logic to improve accuracy and reliability.
- **Style**
    - Updated the styling of the `Image` component in the side navigation for better visual consistency.
- **Documentation**
    - Expanded GraphQL queries to include new `region` and `check` fields, aligning API requests with updated data models.
- **Chores**
    - Updated environment configuration for code generation scripts, optimizing for production settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->