### PR TITLE
(refactor|COS-3272): Drop usage of 'isCustomer' flag -  introduce relationship status, add ability to change stage for prospects

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
@@ -4,18 +4,18 @@ import { useForm } from 'react-inverted-form';
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
 import { useDebounce, useWillUnmount, useDeepCompareEffect } from 'rooks';
 
-import { Organization } from '@graphql/types';
 import { FormUrlInput } from '@ui/form/UrlInput';
 import { Users03 } from '@ui/media/icons/Users03';
 import { Share07 } from '@ui/media/icons/Share07';
 import { Target05 } from '@ui/media/icons/Target05';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
-import { HeartHand } from '@ui/media/icons/HeartHand';
 import { FormSelect } from '@ui/form/Select/FormSelect';
 import { Building07 } from '@ui/media/icons/Building07';
 import { Tag, TagLabel } from '@ui/presentation/Tag/Tag';
+import { HeartHand } from '@ui/media/icons/HeartHand.tsx';
 import { getGraphQLClient } from '@shared/util/getGraphQLClient';
 import { useCopyToClipboard } from '@shared/hooks/useCopyToClipboard';
+import { Organization, OrganizationRelationship } from '@graphql/types';
 import { HorizontalBarChart03 } from '@ui/media/icons/HorizontalBarChart03';
 import { ArrowCircleBrokenUpLeft } from '@ui/media/icons/ArrowCircleBrokenUpLeft';
 import { FormAutoresizeTextarea } from '@ui/form/Textarea/FormAutoresizeTextarea';
@@ -35,8 +35,8 @@ import {
   stageOptions,
   industryOptions,
   employeesOptions,
-  relationshipOptions,
   businessTypeOptions,
+  relationshipOptions,
   lastFundingRoundOptions,
 } from './util';
 
