### PR TITLE
COS-4819: Reply to email step changes

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/edges/StepViewportPortal.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/edges/StepViewportPortal.tsx
@@ -22,7 +22,7 @@ export const StepViewportPortal = observer(
         {ui.flowCommandMenu?.isOpen && id === ui.flowCommandMenu.context.id && (
           <ViewportPortal>
             <div
-              className='border border-gray-200 rounded-lg shadow-lg'
+              className='border border-gray-200 rounded-lg shadow-lg cursor-default'
               style={{
                 transform: `translate(calc(${positionAbsoluteX}px - 50%), ${
                   positionAbsoluteY + 24 // 24 is desired spacing between dropdown and button

--- a/packages/apps/frontera/src/routes/src/components/SplashScreen/SplashScreen.tsx
+++ b/packages/apps/frontera/src/routes/src/components/SplashScreen/SplashScreen.tsx
@@ -15,6 +15,7 @@ const privatePaths = [
   '/organization/',
   '/settings',
   '/invoices',
+  '/flow-editor',
   '/renewals',
   '/customer-map',
 ];


### PR DESCRIPTION
- The Reply to email step should only show when you have already added an email
- When you add this step, and go into the editor, the Subject line should contain the subject line of the previous email formatted like RE: {{previous-email-subject}}



What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

