### PR TITLE
feat: add count of customers to customer-map

### DIFF
--- a/packages/apps/frontera/src/routes/customer-map/src/components/Legend/Legend.tsx
+++ b/packages/apps/frontera/src/routes/customer-map/src/components/Legend/Legend.tsx
@@ -2,6 +2,7 @@ import { scaleOrdinal } from '@visx/scale';
 import { LegendItem, LegendLabel, LegendOrdinal } from '@visx/legend';
 
 interface LegendProps {
+  leftElement?: React.ReactNode;
   data: {
     label: string;
     color: string;
@@ -10,7 +11,7 @@ interface LegendProps {
   }[];
 }
 
-export const Legend = ({ data }: LegendProps) => {
+export const Legend = ({ data, leftElement }: LegendProps) => {
   const scale = scaleOrdinal({
     domain: data.map((d) => d.label),
     range: data.map((d) => d.color),
@@ -19,31 +20,34 @@ export const Legend = ({ data }: LegendProps) => {
   return (
     <LegendOrdinal scale={scale}>
       {(labels) => (
-        <div className='flex justify-end'>
-          {labels.map((label, i) => (
-            <LegendItem key={`legend-quantile-${i}`} margin='0 0.5rem'>
-              <svg
-                width={data[i].borderColor ? 9 : 8}
-                height={data[i].borderColor ? 9 : 8}
-                style={{ marginRight: '0.25rem' }}
-              >
-                <circle
-                  fill={label.value}
-                  cx={data[i].borderColor ? 4.5 : 4}
-                  cy={data[i].borderColor ? 4.5 : 4}
-                  r={data[i].borderColor ? 4 : 4}
-                  strokeWidth={data[i].borderColor ? 1 : 0}
-                  stroke={data[i].borderColor ?? 'transparent'}
-                />
-              </svg>
-              <LegendLabel align='left' margin='0 0 0 4px'>
-                <p className='text-sm'>
-                  {label.text}
-                  {data[i].isMissingData && <span>*</span>}
-                </p>
-              </LegendLabel>
-            </LegendItem>
-          ))}
+        <div className='flex justify-between'>
+          {leftElement}
+          <div className='flex'>
+            {labels.map((label, i) => (
+              <LegendItem key={`legend-quantile-${i}`} margin='0 0.5rem'>
+                <svg
+                  width={data[i].borderColor ? 9 : 8}
+                  height={data[i].borderColor ? 9 : 8}
+                  style={{ marginRight: '0.25rem' }}
+                >
+                  <circle
+                    fill={label.value}
+                    cx={data[i].borderColor ? 4.5 : 4}
+                    cy={data[i].borderColor ? 4.5 : 4}
+                    r={data[i].borderColor ? 4 : 4}
+                    strokeWidth={data[i].borderColor ? 1 : 0}
+                    stroke={data[i].borderColor ?? 'transparent'}
+                  />
+                </svg>
+                <LegendLabel align='left' margin='0 0 0 4px'>
+                  <p className='text-sm'>
+                    {label.text}
+                    {data[i].isMissingData && <span>*</span>}
+                  </p>
+                </LegendLabel>
+              </LegendItem>
+            ))}
+          </div>
         </div>
       )}
     </LegendOrdinal>

--- a/packages/apps/frontera/src/routes/customer-map/src/components/charts/CustomerMap/CustomerMap.chart.tsx
+++ b/packages/apps/frontera/src/routes/customer-map/src/components/charts/CustomerMap/CustomerMap.chart.tsx
@@ -136,7 +136,16 @@ const CustomerMapChart = ({
 
   return (
     <>
-      <Legend data={legendData} />
+      <Legend
+        data={legendData}
+        leftElement={
+          hasContracts ? (
+            <span className='text-gray-500 text-sm'>
+              {data.length} customers
+            </span>
+          ) : undefined
+        }
+      />
       <svg width={outerWidth} height={outerHeight}>
         <Group>
           <text

--- a/packages/apps/spaces/app/customer-map/src/components/Legend/Legend.tsx
+++ b/packages/apps/spaces/app/customer-map/src/components/Legend/Legend.tsx
@@ -1,9 +1,8 @@
-'use client';
-
 import { scaleOrdinal } from '@visx/scale';
 import { LegendItem, LegendLabel, LegendOrdinal } from '@visx/legend';
 
 interface LegendProps {
+  leftElement?: React.ReactNode;
   data: {
     label: string;
     color: string;
@@ -12,7 +11,7 @@ interface LegendProps {
   }[];
 }
 
-export const Legend = ({ data }: LegendProps) => {
+export const Legend = ({ data, leftElement }: LegendProps) => {
   const scale = scaleOrdinal({
     domain: data.map((d) => d.label),
     range: data.map((d) => d.color),
@@ -21,31 +20,34 @@ export const Legend = ({ data }: LegendProps) => {
   return (
     <LegendOrdinal scale={scale}>
       {(labels) => (
-        <div className='flex justify-end'>
-          {labels.map((label, i) => (
-            <LegendItem key={`legend-quantile-${i}`} margin='0 0.5rem'>
-              <svg
-                width={data[i].borderColor ? 9 : 8}
-                height={data[i].borderColor ? 9 : 8}
-                style={{ marginRight: '0.25rem' }}
-              >
-                <circle
-                  fill={label.value}
-                  cx={data[i].borderColor ? 4.5 : 4}
-                  cy={data[i].borderColor ? 4.5 : 4}
-                  r={data[i].borderColor ? 4 : 4}
-                  strokeWidth={data[i].borderColor ? 1 : 0}
-                  stroke={data[i].borderColor ?? 'transparent'}
-                />
-              </svg>
-              <LegendLabel align='left' margin='0 0 0 4px'>
-                <p className='text-sm'>
-                  {label.text}
-                  {data[i].isMissingData && <span>*</span>}
-                </p>
-              </LegendLabel>
-            </LegendItem>
-          ))}
+        <div className='flex justify-between'>
+          {leftElement}
+          <div className='flex'>
+            {labels.map((label, i) => (
+              <LegendItem key={`legend-quantile-${i}`} margin='0 0.5rem'>
+                <svg
+                  width={data[i].borderColor ? 9 : 8}
+                  height={data[i].borderColor ? 9 : 8}
+                  style={{ marginRight: '0.25rem' }}
+                >
+                  <circle
+                    fill={label.value}
+                    cx={data[i].borderColor ? 4.5 : 4}
+                    cy={data[i].borderColor ? 4.5 : 4}
+                    r={data[i].borderColor ? 4 : 4}
+                    strokeWidth={data[i].borderColor ? 1 : 0}
+                    stroke={data[i].borderColor ?? 'transparent'}
+                  />
+                </svg>
+                <LegendLabel align='left' margin='0 0 0 4px'>
+                  <p className='text-sm'>
+                    {label.text}
+                    {data[i].isMissingData && <span>*</span>}
+                  </p>
+                </LegendLabel>
+              </LegendItem>
+            ))}
+          </div>
         </div>
       )}
     </LegendOrdinal>

--- a/packages/apps/spaces/app/customer-map/src/components/charts/CustomerMap/CustomerMap.chart.tsx
+++ b/packages/apps/spaces/app/customer-map/src/components/charts/CustomerMap/CustomerMap.chart.tsx
@@ -137,7 +137,16 @@ const CustomerMapChart = ({
 
   return (
     <>
-      <Legend data={legendData} />
+      <Legend
+        data={legendData}
+        leftElement={
+          hasContracts ? (
+            <span className='text-gray-500 text-sm'>
+              {data.length} customers
+            </span>
+          ) : undefined
+        }
+      />
       <svg width={outerWidth} height={outerHeight}>
         <Group>
           <text


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `Legend` component to accept a `leftElement` prop, allowing additional elements to be displayed on the left side of legend items.
  - Updated the `CustomerMapChart` component to conditionally display the number of customers in the `Legend` based on the presence of contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->