### PR TITLE
(fix|COS-3130): Contract issues fix

### DIFF
--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/ContractNew/RenewalARR/RenewalDetailsModal.tsx
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/ContractNew/RenewalARR/RenewalDetailsModal.tsx
@@ -117,15 +117,25 @@ const RenewalDetailsForm = ({
   const maxAmount = data.maxAmount ?? 0;
   const renewadAt = data?.renewedAt;
 
+  const getAdjustedRate = (value: OpportunityRenewalLikelihood) => {
+    return match(value)
+      .with(OpportunityRenewalLikelihood.LowRenewal, () => 25)
+      .with(OpportunityRenewalLikelihood.MediumRenewal, () => 50)
+      .with(OpportunityRenewalLikelihood.HighRenewal, () => 100)
+      .otherwise(() => 100);
+  };
+
   const defaultValues = useMemo(
     () => ({
-      renewalAdjustedRate: data?.renewalAdjustedRate ?? 50,
+      renewalAdjustedRate:
+        data?.renewalAdjustedRate ?? data?.renewalLikelihood
+          ? getAdjustedRate(data?.renewalLikelihood)
+          : 100,
       renewalLikelihood: data?.renewalLikelihood,
       reason: data?.comments,
     }),
     [data?.renewalLikelihood, data?.amount, data?.comments],
   );
-
   const updatedByUser = usersData?.users.content?.find(
     (u) => u.id === data.renewalUpdatedByUserId,
   );
@@ -160,11 +170,7 @@ const RenewalDetailsForm = ({
         action.type === 'FIELD_CHANGE' &&
         action.payload.name === 'renewalLikelihood'
       ) {
-        const nextRate = match(action.payload.value)
-          .with(OpportunityRenewalLikelihood.LowRenewal, () => 25)
-          .with(OpportunityRenewalLikelihood.MediumRenewal, () => 50)
-          .with(OpportunityRenewalLikelihood.HighRenewal, () => 100)
-          .otherwise(() => 100);
+        const nextRate = getAdjustedRate(action.payload.value);
 
         return {
           ...next,

--- a/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/ContractOld/ServiceLineItemsModal/ServiceLineItemsModal.dto.ts
+++ b/packages/apps/spaces/app/organization/[id]/src/components/Tabs/panels/AccountPanel/ContractOld/ServiceLineItemsModal/ServiceLineItemsModal.dto.ts
@@ -1,4 +1,4 @@
-import { UTCDate } from '@date-fns/utc';
+import { utcToZonedTime } from 'date-fns-tz';
 
 import {
   BilledType,
@@ -38,7 +38,8 @@ export class ServiceLineItemsDTO implements ServiceLineItemBulkUpdateItem {
     this.price = data?.price ?? 0;
     this.billed = data?.billingCycle ?? BilledType.Monthly;
     this.isDeleted = data?.serviceEnded ?? false;
-    this.serviceStarted = data?.serviceStarted;
+    this.serviceStarted =
+      data?.serviceStarted && utcToZonedTime(data?.serviceStarted, 'UTC');
     this.vatRate = data?.tax?.taxRate ?? 0;
     this.type = [
       BilledType.Quarterly,
@@ -57,9 +58,8 @@ export class ServiceLineItemsDTO implements ServiceLineItemBulkUpdateItem {
       price: data?.price ?? 0,
       billed: data?.billingCycle ?? BilledType.Monthly,
       isDeleted: data?.serviceEnded ?? false,
-      serviceStarted: data?.serviceStarted
-        ? new UTCDate(data.serviceStarted)
-        : null,
+      serviceStarted:
+        data?.serviceStarted && utcToZonedTime(data?.serviceStarted, 'UTC'),
       vatRate: data?.tax?.taxRate ?? 0,
       type: [
         BilledType.Quarterly,


### PR DESCRIPTION
- the renewal modal shows a medium renewal ARR on the slider rather than the High that is set, or the $0 that is shown
- Side panel does not correctly display contract term data
- service start date is still using local time


What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced contract details to dynamically display based on the committed period in months.
  - Introduced functionality to calculate and display adjusted renewal rates based on opportunity renewal likelihood.

- **Bug Fixes**
  - Improved time zone handling in service line items by replacing `UTCDate` with `utcToZonedTime` for accurate date conversions.

- **Refactor**
  - Streamlined the retrieval and display logic for renewal dates and periods across various components.
  - Consolidated similar functions across new and old contract components for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->