### PR TITLE
(COS-2879):  Fix backdrop overflow

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Timeline/shared/TimelineEventPreview/TimelinePreviewBackdrop.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Timeline/shared/TimelineEventPreview/TimelinePreviewBackdrop.tsx
@@ -41,7 +41,7 @@ export const TimelinePreviewBackdrop = ({
     <Modal open={isModalOpen} modal={false} onOpenChange={closeModal}>
       <div
         className={cn(
-          'absolute top-0 bottom-0 left-0 right-0 z-10 cursor-pointer flex justify-center align-middle transition-all duration-100 linear',
+          'absolute top-0 bottom-0 left-0 right-0 z-9 cursor-pointer flex justify-center align-middle transition-all duration-100 linear',
         )}
         id='timeline-preview-backdrop'
         style={{
@@ -60,7 +60,7 @@ export const TimelinePreviewBackdrop = ({
                 ? 'w-[650px]'
                 : 'w-[544px]',
               modalContent?.__typename === 'Invoice' ? 'h-[90vh]' : 'h-auto',
-              'absolute top-4 min-w-[544px] bg-transparent',
+              'absolute top-4 min-w-[544px] bg-transparent z-9',
             )}
             onPointerDownOutside={avoidDefaultDomBehavior}
             onInteractOutside={avoidDefaultDomBehavior}


### PR DESCRIPTION

## Proposed changes
Timeline event backdrop should be below page level modals when they are open


## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

