### PR TITLE
feat(COS-4905): Perform node action on double click

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
@@ -36,7 +36,7 @@ export const FlowBuilder = observer(
 
     const flow = store.flows.value.get(id) as FlowStore;
 
-    const [nodes, _setNodes, onNodesChange] = useNodesState(flow?.parsedNodes);
+    const [nodes, setNodes, onNodesChange] = useNodesState(flow?.parsedNodes);
     const [edges, setEdges, onEdgesChange] = useEdgesState(flow?.parsedEdges);
 
     // const { screenToFlowPosition } = useReactFlow();
@@ -58,10 +58,8 @@ export const FlowBuilder = observer(
               data: edgeData,
               markerEnd: {
                 type: MarkerType.Arrow,
-                width: 12,
-                height: 12,
-                strokeWidth: 2,
-                color: '#D0D5DD',
+                width: 20,
+                height: 20,
               },
             },
             eds,
@@ -229,6 +227,30 @@ export const FlowBuilder = observer(
               )
             ) {
               onHasNewChanges();
+            }
+          }}
+          onNodeDoubleClick={(_event, node) => {
+            if (node.type === 'wait' || node.type === 'action') {
+              setNodes((nds) =>
+                nds.map((n) =>
+                  n.id === node.id
+                    ? { ...n, data: { ...n.data, isEditing: true } }
+                    : n,
+                ),
+              );
+
+              return;
+            }
+
+            if (node.type === 'trigger') {
+              ui.flowCommandMenu.setOpen(true);
+              ui.flowCommandMenu.setType('TriggersHub');
+              ui.flowCommandMenu.setContext({
+                id: node.id,
+                entity: 'Trigger',
+              });
+
+              return;
             }
           }}
         >

