### PR TITLE
Check contacts on adding linked in to contact

### DIFF
--- a/packages/server/customer-os-common-module/service/social_service.go
+++ b/packages/server/customer-os-common-module/service/social_service.go
@@ -207,7 +207,20 @@ func (s *socialService) AddSocialToEntity(ctx context.Context, linkWith LinkWith
 				return "", err
 			}
 		} else if linkWith.Type == model.CONTACT {
-			// TODO here is depup logic for contacts
+			alias := socialEntity.Alias
+			if alias == "" {
+				// use identifier as alias
+				alias = socialEntity.ExtractLinkedinPersonIdentifierFromUrl()
+			}
+			contacts, err := s.services.Neo4jRepositories.ContactReadRepository.GetContactsByLinkedIn(ctx, tenant, socialUrl, alias, socialEntity.ExternalId)
+			if err != nil {
+				tracing.TraceErr(span, err)
+				return "", err
+			}
+			if len(contacts) > 0 {
+				err = errors.Errorf("linkedin url %s already used by contact %s", socialUrl, contacts[0].Props["id"])
+				return "", err
+			}
 		}
 	}
 

--- a/packages/server/customer-os-neo4j-repository/entity/social.go
+++ b/packages/server/customer-os-neo4j-repository/entity/social.go
@@ -63,3 +63,29 @@ func (s SocialEntity) ExtractLinkedinCompanyIdentifierFromUrl() string {
 	}
 	return identifier
 }
+
+func (s SocialEntity) ExtractLinkedinPersonIdentifierFromUrl() string {
+	if !s.IsLinkedin() {
+		return ""
+	}
+
+	identifier := s.Url
+
+	// trim trailing / from url
+	identifier = strings.TrimSuffix(s.Url, "/")
+
+	// remove all chars before linkedin.com/company
+	if i := strings.Index(identifier, "linkedin.com/in"); i != -1 {
+		identifier = identifier[i:]
+	}
+
+	if strings.HasPrefix(identifier, "linkedin.com/in") {
+		// get last part of url
+		parts := strings.Split(identifier, "/")
+		identifier = parts[len(parts)-1]
+		if identifier == "in" {
+			identifier = ""
+		}
+	}
+	return identifier
+}


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add logic to prevent duplicate LinkedIn URLs for contacts and organizations by checking existing associations before adding.
> 
>   - **Behavior**:
>     - In `social_service.go`, `AddSocialToEntity` now checks if a LinkedIn URL is already associated with a contact or organization before adding it.
>     - If a LinkedIn URL is already used, an error is returned.
>   - **Functions**:
>     - Added `GetContactsByLinkedIn` in `contact_read_repository.go` to retrieve contacts by LinkedIn URL, alias, or external ID.
>     - Added `GetOrganizationsByLinkedIn` in `organization_read_repository.go` to retrieve organizations by LinkedIn URL or alias.
>   - **Models**:
>     - Added `ExtractLinkedinPersonIdentifierFromUrl` to `SocialEntity` in `social.go` to extract LinkedIn person identifiers from URLs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f73c163194b6388b278b8ac7616332e557c433b0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->