### PR TITLE
COS-5718: Show a tooltip on the count badge when the app is bootstrapped

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
@@ -14,6 +14,7 @@ import { User01 } from '@ui/media/icons/User01';
 import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
 import { Settings03 } from '@ui/media/icons/Settings03';
+import { Tooltip } from '@ui/overlay/Tooltip/Tooltip.tsx';
 import { ChevronRight } from '@ui/media/icons/ChevronRight';
 import { ViewSettings } from '@shared/components/ViewSettings';
 import {
@@ -140,27 +141,35 @@ export const Header = observer(
                   </span>
                 </>
               ) : (
-                <Button
-                  size='xxs'
-                  className='ml-2'
-                  variant='outline'
-                  colorScheme='gray'
-                  leftIcon={<User01 />}
-                  dataTest='flow-contacts'
-                  isLoading={contactsStore.isLoading || store.flows.isLoading}
-                  onClick={() => {
-                    navigate(`?show=finder&preset=${flowContactsPreset}`);
-                  }}
-                  leftSpinner={
-                    <Spinner
-                      size='sm'
-                      label='adding'
-                      className='text-gray-300 fill-gray-400'
-                    />
+                <Tooltip
+                  label={
+                    contactsStore.isLoading || store.flows.isLoading
+                      ? `We're loading your contacts`
+                      : ''
                   }
                 >
-                  {flow?.value?.contacts?.length}
-                </Button>
+                  <Button
+                    size='xxs'
+                    className='ml-2'
+                    variant='outline'
+                    colorScheme='gray'
+                    leftIcon={<User01 />}
+                    dataTest='flow-contacts'
+                    isLoading={contactsStore.isLoading || store.flows.isLoading}
+                    onClick={() => {
+                      navigate(`?show=finder&preset=${flowContactsPreset}`);
+                    }}
+                    leftSpinner={
+                      <Spinner
+                        size='sm'
+                        label='adding'
+                        className='text-gray-300 fill-gray-400'
+                      />
+                    }
+                  >
+                    {flow?.value?.contacts?.length}
+                  </Button>
+                </Tooltip>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a tooltip to the contact count button in `Header.tsx` to indicate loading status.
> 
>   - **Behavior**:
>     - Adds a `Tooltip` to the contact count `Button` in `Header.tsx`.
>     - Tooltip shows "We're loading your contacts" when `contactsStore.isLoading` or `store.flows.isLoading` is true.
>   - **Components**:
>     - Wraps `Button` with `Tooltip` in `Header.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 733bbf81073c9b870df84c6cb10ec3b547ece064. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->