### PR TITLE
COS-5714: Show busy state on the create flow modal button and close modal only after id is returned

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/CreateNewFlow.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/CreateNewFlow.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { useDidMount } from 'rooks';
 import { observer } from 'mobx-react-lite';
 
 import { Input } from '@ui/form/Input';
@@ -15,29 +14,23 @@ import {
 
 export const CreateNewFlow = observer(() => {
   const store = useStore();
-  const [allowSubmit, setAllowSubmit] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const { flows } = useStore();
   const navigate = useNavigate();
 
   const [flowName, setFlowName] = useState('');
 
-  useDidMount(() => {
-    setTimeout(() => {
-      setAllowSubmit(true);
-    }, 100);
-  });
-
   const handleConfirm = () => {
-    if (!allowSubmit) return;
-    setAllowSubmit(false);
+    setIsSaving(true);
 
     flows.create(flowName, {
       onSuccess: (id) => {
+        setIsSaving(false);
+
         navigate(`/flow-editor/${id}`);
+        store.ui.commandMenu.toggle('CreateNewFlow');
       },
     });
-
-    store.ui.commandMenu.toggle('CreateNewFlow');
   };
 
   return (
@@ -88,8 +81,10 @@ export const CreateNewFlow = observer(() => {
 
         <Button
           className='w-full'
+          isLoading={isSaving}
           colorScheme='primary'
           onClick={handleConfirm}
+          loadingText={'Creating…'}
           data-test='confirm-create-new-flow'
         >
           Create


### PR DESCRIPTION

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add loading state to `CreateNewFlow` button and close modal after flow ID is returned.
> 
>   - **Behavior**:
>     - Add `isSaving` state to manage loading state during flow creation in `CreateNewFlow`.
>     - Button shows loading state with `isLoading` and `loadingText` props until flow ID is returned.
>     - Modal closes only after successful flow creation and ID retrieval.
>   - **State Management**:
>     - Remove `allowSubmit` state and `useDidMount` hook.
>     - Use `setIsSaving` to manage button loading state.
>   - **UI Components**:
>     - Update `Button` component to reflect loading state in `CreateNewFlow`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for de069e138454598d686812d4cd90e55f81d8a18e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->