### PR TITLE
Fix weconnect upkeeper cron property name

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/cron/config/config.go
+++ b/packages/runner/customer-os-data-upkeeper/cron/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	CronScheduleUpkeepContacts          string `env:"CRON_SCHEDULE_UPKEEP_CONTACTS" envDefault:"0 */15 * * * *"`
 	CronScheduleEnrichContactsFindEmail string `env:"CRON_SCHEDULE_ENRICH_CONTACTS_FIND_EMAIL" envDefault:"0 */5 * * * *"`
 	CronScheduleEnrichContacts          string `env:"CRON_SCHEDULE_ENRICH_CONTACTS" envDefault:"0 */2 * * * *"`
-	CronScheduleWeConnectSyncContacts   string `env:"CRON_SCHEDULE_ENRICH_CONTACTS" envDefault:"0 * */1 * * *"`
+	CronScheduleWeConnectSyncContacts   string `env:"CRON_SCHEDULE_WECONNECT_SYNC_CONTACTS" envDefault:"0 0 * */1 * *"`
 
 	// Invoices
 	// Defaults to 8:15am


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected environment variable for `WeConnect` sync schedule, ensuring accurate synchronization timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->