### PR TITLE
COS-5725: Show validation modals before starting a flow:

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/page.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/page.tsx
@@ -28,8 +28,9 @@ export const FlowEditor = () => {
       <div className='flex h-full flex-col'>
         <Header
           hasChanges={hasNewChanges}
+          isSidePanelOpen={isSidePanelOpen}
           onToggleHasChanges={setHasNewChanges}
-          onToggleSidePanel={() => setIsSidePanelOpen(!isSidePanelOpen)}
+          onToggleSidePanel={setIsSidePanelOpen}
         />
         <FlowContent
           showSidePanel={isSidePanelOpen}

--- a/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
@@ -31,9 +31,11 @@ export const Header = observer(
     hasChanges,
     onToggleHasChanges,
     onToggleSidePanel,
+    isSidePanelOpen,
   }: {
     hasChanges: boolean;
-    onToggleSidePanel: () => void;
+    isSidePanelOpen: boolean;
+    onToggleSidePanel: (status: boolean) => void;
     onToggleHasChanges: (status: boolean) => void;
   }) => {
     const id = useParams().id as string;
@@ -81,7 +83,7 @@ export const Header = observer(
         if (hasChanges) {
           event.preventDefault();
 
-          return `The changes you've made may not be saved`;
+          return `The changes you've made will NOT BE SAVED`;
         }
       };
 
@@ -202,14 +204,17 @@ export const Header = observer(
                 Save changes
               </Button>
             )}
-            <FlowStatusMenu id={id} />
+            <FlowStatusMenu
+              id={id}
+              handleOpenSettingsPanel={() => onToggleSidePanel(true)}
+            />
             <IconButton
               size='xs'
               variant='ghost'
               icon={<Settings03 />}
-              onClick={onToggleSidePanel}
               aria-label={'Toggle Settings'}
               dataTest={'flow-toggle-settings'}
+              onClick={() => onToggleSidePanel(!isSidePanelOpen)}
             />
           </div>
         </div>

