### PR TITLE
Alex/cos 3309 set new orgs as prospect leads by default

### DIFF
--- a/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
@@ -113,9 +113,24 @@ func (r *mutationResolver) OrganizationCreate(ctx context.Context, input model.O
 	} else if input.IsCustomer != nil && *input.IsCustomer {
 		upsertOrganizationRequest.Relationship = enummapper.MapRelationshipFromModel(model.OrganizationRelationshipCustomer).String()
 	}
+	if upsertOrganizationRequest.Relationship == "" {
+		upsertOrganizationRequest.Relationship = enummapper.MapRelationshipFromModel(model.OrganizationRelationshipProspect).String()
+	}
+
 	if input.Stage != nil {
 		upsertOrganizationRequest.Stage = enummapper.MapStageFromModel(*input.Stage).String()
+	} else {
+		if upsertOrganizationRequest.Relationship == enummapper.MapRelationshipFromModel(model.OrganizationRelationshipCustomer).String() {
+			upsertOrganizationRequest.Stage = enummapper.MapStageFromModel(model.OrganizationStageOnboarding).String()
+		} else if upsertOrganizationRequest.Relationship == enummapper.MapRelationshipFromModel(model.OrganizationRelationshipProspect).String() {
+			upsertOrganizationRequest.Stage = enummapper.MapStageFromModel(model.OrganizationStageLead).String()
+		} else if upsertOrganizationRequest.Relationship == enummapper.MapRelationshipFromModel(model.OrganizationRelationshipNotAFit).String() {
+			upsertOrganizationRequest.Stage = enummapper.MapStageFromModel(model.OrganizationStageUnqualified).String()
+		} else if upsertOrganizationRequest.Relationship == enummapper.MapRelationshipFromModel(model.OrganizationRelationshipFormerCustomer).String() {
+			upsertOrganizationRequest.Stage = enummapper.MapStageFromModel(model.OrganizationStageTarget).String()
+		}
 	}
+
 	if input.Logo != nil {
 		upsertOrganizationRequest.LogoUrl = *input.Logo
 	}


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new organization stages: `READY_TO_BUY`, `ONBOARDING`, `INITIAL_VALUE`, `RECURRING_VALUE`, `MAX_VALUE`, `PENDING_CHURN`.
  - Added `CHURN` as a new table ID type.

- **Updates**
  - Renamed organization relationship `STRANGER` to `NOT_A_FIT`.
  - Removed organization stages: `INTERESTED`, `CLOSED_WON`, `CLOSED_LOST`, `NURTURE`.

- **Enhancements**
  - Improved logic for setting organization stages based on relationship and stage input.
  - Added default handling for churn table view definition if not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->