### PR TITLE
COS-5710: Fix setting initial subject and bodyTemplate in flows email

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailEditorModal.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailEditorModal.tsx
@@ -59,7 +59,7 @@ export const EmailEditorModal = observer(
           }, 0);
         }
       }
-    }, [isEditorOpen, data]);
+    }, [isEditorOpen, data.subject, data.bodyTemplate]);
 
     const flow = store.flows.value.get(id)?.value?.name;
     const placeholder = useMemo(() => getRandomEmailPrompt(), [isEditorOpen]);

--- a/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailEditorModal.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailEditorModal.tsx
@@ -59,7 +59,7 @@ export const EmailEditorModal = observer(
           }, 0);
         }
       }
-    }, [isEditorOpen, data.subject, data.bodyTemplate]);
+    }, [isEditorOpen, data.subject, data.bodyTemplate, data.action]);
 
     const flow = store.flows.value.get(id)?.value?.name;
     const placeholder = useMemo(() => getRandomEmailPrompt(), [isEditorOpen]);


### PR DESCRIPTION
… 

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `useEffect` dependencies in `EmailEditorModal` to ensure correct initial subject and body template values.
> 
>   - **Bugfix**:
>     - Fix `useEffect` dependency array in `EmailEditorModal` to include `data.subject` and `data.bodyTemplate`, ensuring correct initial values when modal opens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 915b3953846d2ce581a45bc7cc95aae45d5a862b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->