### PR TITLE
Alex/cos 3017 renewal likelihood is initialy set to 0 when a contract is

### DIFF
--- a/packages/server/customer-os-api-sdk/graph/generated/generated.go
+++ b/packages/server/customer-os-api-sdk/graph/generated/generated.go
@@ -15418,6 +15418,8 @@ input ServiceLineItemBulkUpdateItem {
     comments:                String
     isRetroactiveCorrection: Boolean
     serviceStarted:          Time
+    closeVersion:            Boolean
+    newVersion:              Boolean
 }
 
 input ServiceLineItemCloseInput {
@@ -99682,7 +99684,7 @@ func (ec *executionContext) unmarshalInputServiceLineItemBulkUpdateItem(ctx cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"serviceLineItemId", "name", "billed", "price", "quantity", "vatRate", "comments", "isRetroactiveCorrection", "serviceStarted"}
+	fieldsInOrder := [...]string{"serviceLineItemId", "name", "billed", "price", "quantity", "vatRate", "comments", "isRetroactiveCorrection", "serviceStarted", "closeVersion", "newVersion"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -99752,6 +99754,20 @@ func (ec *executionContext) unmarshalInputServiceLineItemBulkUpdateItem(ctx cont
 				return it, err
 			}
 			it.ServiceStarted = data
+		case "closeVersion":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("closeVersion"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CloseVersion = data
+		case "newVersion":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("newVersion"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.NewVersion = data
 		}
 	}
 

--- a/packages/server/customer-os-api-sdk/graph/model/models_gen.go
+++ b/packages/server/customer-os-api-sdk/graph/model/models_gen.go
@@ -2553,6 +2553,8 @@ type ServiceLineItemBulkUpdateItem struct {
 	Comments                *string     `json:"comments,omitempty"`
 	IsRetroactiveCorrection *bool       `json:"isRetroactiveCorrection,omitempty"`
 	ServiceStarted          *time.Time  `json:"serviceStarted,omitempty"`
+	CloseVersion            *bool       `json:"closeVersion,omitempty"`
+	NewVersion              *bool       `json:"newVersion,omitempty"`
 }
 
 type ServiceLineItemCloseInput struct {

--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -14546,8 +14546,8 @@ input OpportunityUpdateInput {
 }
 
 input OpportunityRenewalUpdateAllForOrganizationInput {
-    organizationId:     ID!
-    renewalLikelihood:  OpportunityRenewalLikelihood
+    organizationId:         ID!
+    renewalLikelihood:      OpportunityRenewalLikelihood
     renewalAdjustedRate:    Int64
 }`, BuiltIn: false},
 	{Name: "../schemas/order.graphqls", Input: `type Order {
@@ -15417,6 +15417,8 @@ input ServiceLineItemBulkUpdateItem {
     comments:                String
     isRetroactiveCorrection: Boolean
     serviceStarted:          Time
+    closeVersion:            Boolean
+    newVersion:              Boolean
 }
 
 input ServiceLineItemCloseInput {
@@ -99681,7 +99683,7 @@ func (ec *executionContext) unmarshalInputServiceLineItemBulkUpdateItem(ctx cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"serviceLineItemId", "name", "billed", "price", "quantity", "vatRate", "comments", "isRetroactiveCorrection", "serviceStarted"}
+	fieldsInOrder := [...]string{"serviceLineItemId", "name", "billed", "price", "quantity", "vatRate", "comments", "isRetroactiveCorrection", "serviceStarted", "closeVersion", "newVersion"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -99751,6 +99753,20 @@ func (ec *executionContext) unmarshalInputServiceLineItemBulkUpdateItem(ctx cont
 				return it, err
 			}
 			it.ServiceStarted = data
+		case "closeVersion":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("closeVersion"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CloseVersion = data
+		case "newVersion":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("newVersion"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.NewVersion = data
 		}
 	}
 

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -2551,6 +2551,8 @@ type ServiceLineItemBulkUpdateItem struct {
 	Comments                *string     `json:"comments,omitempty"`
 	IsRetroactiveCorrection *bool       `json:"isRetroactiveCorrection,omitempty"`
 	ServiceStarted          *time.Time  `json:"serviceStarted,omitempty"`
+	CloseVersion            *bool       `json:"closeVersion,omitempty"`
+	NewVersion              *bool       `json:"newVersion,omitempty"`
 }
 
 type ServiceLineItemCloseInput struct {

--- a/packages/server/customer-os-api/graph/schemas/service_line_item.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/service_line_item.graphqls
@@ -83,6 +83,8 @@ input ServiceLineItemBulkUpdateItem {
     comments:                String
     isRetroactiveCorrection: Boolean
     serviceStarted:          Time
+    closeVersion:            Boolean
+    newVersion:              Boolean
 }
 
 input ServiceLineItemCloseInput {

--- a/packages/server/events-processing-platform/domain/opportunity/aggregate/aggregate.go
+++ b/packages/server/events-processing-platform/domain/opportunity/aggregate/aggregate.go
@@ -71,8 +71,10 @@ func (a *OpportunityAggregate) createRenewalOpportunity(ctx context.Context, req
 	renewalLikelihood := model.RenewalLikelihood(request.RenewalLikelihood).StringEnumValue()
 	adjustedRate := request.RenewalAdjustedRate
 	if string(renewalLikelihood) == "" {
-		adjustedRate = 100
 		renewalLikelihood = neo4jenum.RenewalLikelihoodHigh
+	}
+	if renewalLikelihood == neo4jenum.RenewalLikelihoodHigh && adjustedRate == 0 {
+		adjustedRate = 100
 	}
 
 	if adjustedRate < 0 {

--- a/packages/server/events-processing-platform/test_app/main.go
+++ b/packages/server/events-processing-platform/test_app/main.go
@@ -30,7 +30,9 @@ const grpcApiKey = "082c1193-a5a2-42fc-87fc-e960e692fffd"
 const appSource = "test_app"
 
 var tenant = "customerosai"
+var userId = "05f382ba-0fa9-4828-940c-efb4e2e6b84c"
 var orgId = "ceae019f-d1e3-49b3-87c5-35ebb68a5ff1"
+var contractId = "769d1fb8-50a1-44bc-aff0-0f4338bd8ff2"
 
 type Clients struct {
 	InteractionEventClient iepb.InteractionEventGrpcServiceClient
@@ -110,6 +112,7 @@ func main() {
 	//testUpdateContract()
 	//testAddContractService()
 	//testCloseLooseOpportunity()
+	//testCreateRenewalOpportunity()
 	//testUpdateOnboardingStatus()
 	//testUpdateOrgOwner()
 	//testRefreshLastTouchpoint()
@@ -718,6 +721,22 @@ func testCloseLooseOpportunity() {
 		Id:             opportunityId,
 		LoggedInUserId: userId,
 		AppSource:      appSource,
+	})
+	if err != nil {
+		log.Fatalf("Failed: %v", err.Error())
+	}
+	log.Printf("Result: %v", result.Id)
+}
+
+func testCreateRenewalOpportunity() {
+
+	result, err := clients.OpportunityClient.CreateRenewalOpportunity(context.Background(), &opportunitypb.CreateRenewalOpportunityGrpcRequest{
+		Tenant:         tenant,
+		LoggedInUserId: userId,
+		ContractId:     contractId,
+		SourceFields: &commonpb.SourceFields{
+			AppSource: appSource,
+		},
 	})
 	if err != nil {
 		log.Fatalf("Failed: %v", err.Error())


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added fields to enhance bulk update capabilities for service line items, allowing for version management.
	- Improved renewal opportunity creation logic by adjusting rates based on renewal likelihood.

- **Bug Fixes**
	- Ensured correct handling of new fields during data processing for service updates and opportunity renewals.

- **Tests**
	- Introduced new tests for renewal opportunities and updated existing tests to include new identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->