### PR TITLE
Fix email addresses on send

### DIFF
--- a/packages/server/comms-api/service/mail_service.go
+++ b/packages/server/comms-api/service/mail_service.go
@@ -186,13 +186,13 @@ func (s *mailService) SendMail(ctx context.Context, request *model.MailReplyRequ
 	if request.Cc != nil {
 		for _, cc := range request.Cc {
 			ccAddress = append(ccAddress, &mimemail.Address{Address: cc})
-			retMail.Cc = toAddress
+			retMail.Cc = ccAddress
 		}
 	}
 	if request.Bcc != nil {
 		for _, bcc := range request.Bcc {
 			bccAddress = append(bccAddress, &mimemail.Address{Address: bcc})
-			retMail.Bcc = toAddress
+			retMail.Bcc = bccAddress
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the assignment of `Cc` and `Bcc` addresses in the email sending functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->