### PR TITLE
(feat|COS-4446): Added ability to duplicate views as shared view

### DIFF
--- a/packages/apps/frontera/src/routes/organizations/src/components/TableViewMenu/TableViewMenu.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/TableViewMenu/TableViewMenu.tsx
@@ -1,3 +1,4 @@
+import { MouseEventHandler } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
@@ -27,15 +28,33 @@ export const TableViewMenu = observer(() => {
 
   const isPreset = tableViewDef?.value?.isPreset;
 
+  const handleAddToMyViews: MouseEventHandler<HTMLDivElement> = (e) => {
+    e.stopPropagation();
+
+    if (!preset) {
+      store.ui.toastError(
+        `We were unable to add this view to favorites`,
+        'dup-view-error',
+      );
+
+      return;
+    }
+    store.ui.commandMenu.toggle('DuplicateView');
+    store.ui.commandMenu.setContext({
+      ids: [preset],
+      entity: 'TableViewDef',
+    });
+  };
+
   return (
     <Menu>
       <MenuButton className='w-6 h-6 mr-2 outline-none focus:outline-none text-gray-400 hover:text-gray-500'>
         <DotsVertical />
       </MenuButton>
       <MenuList align='end' side='bottom'>
-        <MenuItem onClick={() => store.tableViewDefs.createFavorite(preset)}>
+        <MenuItem onClick={handleAddToMyViews}>
           <LayersTwo01 className='text-gray-500' />
-          Duplicate to My Views
+          Duplicate view...
         </MenuItem>
         {tableType !== TableViewType.Invoices && (
           <MenuItem className='py-1.5' onClick={downloadCSV}>

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
@@ -10,6 +10,7 @@ import { CommandMenuType } from '@store/UI/CommandMenu.store';
 import { useStore } from '@shared/hooks/useStore';
 import { useModKey } from '@shared/hooks/useModKey';
 import { useOutsideClick } from '@ui/utils/hooks/useOutsideClick';
+import { DuplicateView } from '@shared/components/CommandMenu/commands/tableViewDef/DuplicateView.tsx';
 import {
   Modal,
   ModalBody,
@@ -91,6 +92,7 @@ const Commands: Record<CommandMenuType, ReactElement> = {
   RenameOrganizationProperty: <RenameOrganizationProperty />,
   ChooseOpportunityOrganization: <ChooseOpportunityOrganization />,
   ContactEmailVerificationInfoModal: <ContactEmailVerificationInfoModal />,
+  DuplicateView: <DuplicateView />,
 };
 
 export const CommandMenu = observer(() => {

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/tableViewDef/DuplicateView.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/tableViewDef/DuplicateView.tsx
@@ -1,0 +1,119 @@
+import { useRef, useState, useEffect } from 'react';
+
+import { match } from 'ts-pattern';
+import { observer } from 'mobx-react-lite';
+
+import { Input } from '@ui/form/Input';
+import { TableViewType } from '@graphql/types';
+import { IconButton } from '@ui/form/IconButton';
+import { Command } from '@ui/overlay/CommandMenu';
+import { useStore } from '@shared/hooks/useStore';
+import { Radio, RadioGroup } from '@ui/form/Radio';
+import { Button } from '@ui/form/Button/Button.tsx';
+import { XClose } from '@ui/media/icons/XClose.tsx';
+
+export const DuplicateView = observer(() => {
+  const store = useStore();
+  const context = store.ui.commandMenu.context;
+  const [value, setValue] = useState<'my-view' | 'team-view'>('team-view');
+  const [name, setName] = useState<string>('');
+  const tableViewDef = store.tableViewDefs.getById(context.ids?.[0]);
+
+  const title = match(tableViewDef?.value?.tableType)
+    .with(TableViewType.Invoices, () => `${tableViewDef?.value.name} Invoices`)
+    .otherwise(() => tableViewDef?.value.name);
+
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleClose = () => {
+    store.ui.commandMenu.toggle('DuplicateView');
+    store.ui.commandMenu.clearCallback();
+  };
+
+  const handleConfirm = () => {
+    store.tableViewDefs.createFavorite({
+      id: store.ui.commandMenu.context.ids[0],
+      name,
+      isShared: value === 'team-view',
+    });
+    store.ui.commandMenu.toggle('DuplicateView');
+    store.ui.commandMenu.clearCallback();
+  };
+
+  useEffect(() => {
+    setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+  }, []);
+
+  return (
+    <Command>
+      <article className='relative w-full p-6 flex flex-col border-b border-b-gray-100'>
+        <div className='flex items-center justify-between'>
+          <h1 className='text-base font-semibold'>Duplicate {title}</h1>
+          <IconButton
+            size='xs'
+            variant='ghost'
+            icon={<XClose />}
+            aria-label='cancel'
+            onClick={handleClose}
+          />
+        </div>
+
+        <Input
+          value={name}
+          ref={inputRef}
+          className='my-4'
+          variant='unstyled'
+          placeholder='View name'
+          onChange={(e) => setName(e.target.value)}
+        />
+
+        <div>
+          <label className='text-sm'>
+            <div className='mb-2  font-medium'>Duplicate to...</div>
+            <RadioGroup
+              value={value}
+              name='last-touchpoint-date-before'
+              onValueChange={(val: 'my-view' | 'team-view') => setValue(val)}
+            >
+              <Radio value={'team-view'}>
+                <span className='text-sm'>Team views</span>
+              </Radio>
+              <Radio value={'my-view'}>
+                <span className='text-sm'>My views</span>
+              </Radio>
+            </RadioGroup>
+          </label>
+        </div>
+        <div className='flex justify-between gap-3 mt-6'>
+          <Button
+            size='sm'
+            variant='outline'
+            className='w-full'
+            onClick={handleClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            size='sm'
+            variant='outline'
+            className='w-full'
+            colorScheme='primary'
+            ref={confirmButtonRef}
+            onClick={handleConfirm}
+            data-test='org-actions-confirm-archive'
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleConfirm();
+              }
+            }}
+          >
+            Duplicate
+          </Button>
+        </div>
+      </article>
+    </Command>
+  );
+});

--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/components/EditableSidenavItem.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/components/EditableSidenavItem.tsx
@@ -1,4 +1,3 @@
-import { useSearchParams } from 'react-router-dom';
 import React, { useState, ReactElement, MouseEventHandler } from 'react';
 
 import { observer } from 'mobx-react-lite';
@@ -38,8 +37,6 @@ export const EditableSideNavItem = observer(
     id,
   }: EditableSideNavItemProps) => {
     const store = useStore();
-    const [searchParams] = useSearchParams();
-    const preset = searchParams.get('preset') ?? '1';
     const [isEditing, setIsEditing] = useState(false);
 
     const handleClick: MouseEventHandler = (e) => {
@@ -107,7 +104,12 @@ export const EditableSideNavItem = observer(
                 onClick={(e) => {
                   e.stopPropagation();
                   e.preventDefault();
-                  store.tableViewDefs.createFavorite(preset);
+                  store.ui.commandMenu.toggle('DuplicateView');
+                  store.ui.commandMenu.setContext({
+                    ids: [id],
+                    entity: 'TableViewDef',
+                  });
+                  // store.tableViewDefs.createFavorite(preset);
                   setIsEditing(false);
                 }}
               >

--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/components/RootSidenavItem.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/components/RootSidenavItem.tsx
@@ -53,7 +53,11 @@ export const RootSidenavItem = observer(
 
         return;
       }
-      store.tableViewDefs.createFavorite(id);
+      store.ui.commandMenu.toggle('DuplicateView');
+      store.ui.commandMenu.setContext({
+        ids: [id],
+        entity: 'TableViewDef',
+      });
     };
 
     return (
@@ -92,7 +96,7 @@ export const RootSidenavItem = observer(
             <MenuList align='end' side='bottom'>
               <MenuItem onClick={handleAddToMyViews}>
                 <LayersTwo01 className='text-gray-500' />
-                Duplicate to My Views
+                Duplicate view...
               </MenuItem>
             </MenuList>
           </Menu>

--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/NavigationSections.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/NavigationSections.tsx
@@ -2,6 +2,7 @@ import { cn } from '@ui/utils/cn.ts';
 import { Bubbles } from '@ui/media/icons/Bubbles';
 import { Preferences } from '@shared/components/RootSidenav/hooks';
 import { SidenavItem } from '@shared/components/RootSidenav/components/SidenavItem';
+import { TeamViewsSectionSection } from '@shared/components/RootSidenav/components/sections/TeamViewsSection.tsx';
 
 import { FavoritesSection } from './FavoritesSection';
 import { GeneralViewsSection } from './GeneralViewsSection';
@@ -39,8 +40,13 @@ export const NavigationSections = ({
           />
         )}
       />
-
       <LifecycleStagesSection
+        preferences={preferences}
+        checkIsActive={checkIsActive}
+        handleItemClick={handleItemClick}
+        togglePreference={togglePreference}
+      />
+      <TeamViewsSectionSection
         preferences={preferences}
         checkIsActive={checkIsActive}
         handleItemClick={handleItemClick}
@@ -52,7 +58,6 @@ export const NavigationSections = ({
         handleItemClick={handleItemClick}
         togglePreference={togglePreference}
       />
-
       <GeneralViewsSection
         preferences={preferences}
         checkIsActive={checkIsActive}

--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/TeamViewsSection.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/TeamViewsSection.tsx
@@ -10,7 +10,7 @@ import { EditableSideNavItem } from '@shared/components/RootSidenav/components/E
 
 import { CollapsibleSection } from '../CollapsibleSection';
 
-interface FavoritesSectionProps {
+interface TeamViewsSectionSectionProps {
   preferences: Preferences;
   handleItemClick: (data: string) => void;
   togglePreference: (data: keyof Preferences) => void;
@@ -20,31 +20,31 @@ interface FavoritesSectionProps {
   ) => boolean;
 }
 
-export const FavoritesSection = observer(
+export const TeamViewsSectionSection = observer(
   ({
     preferences,
     togglePreference,
     handleItemClick,
     checkIsActive,
-  }: FavoritesSectionProps) => {
+  }: TeamViewsSectionSectionProps) => {
     const store = useStore();
     const tableViewDefsList = store.tableViewDefs.toArray();
 
-    const favoritesView =
+    const teamViewsSectionView =
       tableViewDefsList
-        .filter((c) => !c.value.isPreset && !c.value.isShared)
+        .filter((c) => !c.value.isPreset && c.value.isShared)
         .sort((a, b) => a.value.order - b.value.order) ?? [];
 
-    if (!favoritesView.length) return null;
+    if (!teamViewsSectionView.length) return null;
 
     return (
       <CollapsibleSection
-        title='My views'
-        isOpen={preferences.isFavoritesOpen}
-        onToggle={() => togglePreference('isFavoritesOpen')}
+        title='Team views'
+        isOpen={preferences.isTeamViewsOpen}
+        onToggle={() => togglePreference('isTeamViewsOpen')}
       >
-        {preferences.isFavoritesOpen &&
-          favoritesView.map((view) => (
+        {preferences.isTeamViewsOpen &&
+          teamViewsSectionView.map((view) => (
             <EditableSideNavItem
               id={view.value.id}
               key={view.value.id}

--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/hooks/usePreferencesManager.ts
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/hooks/usePreferencesManager.ts
@@ -4,6 +4,7 @@ interface Preferences {
   isViewsOpen: boolean;
   isMyViewsOpen: boolean;
   isFavoritesOpen: boolean;
+  isTeamViewsOpen: boolean;
   isLifecycleViewsOpen: boolean;
 }
 
@@ -15,6 +16,7 @@ export const usePreferencesManager = () => {
       isMyViewsOpen: true,
       isViewsOpen: true,
       isFavoritesOpen: true,
+      isTeamViewsOpen: true,
     } as Preferences,
   );
 

--- a/packages/apps/frontera/src/store/TableViewDefs/TableViewDefs.store.ts
+++ b/packages/apps/frontera/src/store/TableViewDefs/TableViewDefs.store.ts
@@ -180,22 +180,33 @@ export class TableViewDefsStore implements GroupStore<TableViewDef> {
   }
 
   createFavorite = async (
-    favoritePresetId: string,
+    {
+      id,
+      isShared,
+      name,
+    }: {
+      id: string;
+      name?: string;
+      isShared: boolean;
+    },
     options?: { onSuccess?: (serverId: string) => void },
   ) => {
-    const favoritePreset = this.getById(favoritePresetId)?.getPayloadToCopy();
+    const favoritePreset = this.getById(id)?.getPayloadToCopy();
 
     const newTableViewDef = new TableViewDefStore(this.root, this.transport);
 
     newTableViewDef.value = {
       ...getDefaultValue(),
       ...favoritePreset,
-      name: `Copy of ${
-        favoritePreset?.tableType === TableViewType.Invoices
-          ? ` ${favoritePreset?.name} Invoices`
-          : favoritePreset?.name
-      }`,
+      name: name
+        ? name
+        : `Copy of ${
+            favoritePreset?.tableType === TableViewType.Invoices
+              ? ` ${favoritePreset?.name} Invoices`
+              : favoritePreset?.name
+          }`,
       isPreset: false,
+      isShared,
     };
 
     const { id: _id, createdAt, updatedAt, ...payload } = newTableViewDef.value;
@@ -237,7 +248,7 @@ export class TableViewDefsStore implements GroupStore<TableViewDef> {
         setTimeout(() => {
           this.invalidate();
           options?.onSuccess?.(serverId);
-        }, 1000);
+        }, 100);
       }
     }
   };

--- a/packages/apps/frontera/src/store/UI/CommandMenu.store.ts
+++ b/packages/apps/frontera/src/store/UI/CommandMenu.store.ts
@@ -34,6 +34,7 @@ export type CommandMenuType =
   | 'EditTimeZone'
   | 'RenameTableViewDef'
   | 'ContactEmailVerificationInfoModal'
+  | 'DuplicateView'
   | 'ContactBulkCommands';
 
 export type Context = {


### PR DESCRIPTION
- Update menu item from "Duplicate" to "Duplicate view..." in both the navigation and view dropdowns.
- Implement modal for "Duplicate view..." option with optional view name input.
- Default view name to "Copy of {{view-name}}" if no name is provided.
- Add new "Team views" section above "My views" in navigation.
- Rename "My Views" to "My views" (lowercase 'v').


