### PR TITLE
Alex/cos 3006 double query execution on update organization renewal date

### DIFF
--- a/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
+++ b/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
@@ -76,6 +76,11 @@
           "name": "Organization with missing properties",
           "query": "MATCH (n:Organization) WHERE (n.hide IS NULL OR n.isCustomer IS NULL) RETURN count(n) as cnt",
           "description": "Organization with missing boolean properties."
+        },
+        {
+          "name": "Derived next renewal date in past",
+          "query": "MATCH (org:Organization) OPTIONAL MATCH (org)--(c:Contract) WITH org, collect(c) as contracts WHERE size(contracts) > 0 AND ALL(c IN contracts WHERE c.status <> 'OUT_OF_CONTRACT') AND date(org.derivedNextRenewalAt) < date() RETURN count(org) as cnt",
+          "description": "Organization with derived next renewal date in the past. If organization has multiple contracts, all contracts should be in status different than 'OUT_OF_CONTRACT'."
         }
       ]
     },
@@ -266,8 +271,8 @@
     },
     {
       "name": "Check organization derived data consistency",
-      "query": "CALL {\n     MATCH (org:Organization) OPTIONAL MATCH (org)--(c:Contract) WITH org, c WHERE (c IS NULL or c.status <> 'OUT_OF_CONTRACT') AND date(org.derivedNextRenewalAt) < date() RETURN count(org) as cnt\n     UNION ALL\n     MATCH (org:Organization) WHERE org.derivedRenewalLikelihood IS NOT NULL AND NOT org.derivedRenewalLikelihood IN ['','ZERO','LOW','MEDIUM','HIGH'] RETURN count(org) as cnt\n     UNION ALL\n     MATCH (org:Organization) WHERE org.derivedRenewalLikelihood IS NULL AND NOT org.derivedRenewalLikelihood IS NULL RETURN count(org) as cnt\n     UNION ALL MATCH (org:Organization)--(c:Contract)-[:ACTIVE_RENEWAL]->(op:RenewalOpportunity) WHERE (org.renewalForecastMaxArr IS NULL OR org.renewalForecastMaxArr = 0) AND (op.maxAmount > 0) return count(org) AS cnt\n} RETURN sum(cnt)",
-      "description": "Checks: 1 - Organizations with wrong derivedNextRenewalAt date. 2 - Organizations with wrong derivedRenewalLikelihood value. 3 - Organization with renewal likelihood but without renewal date. 4 - Organizations with missing ARR"
+      "query": "CALL {MATCH (org:Organization) WHERE org.derivedRenewalLikelihood IS NOT NULL AND NOT org.derivedRenewalLikelihood IN ['','ZERO','LOW','MEDIUM','HIGH'] RETURN count(org) as cnt\n     UNION ALL\n     MATCH (org:Organization) WHERE org.derivedRenewalLikelihood IS NULL AND NOT org.derivedRenewalLikelihood IS NULL RETURN count(org) as cnt\n     UNION ALL MATCH (org:Organization)--(c:Contract)-[:ACTIVE_RENEWAL]->(op:RenewalOpportunity) WHERE (org.renewalForecastMaxArr IS NULL OR org.renewalForecastMaxArr = 0) AND (op.maxAmount > 0) return count(org) AS cnt\n} RETURN sum(cnt)",
+      "description": "Checks: 2 - Organizations with wrong derivedRenewalLikelihood value. 3 - Organization with renewal likelihood but without renewal date. 4 - Organizations with missing ARR"
     },
     {
       "name": "Check organization data consistency",

--- a/packages/server/events-processing-platform-subscribers/subscriptions/graph/opportunity_event_handler.go
+++ b/packages/server/events-processing-platform-subscribers/subscriptions/graph/opportunity_event_handler.go
@@ -177,8 +177,6 @@ func (h *OpportunityEventHandler) OnCreateRenewal(ctx context.Context, evt event
 			h.log.Errorf("error while updating renewal opportunity %s: %s", opportunityId, err.Error())
 			return nil
 		}
-
-		h.sendEventToUpdateOrganizationRenewalSummary(ctx, eventData.Tenant, opportunityId, span)
 	} else {
 		// Mark event store stream for deletion
 		ctx = tracing.InjectSpanContextIntoGrpcMetadata(ctx, span)

--- a/packages/server/events-processing-platform/domain/organization/request_handler.go
+++ b/packages/server/events-processing-platform/domain/organization/request_handler.go
@@ -96,7 +96,7 @@ func (h *organizationRequestHandler) HandleTemp(ctx context.Context, tenant, obj
 }
 
 func (h *organizationRequestHandler) HandleTempWithRetry(ctx context.Context, tenant, objectId string, request any) (any, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractRequestHandler.Handle")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationRequestHandler.HandleTempWithRetry")
 	defer span.Finish()
 	span.SetTag(tracing.SpanTagTenant, tenant)
 	tracing.LogObjectAsJson(span, "request", request)


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new integrity check query to identify organizations with renewal dates in the past.

- **Enhancements**
  - Improved data consistency checks for organizations to focus on relevant metrics.
  - Updated entity mapping functions to enhance data handling and integration.
  
- **Refactor**
  - Shifted references from `neo4jentity.DataSource` to local `DataSource` in various entities.
  - Replaced `graph_db` with `neo4jmapper` and `neo4jentity` in event processing modules.
  
- **Bug Fixes**
  - Adjusted the operation name in tracing for better clarity and tracking in `organizationRequestHandler`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->