### PR TITLE
(fix|COS-4588): Update Move to sequence functionality and add new keywords

### DIFF
--- a/packages/apps/frontera/src/routes/organizations/src/components/Actions/ContactActions.tsx
+++ b/packages/apps/frontera/src/routes/organizations/src/components/Actions/ContactActions.tsx
@@ -73,6 +73,16 @@ export const ContactTableActions = ({
     },
     { when: enableKeyboardShortcuts && (selectCount === 1 || !!focusedId) },
   );
+
+  useKeys(
+    ['Shift', 'Q'],
+    (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      handleOpen('EditContactSequence');
+    },
+    { when: enableKeyboardShortcuts },
+  );
   useKeyBindings(
     {
       Escape: clearSelection,

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/ContactBulkCommands.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/ContactBulkCommands.tsx
@@ -7,6 +7,7 @@ import { useStore } from '@shared/hooks/useStore';
 import { Archive } from '@ui/media/icons/Archive';
 import { Shuffle01 } from '@ui/media/icons/Shuffle01.tsx';
 import { Certificate02 } from '@ui/media/icons/Certificate02';
+import { ArrowBlockUp } from '@ui/media/icons/ArrowBlockUp.tsx';
 import { Kbd, CommandKbd, CommandItem } from '@ui/overlay/CommandMenu';
 
 import { CommandsContainer } from './shared';
@@ -32,11 +33,20 @@ export const ContactBulkCommands = observer(() => {
 
         <CommandItem
           leftAccessory={<Shuffle01 />}
+          keywords={contactKeywords.move_to_sequence}
           onSelect={() => {
             store.ui.commandMenu.setType('EditContactSequence');
           }}
+          rightAccessory={
+            <>
+              <Kbd>
+                <ArrowBlockUp className='text-inherit size-3' />
+              </Kbd>
+              <Kbd>Q</Kbd>
+            </>
+          }
         >
-          Move to sequence
+          Move to sequence...
         </CommandItem>
         <CommandItem
           leftAccessory={<Certificate02 />}
@@ -68,6 +78,7 @@ export const ContactBulkCommands = observer(() => {
         {contactStores.some((contact) => contact?.sequence !== undefined) && (
           <CommandItem
             leftAccessory={<Shuffle01 />}
+            keywords={contactKeywords.remove_from_sequence}
             onSelect={() => {
               store.ui.commandMenu.setType('UnlinkContactFromSequence');
             }}
@@ -131,4 +142,6 @@ const contactKeywords = {
     'mobile',
     'telephone',
   ],
+  move_to_sequence: ['move', 'to', 'sequence', 'edit', 'change', 'campaign'],
+  remove_from_sequence: ['remove', 'sequence', 'delete', 'campaign'],
 };

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/ContactCommands.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/ContactCommands.tsx
@@ -45,11 +45,20 @@ export const ContactCommands = observer(() => {
 
         <CommandItem
           leftAccessory={<Shuffle01 />}
+          keywords={contactKeywords.move_to_sequence}
           onSelect={() => {
             store.ui.commandMenu.setType('EditContactSequence');
           }}
+          rightAccessory={
+            <>
+              <Kbd>
+                <ArrowBlockUp className='text-inherit size-3' />
+              </Kbd>
+              <Kbd>Q</Kbd>
+            </>
+          }
         >
-          Move to sequence
+          Move to sequence...
         </CommandItem>
 
         {!!contact?.value?.tags?.length && (
@@ -154,6 +163,7 @@ export const ContactCommands = observer(() => {
         {contact?.sequence?.value?.name !== undefined && (
           <CommandItem
             leftAccessory={<Shuffle01 />}
+            keywords={contactKeywords.remove_from_sequence}
             onSelect={() => {
               store.ui.commandMenu.setType('UnlinkContactFromSequence');
             }}
@@ -217,4 +227,6 @@ const contactKeywords = {
     'label',
     'profile',
   ],
+  move_to_sequence: ['move', 'to', 'sequence', 'edit', 'change', 'campaign'],
+  remove_from_sequence: ['remove', 'sequence', 'delete', 'campaign'],
 };

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/EditContactSequence.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/EditContactSequence.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 
 import { observer } from 'mobx-react-lite';
-import { ContactStore } from '@store/Contacts/Contact.store.ts';
+import { ContactStore } from '@store/Contacts/Contact.store';
 import { FlowSequenceStore } from '@store/Sequences/FlowSequence.store';
 
+import { Plus } from '@ui/media/icons/Plus';
 import { Check } from '@ui/media/icons/Check';
 import { useStore } from '@shared/hooks/useStore';
 import { useModKey } from '@shared/hooks/useModKey';
@@ -74,17 +75,41 @@ export const EditContactSequence = observer(() => {
 
   const sequenceOptions = flowSequences.toComputedArray((arr) => arr);
 
+  const handleCreateOption = (value: string) => {
+    flowSequences?.create(
+      { name: value, description: '' },
+      {
+        onSuccess: (sequenceId) => {
+          const newSequence = flowSequences.value.get(
+            sequenceId,
+          ) as FlowSequenceStore;
+
+          if (!newSequence) return;
+          handleSelect(newSequence);
+        },
+      },
+    );
+  };
+  const filteredOptions = sequenceOptions?.filter((sequence) =>
+    sequence.value.name.toLowerCase().includes(search.toLowerCase()),
+  );
+
   return (
-    <Command label='Change or add to sequence'>
+    <Command shouldFilter={false} label='Move to sequence...'>
       <CommandInput
         label={label}
         value={search}
         onValueChange={setSearch}
-        placeholder='Change or add to sequence'
+        placeholder='Move to sequence...'
+        onKeyDownCapture={(e) => {
+          if (e.key === ' ') {
+            e.stopPropagation();
+          }
+        }}
       />
 
       <Command.List>
-        {sequenceOptions.map((flowSequence) => {
+        {filteredOptions.map((flowSequence) => {
           const isSelected =
             context.ids?.length === 1 &&
             contact?.sequence?.id === flowSequence.id;
@@ -101,6 +126,16 @@ export const EditContactSequence = observer(() => {
             </CommandItem>
           );
         })}
+
+        {search && (
+          <CommandItem
+            leftAccessory={<Plus />}
+            onSelect={() => handleCreateOption(search)}
+          >
+            <span className='text-gray-700 ml-1'>Create new sequence:</span>
+            <span className='text-gray-500 ml-1'>{search}</span>
+          </CommandItem>
+        )}
       </Command.List>
     </Command>
   );


### PR DESCRIPTION

## Changes
- Changed command menu option text to "Move to sequence..."
- Updated placeholder text for the list menu to reflect "Move to sequence..."
- Added ability to create a new sequence from the list when the searched sequence doesn't exist (similar behavior to the tag command)
- Added shortcut ⇧ Q for the "Move to sequence..." command
- Added keywords for "Move to sequence..." (move, to, sequence, edit, change, campaign)
- Added keywords for "Remove from sequence" (remove, sequence, delete, campaign)



What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

