### PR TITLE
(fix|COS-4141): Fix and enhance command menu and archive modal functionality

### DIFF
--- a/packages/apps/frontera/src/routes/organizations/src/components/Actions/OrganizationActions.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Actions/OrganizationActions.tsx
@@ -18,13 +18,13 @@ import { TableIdType, OrganizationStage } from '@graphql/types';
 import { LinkedInSolid } from '@ui/media/icons/LinkedInSolid.tsx';
 import { ActionItem } from '@organizations/components/Actions/ActionItem.tsx';
 import { EditTagsModal } from '@organizations/components/Actions/components/EditTagsModal.tsx';
-import { ConfirmDeleteDialog } from '@ui/overlay/AlertDialog/ConfirmDeleteDialog/ConfirmDeleteDialog';
 
 interface TableActionsProps {
+  onHide: () => void;
   tableId?: TableIdType;
   focusedId?: string | null;
+  isCommandMenuOpen: boolean;
   onCreateContact: () => void;
-  onHide: (ids: string[]) => void;
   enableKeyboardShortcuts?: boolean;
   table: TableInstance<OrganizationStore>;
   onMerge: (primaryId: string, mergeIds: string[]) => void;
@@ -40,9 +40,8 @@ export const OrganizationTableActions = ({
   enableKeyboardShortcuts,
   onCreateContact,
   focusedId,
+  isCommandMenuOpen,
 }: TableActionsProps) => {
-  const { open: isOpen, onOpen, onClose } = useDisclosure();
-
   const {
     open: isTagEditOpen,
     onOpen: onOpenTagEdit,
@@ -61,12 +60,6 @@ export const OrganizationTableActions = ({
     if (!targetId || !mergeIds.length) return;
 
     onMerge(targetId, mergeIds);
-    clearSelection();
-  };
-
-  const handleHideOrganizations = () => {
-    onHide(selectedIds);
-    onClose();
     clearSelection();
   };
 
@@ -168,7 +161,7 @@ export const OrganizationTableActions = ({
 
   return (
     <>
-      {selectCount > 0 && (
+      {selectCount > 0 && !isCommandMenuOpen && (
         <ButtonGroup className='flex items-center translate-x-[-50%] justify-center bottom-[32px] *:border-none'>
           {selectCount && (
             <div className='bg-gray-700 px-3 py-2 rounded-s-lg'>
@@ -185,7 +178,7 @@ export const OrganizationTableActions = ({
           )}
 
           <ActionItem
-            onClick={onOpen}
+            onClick={onHide}
             dataTest='org-actions-archive'
             icon={<Archive className='text-inherit size-3' />}
           >
@@ -272,34 +265,11 @@ export const OrganizationTableActions = ({
         </ButtonGroup>
       )}
 
-      {/*<CreateContactFromLinkedInModal*/}
-      {/*  organizationId={targetId ?? ''}*/}
-      {/*  isOpen={isCreateContactModalOpen}*/}
-      {/*  onConfirm={createContactForOrganization}*/}
-      {/*  onClose={() => {*/}
-      {/*    onCloseCreateContactModal();*/}
-      {/*    setTargetId(null);*/}
-      {/*  }}*/}
-      {/*/>*/}
-
       <EditTagsModal
         isOpen={isTagEditOpen}
         onClose={onCloseTagEdit}
         selectedIds={selectedIds}
         clearSelection={clearSelection}
-      />
-
-      <ConfirmDeleteDialog
-        isOpen={isOpen}
-        onClose={onClose}
-        icon={<Archive />}
-        confirmButtonLabel={'Archive'}
-        loadingButtonLabel='Archiving'
-        onConfirm={handleHideOrganizations}
-        dataTest='org-actions-confirm-archive'
-        label={`Archive selected ${
-          selectCount === 1 ? 'organization' : 'organizations'
-        }?`}
       />
     </>
   );

--- a/packages/apps/frontera/src/routes/organizations/src/components/FinderTable/FinderTable.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/FinderTable/FinderTable.tsx
@@ -258,7 +258,7 @@ export const FinderTable = observer(({ isSidePanelOpen }: FinderTableProps) => {
         ids: selectedIds,
       });
     }
-  }, [selection]);
+  }, [selection, isCommandMenuPrompted]);
 
   useEffect(() => {
     store.ui.setSearchCount(data.length);
@@ -375,11 +375,15 @@ export const FinderTable = observer(({ isSidePanelOpen }: FinderTableProps) => {
             <OrganizationTableActions
               focusedId={focusedId}
               onCreateContact={createSocial}
-              onHide={store.organizations.hide}
               onMerge={store.organizations.merge}
               tableId={tableViewDef?.value.tableId}
+              isCommandMenuOpen={isCommandMenuPrompted}
               onUpdateStage={store.organizations.updateStage}
               table={table as TableInstance<OrganizationStore>}
+              onHide={() => {
+                store.ui.commandMenu.setOpen(true);
+                store.ui.commandMenu.setType('DeleteConfirmationModal');
+              }}
               enableKeyboardShortcuts={
                 !isEditing &&
                 !isFiltering &&

--- a/packages/apps/frontera/src/routes/organizations/src/components/Search/Search.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Search/Search.tsx
@@ -180,7 +180,7 @@ export const Search = observer(({ onClose, onOpen, open }: SearchProps) => {
               role='button'
               ref={floatingActionPropmterRef}
               onClick={() => inputRef.current?.focus()}
-              className='flex flex-row items-center gap-1 absolute top-[8px] cursor-text'
+              className='flex flex-row items-center gap-1 absolute top-[11px] cursor-text'
               style={{
                 left: `calc(${measureRef?.current?.offsetWidth ?? 0}px + 24px)`,
               }}

--- a/packages/apps/frontera/src/routes/organizations/src/components/SearchBarFilterData/SearchBarFilterData.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/SearchBarFilterData/SearchBarFilterData.tsx
@@ -80,9 +80,7 @@ export const SearchBarFilterData = observer(() => {
       <SearchSm className='size-5' />
       <div
         data-test={`search-${tableName}`}
-        className={
-          'font-medium flex items-center gap-1 break-keep w-max mb-[2px]'
-        }
+        className={'font-medium flex items-center gap-1 break-keep w-max '}
       >
         {totalResults}{' '}
         {appliedFilters?.length ? (

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import type { ReactElement } from 'react';
 
 import { useKey } from 'rooks';
@@ -6,6 +7,7 @@ import { CommandMenuType } from '@store/UI/CommandMenu.store';
 
 import { useStore } from '@shared/hooks/useStore';
 import { useModKey } from '@shared/hooks/useModKey';
+import { useOutsideClick } from '@ui/utils/hooks/useOutsideClick.ts';
 import {
   Modal,
   ModalBody,
@@ -58,8 +60,15 @@ const Commands: Record<CommandMenuType, ReactElement> = {
 
 export const CommandMenu = observer(() => {
   const store = useStore();
+  const commandRef = useRef(null);
+
+  useOutsideClick({
+    ref: commandRef,
+    handler: () => store.ui.commandMenu.setOpen(false),
+  });
 
   useKey('Escape', () => {
+    // store.ui.commandMenu.toggle(store.ui.commandMenu.type);
     store.ui.commandMenu.setOpen(false);
   });
   useModKey('k', () => {
@@ -75,7 +84,7 @@ export const CommandMenu = observer(() => {
         {/* z-[5001] is needed to ensure tooltips are not overlapping  - tooltips have zIndex of 5000 - this should be revisited */}
         <ModalOverlay className='z-[5001]'>
           <ModalBody>
-            <ModalContent>
+            <ModalContent ref={commandRef}>
               {Commands[store.ui.commandMenu.type ?? 'GlobalHub']}
             </ModalContent>
           </ModalBody>

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/OrganizationCommands.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/OrganizationCommands.tsx
@@ -12,6 +12,7 @@ import { CoinsStacked01 } from '@ui/media/icons/CoinsStacked01.tsx';
 import { OrganizationStage, OrganizationRelationship } from '@graphql/types';
 import { Command, CommandItem, CommandInput } from '@ui/overlay/CommandMenu';
 import { AlignHorizontalCentre02 } from '@ui/media/icons/AlignHorizontalCentre02';
+import { GlobalSharedCommands } from '@shared/components/CommandMenu/commands/GlobalHub.tsx';
 
 // TODO - uncomment keyboard shortcuts when they are implemented
 export const OrganizationCommands = observer(() => {
@@ -31,7 +32,7 @@ export const OrganizationCommands = observer(() => {
             store.ui.commandMenu.setType('AddContactViaLinkedInUrl');
           }}
         >
-          Add contact
+          Add contact via LinkedIn
         </CommandItem>
 
         <CommandItem
@@ -182,6 +183,9 @@ export const OrganizationCommands = observer(() => {
         {/*>*/}
         {/*  Change onboarding stage*/}
         {/*</CommandItem>*/}
+        <Command.Group heading='Navigate'>
+          <GlobalSharedCommands />
+        </Command.Group>
       </Command.List>
     </Command>
   );

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/organization/AddContactViaLinkedInUrl.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/organization/AddContactViaLinkedInUrl.tsx
@@ -78,13 +78,17 @@ export const AddContactViaLinkedInUrl = observer(() => {
           autoComplete='off'
           variant='unstyled'
           name='linkedin-input'
-          placeholder='Add contact'
+          placeholder='Add contact via LinkedIn'
           onChange={(e) => {
             setUrl(e.target.value);
           }}
           onKeyDown={(e) => {
             if (e.key === '/') {
               e.stopPropagation();
+            }
+
+            if (e.key === 'Backspace' && url.length === 1) {
+              setValidationError(false);
             }
           }}
         />

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/shared/AssignOwner.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/shared/AssignOwner.tsx
@@ -15,6 +15,9 @@ export const AssignOwner = observer(() => {
   const users = store.users.toArray();
 
   const entity = match(context.entity)
+    .returnType<
+      OpportunityStore | OrganizationStore | OrganizationStore[] | undefined
+    >()
     .with('Opportunity', () =>
       store.opportunities.value.get((context.ids as string[])?.[0]),
     )

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/shared/ChangeStage.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/shared/ChangeStage.tsx
@@ -31,19 +31,34 @@ export const ChangeStage = observer(() => {
     }));
 
   const entity = match(context.entity)
-    .returnType<OpportunityStore | OrganizationStore | undefined>()
+    .returnType<
+      OpportunityStore | OrganizationStore | OrganizationStore[] | undefined
+    >()
     .with('Opportunity', () =>
       store.opportunities.value.get(context.ids?.[0] as string),
     )
     .with('Organization', () =>
       store.organizations.value.get(context.ids?.[0] as string),
     )
+    .with(
+      'Organizations',
+      () =>
+        context.ids?.map((e: string) =>
+          store.organizations.value.get(e),
+        ) as OrganizationStore[],
+    )
     .otherwise(() => undefined);
 
   const label = match(context.entity)
-    .with('Organization', () => `Organization - ${entity?.value?.name}`)
+    .with(
+      'Organization',
+      () => `Organization - ${(entity as OrganizationStore)?.value?.name}`,
+    )
     .with('Organizations', () => `${context.ids?.length} organizations`)
-    .with('Opportunity', () => `Opportunity - ${entity?.value?.name}`)
+    .with(
+      'Opportunity',
+      () => `Opportunity - ${(entity as OpportunityStore)?.value?.name}`,
+    )
     .otherwise(() => '');
 
   const selectedStageOption = match(context.entity)

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/shared/DeleteConfirmationModal.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/shared/DeleteConfirmationModal.tsx
@@ -10,8 +10,9 @@ export const DeleteConfirmationModal = observer(() => {
   const store = useStore();
   const context = store.ui.commandMenu.context;
 
-  const handleClose = () =>
+  const handleClose = () => {
     store.ui.commandMenu.toggle('DeleteConfirmationModal');
+  };
 
   return (
     <Command label='Change Stage'>
@@ -48,7 +49,7 @@ export const DeleteConfirmationModal = observer(() => {
               handleClose();
             }}
           >
-            Delete
+            Archive
           </Button>
         </div>
       </article>

--- a/packages/apps/frontera/src/styles/cmdk.scss
+++ b/packages/apps/frontera/src/styles/cmdk.scss
@@ -7,7 +7,7 @@
 }
 
 [cmdk-list] {
-  @apply max-h-[470px]  overflow-y-auto overscroll-contain;
+  @apply max-h-[364px]  overflow-y-auto overscroll-contain;
 
   &:has([cmdk-item]) {
     @apply p-2.5


### PR DESCRIPTION
## Changes
- Clicking outside the command menu now dismisses it.
- Added navigation commands to the opportunity menu.
- Set the command menu's max height to 364px.
- Updated the Add contact label and placeholder copy to "Add contact via LinkedIn".
- Hide action bar when multiple rows are selected and the command bar is brought up.
- Fixed issue where changing stage and owner in bulk was unresponsive.
- Updated Archive modal primary button label to "Archive" instead of "Delete".
- Reverted to the original Archive confirmation copy for consistency.
- Implemented new confirmation modal when archiving from the action bar.
- Fixed issue where canceling an archive from the menu and reopening command menu still showed the archive modal.
- Cleared error messages and removed invalid text upon re-entry.



What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

