### PR TITLE
(feat|COS-4315): Save column sizing in table definition

### DIFF
--- a/packages/apps/frontera/src/routes/organizations/src/components/Columns/contacts/columns.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Columns/contacts/columns.tsx
@@ -560,7 +560,8 @@ const columns: Record<string, Column> = {
     'value.connectedUsers',
     {
       id: ColumnViewType.ContactsConnections,
-      size: 150,
+      minSize: 150,
+      maxSize: 600,
       enableColumnFilter: true,
       enableSorting: true,
 

--- a/packages/apps/frontera/src/routes/organizations/src/components/Columns/invoices/columns.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Columns/invoices/columns.tsx
@@ -240,6 +240,8 @@ const columns: Record<string, Column> = {
   INVOICES_PLACEHOLDER: columnHelper.accessor((row) => row, {
     id: 'PLACEHOLDER',
     size: 32,
+    minSize: 32,
+    maxSize: 32,
     fixWidth: true,
     header: () => <></>,
     cell: () => <></>,

--- a/packages/apps/frontera/src/routes/organizations/src/components/Columns/shared/util/getColumnConfig.ts
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Columns/shared/util/getColumnConfig.ts
@@ -17,7 +17,7 @@ export function getColumnConfig<Datum>(
     const column = {
       ...columns[columnTypeName],
       enableHiding: !curr.visible,
-      size: curr.visible ? columns[columnTypeName].size : 0,
+      size: curr.visible ? curr.width : 0,
       minSize: curr.visible ? columns[columnTypeName].minSize : 0,
     };
 

--- a/packages/apps/frontera/src/routes/organizations/src/components/FinderTable/FinderTable.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/FinderTable/FinderTable.tsx
@@ -6,8 +6,8 @@ import { inPlaceSort } from 'fast-sort';
 import { observer } from 'mobx-react-lite';
 import difference from 'lodash/difference';
 import intersection from 'lodash/intersection';
-import { ColumnDef } from '@tanstack/react-table';
 import { OnChangeFn } from '@tanstack/table-core';
+import { ColumnDef } from '@tanstack/react-table';
 import { InvoiceStore } from '@store/Invoices/Invoice.store';
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
 import { ContactStore } from '@store/Contacts/Contact.store.ts';
@@ -18,6 +18,7 @@ import { OrganizationStore } from '@store/Organizations/Organization.store.ts';
 
 import { useStore } from '@shared/hooks/useStore';
 import { Invoice, WorkflowType, TableViewType } from '@graphql/types';
+import { useColumnSizing } from '@organizations/hooks/useColumnSizing.ts';
 import { ConfirmDeleteDialog } from '@ui/overlay/AlertDialog/ConfirmDeleteDialog';
 import {
   Table,
@@ -106,6 +107,8 @@ export const FinderTable = observer(({ isSidePanelOpen }: FinderTableProps) => {
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '');
   };
+
+  const handleColumnSizing = useColumnSizing(tableColumns, tableViewDef);
 
   const organizationsData = store.organizations?.toComputedArray((arr) => {
     if (tableType !== TableViewType.Organizations) return arr;
@@ -507,6 +510,7 @@ export const FinderTable = observer(({ isSidePanelOpen }: FinderTableProps) => {
         getRowId={(row) => row.id}
         enableColumnResizing={true}
         onSortingChange={setSorting}
+        onResizeColumn={handleColumnSizing}
         onFocusedRowChange={handleSetFocused}
         onSelectedIndexChange={setSelectedIndex}
         isLoading={store.organizations.isLoading}

--- a/packages/apps/frontera/src/routes/organizations/src/hooks/useColumnSizing.ts
+++ b/packages/apps/frontera/src/routes/organizations/src/hooks/useColumnSizing.ts
@@ -1,0 +1,49 @@
+import { useMemo, useCallback } from 'react';
+
+import { ContactStore } from '@store/Contacts/Contact.store.ts';
+import { InvoiceStore } from '@store/Invoices/Invoice.store.ts';
+import { ContractStore } from '@store/Contracts/Contract.store.ts';
+import { ColumnDef, ColumnSizingState } from '@tanstack/react-table';
+import { OrganizationStore } from '@store/Organizations/Organization.store.ts';
+import { TableViewDefStore } from '@store/TableViewDefs/TableViewDef.store.ts';
+
+export const useColumnSizing = (
+  tableColumns: ColumnDef<
+    OrganizationStore | ContactStore | InvoiceStore | ContractStore
+  >[],
+  tableViewDef?: TableViewDefStore,
+) => {
+  const columnCache = useMemo(
+    () => new Map<string, { minSize?: number; maxSize?: number }>(),
+    [],
+  );
+
+  const handleColumnSizing = useCallback(
+    (
+      updater:
+        | ColumnSizingState
+        | ((prev: ColumnSizingState) => ColumnSizingState),
+    ) => {
+      const update = typeof updater === 'function' ? updater({}) : updater;
+      const [columnId, width] = Object.entries(update)[0];
+
+      let columnSettings = columnCache.get(columnId);
+
+      if (!columnSettings) {
+        columnSettings = tableColumns.find((e) => e.id === columnId) || {};
+        columnCache.set(columnId, columnSettings);
+      }
+
+      const { minSize, maxSize } = columnSettings;
+      const newWidth = Math.min(
+        Math.max(width, minSize || 0),
+        maxSize || Infinity,
+      );
+
+      tableViewDef?.setColumnSize(columnId, newWidth);
+    },
+    [tableColumns, columnCache, tableViewDef],
+  );
+
+  return handleColumnSizing;
+};

--- a/packages/apps/frontera/src/ui/presentation/Table/Table.tsx
+++ b/packages/apps/frontera/src/ui/presentation/Table/Table.tsx
@@ -3,6 +3,7 @@ import type {
   OnChangeFn,
   SortingState,
   RowSelectionState,
+  ColumnSizingState,
   ColumnFiltersState,
   Table as TableInstance,
 } from '@tanstack/react-table';
@@ -68,6 +69,7 @@ interface TableProps<T extends object> {
   onFullRowSelection?: (id?: string) => void;
   onSortingChange?: OnChangeFn<SortingState>;
   getRowId?: (row: T, index: number) => string;
+  onResizeColumn?: OnChangeFn<ColumnSizingState>;
   onSelectionChange?: OnChangeFn<RowSelectionState>;
   tableRef: MutableRefObject<TableInstance<T> | null>;
   onFocusedRowChange?: (index: number | null) => void;
@@ -102,6 +104,7 @@ export const Table = <T extends object>({
   onSelectedIndexChange,
   enableKeyboardShortcuts,
   enableColumnResizing = false,
+  onResizeColumn,
 }: TableProps<T>) => {
   const scrollElementRef = useRef<HTMLDivElement>(null);
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -132,6 +135,7 @@ export const Table = <T extends object>({
     onSortingChange: onSortingChange ?? setSorting,
     onRowSelectionChange: onSelectionChange ?? setSelection,
     columnResizeDirection: 'ltr',
+    onColumnSizingChange: onResizeColumn,
   });
 
   const { rows } = table.getRowModel();


### PR DESCRIPTION
## Changes
- Implement useColumnSizing custom hook for column resizing
- Create memoized column settings cache
- Add efficient width calculation with min/max constraints
- Integrate new sizing logic with existing tableViewDef store


What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

