### PR TITLE
Fix order and formatting of US addresses + tooltip fix + billing address label fix

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/ContractBillingDetailsForm.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/ContractBillingDetailsForm.tsx
@@ -136,25 +136,20 @@ export const ContractBillingDetailsForm: FC<SubscriptionServiceModalProps> = ({
         onMouseEnter={() => onSetIsBillingDetailsHovered(true)}
         onMouseLeave={() => onSetIsBillingDetailsHovered(false)}
       >
+        <Text fontSize='sm' fontWeight='semibold'>
+          Billing address
+        </Text>
         <FormSelect
           label='Country'
           placeholder='Country'
           name='country'
           formId={formId}
-          isLabelVisible
           options={countryOptions}
           onFocus={() => onSetIsBillingDetailsFocused(true)}
           onBlur={() => onSetIsBillingDetailsFocused(false)}
         />
         <FormInput
-          label='Billing address'
-          isLabelVisible
-          labelProps={{
-            fontSize: 'sm',
-            mb: 0,
-            mt: 2,
-            fontWeight: 'semibold',
-          }}
+          label='Address line 1'
           formId={formId}
           name='addressLine1'
           textOverflow='ellipsis'
@@ -175,16 +170,6 @@ export const ContractBillingDetailsForm: FC<SubscriptionServiceModalProps> = ({
         />
         {country?.value === 'US' && (
           <FormInput
-            label='State'
-            name='region'
-            placeholder='State'
-            formId={formId}
-            onFocus={() => onSetIsBillingDetailsFocused(true)}
-            onBlur={() => onSetIsBillingDetailsFocused(false)}
-          />
-        )}
-        <Flex>
-          <FormInput
             label='City'
             formId={formId}
             name='locality'
@@ -194,6 +179,29 @@ export const ContractBillingDetailsForm: FC<SubscriptionServiceModalProps> = ({
             onBlur={() => onSetIsBillingDetailsFocused(false)}
             autoComplete='off'
           />
+        )}
+        <Flex>
+          {country?.value === 'US' ? (
+            <FormInput
+              label='State'
+              name='region'
+              placeholder='State'
+              formId={formId}
+              onFocus={() => onSetIsBillingDetailsFocused(true)}
+              onBlur={() => onSetIsBillingDetailsFocused(false)}
+            />
+          ) : (
+            <FormInput
+              label='City'
+              formId={formId}
+              name='locality'
+              textOverflow='ellipsis'
+              placeholder='City'
+              onFocus={() => onSetIsBillingDetailsFocused(true)}
+              onBlur={() => onSetIsBillingDetailsFocused(false)}
+              autoComplete='off'
+            />
+          )}
           <FormInput
             label='ZIP/Postal code'
             formId={formId}

--- a/packages/apps/spaces/app/settings/src/components/Tabs/panels/BillingPanel/BillingPanel.tsx
+++ b/packages/apps/spaces/app/settings/src/components/Tabs/panels/BillingPanel/BillingPanel.tsx
@@ -148,7 +148,7 @@ export const BillingPanel = () => {
         addressLine1: '29 Maple Lane',
         addressLine2: 'Springfield, Haven County',
         locality: 'San Francisco',
-        region: 'California',
+        region: 'CA',
         zip: '89302',
         country: 'United States of America',
         email: 'invoices@acme.com',
@@ -437,7 +437,6 @@ export const BillingPanel = () => {
               setIsInvoiceProviderDetailsHovered
             }
             organizationName={state.values?.legalName}
-            check={state.values?.check}
             sendInvoicesFrom={state.values?.sendInvoicesFrom}
             country={state.values?.country}
           />

--- a/packages/apps/spaces/app/settings/src/components/Tabs/panels/BillingPanel/components/TenantBillingDetailsForm.tsx
+++ b/packages/apps/spaces/app/settings/src/components/Tabs/panels/BillingPanel/components/TenantBillingDetailsForm.tsx
@@ -6,7 +6,6 @@ import { LogoUploader } from '@settings/components/LogoUploadComponent/LogoUploa
 import { VatInput } from '@settings/components/Tabs/panels/BillingPanel/components/VatInput';
 import { PaymentMethods } from '@settings/components/Tabs/panels/BillingPanel/components/PaymentMethods';
 
-import { Box } from '@ui/layout/Box';
 import { Flex } from '@ui/layout/Flex';
 import { Text } from '@ui/typography/Text';
 import { CardBody } from '@ui/layout/Card';
@@ -24,12 +23,10 @@ export const TenantBillingPanelDetailsForm = ({
   setIsInvoiceProviderFocused,
   formId,
   organizationName,
-  check,
   sendInvoicesFrom,
   country,
 }: {
   formId: string;
-  check?: boolean | null;
   sendInvoicesFrom?: string;
   organizationName?: string | null;
   country?: SelectOption<string> | null;
@@ -73,25 +70,20 @@ export const TenantBillingPanelDetailsForm = ({
         onMouseEnter={() => setIsInvoiceProviderDetailsHovered(true)}
         onMouseLeave={() => setIsInvoiceProviderDetailsHovered(false)}
       >
+        <Text fontSize='sm' fontWeight='semibold'>
+          Billing address
+        </Text>
         <FormSelect
           name='country'
           placeholder='Country'
           label='Country'
-          isLabelVisible
           formId={formId}
           options={countryOptions}
         />
         <FormInput
           autoComplete='off'
-          label='Billing address'
+          label='Address line 1'
           placeholder='Address line 1'
-          isLabelVisible
-          labelProps={{
-            fontSize: 'sm',
-            mb: 0,
-            mt: 2,
-            fontWeight: 'semibold',
-          }}
           name='addressLine1'
           formId={formId}
           onFocus={() => setIsInvoiceProviderFocused(true)}
@@ -109,25 +101,39 @@ export const TenantBillingPanelDetailsForm = ({
 
         {country?.value === 'US' && (
           <FormInput
-            label='State'
-            name='region'
-            placeholder='State'
+            label='City'
             formId={formId}
+            name='locality'
+            textOverflow='ellipsis'
+            placeholder='City'
             onFocus={() => setIsInvoiceProviderFocused(true)}
             onBlur={() => setIsInvoiceProviderFocused(false)}
+            autoComplete='off'
           />
         )}
 
         <Flex gap={2}>
-          <FormInput
-            autoComplete='off'
-            label='Billing address locality'
-            name='locality'
-            placeholder='City'
-            formId={formId}
-            onFocus={() => setIsInvoiceProviderFocused(true)}
-            onBlur={() => setIsInvoiceProviderFocused(false)}
-          />
+          {country?.value === 'US' ? (
+            <FormInput
+              label='State'
+              name='region'
+              placeholder='State'
+              formId={formId}
+              onFocus={() => setIsInvoiceProviderFocused(true)}
+              onBlur={() => setIsInvoiceProviderFocused(false)}
+            />
+          ) : (
+            <FormInput
+              label='City'
+              formId={formId}
+              name='locality'
+              textOverflow='ellipsis'
+              placeholder='City'
+              onFocus={() => setIsInvoiceProviderFocused(true)}
+              onBlur={() => setIsInvoiceProviderFocused(false)}
+              autoComplete='off'
+            />
+          )}
           <FormInput
             autoComplete='off'
             label='Billing address zip/Postal code'
@@ -166,7 +172,7 @@ export const TenantBillingPanelDetailsForm = ({
         </Flex>
 
         {sendInvoicesFrom && (
-          <Tooltip label='This email is configured by CustomerOs'>
+          <Tooltip label='This email is configured by CustomerOS'>
             <FormInput
               formId={formId}
               autoComplete='off'
@@ -205,21 +211,18 @@ export const TenantBillingPanelDetailsForm = ({
         />
       </Flex>
       <PaymentMethods formId={formId} organizationName={organizationName} />
-      <Box>
-        <FormSwitch
-          size='sm'
-          name='check'
-          formId={formId}
-          label='Checks'
-          fontWeight='semibold'
-          labelProps={{
-            fontSize: 'sm',
-            fontWeight: 'semibold',
-            margin: 0,
-          }}
-        />
-        {check && <Text>Want to pay by check? Contact {sendInvoicesFrom}</Text>}
-      </Box>
+      <FormSwitch
+        size='sm'
+        name='check'
+        formId={formId}
+        label='Checks'
+        fontWeight='semibold'
+        labelProps={{
+          fontSize: 'sm',
+          fontWeight: 'semibold',
+          margin: 0,
+        }}
+      />
     </CardBody>
   );
 };

--- a/packages/apps/spaces/app/src/components/Invoice/components/InvoicePartySection.tsx
+++ b/packages/apps/spaces/app/src/components/Invoice/components/InvoicePartySection.tsx
@@ -85,15 +85,9 @@ export const InvoicePartySection: FC<InvoiceHeaderProps> = ({
       </Text>
 
       {isUSA && (
-        <>
-          <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
-            {locality}
-          </Text>
-          <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
-            {region}
-            {region && zip && ', '} {zip}
-          </Text>
-        </>
+        <Text fontSize='sm' lineHeight={1.2} color='gray.500'>
+          {locality && `${locality}, `} {region} {zip}
+        </Text>
       )}
       {!isUSA && (
         <Text fontSize='sm' lineHeight={1.2} color='gray.500'>


### PR DESCRIPTION
…

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added label for the country field in the billing details form.
- **Enhancements**
	- Reorganized billing address inputs in the contract and tenant billing details forms for better usability.
	- Adjusted logic for displaying the State input based on the selected country in the billing forms.
	- Simplified the display of address details for US-based parties on invoices.
- **Bug Fixes**
	- Changed the label for the address line 1 to enhance clarity.
	- Updated the tooltip label from 'CustomerOs' to 'CustomerOS' for consistency.
- **Refactor**
	- Changed `region` field abbreviation to "CA" in the billing panel.
	- Removed unused `check` field and related logic from billing components.
	- Removed unnecessary imports and components to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->