### PR TITLE
feat: edit renewal forecast from finder

### DIFF
--- a/packages/apps/spaces/app/organizations/src/components/Columns/Cells/renewal/RenewalForecastCell.tsx
+++ b/packages/apps/spaces/app/organizations/src/components/Columns/Cells/renewal/RenewalForecastCell.tsx
@@ -1,32 +1,217 @@
-import { twMerge } from 'tailwind-merge';
+import { useMemo, useState } from 'react';
 
+import set from 'lodash/set';
+import { produce } from 'immer';
+import { twMerge } from 'tailwind-merge';
+import { useQueryClient } from '@tanstack/react-query';
+import { PopoverTrigger } from '@radix-ui/react-popover';
+
+import { cn } from '@ui/utils/cn';
+import { Edit03 } from '@ui/media/icons/Edit03';
+import { toastError } from '@ui/presentation/Toast';
+import { IconButton } from '@ui/form/IconButton/IconButton';
+import { OpportunityRenewalLikelihood } from '@graphql/types';
+import { getGraphQLClient } from '@shared/util/getGraphQLClient';
 import { formatCurrency } from '@spaces/utils/getFormattedCurrencyNumber';
+import { useOrganizationsMeta } from '@shared/state/OrganizationsMeta.atom';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from '@ui/overlay/Popover/Popover';
+import { useInfiniteGetOrganizationsQuery } from '@organizations/graphql/getOrganizations.generated';
+import { useBulkUpdateOpportunityRenewalMutation } from '@shared/graphql/bulkUpdateOpportunityRenewal.generated';
+import {
+  RangeSlider,
+  RangeSliderThumb,
+  RangeSliderTrack,
+  RangeSliderFilledTrack,
+} from '@ui/form/RangeSlider/RangeSlider';
 
 interface RenewalForecastCellProps {
+  id: string;
   amount?: number | null;
   potentialAmount?: number | null;
 }
 
 export const RenewalForecastCell = ({
+  id,
   amount = null,
   potentialAmount = null,
 }: RenewalForecastCellProps) => {
+  const client = getGraphQLClient();
+  const queryClient = useQueryClient();
+  const [isEditing, setIsEditing] = useState(false);
+  const [organizationsMeta] = useOrganizationsMeta();
+
+  const initialValue = useMemo(
+    () => ((amount ?? 0) / (potentialAmount ?? 0)) * 100,
+    [amount, potentialAmount],
+  );
+  const [value, setValue] = useState(initialValue);
+
+  const { getOrganization } = organizationsMeta;
+  const queryKey = useInfiniteGetOrganizationsQuery.getKey(getOrganization);
+
+  const updateOpportunityRenewal = useBulkUpdateOpportunityRenewalMutation(
+    client,
+    {
+      onMutate: (payload) => {
+        queryClient.cancelQueries({ queryKey });
+
+        const { previousEntries } =
+          useInfiniteGetOrganizationsQuery.mutateCacheEntry(
+            queryClient,
+            getOrganization,
+          )((old) =>
+            produce(old, (draft) => {
+              const pageIndex =
+                organizationsMeta.getOrganization.pagination.page - 1;
+
+              const content =
+                draft?.pages?.[pageIndex]?.dashboardView_Organizations?.content;
+              const index = content?.findIndex(
+                (item) => item.metadata.id === payload.input.organizationId,
+              );
+
+              const nextLikelihood = (() => {
+                if (value <= 25) return OpportunityRenewalLikelihood.LowRenewal;
+                if (value > 25 && value < 75)
+                  return OpportunityRenewalLikelihood.MediumRenewal;
+
+                return OpportunityRenewalLikelihood.HighRenewal;
+              })();
+
+              if (content && index !== undefined && index > -1) {
+                set(
+                  content[index],
+                  'accountDetails.renewalSummary.renewalLikelihood',
+                  nextLikelihood,
+                );
+                set(
+                  content[index],
+                  'accountDetails.renewalSummary.arrForecast',
+                  (potentialAmount ?? 0) * (value / 100),
+                );
+              }
+            }),
+          );
+
+        return { previousEntries };
+      },
+      onError: (_, __, context) => {
+        toastError(
+          `We couldn't update the forecast`,
+          'renewal-forecast-update-error',
+        );
+        if (context?.previousEntries) {
+          queryClient.setQueryData(queryKey, context.previousEntries);
+        }
+      },
+      onSettled: () => {
+        setTimeout(() => {
+          queryClient.invalidateQueries({ queryKey });
+        }, 500);
+      },
+    },
+  );
+
   const formattedAmount =
-    amount !== null && amount >= 0 ? formatCurrency(amount, 0) : 'Unknown';
+    amount !== null && amount >= 0
+      ? formatCurrency((potentialAmount ?? 0) * (value / 100), 0)
+      : 'Unknown';
   const formattedPotentialAmount = formatCurrency(potentialAmount ?? 0, 0);
 
   const showPotentialAmount =
     amount !== null &&
     potentialAmount !== null &&
-    formattedAmount !== formattedPotentialAmount;
+    (potentialAmount ?? 0) * (value / 100) !== potentialAmount;
+
+  const trackStyle = cn('h-0.5 transition-colors', {
+    'bg-orangeDark-700': value <= 25,
+    'bg-yellow-400': value > 25 && value < 75,
+    'bg-greenLight-400': value >= 75,
+  });
+
+  const thumbStyle = cn('ring-1 transition-colors shadow-md cursor-pointer', {
+    'ring-orangeDark-700': value <= 25,
+    'ring-yellow-400': value > 25 && value < 75,
+    'ring-greenLight-400': value >= 75,
+  });
+
+  const handleChange = (value: number) => {
+    updateOpportunityRenewal.mutate({
+      input: {
+        organizationId: id,
+        renewalAdjustedRate: value,
+        renewalLikelihood: (() => {
+          if (value <= 25) return OpportunityRenewalLikelihood.LowRenewal;
+          if (value > 25 && value < 75)
+            return OpportunityRenewalLikelihood.MediumRenewal;
+
+          return OpportunityRenewalLikelihood.HighRenewal;
+        })(),
+      },
+    });
+  };
 
   if (formattedAmount === 'Unknown')
     return <span className='text-gray-400'>Unknown</span>;
   const textColor = amount ? 'text-gray-700' : 'text-gray-500';
 
   return (
-    <div className='flex flex-col justify-center'>
-      <span className={twMerge('text-sm', textColor)}>{formattedAmount}</span>
+    <div className='flex flex-col justify-center group/forecast'>
+      <Popover open={isEditing} onOpenChange={setIsEditing}>
+        <div className='flex gap-1 items-center'>
+          <PopoverAnchor>
+            <span className={twMerge('text-sm', textColor)}>
+              {formattedAmount}
+            </span>
+          </PopoverAnchor>
+
+          <PopoverTrigger asChild>
+            <IconButton
+              size='xxs'
+              variant='ghost'
+              aria-label='edit renewal likelihood'
+              icon={<Edit03 className='text-gray-500' />}
+              className={cn(
+                'rounded-md opacity-0 group-hover/forecast:opacity-100',
+                isEditing && 'opacity-100',
+              )}
+            />
+          </PopoverTrigger>
+        </div>
+
+        <PopoverContent
+          sideOffset={showPotentialAmount ? 30 : 20}
+          align='start'
+        >
+          <RangeSlider
+            step={1}
+            min={0}
+            max={100}
+            value={[value]}
+            className='w-40'
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                setValue(initialValue);
+              }
+            }}
+            onValueChange={(values) => {
+              setValue(values[0]);
+            }}
+            onValueCommit={(values) => {
+              handleChange(values[0]);
+            }}
+          >
+            <RangeSliderTrack className='bg-gray-400 h-0.5'>
+              <RangeSliderFilledTrack className={trackStyle} />
+            </RangeSliderTrack>
+            <RangeSliderThumb className={thumbStyle} />
+          </RangeSlider>
+        </PopoverContent>
+      </Popover>
       {showPotentialAmount && (
         <span className='text-sm text-gray-500 line-through'>
           {formattedPotentialAmount}

--- a/packages/apps/spaces/app/organizations/src/components/Columns/Columns.tsx
+++ b/packages/apps/spaces/app/organizations/src/components/Columns/Columns.tsx
@@ -234,6 +234,7 @@ export const columns = [
 
       return (
         <RenewalForecastCell
+          id={props.row.original.metadata.id}
           amount={amount}
           potentialAmount={potentialAmount}
         />

--- a/packages/apps/spaces/app/organizations/src/components/Columns/columnsDictionary.tsx
+++ b/packages/apps/spaces/app/organizations/src/components/Columns/columnsDictionary.tsx
@@ -242,6 +242,7 @@ const columns: Record<string, Column> = {
         <RenewalForecastCell
           amount={amount}
           potentialAmount={potentialAmount}
+          id={props.row.original.metadata.id}
         />
       );
     },

--- a/packages/apps/spaces/app/renewals/src/components/Columns/Cells/renewal/RenewalForecastCell.tsx
+++ b/packages/apps/spaces/app/renewals/src/components/Columns/Cells/renewal/RenewalForecastCell.tsx
@@ -1,39 +1,222 @@
+import { useState, useEffect } from 'react';
+
+import set from 'lodash/set';
+import { produce } from 'immer';
+import { twMerge } from 'tailwind-merge';
+import { useQueryClient } from '@tanstack/react-query';
+import { PopoverTrigger } from '@radix-ui/react-popover';
+import { useInfiniteGetRenewalsQuery } from '@renewals/graphql/getRenewals.generated';
+
 import { cn } from '@ui/utils/cn';
+import { Edit03 } from '@ui/media/icons/Edit03';
+import { toastError } from '@ui/presentation/Toast';
+import { IconButton } from '@ui/form/IconButton/IconButton';
+import { OpportunityRenewalLikelihood } from '@graphql/types';
+import { getGraphQLClient } from '@shared/util/getGraphQLClient';
+import { useRenewalsMeta } from '@shared/state/RenewalsMeta.atom';
 import { formatCurrency } from '@spaces/utils/getFormattedCurrencyNumber';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from '@ui/overlay/Popover/Popover';
+import { useUpdateOpportunityRenewalMutation } from '@organization/src/graphql/updateOpportunityRenewal.generated';
+import {
+  RangeSlider,
+  RangeSliderThumb,
+  RangeSliderTrack,
+  RangeSliderFilledTrack,
+} from '@ui/form/RangeSlider/RangeSlider';
 
 interface RenewalForecastCellProps {
+  id: string;
+  opportunityId: string;
   amount?: number | null;
+  adjustedRate?: number | null;
   potentialAmount?: number | null;
 }
 
 export const RenewalForecastCell = ({
+  id,
   amount = null,
+  opportunityId,
+  adjustedRate = 0,
   potentialAmount = null,
 }: RenewalForecastCellProps) => {
+  const client = getGraphQLClient();
+  const queryClient = useQueryClient();
+  const [isEditing, setIsEditing] = useState(false);
+  const [renewalsMeta] = useRenewalsMeta();
+
+  const [value, setValue] = useState(adjustedRate ?? 0);
+
+  const { getRenewals } = renewalsMeta;
+  const queryKey = useInfiniteGetRenewalsQuery.getKey(getRenewals);
+
+  const updateOpportunityRenewal = useUpdateOpportunityRenewalMutation(client, {
+    onMutate: () => {
+      queryClient.cancelQueries({ queryKey });
+
+      const { previousEntries } = useInfiniteGetRenewalsQuery.mutateCacheEntry(
+        queryClient,
+        getRenewals,
+      )((old) =>
+        produce(old, (draft) => {
+          const pageIndex = renewalsMeta.getRenewals.pagination.page - 1;
+
+          const content =
+            draft?.pages?.[pageIndex]?.dashboardView_Renewals?.content;
+          const index = content?.findIndex(
+            (item) => item.organization.metadata.id === id,
+          );
+
+          const nextLikelihood = (() => {
+            if (value <= 25) return OpportunityRenewalLikelihood.LowRenewal;
+            if (value > 25 && value < 75)
+              return OpportunityRenewalLikelihood.MediumRenewal;
+
+            return OpportunityRenewalLikelihood.HighRenewal;
+          })();
+
+          if (content && index !== undefined && index > -1) {
+            set(
+              content[index],
+              'opportunity.renewalLikelihood',
+              nextLikelihood,
+            );
+            set(
+              content[index],
+              'opportunity.amount',
+              (potentialAmount ?? 0) * (value / 100),
+            );
+          }
+        }),
+      );
+
+      return { previousEntries };
+    },
+    onError: (_, __, context) => {
+      toastError(
+        `We couldn't update the forecast`,
+        'renewal-forecast-update-error',
+      );
+      if (context?.previousEntries) {
+        queryClient.setQueryData(queryKey, context.previousEntries);
+      }
+    },
+    onSettled: () => {
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey });
+      }, 500);
+    },
+  });
+
   const formattedAmount =