@@ -78,13 +78,14 @@ export const AboutPanel = () => {
 
   const debouncedMutateOrganization = useDebounce(mutateOrganization, 500);
 
-  const { setDefaultValues } = useForm<OrganizationAboutForm>({
+  const { setDefaultValues, state } = useForm<OrganizationAboutForm>({
     formId: 'organization-about',
     defaultValues,
     stateReducer: (state, action, next) => {
       if (action.type === 'FIELD_CHANGE') {
         switch (action.payload.name) {
-          case 'isCustomer':
+          case 'relationship':
+          case 'stage':
           case 'industry':
           case 'employees':
           case 'businessType':
@@ -231,27 +232,31 @@ export const AboutPanel = () => {
             />
           )}
 
+        <div className='flex w-full'>
+          <FormSelect
+            isClearable
+            name='relationship'
+            formId='organization-about'
+            placeholder='Relationship'
+            options={relationshipOptions}
+            leftElement={<HeartHand className='text-gray-500 mr-3' />}
+          />
+        </div>
+
         <div className='flex flex-col w-full flex-1 items-start justify-start gap-0'>
-          <div className='flex w-full'>
-            <FormSelect
-              isClearable
-              name='isCustomer'
-              formId='organization-about'
-              placeholder='Relationship'
-              options={relationshipOptions}
-              leftElement={<HeartHand className='text-gray-500 mr-3' />}
-            />
-          </div>
-          <div className='flex w-full'>
-            <FormSelect
-              isClearable
-              name='stage'
-              formId='organization-about'
-              placeholder='Stage'
-              options={stageOptions}
-              leftElement={<HeartHand className='text-gray-500 mr-3' />}
-            />
-          </div>
+          {state?.values?.relationship?.value ===
+            OrganizationRelationship.Prospect && (
+            <div className='flex w-full'>
+              <FormSelect
+                isClearable
+                name='stage'
+                formId='organization-about'
+                placeholder='Stage'
+                options={stageOptions}
+                leftElement={<Target05 className='text-gray-500 mt-1 mr-3' />}
+              />
+            </div>
+          )}
 
           <FormSelect
             name='industry'
@@ -262,14 +267,14 @@ export const AboutPanel = () => {
             leftElement={<Building07 className='text-gray-500 mr-3' />}
           />
 
-          <FormAutoresizeTextarea
-            size='xs'
-            className='items-start'
-            name='targetAudience'
-            formId='organization-about'
-            placeholder='Target Audience'
-            leftElement={<Target05 className='text-gray-500 mt-1 mr-1' />}
-          />
+          {/*<FormAutoresizeTextarea*/}
+          {/*  size='xs'*/}
+          {/*  className='items-start'*/}
+          {/*  name='targetAudience'*/}
+          {/*  formId='organization-about'*/}
+          {/*  placeholder='Target Audience'*/}
+          {/*  leftElement={<Target05 className='text-gray-500 mt-1 mr-1' />}*/}
+          {/*/>*/}
 
           <FormSelect
             isClearable

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
@@ -32,6 +32,7 @@ import {
   OrganizationAboutFormDto,
 } from './OrganizationAbout.dto';
 import {
+  stageOptions,
   industryOptions,
   employeesOptions,
   relationshipOptions,
@@ -238,6 +239,16 @@ export const AboutPanel = () => {
               formId='organization-about'
               placeholder='Relationship'
               options={relationshipOptions}
+              leftElement={<HeartHand className='text-gray-500 mr-3' />}
+            />
+          </div>
+          <div className='flex w-full'>
+            <FormSelect
+              isClearable
+              name='stage'
+              formId='organization-about'
+              placeholder='Stage'
+              options={stageOptions}
               leftElement={<HeartHand className='text-gray-500 mr-3' />}
             />
           </div>

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/OrganizationAbout.dto.ts
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/OrganizationAbout.dto.ts
@@ -1,8 +1,15 @@
 import { SelectOption } from '@shared/types/SelectOptions';
-import { Social, Organization, OrganizationUpdateInput } from '@graphql/types';
 import { OrganizationQuery } from '@organization/graphql/organization.generated';
+import {
+  Social,
+  Organization,
+  OrganizationStage,
+  OrganizationUpdateInput,
+  OrganizationRelationship,
+} from '@graphql/types';
 
 import {
+  stageOptions,
   industryOptions,
   employeesOptions,
   businessTypeOptions,
@@ -32,7 +39,8 @@ export interface OrganizationAboutForm
   lastFundingRound: SelectOption | null;
   socials: Pick<Social, 'id' | 'url'>[];
   employees: SelectOption<number> | null;
-  isCustomer?: SelectOption<boolean> | null;
+  stage?: SelectOption<OrganizationStage> | null;
+  relationship?: SelectOption<OrganizationRelationship> | null;
 }
 
 export class OrganizationAboutFormDto implements OrganizationAboutForm {
@@ -48,7 +56,8 @@ export class OrganizationAboutFormDto implements OrganizationAboutForm {
   lastFundingRound: SelectOption | null;
   lastFundingAmount?: string;
   socials: Pick<Social, 'id' | 'url'>[];
-  isCustomer?: SelectOption<boolean> | null;
+  stage?: SelectOption<OrganizationStage> | null;
+  relationship?: SelectOption<OrganizationRelationship> | null;
 
   constructor(data?: Partial<OrganizationQuery['organization']> | null) {
     this.id = data?.id || '';
@@ -74,8 +83,9 @@ export class OrganizationAboutFormDto implements OrganizationAboutForm {
       null;
     this.lastFundingAmount = data?.lastFundingAmount ?? '';
     this.socials = data?.socials || [];
-    this.isCustomer = relationshipOptions.find(
-      (i) => data?.isCustomer === i.value,
+    this.stage = stageOptions.find((i) => data?.stage === i.value);
+    this.relationship = relationshipOptions.find(
+      (i) => data?.relationship === i.value,
     );
   }
 
@@ -97,7 +107,8 @@ export class OrganizationAboutFormDto implements OrganizationAboutForm {
       valueProposition: data.valueProposition,
       lastFundingRound: data.lastFundingRound?.value,
       lastFundingAmount: data.lastFundingAmount,
-      isCustomer: data.isCustomer?.value,
+      stage: data.stage?.value,
+      relationship: data.relationship?.value,
     } as OrganizationUpdateInput;
   }
 }

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/util.ts
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/util.ts
@@ -1,4 +1,4 @@
-import { FundingRound } from '@graphql/types';
+import { FundingRound, OrganizationStage } from '@graphql/types';
 import { SelectOption, GroupedOption } from '@shared/types/SelectOptions';
 
 export const relationshipOptions: SelectOption<boolean>[] = [
@@ -9,6 +9,40 @@ export const relationshipOptions: SelectOption<boolean>[] = [
   {
     label: 'Prospect',
     value: false,
+  },
+];
+export const stageOptions: SelectOption<OrganizationStage>[] = [
+  {
+    label: 'Target',
+    value: OrganizationStage.Target,
+  },
+  {
+    label: 'Interested',
+    value: OrganizationStage.Interested,
+  },
+  {
+    label: 'Engaged',
+    value: OrganizationStage.Engaged,
+  },
+  {
+    label: 'Lead',
+    value: OrganizationStage.Lead,
+  },
+  {
+    label: 'Nurture',
+    value: OrganizationStage.Nurture,
+  },
+  {
+    label: 'Unqualified',
+    value: OrganizationStage.Unqualified,
+  },
+  {
+    label: 'Closed Lost',
+    value: OrganizationStage.ClosedLost,
+  },
+  {
+    label: 'Closed Won',
+    value: OrganizationStage.ClosedWon,
   },
 ];
 

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/util.ts
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/util.ts
@@ -1,14 +1,26 @@
-import { FundingRound, OrganizationStage } from '@graphql/types';
 import { SelectOption, GroupedOption } from '@shared/types/SelectOptions';
+import {
+  FundingRound,
+  OrganizationStage,
+  OrganizationRelationship,
+} from '@graphql/types';
 
-export const relationshipOptions: SelectOption<boolean>[] = [
+export const relationshipOptions: SelectOption<OrganizationRelationship>[] = [
   {
     label: 'Customer',
-    value: true,
+    value: OrganizationRelationship.Customer,
   },
   {
     label: 'Prospect',
-    value: false,
+    value: OrganizationRelationship.Prospect,
+  },
+  {
+    label: 'Stranger',
+    value: OrganizationRelationship.Stranger,
+  },
+  {
+    label: 'Former Customer',
+    value: OrganizationRelationship.FormerCustomer,
   },
 ];
 export const stageOptions: SelectOption<OrganizationStage>[] = [

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/RelationshipButton.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/RelationshipButton.tsx
@@ -6,6 +6,7 @@ import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import { cn } from '@ui/utils/cn';
 import { Spinner } from '@ui/feedback/Spinner';
 import { Button } from '@ui/form/Button/Button';
+import { OrganizationRelationship } from '@graphql/types';
 import { ActivityHeart } from '@ui/media/icons/ActivityHeart';
 import { getGraphQLClient } from '@shared/util/getGraphQLClient';
 import { useOrganizationsMeta } from '@shared/state/OrganizationsMeta.atom';
@@ -45,7 +46,7 @@ export const RelationshipButton = () => {
             );
 
             if (content && index !== undefined && index > -1) {
-              content[index].isCustomer = payload.input.isCustomer;
+              content[index].relationship = payload.input.relationship;
             }
           });
         },
@@ -67,11 +68,13 @@ export const RelationshipButton = () => {
       }),
   });
   const selectedValue = relationshipOptions.find(
-    (option) => option.value === data?.organization?.isCustomer,
+    (option) => option.value === data?.organization?.relationship,
   );
-  const spinnerColors = selectedValue?.value
-    ? 'text-success-500 fill-succes-700'
-    : 'text-gray-400 fill-gray-700';
+
+  const spinnerColors =
+    selectedValue?.value === OrganizationRelationship.Customer
+      ? 'text-success-500 fill-succes-700'
+      : 'text-gray-400 fill-gray-700';
 
   return (
     <div>
@@ -81,10 +84,12 @@ export const RelationshipButton = () => {
             variant='outline'
             size='xxs'
             colorScheme={
-              selectedValue?.label === 'Customer' ? 'success' : 'gray'
+              selectedValue?.value === OrganizationRelationship.Customer
+                ? 'success'
+                : 'gray'
             }
             className={cn(
-              selectedValue?.label === 'Customer'
+              selectedValue?.value === OrganizationRelationship.Customer
                 ? 'text-success-500'
                 : 'text-gray-500',
               'rounded-full font-normal  text-ellipsis mb-[2.5px]',
@@ -96,7 +101,7 @@ export const RelationshipButton = () => {
                   size='sm'
                   className={cn(spinnerColors)}
                 />
-              ) : selectedValue?.value ? (
+              ) : selectedValue?.value === OrganizationRelationship.Customer ? (
                 <ActivityHeart className='text-success-500' />
               ) : (
                 <></>
@@ -116,15 +121,15 @@ export const RelationshipButton = () => {
                 'px-2 py-1 border border-transparent hover:border-gray-200 hover:border rounded-md',
               )}
               key={idx}
-              onClick={() =>
+              onClick={() => {
                 updateOrganization.mutate({
                   input: {
                     id,
-                    isCustomer: option.value,
+                    relationship: option.value,
                     patch: true,
                   },
-                })
-              }
+                });
+              }}
             >
               {option.label}
             </MenuItem>

--- a/packages/apps/frontera/src/routes/organization/src/graphql/organization.generated.ts
+++ b/packages/apps/frontera/src/routes/organization/src/graphql/organization.generated.ts
@@ -49,9 +49,10 @@ export type OrganizationQuery = {
     employees?: any | null;
     referenceId?: string | null;
     customerOsId: string;
-    isCustomer?: boolean | null;
     hide: boolean;
     slackChannelId?: string | null;
+    stage?: Types.OrganizationStage | null;
+    relationship?: Types.OrganizationRelationship | null;
     socials: Array<{ __typename?: 'Social'; id: string; url: string }>;
     subsidiaryOf: Array<{
       __typename?: 'LinkedOrganization';
@@ -99,9 +100,10 @@ export const OrganizationDocument = `
     employees
     referenceId
     customerOsId
-    isCustomer
     hide
     slackChannelId
+    stage
+    relationship
     socials {
       id
       url

--- a/packages/apps/frontera/src/routes/organization/src/graphql/organization.graphql
+++ b/packages/apps/frontera/src/routes/organization/src/graphql/organization.graphql
@@ -17,9 +17,10 @@ query Organization($id: ID!) {
     employees
     referenceId
     customerOsId
-    isCustomer
     hide
     slackChannelId
+    stage
+    relationship
     socials {
       id
       url

--- a/packages/apps/frontera/src/routes/organizations/src/components/Columns/Cells/relationship/OrganizationRelationship.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Columns/Cells/relationship/OrganizationRelationship.tsx
@@ -11,6 +11,7 @@ import { getGraphQLClient } from '@shared/util/getGraphQLClient';
 import { useOrganizationsMeta } from '@shared/state/OrganizationsMeta.atom';
 import { Menu, MenuList, MenuItem, MenuButton } from '@ui/overlay/Menu/Menu';
 import { useOrganizationQuery } from '@organization/graphql/organization.generated';
+import { OrganizationRelationship as OrganizationRelationshipEnum } from '@graphql/types';
 import { useUpdateOrganizationMutation } from '@shared/graphql/updateOrganization.generated';
 import {
   OrganizationRowDTO,
@@ -57,7 +58,7 @@ export const OrganizationRelationship = ({
             );
 
             if (content && index !== undefined && index > -1) {
-              content[index].isCustomer = payload.input.isCustomer;
+              content[index].relationship = payload.input.relationship;
             }
           });
         },
@@ -92,15 +93,15 @@ export const OrganizationRelationship = ({
   const queryKey = useInfiniteGetOrganizationsQuery.getKey(getOrganization);
 
   const value = relationshipOptions.find(
-    (option) => option.value === organization.isCustomer,
+    (option) => option.value === organization.relationship,
   );
 
   const handleSelect = useCallback(
-    (option: SelectOption<boolean>) => {
+    (option: SelectOption<OrganizationRelationshipEnum>) => {
       updateOrganization.mutate(
         OrganizationRowDTO.toUpdatePayload({
           ...organization,
-          isCustomer: option.value,
+          relationship: option.value,
         }),
       );
     },
@@ -119,7 +120,7 @@ export const OrganizationRelationship = ({
         className='cursor-default text-gray-700'
         onDoubleClick={() => setIsEditing(true)}
       >
-        {value?.value ? 'Customer' : 'Prospect'}
+        {value?.label || 'Unknown'}
       </p>
       <Menu open={isEditing} onOpenChange={setIsEditing}>
         <MenuButton asChild>

--- a/packages/apps/frontera/src/routes/organizations/src/components/Columns/Cells/relationship/util.ts
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Columns/Cells/relationship/util.ts
@@ -1,15 +1,21 @@
-export type RelationshipType = 'Customer' | 'Prospect';
+import { OrganizationRelationship } from '@graphql/types';
+import { SelectOption } from '@shared/types/SelectOptions';
 
-export const relationshipOptions: {
-  value: boolean;
-  label: RelationshipType;
-}[] = [
+export const relationshipOptions: SelectOption<OrganizationRelationship>[] = [
   {
-    value: true,
     label: 'Customer',
+    value: OrganizationRelationship.Customer,
   },
   {
-    value: false,
     label: 'Prospect',
+    value: OrganizationRelationship.Prospect,
+  },
+  {
+    label: 'Stranger',
+    value: OrganizationRelationship.Stranger,
+  },
+  {
+    label: 'Former Customer',
+    value: OrganizationRelationship.FormerCustomer,
   },
 ];

--- a/packages/apps/frontera/src/routes/organizations/src/components/Columns/columnsDictionary.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Columns/columnsDictionary.tsx
@@ -132,7 +132,7 @@ const columns: Record<string, Column> = {
     ),
     skeleton: () => <Skeleton className='w-[50%] h-[18px]' />,
   }),
-  ORGANIZATIONS_RELATIONSHIP: columnHelper.accessor('isCustomer', {
+  ORGANIZATIONS_RELATIONSHIP: columnHelper.accessor('relationship', {
     id: 'RELATIONSHIP',
     minSize: 200,
     filterFn: filterRelationshipFn,

--- a/packages/apps/frontera/src/routes/organizations/src/graphql/getOrganizations.generated.ts
+++ b/packages/apps/frontera/src/routes/organizations/src/graphql/getOrganizations.generated.ts
@@ -39,11 +39,12 @@ export type GetOrganizationsQuery = {
     content: Array<{
       __typename?: 'Organization';
       name: string;
+      stage?: Types.OrganizationStage | null;
+      relationship?: Types.OrganizationRelationship | null;
       description?: string | null;
       industry?: string | null;
       website?: string | null;
       domains: Array<string>;
-      isCustomer?: boolean | null;
       logo?: string | null;
       icon?: string | null;
       leadSource?: string | null;
@@ -215,6 +216,8 @@ export const GetOrganizationsDocument = `
   dashboardView_Organizations(pagination: $pagination, where: $where, sort: $sort) {
     content {
       name
+      stage
+      relationship
       metadata {
         id
         created
@@ -237,7 +240,6 @@ export const GetOrganizationsDocument = `
       industry
       website
       domains
-      isCustomer
       logo
       icon
       leadSource

--- a/packages/apps/frontera/src/routes/organizations/src/graphql/getOrganizations.graphql
+++ b/packages/apps/frontera/src/routes/organizations/src/graphql/getOrganizations.graphql
@@ -10,6 +10,8 @@ query getOrganizations(
   ) {
     content {
       name
+      stage
+      relationship
       metadata {
         id
         created
@@ -32,7 +34,6 @@ query getOrganizations(
       industry
       website
       domains
-      isCustomer
       logo
       icon
       leadSource

--- a/packages/apps/frontera/src/routes/organizations/src/util/Organization.dto.ts
+++ b/packages/apps/frontera/src/routes/organizations/src/util/Organization.dto.ts
@@ -18,7 +18,7 @@ const defaults: GetOrganizationRowResult = {
   industry: null,
   website: null,
   domains: [],
-  isCustomer: false,
+  relationship: undefined,
   lastTouchpoint: {
     lastTouchPointTimelineEventId: null,
     lastTouchPointAt: null,
@@ -61,7 +61,7 @@ export class OrganizationRowDTO {
         industry: data.industry,
         website: data.website,
         domains: data.domains,
-        isCustomer: data.isCustomer,
+        relationship: data.relationship,
       },
     };
   }

--- a/packages/apps/frontera/src/routes/prospects/src/components/KanbanCard/KanbanCard.tsx
+++ b/packages/apps/frontera/src/routes/prospects/src/components/KanbanCard/KanbanCard.tsx
@@ -71,7 +71,6 @@ export const KanbanCard: React.FC<KanbanCardProps> = ({
   const handleChangeStage = (stage: OrganizationStage): void => {
     card.updateStage(stage);
   };
-  console.log('🏷️ ----- snapshot?.isDragging: ', snapshot);
 
   return (
     <div

--- a/packages/apps/frontera/src/routes/src/graphql/updateOrganization.generated.ts
+++ b/packages/apps/frontera/src/routes/src/graphql/updateOrganization.generated.ts
@@ -37,6 +37,7 @@ export type UpdateOrganizationMutation = {
     market?: Types.Market | null;
     employees?: any | null;
     stage?: Types.OrganizationStage | null;
+    relationship?: Types.OrganizationRelationship | null;
     targetAudience?: string | null;
     valueProposition?: string | null;
     lastFundingRound?: Types.FundingRound | null;
@@ -58,6 +59,7 @@ export const UpdateOrganizationDocument = `
     market
     employees
     stage
+    relationship
     targetAudience
     valueProposition
     lastFundingRound

--- a/packages/apps/frontera/src/routes/src/graphql/updateOrganization.graphql
+++ b/packages/apps/frontera/src/routes/src/graphql/updateOrganization.graphql
@@ -11,6 +11,7 @@ mutation updateOrganization($input: OrganizationUpdateInput!) {
     market
     employees
     stage
+    relationship
     targetAudience
     valueProposition
     lastFundingRound

--- a/packages/apps/frontera/src/routes/src/types/__generated__/graphql.types.ts
+++ b/packages/apps/frontera/src/routes/src/types/__generated__/graphql.types.ts
@@ -3536,6 +3536,10 @@ export type Organization = MetadataInterface & {
   inboundCommsCount: Scalars['Int64']['output'];
   industry?: Maybe<Scalars['String']['output']>;
   industryGroup?: Maybe<Scalars['String']['output']>;
+  /**
+   * Deprecated, use relationship instead
+   * @deprecated Use relationship
+   */
   isCustomer?: Maybe<Scalars['Boolean']['output']>;
   /**
    * Deprecated
@@ -3668,6 +3672,7 @@ export type OrganizationInput = {
   icon?: InputMaybe<Scalars['String']['input']>;
   industry?: InputMaybe<Scalars['String']['input']>;
   industryGroup?: InputMaybe<Scalars['String']['input']>;
+  /** Deprecated, use relationship instead */
   isCustomer?: InputMaybe<Scalars['Boolean']['input']>;
   /** Deprecated */
   isPublic?: InputMaybe<Scalars['Boolean']['input']>;
@@ -3861,6 +3866,7 @@ export type OrganizationUpdateInput = {
   id: Scalars['ID']['input'];
   industry?: InputMaybe<Scalars['String']['input']>;
   industryGroup?: InputMaybe<Scalars['String']['input']>;
+  /** Deprecated, use relationship instead */
   isCustomer?: InputMaybe<Scalars['Boolean']['input']>;
   /** Deprecated, use public instead */
   isPublic?: InputMaybe<Scalars['Boolean']['input']>;


### PR DESCRIPTION
## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new fields `relationship` and `stage` to organization forms and queries.

- **Improvements**
  - Replaced `isCustomer` field with `relationship` across multiple components for better clarity and flexibility.
  - Introduced conditional UI elements based on the selected `relationship` and `stage`.

- **Bug Fixes**
  - Removed unnecessary `console.log` statement in the KanbanCard component.

- **GraphQL Updates**
  - Updated queries and mutations to include `relationship` and `stage` fields.
  - Deprecated `isCustomer` and `isPublic` fields in favor of `relationship` and `public`.

- **Refactor**
  - Refactored form handling logic to accommodate new `relationship` and `stage` fields.
  - Adjusted UI components to reflect changes in organization relationship handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->