### PR TITLE
[COS-2645] - Fix invoice PDF missing link

### DIFF
--- a/packages/server/events-processing-platform-subscribers/subscriptions/invoice/pdf_template/index.html
+++ b/packages/server/events-processing-platform-subscribers/subscriptions/invoice/pdf_template/index.html
@@ -430,7 +430,7 @@
             <img alt="CustomerOS" class="invoice-printed-customer-os" src="customer-os.png"/>
         </div>
         <div class="invoice-customeros-text TextxsRegular">
-            Powered by CustomerOS - Revenue Intelligence for B2B hyperscalers
+            Powered by <a href="https://customeros.ai">CustomerOS</a> - Revenue Intelligence for B2B hyperscalers
         </div>
         <div class="invoice-question-text">
             <a href="mailto:{{.ProviderEmail}}?subject=Questions about invoice {{.InvoiceNumber}}&body=Hi team, I have some questions about invoice {{.InvoiceNumber}}">Questions?</a>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a hyperlink to "Powered by CustomerOS" in the invoice PDF template, linking to the CustomerOS website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->