### PR TITLE
(COS-4925): Editor tweaks

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/components/EmailEditorModal.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/EmailEditorModal.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useRef, useMemo, useState, useEffect } from 'react';
 
 import { observer } from 'mobx-react-lite';
 import { FlowActionType } from '@store/Flows/types.ts';
@@ -35,6 +35,8 @@ export const EmailEditorModal = observer(
     data,
   }: EmailEditorModalProps) => {
     const id = useParams().id as string;
+    const inputRef = useRef<HTMLInputElement>(null);
+
     const [subject, setSubject] = useState(data?.subject ?? '');
     const [bodyTemplate, setBodyTemplate] = useState(data?.bodyTemplate ?? '');
 
@@ -42,6 +44,15 @@ export const EmailEditorModal = observer(
       if (isEditorOpen) {
         setSubject(data?.subject ?? '');
         setBodyTemplate(data?.bodyTemplate ?? '');
+
+        if (
+          data.action !== FlowActionType.EMAIL_REPLY &&
+          data?.subject?.trim()?.length === 0
+        ) {
+          setTimeout(() => {
+            inputRef.current?.focus();
+          }, 0);
+        }
       }
     }, [isEditorOpen]);
 
@@ -85,11 +96,11 @@ export const EmailEditorModal = observer(
                 </div>
 
                 <Input
-                  size='lg'
+                  ref={inputRef}
                   value={subject}
                   variant='unstyled'
                   placeholder='Subject'
-                  className='font-medium text-lg'
+                  className='font-medium text-lg min-h-[auto]'
                   onChange={(e) => setSubject(e.target.value)}
                   disabled={data.action === FlowActionType.EMAIL_REPLY}
                 />

--- a/packages/apps/frontera/src/ui/form/Editor/Editor.tsx
+++ b/packages/apps/frontera/src/ui/form/Editor/Editor.tsx
@@ -178,7 +178,10 @@ export const Editor = forwardRef<LexicalEditor | null, EditorProps>(
     }, []);
 
     return (
-      <div className='relative w-full h-full lexical-editor'>
+      <div
+        onClick={() => editor.current?.focus()}
+        className='relative w-full h-full lexical-editor cursor-text'
+      >
         <LexicalComposer initialConfig={initialConfig}>
           <EditorRefPlugin editorRef={editor} />
           <CheckListPlugin />


### PR DESCRIPTION
- Focus subject field by default when empty
- Show text cursor on hover over empty body
- Reduce spacing between Subject and body by 16px
- Close text editor bar when clicking outside or pressing Escape Add 4px padding between text editor bar buttons
- Add tooltips with shortcuts on hover
- Add format text shortcuts

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

