### PR TITLE
COS-5712: Only show the Save button if there are unsaved changes

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
@@ -281,7 +281,10 @@ export const FlowBuilder = observer(
               e.type === 'add' || e.type === 'remove' || e.type === 'replace',
           )
         ) {
-          onHasNewChanges();
+          // avoid setting new changes flag  to true on nodes init
+          if (nodes.length !== changes.length) {
+            onHasNewChanges();
+          }
         }
 
         // Check if we need to open the side panel

--- a/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
@@ -81,7 +81,7 @@ export const Header = observer(
         if (hasChanges) {
           event.preventDefault();
 
-          return 'You have unsaved changes. If you leave this page, your changes will be lost.';
+          return `The changes you've made may not be saved`;
         }
       };
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Show 'Save' button only when there are unsaved changes and update unsaved changes warning in `FlowBuilder.tsx` and `Header.tsx`.
> 
>   - **Behavior**:
>     - In `FlowBuilder.tsx`, modify `onNodesChangeHandler` to only call `onHasNewChanges()` if `nodes.length !== changes.length`.
>     - In `Header.tsx`, update `handleBeforeUnload` to warn about unsaved changes with a new message.
>   - **UI**:
>     - In `Header.tsx`, conditionally render 'Save changes' button based on `canSave` which checks `hasChanges` and `status`.
>   - **Misc**:
>     - Update warning message in `Header.tsx` to "The changes you've made may not be saved".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2896bc0ea37418de9a6476445bc99817eb345a3c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->