### PR TITLE
COS-4778: Flow builder related ui changes

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
@@ -1,23 +1,17 @@
 import { useEffect } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 
-import { Button } from '@ui/form/Button/Button.tsx';
-// import { Users01 } from '@ui/media/icons/Users01.tsx';
-// import { PieChart03 } from '@ui/media/icons/PieChart03.tsx';
-// import { Dataflow03 } from '@ui/media/icons/Dataflow03.tsx';
-import { ChevronRight } from '@ui/media/icons/ChevronRight.tsx';
-// import { Tag, TagLabel, TagLeftIcon } from '@ui/presentation/Tag';
-
 import { observer } from 'mobx-react-lite';
 import { useReactFlow } from '@xyflow/react';
 import { FlowStore } from '@store/Flows/Flow.store.ts';
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
 
 import { cn } from '@ui/utils/cn';
-import { Check } from '@ui/media/icons/Check.tsx';
 import { useStore } from '@shared/hooks/useStore';
+import { Button } from '@ui/form/Button/Button.tsx';
 import { User01 } from '@ui/media/icons/User01.tsx';
 import { ViewSettings } from '@shared/components/ViewSettings';
+import { ChevronRight } from '@ui/media/icons/ChevronRight.tsx';
 import { TableViewType } from '@shared/types/__generated__/graphql.types';
 
 import { FlowStatusMenu } from './components';
