### PR TITLE
(fix|COS-4026): Automatically update stage when user changes relationship.

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/RelationshipButton.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/RelationshipButton.tsx
@@ -44,6 +44,17 @@ export const RelationshipButton = () => {
         org.stage = OrganizationStage.Lead;
       }
 
+      if (option.value === OrganizationRelationship.Customer) {
+        org.stage = undefined;
+      }
+
+      if (option.value === OrganizationRelationship.NotAFit) {
+        org.stage = OrganizationStage.Unqualified;
+      }
+      if (option.value === OrganizationRelationship.FormerCustomer) {
+        org.stage = undefined;
+      }
+
       return org;
     });
   };

--- a/packages/apps/frontera/src/routes/organizations/src/components/Columns/Cells/stage/OrganizationStageCell.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Columns/Cells/stage/OrganizationStageCell.tsx
@@ -2,8 +2,11 @@ import { useState, useEffect } from 'react';
 
 import { observer } from 'mobx-react-lite';
 
+import { cn } from '@ui/utils/cn.ts';
+import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
 import { OrganizationStage } from '@graphql/types';
+import { Edit03 } from '@ui/media/icons/Edit03.tsx';
 import { Seeding } from '@ui/media/icons/Seeding.tsx';
 import { BrokenHeart } from '@ui/media/icons/BrokenHeart.tsx';
 import { ActivityHeart } from '@ui/media/icons/ActivityHeart.tsx';
@@ -51,25 +54,53 @@ export const OrganizationStageCell = observer(
       });
     };
 
+    const handleToggleEdit = (newState: boolean) => {
+      if (newState && !!applicableStageOptions.length) {
+        setIsEdit(true);
+      }
+
+      if (!newState) {
+        setIsEdit(false);
+      }
+    };
+
     return (
       <div
-        className='flex-1'
-        onDoubleClick={() => setIsEdit(true)}
+        className='flex gap-1 group/stage'
+        onDoubleClick={() => handleToggleEdit(true)}
         onKeyDown={(e) => e.metaKey && setMetaKey(true)}
         onKeyUp={() => metaKey && setMetaKey(false)}
-        onClick={() => metaKey && setIsEdit(true)}
-        onBlur={() => setIsEdit(false)}
+        onClick={() => metaKey && handleToggleEdit(true)}
+        onBlur={() => handleToggleEdit(false)}
       >
-        <Menu>
-          <MenuButton className='outline-none focus:outline-none'>
-            <span>
-              {selectedStageOption?.label ? (
-                selectedStageOption?.label
-              ) : (
-                <span className='text-gray-400'>Not applicable</span>
-              )}
-            </span>
+        <p
+          className={cn(
+            'cursor-default text-gray-700',
+            !selectedStageOption?.value && 'text-gray-400',
+          )}
+          data-test='organization-stage-in-all-orgs-table'
+          onDoubleClick={() => handleToggleEdit(true)}
+        >
+          {selectedStageOption?.label ?? 'Not applicable'}
+        </p>
+        <Menu open={isEdit} onOpenChange={handleToggleEdit}>
+          <MenuButton>
+            {!!applicableStageOptions.length && (
+              <IconButton
+                className={cn(
+                  'rounded-md opacity-0 group-hover/stage:opacity-100',
+                  isEdit && 'opacity-100',
+                )}
+                aria-label='edit stage'
+                size='xxs'
+                variant='ghost'
+                id='edit-button'
+                onClick={() => handleToggleEdit(true)}
+                icon={<Edit03 className='text-gray-500' />}
+              />
+            )}
           </MenuButton>
+
           <MenuList side='bottom' align='center' className='min-w-[280px]'>
             {applicableStageOptions.map((option) => (
               <MenuItem

--- a/packages/apps/frontera/src/routes/organizations/src/components/Columns/organizations/Cells/relationship/OrganizationRelationship.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Columns/organizations/Cells/relationship/OrganizationRelationship.tsx
@@ -35,6 +35,17 @@ export const OrganizationRelationshipCell = observer(
           org.stage = OrganizationStage.Lead;
         }
 
+        if (option.value === OrganizationRelationship.Customer) {
+          org.stage = undefined;
+        }
+
+        if (option.value === OrganizationRelationship.NotAFit) {
+          org.stage = OrganizationStage.Unqualified;
+        }
+        if (option.value === OrganizationRelationship.FormerCustomer) {
+          org.stage = undefined;
+        }
+
         return org;
       });
       setIsEditing(false);

--- a/packages/apps/frontera/src/routes/organizations/src/components/Columns/organizations/columns.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Columns/organizations/columns.tsx
@@ -148,7 +148,7 @@ export const columns: Record<string, Column> = {
     'value.relationship',
     {
       id: ColumnViewType.OrganizationsRelationship,
-      size: 150,
+      size: 165,
       header: (props) => (
         <THead
           id={ColumnViewType.OrganizationsRelationship}
@@ -711,7 +711,7 @@ export const columns: Record<string, Column> = {
   }),
   [ColumnViewType.OrganizationsStage]: columnHelper.accessor('value', {
     id: ColumnViewType.OrganizationsStage,
-    size: 120,
+    size: 150,
     enableColumnFilter: true,
     enableSorting: true,
     cell: (props) => {


### PR DESCRIPTION
## Changes
- increase the width of the relationship column to fit former customer status and edit icon in one cell
- change stage cell to require dbl click or edit icon click to enter edit mode

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `RelationshipButton` to support more organization relationship options, improving the accuracy of organization stages.
	- Updated `OrganizationStageCell` for a streamlined editing experience and clearer interaction cues.
	- Added conditional logic in `OrganizationRelationship` to better manage different relationship types.
  
- **UI Improvements**
	- Increased column sizes for better readability in the organization display layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->