### PR TITLE
(fix|COS-3900): Invoice subtotal fix & (fix|COS-3948): Make button section on contract edit modal sticky &  (fix|COS-3962): Copy change

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/EditContractModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/EditContractModal.tsx
@@ -362,7 +362,7 @@ export const EditContractModal = ({
                   onChangeModalMode(EditModalMode.BillingDetails)
                 }
               />
-              <ModalFooter className='p-0 flex'>
+              <ModalFooter className='p-0 flex sticky -bottom-5 -mb-6 pb-6 pt-3 bg-gray-25'>
                 <Button
                   variant='outline'
                   colorScheme='gray'

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/EditContractModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/EditContractModal.tsx
@@ -383,7 +383,9 @@ export const EditContractModal = ({
                   onClick={() => handleApplyChanges()}
                   loadingText='Saving...'
                 >
-                  Save
+                  {contractStore?.value?.contractStatus === ContractStatus.Draft
+                    ? 'Save draft'
+                    : 'Save'}
                 </Button>
               </ModalFooter>
             </motion.div>

--- a/packages/apps/frontera/src/store/Invoices/Invoice.store.ts
+++ b/packages/apps/frontera/src/store/Invoices/Invoice.store.ts
@@ -179,6 +179,7 @@ const INVOICES_QUERY = gql`
       currency
       dryRun
       status
+      subtotal
       invoiceLineItems {
         metadata {
           id

--- a/packages/apps/frontera/src/store/Invoices/Invoices.store.ts
+++ b/packages/apps/frontera/src/store/Invoices/Invoices.store.ts
@@ -181,6 +181,8 @@ const INVOICES_QUERY = gql`
         dryRun
         status
         preview
+        subtotal
+        taxDue
         invoiceLineItems {
           metadata {
             id


### PR DESCRIPTION
## Changes

- (fix|COS-3962): Copy change
- (fix|COS-3900): Invoice subtotal fix
- (fix|COS-3948): Make button section on contract edit modal sticky

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced invoice details display with additional information such as `subtotal` and `taxDue`.
  - Improved modal interactions and control flow within the `ContractModalsContextProvider`.

- **UI Updates**
  - Updated the styling of the `EditContractModal` and adjusted button text based on contract status.
  - Added contract renewal period and auto-renewal information to the Upcoming Invoices section.
  - Changed button color schemes in the Upcoming Invoices section to a consistent 'gray' theme.

- **Bug Fixes**
  - Addressed potential issues with modal operations by introducing a new context handling method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->