-    amount !== null && amount >= 0 ? formatCurrency(amount, 0) : 'Unknown';
+    amount !== null && amount >= 0
+      ? formatCurrency((potentialAmount ?? 0) * (value / 100), 0)
+      : 'Unknown';
   const formattedPotentialAmount = formatCurrency(potentialAmount ?? 0, 0);
 
   const showPotentialAmount =
     amount !== null &&
     potentialAmount !== null &&
-    formattedAmount !== formattedPotentialAmount;
+    (potentialAmount ?? 0) * (value / 100) !== potentialAmount;
 
-  if (formattedAmount === 'Unknown')
-    return <p className='text-gray-400'>Unknown</p>;
+  const trackStyle = cn('h-0.5 transition-colors', {
+    'bg-orangeDark-700': value <= 25,
+    'bg-yellow-400': value > 25 && value < 75,
+    'bg-greenLight-400': value >= 75,
+  });
+
+  const thumbStyle = cn('ring-1 transition-colors shadow-md cursor-pointer', {
+    'ring-orangeDark-700': value <= 25,
+    'ring-yellow-400': value > 25 && value < 75,
+    'ring-greenLight-400': value >= 75,
+  });
+
+  const handleChange = (value: number) => {
+    updateOpportunityRenewal.mutate({
+      input: {
+        opportunityId,
+        renewalAdjustedRate: value,
+        renewalLikelihood: (() => {
+          if (value <= 25) return OpportunityRenewalLikelihood.LowRenewal;
+          if (value > 25 && value < 75)
+            return OpportunityRenewalLikelihood.MediumRenewal;
+
+          return OpportunityRenewalLikelihood.HighRenewal;
+        })(),
+      },
+    });
+  };
+
+  useEffect(() => {
+    setValue(adjustedRate ?? 0);
+  }, [adjustedRate]);
+
+  if (!amount && !potentialAmount)
+    return <span className='text-gray-400'>Unknown</span>;
+
+  const textColor = amount ? 'text-gray-700' : 'text-gray-500';
 
   return (
-    <span className='flex flex-col justify-center'>
-      <span
-        className={cn('text-sm', amount ? 'text-gray-700' : 'text-gray-500')}
-      >
-        {formattedAmount}
-      </span>
+    <div className='flex flex-col justify-center group/forecast'>
+      <Popover open={isEditing} onOpenChange={setIsEditing}>
+        <div className='flex gap-1 items-center'>
+          <PopoverAnchor>
+            <span className={twMerge('text-sm', textColor)}>
+              {formattedAmount}
+            </span>
+          </PopoverAnchor>
+
+          <PopoverTrigger asChild>
+            <IconButton
+              size='xxs'
+              variant='ghost'
+              aria-label='edit renewal likelihood'
+              icon={<Edit03 className='text-gray-500' />}
+              className={cn(
+                'rounded-md opacity-0 group-hover/forecast:opacity-100',
+                isEditing && 'opacity-100',
+              )}
+            />
+          </PopoverTrigger>
+        </div>
+
+        <PopoverContent
+          sideOffset={showPotentialAmount ? 30 : 20}
+          align='start'
+        >
+          <RangeSlider
+            step={1}
+            min={0}
+            max={100}
+            value={[value]}
+            className='w-40'
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                setValue(adjustedRate ?? 0);
+              }
+            }}
+            onValueChange={(values) => {
+              setValue(values[0]);
+            }}
+            onValueCommit={(values) => {
+              handleChange(values[0]);
+            }}
+          >
+            <RangeSliderTrack className='bg-gray-400 h-0.5'>
+              <RangeSliderFilledTrack className={trackStyle} />
+            </RangeSliderTrack>
+            <RangeSliderThumb className={thumbStyle} />
+          </RangeSlider>
+        </PopoverContent>
+      </Popover>
       {showPotentialAmount && (
         <span className='text-sm text-gray-500 line-through'>
           {formattedPotentialAmount}
         </span>
       )}
