### PR TITLE
Alex/cos 3082 add integrity checker for iscustomer be same as relationship

### DIFF
--- a/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
+++ b/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
@@ -84,7 +84,7 @@
         },
         {
           "name": "Organization relationship mismatch",
-          "query": "MATCH (n:Organization) WHERE (n.isCustomer = true AND (n.relationship IS NULL OR n.relationship <> 'CUSTOMER')) OR (n.isCustomer = true AND n.relationship = 'CUSTOMER') RETURN count(n)",
+          "query": "MATCH (n:Organization) WHERE (n.isCustomer = true AND (n.relationship IS NULL OR n.relationship <> 'CUSTOMER')) OR (n.isCustomer = false AND n.relationship = 'CUSTOMER') RETURN count(n)",
           "description": "IsCustomer boolean property should match with relationship property."
         }
       ]

--- a/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
+++ b/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
@@ -78,9 +78,14 @@
           "description": "Organization with missing boolean properties."
         },
         {
-          "name": "Derived next renewal date in past",
+          "name": "Organization derived next renewal date in past",
           "query": "MATCH (org:Organization) OPTIONAL MATCH (org)--(c:Contract) WITH org, collect(c) as contracts WHERE size(contracts) > 0 AND ALL(c IN contracts WHERE c.status <> 'OUT_OF_CONTRACT') AND date(org.derivedNextRenewalAt) < date() RETURN count(org)",
           "description": "Organization with derived next renewal date in the past. If organization has multiple contracts, all contracts should be in status different than 'OUT_OF_CONTRACT'."
+        },
+        {
+          "name": "Organization relationship mismatch",
+          "query": "MATCH (n:Organization) WHERE (n.isCustomer = true AND (n.relationship IS NULL OR n.relationship <> 'CUSTOMER')) OR (n.isCustomer = true AND n.relationship = 'CUSTOMER') RETURN count(n)",
+          "description": "IsCustomer boolean property should match with relationship property."
         }
       ]
     },


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new queries for checking organization renewal dates and relationship mismatches.
  - Introduced new functionalities to handle organization stages and relationships across various services and APIs.
- **Enhancements**
  - Improved existing components to support organization relationship and stage fields.
- **Deprecations**
  - Marked all entity types in `customer-os-api` as deprecated, advising the use of the neo4j module instead.
- **Refactor**
  - Updated various mappers and services to utilize the `enummapper` package for enhanced enum handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->