### PR TITLE
(fix|COS-3301): Clear search when navigate between table views and store search value per preset so user can navigate back to searched table

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/RootSidenav.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/RootSidenav.tsx
@@ -59,13 +59,18 @@ export const RootSidenav = observer(() => {
   const [searchParams] = useSearchParams();
   const [_, setOrganizationsMeta] = useOrganizationsMeta();
   const showMyViewsItems = useFeatureIsOn('my-views-nav-item');
-
+  const preset = searchParams.get('preset');
+  const search = searchParams.get('search');
   const store = useStore();
 
   const [lastActivePosition, setLastActivePosition] = useLocalStorage(
     `customeros-player-last-position`,
     { root: 'organization' },
   );
+  const [lastSearchForPreset, setLastSearchForPreset] = useLocalStorage<{
+    [key: string]: string;
+  }>(`customeros-last-search-for-preset`, { root: 'root' });
+
   const [preferences, setPreferences] = useLocalStorage(
     'customeros-preferences',
     {
@@ -110,6 +115,13 @@ export const RootSidenav = observer(() => {
 
   const handleItemClick = (path: string) => {
     setLastActivePosition({ ...lastActivePosition, root: path });
+    if (preset) {
+      setLastSearchForPreset({
+        ...lastSearchForPreset,
+        [preset]: search ?? '',
+      });
+    }
+
     setOrganizationsMeta((prev) =>
       produce(prev, (draft) => {
         draft.getOrganization.pagination.page = 1;


### PR DESCRIPTION

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented local storage functionality to save and persist the last search for presets, enhancing user experience by retaining previous search terms.
	- Updated the search component to automatically populate the input field with the last search value if available.
	- Improved the `RootSidenav` component to dynamically manage and update search parameters in local storage based on user interactions. 

- **Bug Fixes**
	- Fixed logic to ensure search parameters are cleared or updated correctly based on preset changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->