### PR TITLE
default billing cycle in contracts to 1 on creation

### DIFF
--- a/packages/server/customer-os-api/service/contract_service.go
+++ b/packages/server/customer-os-api/service/contract_service.go
@@ -105,6 +105,7 @@ func (s *contractService) createContractWithEvents(ctx context.Context, contract
 		AutoRenew:              utils.IfNotNilBool(contractDetails.Input.AutoRenew),
 		DueDays:                utils.IfNotNilInt64(contractDetails.Input.DueDays),
 		Approved:               utils.IfNotNilBool(contractDetails.Input.Approved),
+		BillingCycleInMonths:   1,
 	}
 
 	if contractDetails.Input.ContractSigned != nil {


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `BillingCycleInMonths` field to contract details with a default value of 1 month. This will allow users to define the billing cycle length for new contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->