@@ -58,7 +52,7 @@ export const Header = observer(() => {
 
   return (
     <div>
-      <div className='bg-white pl-3 pr-4 h-10 border-b flex items-center justify-between'>
+      <div className='bg-white px-4 h-14 border-b flex items-center text-base font-bold justify-between'>
         <div className='flex items-center'>
           <div className='flex items-center gap-1 font-medium'>
             <span
@@ -107,18 +101,17 @@ export const Header = observer(() => {
           <ViewSettings type={TableViewType.Contacts} />
         ) : (
           <div className='flex gap-2'>
-            <FlowStatusMenu id={id} />
             {saveFlag && (
               <Button
                 size='xs'
                 variant='outline'
                 colorScheme='gray'
                 onClick={handleSave}
-                leftIcon={<Check />}
               >
                 Save
               </Button>
             )}
+            <FlowStatusMenu id={id} />
           </div>
         )}
       </div>

--- a/packages/apps/frontera/src/routes/flow-editor/src/edges/StepViewportPortal.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/edges/StepViewportPortal.tsx
@@ -24,7 +24,7 @@ export const StepViewportPortal = observer(
             <div
               style={{
                 transform: `translate(calc(${positionAbsoluteX}px - 50%), ${
-                  positionAbsoluteY + 15
+                  positionAbsoluteY + 24 // 24 is desired spacing between dropdown and button
                 }px)`,
                 position: 'absolute',
                 pointerEvents: 'all',

--- a/packages/apps/frontera/src/routes/flow-editor/src/hooks/useLayoutedElements.ts
+++ b/packages/apps/frontera/src/routes/flow-editor/src/hooks/useLayoutedElements.ts
@@ -69,33 +69,33 @@ export const getNodeWidth = (node: Node) => {
   if (node.type === 'trigger') {
     return {
       width: 300,
-      height: 56,
+      height: 48,
     };
   }
 
   if (node.type === 'control') {
     return {
       width: 131,
-      height: 56,
+      height: 48,
     };
   }
 
   if (node.type === 'wait') {
     return {
       width: 150,
-      height: 56,
+      height: 48,
     };
   }
 
   if (node.type === 'action') {
     return {
       width: 300,
-      height: 56,
+      height: 48,
     };
   }
 
   return {
     width: 200,
-    height: 75,
+    height: 48,
   };
 };

--- a/packages/apps/frontera/src/routes/flow-editor/src/nodes/ActionNode.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/nodes/ActionNode.tsx
@@ -71,10 +71,10 @@ export const ActionNode = ({
       <div
         className={`aspect-[9/1] max-w-[300px] bg-white border border-grayModern-300 p-3 rounded-lg group cursor-pointer`}
       >
-        <div className='truncate  text-sm flex items-center '>
+        <div className='text-sm flex items-center justify-between '>
           <div className='truncate text-sm flex items-center'>
             <div
-              className={`size-6 mr-2 bg-${color}-50 text-${color}-500 border border-${color}-100  rounded flex items-center justify-center`}
+              className={`size-6 min-w-6 mr-2 bg-${color}-50 text-${color}-500 border border-${color}-100  rounded flex items-center justify-center`}
             >
               {iconMap?.[data.action]}
             </div>
@@ -93,7 +93,7 @@ export const ActionNode = ({
           </div>
 
           <IconButton
-            size='xs'
+            size='xxs'
             variant='ghost'
             aria-label='Edit'
             icon={<Edit03 />}

--- a/packages/apps/frontera/src/routes/flow-editor/src/nodes/TriggerNode.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/nodes/TriggerNode.tsx
@@ -12,10 +12,6 @@ import { Lightning01 } from '@ui/media/icons/Lightning01.tsx';
 import { Handle } from '../components';
 import { DropdownCommandMenu } from '../commands/Commands.tsx';
 
-// const triggerEventMapper: Record<string, string> = {
-//   RecordAddedManually: 'added manually',
-// };
-
 export const TriggerNode = (
   props: NodeProps & { data: Record<string, string> },
 ) => {
@@ -34,13 +30,9 @@ export const TriggerNode = (
   return (
     <>
       <div
-        className={`aspect-[9/1] h-[56px] w-[300px] bg-white border border-grayModern-300 p-3 rounded-lg group relative cursor-pointer`}
+        className={`aspect-[9/1] w-[300px] bg-white border border-grayModern-300 p-3 rounded-lg group relative cursor-pointer`}
       >
-        {/*<div className='flex items-center text-gray-400 uppercase text-xs mb-1 absolute top-[-20px]'>*/}
-        {/*  Trigger*/}
-        {/*</div>*/}
-
-        <div className='truncate  text-sm flex items-center justify-between '>
+        <div className='flex items-center justify-between '>
           <div className='truncate text-sm flex items-center'>
             <div className='size-6 mr-2 bg-gray-50 border border-gray-100 rounded flex items-center justify-center'>
               {props.data.entity && props.data?.triggerType ? (
@@ -65,7 +57,7 @@ export const TriggerNode = (
           </div>
 
           <IconButton
-            size='xs'
+            size='xxs'
             variant='ghost'
             aria-label='Edit'
             icon={<Edit03 />}
@@ -104,7 +96,7 @@ export const TriggerViewportPortal = observer(
             <div
               style={{
                 transform: `translate(calc(${positionAbsoluteX}px + 150px - 180px), ${
-                  positionAbsoluteY + 70
+                  positionAbsoluteY + 48 + 24 // 48 is height of the node, 24 is desired spacing
                 }px)`,
                 position: 'absolute',
                 pointerEvents: 'all',

--- a/packages/apps/frontera/src/routes/flow-editor/src/nodes/WaitNode.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/nodes/WaitNode.tsx
@@ -56,47 +56,50 @@ export const WaitNode = ({
 
   return (
     <div
-      className={`h-[56px] w-[150px] bg-white border border-grayModern-300 p-3 rounded-lg group cursor-pointer`}
+      className={`w-[150px] bg-white border border-grayModern-300 p-3 rounded-lg group cursor-pointer`}
     >
-      <div className='truncate  text-sm flex items-center '>
-        <div
-          className={`size-6 min-w-6 mr-2 bg-gray-50 text-gray-500 border-gray-100  rounded flex items-center justify-center`}
-        >
-          <Hourglass02 />
-        </div>
+      <div className='truncate text-sm flex items-center justify-between'>
+        <div className='flex items-center'>
+          <div
+            className={`size-6 min-w-6 mr-2 bg-gray-50 text-gray-500 border-gray-100  rounded flex items-center justify-center`}
+          >
+            <Hourglass02 />
+          </div>
 
-        {isFocused ? (
-          <div className='flex mr-1 items-baseline'>
-            <ResizableInput
-              min={0}
-              size='xs'
-              autoFocus
-              step={0.5}
-              type='number'
-              variant='unstyled'
-              value={data.waitDuration || 0}
-              onFocus={(e) => e.target.select()}
-              className=' min-w-2.5 min-h-0 max-h-4'
-              onChange={(e) => handleDurationChange(e.target.value)}
-            />
-            <span className='ml-1'>
+          {isFocused ? (
+            <div className='flex mr-1 items-baseline'>
+              <ResizableInput
+                min={0}
+                size='xs'
+                autoFocus
+                step={0.5}
+                type='number'
+                variant='unstyled'
+                value={data.waitDuration || 0}
+                onFocus={(e) => e.target.select()}
+                className=' min-w-2.5 min-h-0 max-h-4'
+                onChange={(e) => handleDurationChange(e.target.value)}
+              />
+              <span className='ml-1'>
+                {data.waitDuration === 1 ? 'day' : 'days'}
+              </span>
+            </div>
+          ) : (
+            <span className='truncate'>
+              {data.waitDuration || 0}{' '}
               {data.waitDuration === 1 ? 'day' : 'days'}
             </span>
-          </div>
-        ) : (
-          <span className='truncate'>
-            {data.waitDuration || 0} {data.waitDuration === 1 ? 'day' : 'days'}
-          </span>
-        )}
+          )}
+        </div>
 
         <IconButton
-          size='xs'
+          size='xxs'
           variant='ghost'
           aria-label='Edit'
           icon={<Edit03 />}
           onClick={() => setFocused(!isFocused)}
           className={cn(
-            'ml-2 w-0 group-hover:w-auto opacity-0 group-hover:opacity-100 pointer-events-all',
+            'ml-2  opacity-0 group-hover:opacity-100 pointer-events-all',
             {
               'opacity-0 group-hover:opacity-0': isFocused,
             },


### PR DESCRIPTION
Remove spacing on the right of the buttons to the top

- The email node icon get's squashed when the subject line is long

- Reduce the padding to the left of the Flow breadcrumb with 16px

- Save buttons should be to the left of Start flow and no icon

- Spacing between the node and dropdown menu should be 24px

- Padding to the left of the node icon should be the same as top/bottom padding

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

