### PR TITLE
Fix outlook read emails limit

### DIFF
--- a/packages/server/customer-os-common-module/service/azure_service.go
+++ b/packages/server/customer-os-common-module/service/azure_service.go
@@ -49,7 +49,7 @@ func (s *azureService) ReadEmailsFromAzureAd(ctx context.Context, importState *p
 		reqUrl = "https://graph.microsoft.com/v1.0/me/messages"
 
 		queryParams := url.Values{}
-		queryParams.Add("$top", fmt.Sprintf("%d", 1))
+		queryParams.Add("$top", fmt.Sprintf("%d", 100))
 
 		reqUrl = reqUrl + "?" + queryParams.Encode()
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Improved email fetching functionality by increasing the number of emails fetched from 1 to 100 per request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->