### PR TITLE
(fix|COS-3797): Close tag dropdown on tag select

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/Tags/Tags.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/Tags/Tags.tsx
@@ -15,6 +15,7 @@ interface TagsProps {
   hideBorder?: boolean;
   icon: React.ReactNode;
   value: SelectOption[];
+  closeMenuOnSelect?: boolean;
   menuPortalTarget?: HTMLElement;
   onCreateOption?: (value: string) => void;
   onChange: (value: [SelectOption]) => void;
@@ -30,6 +31,7 @@ export const Tags = observer(
     menuPortalTarget,
     autofocus,
     hideBorder,
+    closeMenuOnSelect,
   }: TagsProps) => {
     const store = useStore();
 
@@ -55,6 +57,7 @@ export const Tags = observer(
         backspaceRemovesValue
         menuPortalTarget={menuPortalTarget}
         defaultOptions={options}
+        closeMenuOnSelect={closeMenuOnSelect}
         placeholder={placeholder}
         onCreateOption={onCreateOption}
         leftElement={icon}

--- a/packages/apps/frontera/src/routes/organizations/src/components/Actions/ContactActions.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Actions/ContactActions.tsx
@@ -143,6 +143,7 @@ export const ContactTableActions = ({
               autofocus
               placeholder='Persona'
               icon={null}
+              closeMenuOnSelect={true}
               value={selectedTags}
               onChange={(e) => setSelectedTags(e)}
             />


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new option to close the menu upon selection in tags and contacts actions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->