### PR TITLE
COS-5616: Hyperlinks in email editor style changes

### DIFF
--- a/packages/apps/frontera/src/styles/globals.scss
+++ b/packages/apps/frontera/src/styles/globals.scss
@@ -406,3 +406,9 @@
 .editor__nestedListItem {
   list-style: none;
 }
+
+.editor-link {
+  color: #0000EE;
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/packages/apps/frontera/src/ui/form/Editor/Editor.tsx
+++ b/packages/apps/frontera/src/ui/form/Editor/Editor.tsx
@@ -71,6 +71,7 @@ const theme: EditorThemeClasses = {
     listitemChecked: 'editor__listItemChecked',
     listitemUnchecked: 'editor__listItemUnchecked',
   },
+  link: 'editor-link',
   text: {
     bold: 'editor-textBold',
     code: 'editor-textCode',


### PR DESCRIPTION
- Hyperlink text in email editor should be default blue
- Show hand cursor on hover

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context