--- a/packages/apps/frontera/src/routes/flow-editor/src/components/FlowStatusMenu.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/FlowStatusMenu.tsx
@@ -95,7 +95,7 @@ export const FlowStatusMenu = observer(
       ) {
         showValidationMessage(ValidationMessage.NO_MAILBOXES, true);
 
-        return;
+        return true;
       }
 
       if (

--- a/packages/apps/frontera/src/routes/flow-editor/src/components/FlowStatusMenu.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/FlowStatusMenu.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
 import { observer } from 'mobx-react-lite';
+import { useReactFlow } from '@xyflow/react';
+import { FlowActionType } from '@store/Flows/types.ts';
 
 import { cn } from '@ui/utils/cn.ts';
 import { FlowStatus } from '@graphql/types';
@@ -16,85 +18,207 @@ import { Menu, MenuItem, MenuList, MenuButton } from '@ui/overlay/Menu/Menu';
 
 interface FlowStatusMenuSelectProps {
   id: string;
+  handleOpenSettingsPanel: () => void;
 }
 
-export const FlowStatusMenu = observer(({ id }: FlowStatusMenuSelectProps) => {
-  const store = useStore();
+export const FlowStatusMenu = observer(
+  ({ id, handleOpenSettingsPanel }: FlowStatusMenuSelectProps) => {
+    const store = useStore();
 
-  const flow = store.flows.value.get(id);
-  const status = flow?.value.status;
+    const flow = store.flows.value.get(id);
+    const status = flow?.value.status;
+    const { getNodes } = useReactFlow();
 
-  if (status !== FlowStatus.Active) {
-    return (
-      <Tooltip
-        label={
-          status === FlowStatus.Scheduling
-            ? 'We’re scheduling this flow’s contacts'
-            : ''
-        }
-      >
-        <div>
-          <Button
-            size='xs'
-            variant='outline'
-            leftIcon={<Play />}
-            dataTest='start-flow'
-            loadingText='Scheduling...'
-            isLoading={status === FlowStatus.Scheduling}
-            colorScheme={status === FlowStatus.Scheduling ? 'gray' : 'primary'}
-            onClick={() => {
-              store.ui.commandMenu.toggle('StartFlow');
-            }}
-            className={cn({
-              'text-gray-500 pointer-events-none':
-                status === FlowStatus.Scheduling,
-            })}
-            leftSpinner={
-              <Spinner
-                size='sm'
-                label='Scheduling'
-                className='text-gray-500 fill-gray-200'
-              />
-            }
-          >
-            Start flow
-          </Button>
-        </div>
-      </Tooltip>
-    );
-  }
+    const showValidationMessage = (
+      meta: (typeof ValidationMessage)[keyof typeof ValidationMessage],
+      openSettings = false,
+    ) => {
+      if (openSettings) {
+        store.ui.commandMenu.setCallback(handleOpenSettingsPanel);
+      }
+      store.ui.commandMenu.toggle('FlowValidationMessage', {
+        ...store.ui.commandMenu.context,
+        meta,
+      });
+    };
 
-  return (
-    <>
-      <Menu>
-        <MenuButton
-          className='text-success-500 h-full'
-          data-test='flow-editor-status-change-button'
+    const handleFlowValidation = () => {
+      const steps = getNodes();
+      const hasOnlyControlSteps = steps.every(
+        (step) => step.type === 'trigger' || step.type === 'control',
+      );
+
+      const hasEmailSteps = steps.some(
+        (e) => e.data.action === FlowActionType.EMAIL_NEW,
+      );
+      const hasLinkedInSteps = steps.some(
+        (e) => e.data.action === FlowActionType.LINKEDIN_CONNECTION_REQUEST,
+      );
+
+      if (hasOnlyControlSteps) {
+        showValidationMessage(ValidationMessage.NO_STEPS);
+
+        return true;
+      }
+
+      if (!flow?.value.senders.length) {
+        showValidationMessage(ValidationMessage.NO_SENDERS, true);
+
+        return true;
+      }
+      const senders = flow.value.senders
+        .map(
+          (sender) =>
+            sender.user?.id && store.users.value.get(sender.user.id)?.value,
+        )
+        .filter(Boolean);
+
+      if (
+        hasEmailSteps &&
+        hasLinkedInSteps &&
+        senders.every(
+          (sender) =>
+            !sender || !sender?.mailboxes.length || !sender?.hasLinkedInToken,
+        )
+      ) {
+        showValidationMessage(
+          ValidationMessage.NO_MAILBOXES_AND_LINKEDIN,
+          true,
+        );
+
+        return true;
+      }
+
+      if (
+        hasEmailSteps &&
+        senders.every((sender) => !sender || !sender?.mailboxes.length)
+      ) {
+        showValidationMessage(ValidationMessage.NO_MAILBOXES, true);
+
+        return;
+      }
+
+      if (
+        hasLinkedInSteps &&
+        senders.every((sender) => !sender || !sender?.hasLinkedInToken)
+      ) {
+        showValidationMessage(ValidationMessage.NO_LINKEDIN, true);
+
+        return true;
+      }
+
+      return false;
+    };
+
+    const handleStartFlow = () => {
+      const hasErrors = handleFlowValidation();
+
+      if (hasErrors) return;
+
+      store.ui.commandMenu.toggle('StartFlow');
+    };
+
+    if (status !== FlowStatus.Active) {
+      return (
+        <Tooltip
+          label={
+            status === FlowStatus.Scheduling
+              ? 'We’re scheduling this flow’s contacts'
+              : ''
+          }
         >
-          <Tag
-            variant='outline'
-            colorScheme='success'
-            className='h-full rounded-md px-2 py-1'
+          <div>
+            <Button
+              size='xs'
+              variant='outline'
+              leftIcon={<Play />}
+              dataTest='start-flow'
+              onClick={handleStartFlow}
+              loadingText='Scheduling...'
+              isLoading={status === FlowStatus.Scheduling}
+              colorScheme={
+                status === FlowStatus.Scheduling ? 'gray' : 'primary'
+              }
+              className={cn({
+                'text-gray-500 pointer-events-none':
+                  status === FlowStatus.Scheduling,
+              })}
+              leftSpinner={
+                <Spinner
+                  size='sm'
+                  label='Scheduling'
+                  className='text-gray-500 fill-gray-200'
+                />
+              }
+            >
+              Start flow
+            </Button>
+          </div>
+        </Tooltip>
+      );
+    }
+
+    return (
+      <>
+        <Menu>
+          <MenuButton
+            className='text-success-500 h-full'
+            data-test='flow-editor-status-change-button'
           >
-            <TagLeftIcon>
-              <div>
-                <DotLive className='text-success-500 mr-1 [&>*:nth-child(1)]:fill-success-200 [&>*:nth-child(1)]:stroke-success-300 [&>*:nth-child(2)]:fill-success-600 ' />
-              </div>
-            </TagLeftIcon>
-            <TagLabel className='text-success-500'>Live</TagLabel>
-          </Tag>
-        </MenuButton>
-        <MenuList align='end' side='bottom' className='p-0 z-[11]'>
-          <MenuItem
-            className='flex items-center '
-            data-test='stop-flow-menu-button'
-            onClick={() => store.ui.commandMenu.toggle('StopFlow')}
-          >
-            <StopCircle className='mr-1 text-gray-500' />
-            Stop flow...
-          </MenuItem>
-        </MenuList>
-      </Menu>
-    </>
-  );
-});
+            <Tag
+              variant='outline'
+              colorScheme='success'
+              className='h-full rounded-md px-2 py-1'
+            >
+              <TagLeftIcon>
+                <div>
+                  <DotLive className='text-success-500 mr-1 [&>*:nth-child(1)]:fill-success-200 [&>*:nth-child(1)]:stroke-success-300 [&>*:nth-child(2)]:fill-success-600 ' />
+                </div>
+              </TagLeftIcon>
+              <TagLabel className='text-success-500'>Live</TagLabel>
+            </Tag>
+          </MenuButton>
+          <MenuList align='end' side='bottom' className='p-0 z-[11]'>
+            <MenuItem
+              className='flex items-center '
+              data-test='stop-flow-menu-button'
+              onClick={() => store.ui.commandMenu.toggle('StopFlow')}
+            >
+              <StopCircle className='mr-1 text-gray-500' />
+              Stop flow...
+            </MenuItem>
+          </MenuList>
+        </Menu>
+      </>
+    );
+  },
+);
+const ValidationMessage = {
+  NO_STEPS: {
+    title: 'Add at least one step',
+    description: 'To start this flow, add at least one step to it',
+    buttonText: 'Got it',
+  },
+  NO_SENDERS: {
+    title: 'Add a sender first',
+    description: 'To start this flow, add at least one sender to it',
+    buttonText: 'Go to flow settings',
+  },
+  NO_MAILBOXES_AND_LINKEDIN: {
+    title: 'Add mailboxes and the LinkedIn extension',
+    description:
+      'To start this flow, add some mailboxes and the CustomerOS LinkedIn browser extension to a sender.',
+    buttonText: 'Go to flow settings',
+  },
+  NO_MAILBOXES: {
+    title: 'Add some mailboxes first',
+    description: 'To start this flow, add some mailboxes to a sender',
+    buttonText: 'Go to flow settings',
+  },
+  NO_LINKEDIN: {
+    title: 'Add the LinkedIn browser extension first',
+    description:
+      'To start this flow, add the CustomerOS LinkedIn browser extension to a sender',
+    buttonText: 'Go to flow settings',
+  },
+};

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
@@ -59,6 +59,7 @@ import {
   ChangeBulkArrEstimate,
   UnlinkContactFromFlow,
   ConfirmSingleFlowEdit,
+  FlowValidationMessage,
   ChooseOpportunityStage,
   MergeConfirmationModal,
   SetOpportunityNextSteps,
@@ -131,6 +132,7 @@ const Commands: Record<CommandMenuType, ReactElement> = {
   RenameFlow: <RenameFlow />,
   ChangeFlowStatus: <ChangeFlowStatus />,
   EditContactFlow: <EditContactFlow />,
+  FlowValidationMessage: <FlowValidationMessage />,
   GetBrowserExtensionLink: <GetBrowserExtensionLink />,
   InstallLinkedInExtension: <InstallLinkedInExtension />,
 

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/FlowValidationMessage.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/FlowValidationMessage.tsx
@@ -1,0 +1,59 @@
+import React, { useRef } from 'react';
+
+import { observer } from 'mobx-react-lite';
+
+import { Button } from '@ui/form/Button/Button';
+import { useStore } from '@shared/hooks/useStore';
+import { Command, CommandCancelIconButton } from '@ui/overlay/CommandMenu';
+
+export const FlowValidationMessage = observer(() => {
+  const store = useStore();
+  const context = store.ui.commandMenu.context;
+
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+
+  const handleClose = () => {
+    store.ui.commandMenu.setOpen(false);
+    store.ui.commandMenu.setContext({
+      ...context,
+      meta: undefined,
+    });
+    store.ui.commandMenu.clearCallback();
+  };
+
+  const handleConfirm = () => {
+    context.callback?.();
+    handleClose();
+  };
+
+  return (
+    <Command>
+      <article className='relative w-full p-6 flex flex-col border-b border-b-gray-100'>
+        <div className='flex items-center justify-between'>
+          <h1 className='text-base font-semibold'>{context.meta?.title}</h1>
+          <CommandCancelIconButton onClose={handleClose} />
+        </div>
+
+        <p className='text-sm mt-2'>{context.meta?.description}</p>
+        <div className='flex justify-between gap-3 mt-6'>
+          <Button
+            size='sm'
+            variant='outline'
+            className='w-full'
+            colorScheme='primary'
+            ref={confirmButtonRef}
+            onClick={handleConfirm}
+            data-test='flow-validation-message-close-button'
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleConfirm();
+              }
+            }}
+          >
+            {context.meta?.buttonText}
+          </Button>
+        </div>
+      </article>
+    </Command>
+  );
+});

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/index.ts
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/index.ts
@@ -5,3 +5,4 @@ export * from './RenameFlow.tsx';
 export * from './ChangeFlowStatus';
 export * from './GetBrowserExtensionLink';
 export * from './InstallLinkedInExtension';
