### PR TITLE
Skip slack notification for same org

### DIFF
--- a/packages/runner/sync-tracking/service/tracking_service.go
+++ b/packages/runner/sync-tracking/service/tracking_service.go
@@ -575,7 +575,7 @@ func (s *trackingService) notifyOnSlack(c context.Context, r *entity.Tracking) e
 	}
 
 	//skip notification if the identified company domain is the same as the workspace domain in the tenant ( basically skip employees from triggering notifications)
-	if record.OrganizationDomain != nil && *record.OrganizationDomain == "" {
+	if record.OrganizationDomain != nil && *record.OrganizationDomain != "" {
 
 		workspaceNodeList, err := s.services.CommonServices.Neo4jRepositories.WorkspaceReadRepository.Get(ctx, record.Tenant)
 		if err != nil {
@@ -584,7 +584,9 @@ func (s *trackingService) notifyOnSlack(c context.Context, r *entity.Tracking) e
 		}
 
 		for _, workspaceNode := range workspaceNodeList {
-			if workspaceNode.Props["name"] == record.OrganizationDomain {
+			props := utils.GetPropsFromNode(*workspaceNode)
+			domainName := utils.GetStringPropOrEmpty(props, "name")
+			if domainName == *record.OrganizationDomain {
 				err := s.services.CommonServices.PostgresRepositories.TrackingRepository.MarkAsNotified(ctx, record.ID)
 				if err != nil {
 					tracing.TraceErr(span, err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected logic for sending notifications based on the organization domain, ensuring notifications are sent only when the domain is present and non-empty. 

- **Improvements**
	- Enhanced the process of retrieving organization domain information for better clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->