### PR TITLE
COS-5867: Pause modal button should be primary

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/PauseFlow.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/PauseFlow.tsx
@@ -59,7 +59,7 @@ export const PauseFlow = observer(() => {
             size='sm'
             variant='outline'
             className='w-full'
-            colorScheme='error'
+            colorScheme='primary'
             ref={confirmButtonRef}
             onClick={handleConfirm}
             data-test='flow-actions-confirm-stop'


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `Button` color scheme from `error` to `primary` in `PauseFlow.tsx`.
> 
>   - **UI Change**:
>     - In `PauseFlow.tsx`, change `Button` color scheme from `error` to `primary` for the pause confirmation button.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7ed9863dd609fc908cec218a5fd77e0ef0cee24e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->