-    </span>
+    </div>
   );
 };

--- a/packages/apps/spaces/app/renewals/src/components/Columns/Columns.tsx
+++ b/packages/apps/spaces/app/renewals/src/components/Columns/Columns.tsx
@@ -99,37 +99,36 @@ const columns: Record<string, Column> = {
       </div>
     ),
   }),
-  RENEWALS_RENEWAL_LIKELIHOOD: columnHelper.accessor(
-    'organization.accountDetails',
-    {
-      id: 'RENEWAL_LIKELIHOOD',
-      minSize: 100,
-      filterFn: filterRenewalLikelihoodFn,
-      cell: (props) => {
-        const value = props.getValue()?.renewalSummary?.renewalLikelihood;
+  RENEWALS_RENEWAL_LIKELIHOOD: columnHelper.accessor('opportunity', {
+    id: 'RENEWAL_LIKELIHOOD',
+    minSize: 100,
+    filterFn: filterRenewalLikelihoodFn,
+    cell: (props) => {
+      const opportunityId = props.getValue().id;
+      const value = props.getValue().renewalLikelihood;
 
-        return (
-          <RenewalLikelihoodCell
-            value={value}
-            id={props.row.original.organization.metadata.id}
-          />
-        );
-      },
-      header: (props) => (
-        <THead
-          id='renewalLikelihood'
-          title='Health'
-          renderFilter={() => <RenewalLikelihoodFilter column={props.column} />}
-          {...getTHeadProps<RenewalRecord>(props)}
+      return (
+        <RenewalLikelihoodCell
+          value={value}
+          opportunityId={opportunityId}
+          id={props.row.original.organization.metadata.id}
         />
-      ),
-      skeleton: () => (
-        <div className='flex flex-col gap-1'>
-          <Skeleton className='w-[50%] h-[18px] bg-gray-300' />
-        </div>
-      ),
+      );
     },
-  ),
+    header: (props) => (
+      <THead
+        id='renewalLikelihood'
+        title='Health'
+        renderFilter={() => <RenewalLikelihoodFilter column={props.column} />}
+        {...getTHeadProps<RenewalRecord>(props)}
+      />
+    ),
+    skeleton: () => (
+      <div className='flex flex-col gap-1'>
+        <Skeleton className='w-[50%] h-[18px] bg-gray-300' />
+      </div>
+    ),
+  }),
   RENEWALS_RENEWAL_DATE: columnHelper.accessor('organization.accountDetails', {
     id: 'RENEWAL_DATE',
     minSize: 100,
@@ -155,20 +154,25 @@ const columns: Record<string, Column> = {
     ),
     skeleton: () => <Skeleton className='w-[50%] h-[18px] bg-gray-300' />,
   }),
-  RENEWALS_FORECAST_ARR: columnHelper.accessor('organization.accountDetails', {
+  RENEWALS_FORECAST_ARR: columnHelper.accessor('opportunity', {
     id: 'FORECAST_ARR',
     minSize: 100,
     filterFn: filterForecastFn,
     enableColumnFilter: false,
     cell: (props) => {
-      const value = props.getValue()?.renewalSummary;
-      const amount = value?.arrForecast;
-      const potentialAmount = value?.maxArrForecast;
+      const value = props.getValue();
+      const amount = value?.amount;
+      const potentialAmount = value?.maxAmount;
+      const opportunityId = value?.id;
+      const renewalAdjustedRate = value?.renewalAdjustedRate;
 
       return (
         <RenewalForecastCell
           amount={amount}
+          opportunityId={opportunityId}
           potentialAmount={potentialAmount}
+          adjustedRate={renewalAdjustedRate}
+          id={props.row.original.organization?.metadata.id}
         />
       );
     },

--- a/packages/apps/spaces/app/renewals/src/graphql/getRenewals.generated.ts
+++ b/packages/apps/spaces/app/renewals/src/graphql/getRenewals.generated.ts
@@ -183,6 +183,11 @@ export type GetRenewalsQuery = {
       };
       opportunity?: {
         __typename?: 'Opportunity';
+        id: string;
+        amount: number;
+        maxAmount: number;
+        renewalLikelihood: Types.OpportunityRenewalLikelihood;
+        renewalAdjustedRate: any;
         owner?: {
           __typename?: 'User';
           id: string;
@@ -320,6 +325,11 @@ export const GetRenewalsDocument = `
         contractName
       }
       opportunity {
+        id
+        amount
+        maxAmount
+        renewalLikelihood
+        renewalAdjustedRate
         owner {
           id
           firstName

--- a/packages/apps/spaces/app/renewals/src/graphql/getRenewals.graphql
+++ b/packages/apps/spaces/app/renewals/src/graphql/getRenewals.graphql
@@ -122,6 +122,11 @@ query getRenewals($pagination: Pagination!, $where: Filter, $sort: SortBy) {
         contractName
       }
       opportunity {
+        id
+        amount
+        maxAmount
+        renewalLikelihood
+        renewalAdjustedRate
         owner {
           id
           firstName

--- a/packages/apps/spaces/app/src/types/__generated__/graphql.types.ts
+++ b/packages/apps/spaces/app/src/types/__generated__/graphql.types.ts
@@ -1764,7 +1764,6 @@ export type InvoiceSimulate = {
   postpaid: Scalars['Boolean']['output'];
   provider: InvoiceProvider;
   subtotal: Scalars['Float']['output'];
-  taxDue: Scalars['Float']['output'];
   total: Scalars['Float']['output'];
 };
 
@@ -4418,11 +4417,9 @@ export type ServiceLineItemBulkUpdateInput = {
 
 export type ServiceLineItemBulkUpdateItem = {
   billed?: InputMaybe<BilledType>;
-  closeVersion?: InputMaybe<Scalars['Boolean']['input']>;
   comments?: InputMaybe<Scalars['String']['input']>;
   isRetroactiveCorrection?: InputMaybe<Scalars['Boolean']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
-  newVersion?: InputMaybe<Scalars['Boolean']['input']>;
   price?: InputMaybe<Scalars['Float']['input']>;
   quantity?: InputMaybe<Scalars['Int64']['input']>;
   serviceLineItemId?: InputMaybe<Scalars['ID']['input']>;


### PR DESCRIPTION
What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the user interface for `RenewalForecastCell` to allow real-time editing of renewal likelihood and amounts with a new popover feature.
  - Improved efficiency by updating `RenewalLikelihoodCell` to use a more optimized mutation process.
  - Expanded GraphQL queries and types to include additional renewal metrics for better data insights.

- **Bug Fixes**
  - Adjusted column definitions and data handling in `Columns.tsx` to ensure accurate display of updated renewal data and forecasts.

- **Refactor**
  - Optimized mutation handling in renewal components to enhance performance and stability.

- **Documentation**
  - Updated component and query documentation to reflect new and modified data fields and functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->