+export * from './FlowValidationMessage';

--- a/packages/apps/frontera/src/store/UI/CommandMenu.store.ts
+++ b/packages/apps/frontera/src/store/UI/CommandMenu.store.ts
@@ -51,6 +51,7 @@ export type CommandMenuType =
   | 'ConfirmSingleFlowEdit'
   | 'GetBrowserExtensionLink'
   | 'InstallLinkedInExtension'
+  | 'FlowValidationMessage'
   | 'ContactBulkCommands';
 
 export type Context = {


### PR DESCRIPTION
Added validation for:
- No steps were added
- No senders were added
- No mailboxes were added for a sender
- No LinkedIn extension were added for a sender
- No mailboxes and LinkedIn extension were added for a sender


What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add validation modals to ensure required elements are present before starting a flow, integrating `FlowValidationMessage` into the command menu.
> 
>   - **Validation Modals**:
>     - Added `FlowValidationMessage` component to display validation messages before starting a flow.
>     - Handles cases where no steps, senders, mailboxes, or LinkedIn extensions are added.
>   - **Command Menu**:
>     - Integrated `FlowValidationMessage` into `CommandMenu` in `CommandMenu.tsx`.
>     - Updated `CommandMenuType` in `CommandMenu.store.ts` to include `FlowValidationMessage`.
>   - **Header and Flow Editor**:
>     - Modified `Header.tsx` to handle side panel toggling with validation.
>     - Updated `page.tsx` to pass `isSidePanelOpen` state to `Header`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3d6e513177e3f08e4929f8c78da484e63fe11af8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->