### PR TITLE
(fix|COS-3420): Fixed contract upcoming invoices ui issues

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/UpcomingInvoices/UpcomingInvoice.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/UpcomingInvoices/UpcomingInvoice.tsx
@@ -1,48 +1,74 @@
 import { observer } from 'mobx-react-lite';
 
+import { Contract } from '@graphql/types';
 import { DateTimeUtils } from '@utils/date';
 import { useStore } from '@shared/hooks/useStore';
 import { formatCurrency } from '@utils/getFormattedCurrencyNumber';
 import { useTimelineEventPreviewMethodsContext } from '@organization/components/Timeline/shared/TimelineEventPreview/context/TimelineEventPreviewContext';
 
-interface UpcomingInvoiceProps {
-  id: string;
+function getCommittedPeriodLabel(months: string | number) {
+  if (`${months}` === '1') {
+    return 'Monthly';
+  }
+  if (`${months}` === '3') {
+    return 'Quarterly';
+  }
+
+  if (`${months}` === '12') {
+    return 'Annual';
+  }
+
+  return `${months}-month`;
 }
 
-export const UpcomingInvoice = observer(({ id }: UpcomingInvoiceProps) => {
-  const store = useStore();
-  const { handleOpenInvoice } = useTimelineEventPreviewMethodsContext();
-  const invoice = store.invoices.value.get(id)?.value;
+interface UpcomingInvoiceProps {
+  id: string;
+  contractId: string;
+}
 
-  if (!invoice?.metadata.id) return null;
+export const UpcomingInvoice = observer(
+  ({ id, contractId }: UpcomingInvoiceProps) => {
+    const store = useStore();
+    const { handleOpenInvoice } = useTimelineEventPreviewMethodsContext();
+    const invoice = store.invoices.value.get(id)?.value;
 
-  return (
-    <div
-      key={invoice.metadata.id}
-      className='flex  text-sm'
-      role='button'
-      tabIndex={0}
-      onClick={() => handleOpenInvoice(invoice.metadata.id)}
-    >
-      <div className='whitespace-nowrap mr-1'>Monthly recurring:</div>
-      <div className='whitespace-nowrap text-gray-500 underline'>
-        {formatCurrency(invoice.amountDue, 2, invoice?.currency)} on{' '}
-        {DateTimeUtils.format(
-          invoice?.due,
-          DateTimeUtils.defaultFormatShortString,
-        )}{' '}
-        (
-        {DateTimeUtils.format(
-          invoice?.invoicePeriodStart,
-          DateTimeUtils.dateDayAndMonth,
-        )}{' '}
-        -{' '}
-        {DateTimeUtils.format(
-          invoice?.invoicePeriodEnd,
-          DateTimeUtils.dateDayAndMonth,
-        )}
-        )
+    if (!invoice?.metadata.id) return null;
+    const contract = store.contracts.value.get(contractId)?.value as Contract;
+    const renewalPeriod = getCommittedPeriodLabel(
+      contract?.committedPeriodInMonths,
+    );
+    const autoRenewal = contract?.autoRenew;
+
+    return (
+      <div
+        key={invoice.metadata.id}
+        className='flex  text-sm'
+        role='button'
+        tabIndex={0}
+        onClick={() => handleOpenInvoice(invoice.metadata.id)}
+      >
+        <div className='whitespace-nowrap mr-1'>
+          {renewalPeriod} {autoRenewal ? 'recurring' : ''}:
+        </div>
+        <div className='whitespace-nowrap text-gray-500 underline'>
+          {formatCurrency(invoice.amountDue, 2, invoice?.currency)} on{' '}
+          {DateTimeUtils.format(
+            invoice?.due,
+            DateTimeUtils.defaultFormatShortString,
+          )}{' '}
+          (
+          {DateTimeUtils.format(
+            invoice?.invoicePeriodStart,
+            DateTimeUtils.dateDayAndMonth,
+          )}{' '}
+          -{' '}
+          {DateTimeUtils.format(
+            invoice?.invoicePeriodEnd,
+            DateTimeUtils.dateWithShortYear,
+          )}
+          )
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/UpcomingInvoices/UpcomingInvoices.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/UpcomingInvoices/UpcomingInvoices.tsx
@@ -67,7 +67,7 @@ export const UpcomingInvoices = ({
         <Button
           className='ml-2 font-normal rounded'
           size='xxs'
-          colorScheme='warning'
+          colorScheme='gray'
           onClick={onOpenBillingDetailsModal}
           leftIcon={<Edit03 className='size-3' />}
         >
@@ -80,7 +80,7 @@ export const UpcomingInvoices = ({
         <Button
           className='ml-2 font-normal rounded'
           size='xxs'
-          colorScheme='primary'
+          colorScheme='gray'
           onClick={onOpenServiceLineItemsModal}
           leftIcon={<Plus className='size-3' />}
         >
@@ -93,8 +93,8 @@ export const UpcomingInvoices = ({
       return (
         <Button
           className='ml-2 font-normal rounded'
-          size='xs'
-          colorScheme='primary'
+          size='xxs'
+          colorScheme='gray'
           onClick={() => onStatusModalOpen(ContractStatusModalMode.Renew)}
           leftIcon={<RefreshCw05 />}
         >
@@ -107,7 +107,7 @@ export const UpcomingInvoices = ({
         <Button
           className='ml-2 font-normal rounded'
           size='xxs'
-          colorScheme='primary'
+          colorScheme='gray'
           onClick={() => onStatusModalOpen(ContractStatusModalMode.Start)}
           leftIcon={<Play />}
         >
@@ -136,6 +136,7 @@ export const UpcomingInvoices = ({
         {data?.upcomingInvoices.map((invoice: Invoice) => (
           <UpcomingInvoice
             key={invoice?.metadata?.id}
+            contractId={data?.metadata?.id}
             id={invoice?.metadata?.id}
           />
         ))}

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/context/ContractModalsContext.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/context/ContractModalsContext.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 
 import { useDisclosure } from '@ui/utils/hooks/useDisclosure';
+import { useTimelineEventPreviewMethodsContext } from '@organization/components/Timeline/shared/TimelineEventPreview/context/TimelineEventPreviewContext.tsx';
 
 export enum EditModalMode {
   ContractDetails,
@@ -41,6 +42,8 @@ export const ContractModalsContextProvider = ({
   const [editModalMode, setEditModalMode] = useState<EditModalMode>(
     EditModalMode.ContractDetails,
   );
+  const { closeModal: closeTimelineModal } =
+    useTimelineEventPreviewMethodsContext();
 
   const {
     onOpen: onEditModalOpen,
@@ -50,11 +53,16 @@ export const ContractModalsContextProvider = ({
     id: `edit-contract-modal-${id}`,
   });
 
+  const handleOpen = () => {
+    onEditModalOpen();
+    closeTimelineModal();
+  };
+
   return (
     <ContractPanelStateContext.Provider
       value={{
         isEditModalOpen,
-        onEditModalOpen,
+        onEditModalOpen: handleOpen,
         onEditModalClose,
         editModalMode,
         onChangeModalMode: setEditModalMode,


### PR DESCRIPTION
## Changes

- For the next invoice, we should have a year after the last date
- If a modal from the timeline is open and you open the contract modal, we should close the timeline modal
- We should use the xxs button size next to the Paused status
  - Also, they should all be grey buttons instead of orange or purple

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `UpcomingInvoice` component to display contract renewal information.
	
- **Changes**
	- Updated color scheme of buttons in `UpcomingInvoices` component from primary to gray.
	- Adjusted button sizes in `UpcomingInvoices` component.
	- Added contract ID prop to ensure accurate data retrieval and display in `UpcomingInvoice`.
	
- **Bug Fixes**
	- Improved modal functionality to close the timeline modal alongside an edit modal for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->