### PR TITLE
(fix|COS-4502): Add shortcut to archive tooltip + fix padding  & (fix|COS-4502): Fix: Pressing enter to submit a modal or ⌘ menu should not also select/unselect a row

### DIFF
--- a/packages/apps/frontera/src/routes/organizations/src/components/Actions/OrganizationActions.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Actions/OrganizationActions.tsx
@@ -9,6 +9,7 @@ import { Copy07 } from '@ui/media/icons/Copy07';
 import { Archive } from '@ui/media/icons/Archive';
 import { ButtonGroup } from '@ui/form/ButtonGroup';
 import { OrganizationStage } from '@graphql/types';
+import { Delete } from '@ui/media/icons/Delete.tsx';
 import { useModKey } from '@shared/hooks/useModKey';
 import { CommandKbd } from '@ui/overlay/CommandMenu';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
@@ -179,12 +180,12 @@ export const OrganizationTableActions = ({
         <ButtonGroup className='flex items-center translate-x-[-50%] justify-center bottom-[32px] *:border-none'>
           {selectCount && (
             <Tooltip
-              className='p-1 pl-2'
+              className='p-1.5'
               label={
                 <div className='flex items-center text-sm'>
                   Open command menu
                   <CommandKbd className='bg-gray-600 text-gray-25 mx-1' />
-                  <div className='bg-gray-600 text-xs h-5 w-5 rounded-sm flex justify-center items-center'>
+                  <div className='bg-gray-600 text-xs min-h-5 min-w-5 rounded-sm flex justify-center items-center'>
                     K
                   </div>
                 </div>
@@ -206,15 +207,26 @@ export const OrganizationTableActions = ({
 
           <ActionItem
             onClick={onHide}
-            tooltip='Archive'
             dataTest='org-actions-archive'
             icon={<Archive className='text-inherit size-3' />}
+            tooltip={
+              <div className='flex gap-1'>
+                <span className='text-sm'>Archive</span>
+                <div className='bg-gray-600  min-h-5 min-w-5 rounded flex justify-center items-center'>
+                  {isUserPlatformMac() ? '⌘' : 'Ctrl'}
+                </div>
+                <div className='bg-gray-600  min-h-5 min-w-5 rounded flex justify-center items-center'>
+                  <Delete className='text-inherit' />
+                </div>
+              </div>
+            }
           >
             Archive
           </ActionItem>
           {selectCount > 1 && (
             <ActionItem
               onClick={handleMergeOrganizations}
+              tooltip={<span className='text-sm'>Merge</span>}
               icon={<Copy07 className='text-inherit size-3' />}
             >
               Merge
@@ -224,7 +236,7 @@ export const OrganizationTableActions = ({
             onClick={onOpenCommandK}
             dataTest='org-actions-commandk'
             icon={
-              <span className='text-inherit'>
+              <span className='text-inherit w-auto h-auto'>
                 {isUserPlatformMac() ? '⌘' : 'Ctrl'}
               </span>
             }

--- a/packages/apps/frontera/src/routes/organizations/src/components/Actions/components/ActionItem.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Actions/components/ActionItem.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 
-import { cn } from '@ui/utils/cn';
 import { Button } from '@ui/form/Button/Button';
 import { CommandKbd } from '@ui/overlay/CommandMenu';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
 
 interface ActionItemProps {
-  tooltip?: string;
   dataTest?: string;
   onClick: () => void;
-  shortcutKey?: string;
   icon: React.ReactElement;
+  tooltip?: React.ReactNode;
   children: React.ReactNode;
 }
 
@@ -19,31 +17,20 @@ export const ActionItem = ({
   onClick,
   dataTest,
   tooltip,
-  shortcutKey,
   children,
 }: ActionItemProps) => {
   return (
     <Tooltip
-      className=''
+      className='p-1.5'
       label={
         tooltip ? (
-          <div className='flex items-center text-sm'>
-            {tooltip}
-            <span
-              className={cn(
-                'bg-gray-600 text-xs rounded-sm leading-[1.125rem]',
-                shortcutKey && 'pl-2',
-              )}
-            >
-              {shortcutKey}
-            </span>
-          </div>
+          tooltip
         ) : (
           <>
             <div className='flex items-center text-sm'>
               Open command menu
               <CommandKbd className='bg-gray-600 text-gray-25 mx-1' />
-              <div className='bg-gray-600 text-xs h-5 w-5 rounded-sm flex justify-center items-center'>
+              <div className='bg-gray-600 text-xs min-h-5 min-w-5 rounded flex justify-center items-center'>
                 K
               </div>
             </div>

--- a/packages/apps/frontera/src/routes/organizations/src/components/Actions/components/SharedActions.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Actions/components/SharedActions.tsx
@@ -3,6 +3,7 @@ import { CommandMenuType } from '@store/UI/CommandMenu.store.ts';
 
 import { X } from '@ui/media/icons/X.tsx';
 import { ButtonGroup } from '@ui/form/ButtonGroup';
+import { Delete } from '@ui/media/icons/Delete.tsx';
 import { Archive } from '@ui/media/icons/Archive.tsx';
 import { TableInstance } from '@ui/presentation/Table';
 import { isUserPlatformMac } from '@utils/getUserPlatform.ts';
@@ -46,10 +47,20 @@ export const SharedTableActions = ({
         )}
 
         <ActionItem
-          tooltip='Archive'
           onClick={() => onHide()}
           dataTest='contacts-actions-archive'
           icon={<Archive className='text-inherit size-3' />}
+          tooltip={
+            <div className='flex gap-1'>
+              <span className='text-sm'>Archive</span>
+              <div className='bg-gray-600  min-h-5 min-w-5 rounded flex justify-center items-center'>
+                {isUserPlatformMac() ? '⌘' : 'Ctrl'}
+              </div>
+              <div className='bg-gray-600  min-h-5 min-w-5 rounded flex justify-center items-center'>
+                <Delete className='text-inherit' />
+              </div>
+            </div>
+          }
         >
           Archive
         </ActionItem>
@@ -57,7 +68,7 @@ export const SharedTableActions = ({
           onClick={onOpenCommandK}
           dataTest='org-actions-commandk'
           icon={
-            <span className='text-inherit'>
+            <span className='text-inherit w-auto h-auto'>
               {isUserPlatformMac() ? '⌘' : 'Ctrl'}
             </span>
           }

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/opportunity/SetOpportunityNextSteps.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/opportunity/SetOpportunityNextSteps.tsx
@@ -23,6 +23,8 @@ export const SetOpportunityNextSteps = observer(() => {
     .otherwise(() => 'Change ARR estimate');
 
   const handleEnterKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+
     if (e.key === 'Enter' && e.metaKey) {
       opportunity?.update((o) => {
         const plainTextValue = value;

--- a/packages/apps/frontera/src/store/UI/CommandMenu.store.ts
+++ b/packages/apps/frontera/src/store/UI/CommandMenu.store.ts
@@ -78,8 +78,15 @@ export class CommandMenuStore {
     },
   ) {
     runInAction(() => {
-      this.isOpen = open;
-      this.type = options?.type ?? this.type;
+      setTimeout(() => {
+        /**
+         * Note: The 10ms timeout prevents event propagation issues
+         * with CMDK's onSelect handler, avoiding conflicts between
+         * the menu and its parent components (e.g., tables).
+         */
+        this.isOpen = open;
+        this.type = options?.type ?? this.type;
+      }, 10);
     });
   }
 
@@ -91,12 +98,19 @@ export class CommandMenuStore {
 
   toggle(type?: CommandMenuType, context?: Context) {
     runInAction(() => {
-      this.isOpen = !this.isOpen;
-      this.type = type ?? 'GlobalHub';
+      /**
+       * Note: The 10ms timeout prevents event propagation issues
+       * with CMDK's onSelect handler, avoiding conflicts between
+       * the menu and its parent components (e.g., tables).
+       */
+      setTimeout(() => {
+        this.isOpen = !this.isOpen;
+        this.type = type ?? 'GlobalHub';
 
-      if (context) {
-        Object.assign(this.context, context);
-      }
+        if (context) {
+          Object.assign(this.context, context);
+        }
+      }, 10);
     });
   }
 


### PR DESCRIPTION
## Proposed changes
- (fix|COS-4502): Add shortcut to archive tooltip + fix padding 
- (fix|COS-4502): Fix: Pressing enter to submit a modal or ⌘ menu should not also select/unselect a row
  -  Add 10ms delay to prevent conflicts with parent components
  -  Update comment explaining the workaround for CMDK limitations
## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

