### PR TITLE
(fix|COS-3971|COS-3978): Fixed UI issues

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/OrganizationSidenav/OrganizationSidenav.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/OrganizationSidenav/OrganizationSidenav.tsx
@@ -54,7 +54,7 @@ export const OrganizationSidenav = observer(() => {
           variant='ghost'
           className='p-0.5'
           onClick={() => {
-            navigate(`/${lastActivePosition?.root || 'organizations'}`);
+            navigate(`/${lastActivePosition?.root || 'finder'}`);
           }}
           icon={
             <ArrowNarrowRight className='rotate-180 text-gray-700 size-6' />

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
@@ -79,7 +79,7 @@ export const ContractCard = observer(
         >
           <article className='flex justify-between flex-1 w-full'>
             <Input
-              className='font-semibold no-border-bottom hover:border-none focus:border-none max-h-6 min-h-0 w-full overflow-hidden overflow-ellipsis'
+              className='font-semibold hover:border-none focus:border-none max-h-6 min-h-0 w-full overflow-hidden overflow-ellipsis border-0'
               name='contractName'
               placeholder='Add contract name'
               value={contract?.contractName}

--- a/packages/apps/frontera/src/routes/organizations/src/components/Columns/organizations/Cells/website/WebsiteCell.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Columns/organizations/Cells/website/WebsiteCell.tsx
@@ -7,6 +7,7 @@ import { Edit03 } from '@ui/media/icons/Edit03';
 import { useStore } from '@shared/hooks/useStore';
 import { IconButton } from '@ui/form/IconButton/IconButton';
 import { LinkExternal02 } from '@ui/media/icons/LinkExternal02';
+import { removeTrailingSlash } from '@utils/removeTrailingSlash.ts';
 import { getExternalUrl, getFormattedLink } from '@utils/getExternalLink';
 
 interface WebsiteCellProps {
@@ -151,7 +152,7 @@ export const WebsiteCell = observer(({ organizationId }: WebsiteCellProps) => {
             if (e.metaKey) setIsEdit(true);
           }}
         >
-          {formattedLink || 'Unknown'}
+          {formattedLink ? removeTrailingSlash(formattedLink) : 'Unknown'}
         </p>
       )}
       {isHovered && !isEdit && (

--- a/packages/apps/frontera/src/store/Contracts/Contract.store.ts
+++ b/packages/apps/frontera/src/store/Contracts/Contract.store.ts
@@ -233,6 +233,9 @@ export class ContractStore implements Store<Contract> {
     } finally {
       runInAction(() => {
         this.isLoading = false;
+        setTimeout(() => {
+          this.invalidate();
+        }, 600);
       });
     }
   }
@@ -269,6 +272,9 @@ export class ContractStore implements Store<Contract> {
     } finally {
       runInAction(() => {
         this.isLoading = false;
+        setTimeout(() => {
+          this.invalidate();
+        }, 600);
       });
     }
   }

--- a/packages/apps/frontera/src/store/Contracts/Contracts.store.ts
+++ b/packages/apps/frontera/src/store/Contracts/Contracts.store.ts
@@ -175,10 +175,18 @@ export class ContractsStore implements GroupStore<Contract> {
       this.isPending.delete(payload.organizationId);
 
       if (serverId) {
+        newContract.value.billingDetails = {
+          ...newContract.value.billingDetails,
+          organizationLegalName: this.root.organizations.value.get(
+            payload.organizationId,
+          )?.value?.name,
+        };
+
         setTimeout(() => {
           runInAction(() => {
             this.root.organizations.value.get(organizationId)?.invalidate();
-            this.value.get(serverId)?.invalidate();
+
+            (this.value.get(serverId) as ContractStore)?.updateBillingAddress();
 
             this.root.organizations.sync({
               action: 'INVALIDATE',

--- a/packages/apps/frontera/src/store/Settings/Tenant.store.ts
+++ b/packages/apps/frontera/src/store/Settings/Tenant.store.ts
@@ -17,7 +17,7 @@ export class TenantStore {
 
   async bootstrap() {
     if (this.root.demoMode) {
-      this.value = mock.data.tenantSettings as TenantSettings;
+      this.value = mock.data.tenantSettings as unknown as TenantSettings;
       this.isBootstrapped = true;
 
       return;

--- a/packages/apps/frontera/src/store/Settings/Tenant.store.ts
+++ b/packages/apps/frontera/src/store/Settings/Tenant.store.ts
@@ -17,7 +17,7 @@ export class TenantStore {
 
   async bootstrap() {
     if (this.root.demoMode) {
-      this.value = mock.data.tenantSettings as unknown as TenantSettings;
+      this.value = mock.data.tenantSettings as TenantSettings;
       this.isBootstrapped = true;
 
       return;

--- a/packages/apps/frontera/src/utils/index.ts
+++ b/packages/apps/frontera/src/utils/index.ts
@@ -3,3 +3,4 @@ export { uuidv4 } from './generateUuid';
 export { getContactDisplayName } from './getContactName';
 export { DateTimeUtils } from './date';
 export { getContactPageTitle } from './getContactPageTitle';
+export { removeTrailingSlash } from './removeTrailingSlash';

--- a/packages/apps/frontera/src/utils/removeTrailingSlash.ts
+++ b/packages/apps/frontera/src/utils/removeTrailingSlash.ts
@@ -1,0 +1,3 @@
+export function removeTrailingSlash(url: string) {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}


### PR DESCRIPTION
## Changes
- Fixed UI issue where hovering over the contract title caused it to move down by 1 or 2 pixels.
- Resolved issue where the legal name set for a new organization via LinkedIn required editing the default name before it appeared correctly under "Invoices are billed to this address".
- Updated behavior to always use the default name for new organizations, even if it is "Unnamed".
- Dropped trailing slash from website on tables


What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated navigation link in `OrganizationSidenav` to dynamically redirect users to `finder` based on the `lastActivePosition` or default value.
  - Enhanced `ContractsStore` with better handling of billing details, including setting `organizationLegalName` and improving address updates.

- **Bug Fixes**
  - Improved URL formatting in `WebsiteCell` component by removing trailing slashes for better link consistency.
  
- **Style**
  - Updated CSS classes in the `ContractCard` component to refine input field appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->