### PR TITLE
Expose closed field in SLI graphql

### DIFF
--- a/packages/server/customer-os-api-sdk/graph/generated/generated.go
+++ b/packages/server/customer-os-api-sdk/graph/generated/generated.go
@@ -1441,6 +1441,7 @@ type ComplexityRoot struct {
 
 	ServiceLineItem struct {
 		BillingCycle   func(childComplexity int) int
+		Closed         func(childComplexity int) int
 		Comments       func(childComplexity int) int
 		CreatedBy      func(childComplexity int) int
 		Description    func(childComplexity int) int
@@ -10639,6 +10640,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ServiceLineItem.BillingCycle(childComplexity), true
 
+	case "ServiceLineItem.closed":
+		if e.complexity.ServiceLineItem.Closed == nil {
+			break
+		}
+
+		return e.complexity.ServiceLineItem.Closed(childComplexity), true
+
 	case "ServiceLineItem.comments":
 		if e.complexity.ServiceLineItem.Comments == nil {
 			break
@@ -15184,6 +15192,7 @@ type ServiceLineItem implements MetadataInterface {
     tax:                Tax!
     createdBy:          User @goField(forceResolver: true)
     externalLinks:      [ExternalSystem!]! @goField(forceResolver: true)
+    closed:             Boolean!
 }
 
 input ServiceLineItemInput {
@@ -27598,6 +27607,8 @@ func (ec *executionContext) fieldContext_Contract_contractLineItems(ctx context.
 				return ec.fieldContext_ServiceLineItem_createdBy(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_ServiceLineItem_externalLinks(ctx, field)
+			case "closed":
+				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -29145,6 +29156,8 @@ func (ec *executionContext) fieldContext_Contract_serviceLineItems(ctx context.C
 				return ec.fieldContext_ServiceLineItem_createdBy(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_ServiceLineItem_externalLinks(ctx, field)
+			case "closed":
+				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -64180,6 +64193,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Create(ctx co
 				return ec.fieldContext_ServiceLineItem_createdBy(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_ServiceLineItem_externalLinks(ctx, field)
+			case "closed":
+				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -64291,6 +64306,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Update(ctx co
 				return ec.fieldContext_ServiceLineItem_createdBy(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_ServiceLineItem_externalLinks(ctx, field)
+			case "closed":
+				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -82339,6 +82356,8 @@ func (ec *executionContext) fieldContext_Query_serviceLineItem(ctx context.Conte
 				return ec.fieldContext_ServiceLineItem_createdBy(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_ServiceLineItem_externalLinks(ctx, field)
+			case "closed":
+				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -85337,6 +85356,50 @@ func (ec *executionContext) fieldContext_ServiceLineItem_externalLinks(ctx conte
 				return ec.fieldContext_ExternalSystem_externalSource(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ExternalSystem", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceLineItem_closed(ctx context.Context, field graphql.CollectedField, obj *model.ServiceLineItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceLineItem_closed(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Closed, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceLineItem_closed(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceLineItem",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -113426,6 +113489,11 @@ func (ec *executionContext) _ServiceLineItem(ctx context.Context, sel ast.Select
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "closed":
+			out.Values[i] = ec._ServiceLineItem_closed(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/packages/server/customer-os-api-sdk/graph/model/models_gen.go
+++ b/packages/server/customer-os-api-sdk/graph/model/models_gen.go
@@ -2497,6 +2497,7 @@ type ServiceLineItem struct {
 	Tax            *Tax              `json:"tax"`
 	CreatedBy      *User             `json:"createdBy,omitempty"`
 	ExternalLinks  []*ExternalSystem `json:"externalLinks"`
+	Closed         bool              `json:"closed"`
 }
 
 func (ServiceLineItem) IsMetadataInterface()        {}

--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -1440,6 +1440,7 @@ type ComplexityRoot struct {
 
 	ServiceLineItem struct {
 		BillingCycle   func(childComplexity int) int
+		Closed         func(childComplexity int) int
 		Comments       func(childComplexity int) int
 		CreatedBy      func(childComplexity int) int
 		Description    func(childComplexity int) int
@@ -10638,6 +10639,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ServiceLineItem.BillingCycle(childComplexity), true
 
+	case "ServiceLineItem.closed":
+		if e.complexity.ServiceLineItem.Closed == nil {
+			break
+		}
+
+		return e.complexity.ServiceLineItem.Closed(childComplexity), true
+
 	case "ServiceLineItem.comments":
 		if e.complexity.ServiceLineItem.Comments == nil {
 			break
@@ -15183,6 +15191,7 @@ type ServiceLineItem implements MetadataInterface {
     tax:                Tax!
     createdBy:          User @goField(forceResolver: true)
     externalLinks:      [ExternalSystem!]! @goField(forceResolver: true)
+    closed:             Boolean!
 }
 
 input ServiceLineItemInput {
@@ -27597,6 +27606,8 @@ func (ec *executionContext) fieldContext_Contract_contractLineItems(ctx context.
 				return ec.fieldContext_ServiceLineItem_createdBy(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_ServiceLineItem_externalLinks(ctx, field)
+			case "closed":
+				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -29144,6 +29155,8 @@ func (ec *executionContext) fieldContext_Contract_serviceLineItems(ctx context.C
 				return ec.fieldContext_ServiceLineItem_createdBy(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_ServiceLineItem_externalLinks(ctx, field)
+			case "closed":
+				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -64179,6 +64192,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Create(ctx co
 				return ec.fieldContext_ServiceLineItem_createdBy(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_ServiceLineItem_externalLinks(ctx, field)
+			case "closed":
+				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -64290,6 +64305,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Update(ctx co
 				return ec.fieldContext_ServiceLineItem_createdBy(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_ServiceLineItem_externalLinks(ctx, field)
+			case "closed":
+				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -82338,6 +82355,8 @@ func (ec *executionContext) fieldContext_Query_serviceLineItem(ctx context.Conte
 				return ec.fieldContext_ServiceLineItem_createdBy(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_ServiceLineItem_externalLinks(ctx, field)
+			case "closed":
+				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -85336,6 +85355,50 @@ func (ec *executionContext) fieldContext_ServiceLineItem_externalLinks(ctx conte
 				return ec.fieldContext_ExternalSystem_externalSource(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ExternalSystem", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceLineItem_closed(ctx context.Context, field graphql.CollectedField, obj *model.ServiceLineItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceLineItem_closed(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Closed, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceLineItem_closed(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceLineItem",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -113425,6 +113488,11 @@ func (ec *executionContext) _ServiceLineItem(ctx context.Context, sel ast.Select
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "closed":
+			out.Values[i] = ec._ServiceLineItem_closed(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -2495,6 +2495,7 @@ type ServiceLineItem struct {
 	Tax            *Tax              `json:"tax"`
 	CreatedBy      *User             `json:"createdBy,omitempty"`
 	ExternalLinks  []*ExternalSystem `json:"externalLinks"`
+	Closed         bool              `json:"closed"`
 }
 
 func (ServiceLineItem) IsMetadataInterface()        {}

--- a/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_arr_breakdown_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/dashboard.resolvers_arr_breakdown_it_test.go
@@ -516,10 +516,10 @@ func Test_Dashboard_ARR_Breakdown_Cancellations_No_Recurring_SLI(t *testing.T) {
 	sli1StartedAt := utils.FirstTimeOfMonth(2023, 7)
 
 	neo4jtest.CreateServiceLineItemForContract(ctx, driver, tenantName, contractId, neo4jentity.ServiceLineItemEntity{
-		Price:      1,
-		Quantity:   2,
-		IsCanceled: true,
-		StartedAt:  sli1StartedAt,
+		Price:     1,
+		Quantity:  2,
+		Canceled:  true,
+		StartedAt: sli1StartedAt,
 	})
 
 	rawResponse := callGraphQL(t, "dashboard_view/dashboard_arr_breakdown",

--- a/packages/server/customer-os-api/graph/schemas/service_line_item.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/service_line_item.graphqls
@@ -23,6 +23,7 @@ type ServiceLineItem implements MetadataInterface {
     tax:                Tax!
     createdBy:          User @goField(forceResolver: true)
     externalLinks:      [ExternalSystem!]! @goField(forceResolver: true)
+    closed:             Boolean!
 }
 
 input ServiceLineItemInput {

--- a/packages/server/customer-os-api/mapper/service_line_item_mapper.go
+++ b/packages/server/customer-os-api/mapper/service_line_item_mapper.go
@@ -29,6 +29,7 @@ func MapEntityToServiceLineItem(entity *neo4jentity.ServiceLineItemEntity) *mode
 		Tax: &model.Tax{
 			TaxRate: entity.VatRate,
 		},
+		Closed: entity.Canceled,
 	}
 }
 

--- a/packages/server/customer-os-neo4j-repository/entity/service_line_item.go
+++ b/packages/server/customer-os-neo4j-repository/entity/service_line_item.go
@@ -14,7 +14,7 @@ type ServiceLineItemEntity struct {
 	UpdatedAt        time.Time
 	StartedAt        time.Time  // DateTime
 	EndedAt          *time.Time // DateTime
-	IsCanceled       bool
+	Canceled         bool
 	Billed           enum.BilledType
 	Price            float64
 	Quantity         int64

--- a/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
+++ b/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
@@ -478,7 +478,7 @@ func MapDbNodeToServiceLineItemEntity(dbNode *dbtype.Node) *entity.ServiceLineIt
 		Quantity:      utils.GetInt64PropOrZero(props, "quantity"),
 		Comments:      utils.GetStringPropOrEmpty(props, "comments"),
 		ParentID:      utils.GetStringPropOrEmpty(props, "parentId"),
-		IsCanceled:    utils.GetBoolPropOrFalse(props, "isCanceled"),
+		Canceled:      utils.GetBoolPropOrFalse(props, "isCanceled"),
 		VatRate:       utils.GetFloatPropOrZero(props, "vatRate"),
 	}
 	return &serviceLineItem

--- a/packages/server/customer-os-neo4j-repository/test/neo4j_data_helper.go
+++ b/packages/server/customer-os-neo4j-repository/test/neo4j_data_helper.go
@@ -876,7 +876,7 @@ func CreateServiceLineItemForContract(ctx context.Context, driver *neo4j.DriverW
 		"source":           serviceLineItem.Source,
 		"sourceOfTruth":    serviceLineItem.SourceOfTruth,
 		"appSource":        serviceLineItem.AppSource,
-		"isCanceled":       serviceLineItem.IsCanceled,
+		"isCanceled":       serviceLineItem.Canceled,
 		"billed":           serviceLineItem.Billed,
 		"quantity":         serviceLineItem.Quantity,
 		"price":            serviceLineItem.Price,
@@ -942,14 +942,14 @@ func InsertServiceLineItemCanceled(ctx context.Context, driver *neo4j.DriverWith
 	rand, _ := uuid.NewRandom()
 	id := rand.String()
 	CreateServiceLineItemForContract(ctx, driver, tenant, contractId, entity.ServiceLineItemEntity{
-		ID:         id,
-		ParentID:   id,
-		Billed:     billedType,
-		Price:      price,
-		Quantity:   quantity,
-		IsCanceled: true,
-		StartedAt:  startedAt,
-		EndedAt:    &endedAt,
+		ID:        id,
+		ParentID:  id,
+		Billed:    billedType,
+		Price:     price,
+		Quantity:  quantity,
+		Canceled:  true,
+		StartedAt: startedAt,
+		EndedAt:   &endedAt,
 	})
 	return id
 }
@@ -999,7 +999,7 @@ func InsertServiceLineItemCanceledWithParent(ctx context.Context, driver *neo4j.
 		PreviousBilled:   previousBilledType,
 		PreviousPrice:    previousPrice,
 		PreviousQuantity: previousQuantity,
-		IsCanceled:       true,
+		Canceled:         true,
 		StartedAt:        startedAt,
 		EndedAt:          &endedAt,
 	})

--- a/packages/server/events-processing-platform-subscribers/subscriptions/graph/service_line_item_event_handler_it_test.go
+++ b/packages/server/events-processing-platform-subscribers/subscriptions/graph/service_line_item_event_handler_it_test.go
@@ -448,7 +448,7 @@ func TestServiceLineItemEventHandler_OnClose(t *testing.T) {
 	require.Equal(t, serviceLineItemId, serviceLineItem.ID)
 	require.Equal(t, now, serviceLineItem.UpdatedAt)
 	require.Equal(t, utils.ToDate(now), *serviceLineItem.EndedAt)
-	require.True(t, serviceLineItem.IsCanceled)
+	require.True(t, serviceLineItem.Canceled)
 
 	// verify events platform was called
 	require.True(t, calledEventsPlatformToUpdateOpportunity)


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new `Closed` field to the `ServiceLineItem` to indicate if a service line item is closed.

- **Refactor**
	- Updated field name from `IsCanceled` to `Canceled` across various structures and tests to improve consistency.

- **Documentation**
	- Updated GraphQL schema documentation to include the new `closed` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->