### PR TITLE
COS-5723: Use beforeunload to ensure saved changes aren’t lost on refresh or tab close

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
@@ -76,6 +76,22 @@ export const Header = observer(
       }
     });
 
+    useEffect(() => {
+      const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+        if (hasChanges) {
+          event.preventDefault();
+
+          return 'You have unsaved changes. If you leave this page, your changes will be lost.';
+        }
+      };
+
+      window.addEventListener('beforeunload', handleBeforeUnload);
+
+      return () => {
+        window.removeEventListener('beforeunload', handleBeforeUnload);
+      };
+    }, [hasChanges]);
+
     const handleSave = () => {
       const nodes = getNodes();
       const edges = getEdges();


### PR DESCRIPTION
…
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `beforeunload` event listener in `Header.tsx` to warn users of unsaved changes on refresh or tab close.
> 
>   - **Behavior**:
>     - Adds `beforeunload` event listener in `Header.tsx` to warn users of unsaved changes on refresh or tab close.
>     - Displays message: 'You have unsaved changes. If you leave this page, your changes will be lost.'
>   - **Functions**:
>     - `useEffect` in `Header.tsx` manages the `beforeunload` event listener based on `hasChanges` state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 783301a4c7387cb7cd03e82175f3b85cc4d8f0fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->