--- a/packages/apps/frontera/src/routes/flow-editor/src/commands/action/StepsHub.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/commands/action/StepsHub.tsx
@@ -105,7 +105,11 @@ export const StepsHub = observer(() => {
       source: ui.flowCommandMenu.context.meta?.source,
       target: newNode.id,
       type: 'baseEdge',
-      markerEnd: { type: MarkerType.Arrow },
+      markerEnd: {
+        type: MarkerType.Arrow,
+        width: 20,
+        height: 20,
+      },
     };
 
     const edgeFromNewNode = {
@@ -113,7 +117,11 @@ export const StepsHub = observer(() => {
       source: newNode.id,
       target: ui.flowCommandMenu.context.meta?.target,
       type: 'baseEdge',
-      markerEnd: { type: MarkerType.Arrow },
+      markerEnd: {
+        type: MarkerType.Arrow,
+        width: 20,
+        height: 20,
+      },
     };
 
     const updatedEdges = edges.filter(

--- a/packages/apps/frontera/src/routes/flow-editor/src/nodes/ActionNode.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/nodes/ActionNode.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, ReactElement } from 'react';
+import { useMemo, ReactElement } from 'react';
 
 import { htmlToText } from 'html-to-text';
 import { FlowActionType } from '@store/Flows/types.ts';
@@ -27,11 +27,11 @@ export const ActionNode = ({
 }: NodeProps & {
   data: {
     subject: string;
+    isEditing?: boolean;
     bodyTemplate: string;
     action: FlowActionType;
   };
 }) => {
-  const [isEditorOpen, setIsEditorOpen] = useState(false);
   const { setNodes } = useReactFlow();
 
   const color = colorMap?.[data.action];
@@ -52,6 +52,7 @@ export const ActionNode = ({
               ...node.data,
               subject,
               bodyTemplate,
+              isEditing: false,
             },
           };
         }
@@ -75,6 +76,16 @@ export const ActionNode = ({
     () => htmlToText(data?.bodyTemplate).trim(),
     [data?.bodyTemplate],
   );
+
+  const toggleEditing = () => {
+    setNodes((nds) =>
+      nds.map((node) =>
+        node.id === id
+          ? { ...node, data: { ...node.data, isEditing: true } }
+          : node,
+      ),
+    );
+  };
 
   return (
     <>
@@ -107,15 +118,23 @@ export const ActionNode = ({
             variant='ghost'
             aria-label='Edit'
             icon={<Edit03 />}
-            onClick={() => setIsEditorOpen(true)}
+            onClick={toggleEditing}
             className='ml-2 opacity-0 group-hover:opacity-100 pointer-events-all'
           />
         </div>
         <EmailEditorModal
           data={data}
-          isEditorOpen={isEditorOpen}
-          setIsEditorOpen={setIsEditorOpen}
+          isEditorOpen={data.isEditing || false}
           handleEmailDataChange={handleEmailDataChange}
+          setIsEditorOpen={(isOpen: boolean) => {
+            setNodes((nds) =>
+              nds.map((node) =>
+                node.id === id
+                  ? { ...node, data: { ...node.data, isEditing: isOpen } }
+                  : node,
+              ),
+            );
+          }}
         />
         <Handle type='target' />
         <Handle type='source' />

--- a/packages/apps/frontera/src/routes/flow-editor/src/nodes/WaitNode.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/nodes/WaitNode.tsx
@@ -1,21 +1,21 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 
-import { NodeProps, useReactFlow } from '@xyflow/react';
+import { NodeProps, useNodesData, useReactFlow } from '@xyflow/react';
 
-import { cn } from '@ui/utils/cn.ts';
+import { cn } from '@ui/utils/cn';
 import { ResizableInput } from '@ui/form/Input';
+import { Edit03 } from '@ui/media/icons/Edit03';
 import { IconButton } from '@ui/form/IconButton';
-import { Edit03 } from '@ui/media/icons/Edit03.tsx';
-import { Hourglass02 } from '@ui/media/icons/Hourglass02.tsx';
+import { Hourglass02 } from '@ui/media/icons/Hourglass02';
 
 import { Handle } from '../components';
 
 export const WaitNode = ({
   id,
   data,
-}: NodeProps & { data: Record<string, string | number> }) => {
-  const [isFocused, setFocused] = useState(false);
+}: NodeProps & { data: Record<string, string | number | boolean> }) => {
   const { setNodes, getNode } = useReactFlow();
+  const nodeData = useNodesData(id);
 
   const handleDurationChange = (newValue: string) => {
     setNodes((nds) => {
@@ -53,24 +53,35 @@ export const WaitNode = ({
   };
 
   const selected = getNode(id)?.selected;
+  const isEditing = nodeData?.data?.isEditing;
 
   useEffect(() => {
-    if (isFocused && !selected) {
-      setFocused(false);
+    if (isEditing && !selected) {
+      setNodes((nds) =>
+        nds.map((n) =>
+          n.id === id ? { ...n, data: { ...n.data, isEditing: false } } : n,
+        ),
+      );
     }
-  }, [selected]);
+  }, [selected, id, setNodes, isEditing]);
+
+  const toggleEditing = () => {
+    setNodes((nds) =>
+      nds.map((n) =>
+        n.id === id ? { ...n, data: { ...n.data, isEditing: true } } : n,
+      ),
+    );
+  };
 
   return (
-    <div
-      className={`w-[150px] bg-white border border-grayModern-300 p-3 rounded-lg group cursor-pointer`}
-    >
+    <div className='w-[150px] bg-white border border-grayModern-300 p-3 rounded-lg group cursor-pointer'>
       <div className='truncate text-sm flex items-center justify-between'>
         <div className='flex items-center'>
           <div className='size-6 mr-2 bg-gray-50 border border-gray-100 rounded flex items-center justify-center'>
             <Hourglass02 className='text-gray-500' />
           </div>
 
-          {isFocused ? (
+          {isEditing ? (
             <div className='flex mr-1 items-baseline'>
               <ResizableInput
                 min={0}
@@ -80,9 +91,9 @@ export const WaitNode = ({
                 type='number'
                 placeholder={'0'}
                 variant='unstyled'
-                value={data.waitDuration || ''}
                 onFocus={(e) => e.target.select()}
-                className=' min-w-2.5 min-h-0 max-h-4'
+                className='min-w-2.5 min-h-0 max-h-4'
+                value={data?.waitDuration?.toString() || ''}
                 onChange={(e) => handleDurationChange(e.target.value)}
               />
               <span className='ml-1'>
@@ -102,11 +113,11 @@ export const WaitNode = ({
           variant='ghost'
           aria-label='Edit'
           icon={<Edit03 />}
-          onClick={() => setFocused(true)}
+          onClick={toggleEditing}
           className={cn(
-            'ml-2  opacity-0 group-hover:opacity-100 pointer-events-all',
+            'ml-2 opacity-0 group-hover:opacity-100 pointer-events-all',
             {
-              'opacity-0 group-hover:opacity-0': isFocused,
+              'opacity-0 group-hover:opacity-0': isEditing,
             },
           )}
         />


### PR DESCRIPTION
Refactor WaitNode and ActionNode to use node data for editing state

- Replace local isEditorOpen/isFocused state with isEditing flag in node data
- Update WaitNode to toggle and respond to isEditing flag
- Modify ActionNode to use isEditing for EmailEditorModal visibility
- Adjust event handlers to update node data instead of local state
- Ensure consistent state management across flow components

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

