### PR TITLE
(fix|COS-3595): Move renewal date calculation to FE

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/EditContractModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/EditContractModal.tsx
@@ -76,7 +76,6 @@ const variants = {
 export const EditContractModal = ({
   contractId,
   organizationName,
-  renewsAt,
   status,
   serviceStarted,
   opportunityId,
@@ -259,7 +258,6 @@ export const EditContractModal = ({
             tenantBillingProfile={
               tenantBillingProfiles?.[0]?.value as TenantBillingProfile
             }
-            renewedAt={renewsAt}
             bankAccounts={bankAccounts}
             billingEnabled={tenantSettings?.billingEnabled}
             contractStatus={contractStore?.value?.contractStatus}

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
@@ -1,7 +1,5 @@
-import { useParams } from 'react-router-dom';
 import { useMemo, useState, useEffect } from 'react';
 
-import { comparer, reaction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 
 import { Input } from '@ui/form/Input';
@@ -152,7 +150,6 @@ export const ContractCard = observer(
             serviceStarted={contract?.serviceStarted}
             organizationName={organizationName}
             notes={contract?.billingDetails?.invoiceNote}
-            renewsAt={contract?.opportunities?.[0]?.renewedAt}
           />
         </CardFooter>
       </Card>

--- a/packages/apps/frontera/src/utils/date.ts
+++ b/packages/apps/frontera/src/utils/date.ts
@@ -145,8 +145,8 @@ export class DateTimeUtils {
     return addYearsDateFns(this.getDate(date), yearsCount);
   }
 
-  public static addMonth(date: string, yearsCount: number): Date {
-    return addMonthsDateFns(this.getDate(date), yearsCount);
+  public static addMonth(date: string, monthsCount: number): Date {
+    return addMonthsDateFns(this.getDate(date), monthsCount);
   }
   public static addDays(date: string, daysCount: number): Date {
     return addDaysDateFns(this.getDate(date), daysCount);


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved contract renewal date calculations and formatting.
  - Enhanced date handling and conversion for better accuracy in displaying service start dates.

- **Bug Fixes**
  - Corrected method signature for adding months, ensuring proper functionality.

- **Refactor**
  - Removed deprecated `renewedAt` property and associated logic.
  - Streamlined components by removing unused imports and props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->