### PR TITLE
(fix|COS-3587): Account tab fixes after review

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/EditContractModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/EditContractModal.tsx
@@ -1,3 +1,4 @@
+import { useParams } from 'react-router-dom';
 import { useRef, useMemo, useState, useEffect } from 'react';
 
 import { motion, Variants } from 'framer-motion';
@@ -28,7 +29,9 @@ interface SubscriptionServiceModalProps {
   onClose: () => void;
   notes?: string | null;
   status: ContractStatus;
+  opportunityId?: string;
   serviceStarted?: string;
+
   organizationName: string;
 }
 
@@ -76,10 +79,16 @@ export const EditContractModal = ({
   renewsAt,
   status,
   serviceStarted,
+  opportunityId,
 }: SubscriptionServiceModalProps) => {
   const store = useStore();
+  const organizationId = useParams().id as string;
   const contractStore = store.contracts.value.get(contractId);
   const contractNameInputRef = useRef<HTMLInputElement | null>(null);
+  const organizationStore = store.organizations.value.get(organizationId);
+  const opportunityStore = opportunityId
+    ? store.opportunities.value.get(opportunityId)
+    : undefined;
 
   const [initialOpen, setInitialOpen] = useState(EditModalMode.ContractDetails);
   useState<boolean>(false);
@@ -94,7 +103,6 @@ export const EditContractModal = ({
   const tenantSettings = store.settings.tenant.value;
   const tenantBillingProfiles = store.settings.tenantBillingProfiles.toArray();
   const contractLineItemsStore = store.contractLineItems;
-
   useEffect(() => {
     if (isEditModalOpen) {
       setInitialOpen(editModalMode);
@@ -142,7 +150,10 @@ export const EditContractModal = ({
 
       itemStore?.update((prev) => prev);
     });
-
+    setTimeout(() => {
+      organizationStore?.invalidate();
+      opportunityStore?.invalidate();
+    }, 800);
     handleCloseModal();
   };
 

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/Services/components/ServiceItem/ServiceItemEdit.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/Services/components/ServiceItem/ServiceItemEdit.tsx
@@ -159,7 +159,9 @@ export const ServiceItemEdit: React.FC<ServiceItemProps> = observer(
     };
     const updatePrice = (price: string) => {
       service.update(
-        (prev) => ({ ...prev, price: price ? parseFloat(price) : 0 }),
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error  we allow undefined during edition but on blur we still enforce value therefore this is false positive
+        (prev) => ({ ...prev, price: price ? parseFloat(price) : undefined }),
         { mutate: false },
       );
     };
@@ -167,7 +169,12 @@ export const ServiceItemEdit: React.FC<ServiceItemProps> = observer(
       service.update(
         (prev) => ({
           ...prev,
-          tax: { ...prev.tax, taxRate: taxRate ? parseFloat(taxRate) : 0 },
+          tax: {
+            ...prev.tax,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error we allow undefined during edition but on blur we still enforce value therefore this is false positive
+            taxRate: taxRate ? parseFloat(taxRate) : undefined,
+          },
         }),
         {
           mutate: false,

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
@@ -1,5 +1,7 @@
+import { useParams } from 'react-router-dom';
 import { useMemo, useState, useEffect } from 'react';
 
+import { comparer, reaction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 
 import { Input } from '@ui/form/Input';
@@ -84,15 +86,10 @@ export const ContractCard = observer(
               placeholder='Add contract name'
               value={contract?.contractName}
               onChange={(e) =>
-                contractStore?.update(
-                  (prev) => ({
-                    ...prev,
-                    contractName: e.target.value,
-                  }),
-                  {
-                    mutate: false,
-                  },
-                )
+                contractStore?.update((prev) => ({
+                  ...prev,
+                  contractName: e.target.value,
+                }))
               }
               onFocus={(e) => e.target.select()}
             />
@@ -147,6 +144,7 @@ export const ContractCard = observer(
           )}
 
           <EditContractModal
+            opportunityId={opportunityId}
             isOpen={isEditModalOpen}
             status={contract?.contractStatus}
             contractId={contract?.metadata?.id}

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalDetailsModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/RenewalARR/RenewalDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useForm, useField } from 'react-inverted-form';
 
 import { match } from 'ts-pattern';
@@ -92,7 +92,6 @@ const RenewalDetailsForm = ({
   const store = useStore();
   const users = store.users.toArray();
   const formId = `renewal-details-form-${data.id}`;
-
   const updatedAt = data?.updatedAt
     ? DateTimeUtils.timeAgo(data?.updatedAt)
     : null;
@@ -107,17 +106,16 @@ const RenewalDetailsForm = ({
       .otherwise(() => 100);
   };
 
-  const defaultValues = useMemo(
-    () => ({
-      renewalAdjustedRate:
-        data?.renewalAdjustedRate ?? data?.renewalLikelihood
-          ? getAdjustedRate(data?.renewalLikelihood)
-          : 100,
-      renewalLikelihood: data?.renewalLikelihood,
-      reason: data?.comments,
-    }),
-    [data?.renewalLikelihood, data?.amount, data?.comments],
-  );
+  const defaultValues = {
+    renewalAdjustedRate: data?.renewalAdjustedRate
+      ? data?.renewalAdjustedRate
+      : data?.renewalLikelihood
+      ? getAdjustedRate(data?.renewalLikelihood)
+      : 100,
+    renewalLikelihood: data?.renewalLikelihood,
+    reason: data?.comments,
+  };
+
   const updatedByUser = users?.find(
     (u) => u.id === data.renewalUpdatedByUserId,
   );

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contracts/Contracts.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contracts/Contracts.tsx
@@ -1,6 +1,7 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
+import { reaction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 
 import { useStore } from '@shared/hooks/useStore';

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/EmptyContracts.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/EmptyContracts.tsx
@@ -23,6 +23,7 @@ export const EmptyContracts: FC<
           colorScheme='primary'
           variant='outline'
           onClick={onCreate}
+          isDisabled={isPending}
         >
           {isPending ? 'Creating contract...' : 'New contract'}
         </Button>

--- a/packages/apps/frontera/src/store/Contracts/Contract.store.ts
+++ b/packages/apps/frontera/src/store/Contracts/Contract.store.ts
@@ -185,12 +185,11 @@ export class ContractStore implements Store<Contract> {
 
   init(data: Contract) {
     const output = merge(this.value, data);
-    const contractLineItems =
-      data.contractLineItems?.map((item) => {
-        this.root.contractLineItems.load([item]);
+    const contractLineItems = data.contractLineItems?.map((item) => {
+      this.root.contractLineItems.load([item]);
 
-        return this.root.contractLineItems.value.get(item?.metadata?.id)?.value;
-      }) || [];
+      return this.root.contractLineItems.value.get(item?.metadata?.id)?.value;
+    });
     const opportunities = data.opportunities?.map((item) => {
       this.root.opportunities.load([item]);
 
@@ -207,10 +206,9 @@ export class ContractStore implements Store<Contract> {
 
       return this.root.invoices.value.get(item.metadata.id)?.value;
     });
-
-    set(output, 'contractLineItems', contractLineItems);
-    set(output, 'opportunities', opportunities);
-    set(output, 'upcomingInvoices', upcomingInvoices);
+    contractLineItems && set(output, 'contractLineItems', contractLineItems);
+    opportunities && set(output, 'opportunities', opportunities);
+    opportunities && set(output, 'upcomingInvoices', upcomingInvoices);
 
     return output;
   }


### PR DESCRIPTION
- fixed init of CLI
- allow to remove value from SLI
- invalidate opportunity and organization - to update renewal forecast on org level

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added conditional disabling of the button in the `EmptyContracts` component based on the `isPending` state.
  - Included `opportunityId` as a prop in the `EditContractModal`.

- **Bug Fixes**
  - Updated `updatePrice` and `updateTaxRate` functions in `ServiceItemEdit` to handle `undefined` values correctly.

- **Refactor**
  - Simplified the logic in several components for handling imports, state updates, and side effects.
  - Removed unnecessary `useMemo` and `useCallback` hooks from `RenewalDetailsModal`.

- **Chores**
  - Added timeout functions to invalidate stores and handle data updates more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->