### PR TITLE
Flows fix

### DIFF
--- a/packages/server/customer-os-neo4j-repository/repository/flow_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_write_repository.go
@@ -69,7 +69,7 @@ func (r *flowWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.ManagedTr
 		"name":           entity.Name,
 		"nodes":          entity.Nodes,
 		"edges":          entity.Edges,
-		"firstStartedAt": entity.FirstStartedAt,
+		"firstStartedAt": utils.TimePtrAsAny(entity.FirstStartedAt),
 		"status":         entity.Status,
 		"createdAt":      utils.NowIfZero(entity.CreatedAt),
 		"updatedAt":      utils.NowIfZero(entity.UpdatedAt),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `firstStartedAt` handling in `Merge` function of `flow_write_repository.go` to use `utils.TimePtrAsAny`.
> 
>   - **Behavior**:
>     - Modify `firstStartedAt` parameter handling in `Merge` function of `flow_write_repository.go` to use `utils.TimePtrAsAny`.
>   - **Misc**:
>     - This change likely addresses a type or format issue with `firstStartedAt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 53cf1580fcf802b7ee0cd0eaa97028c399bcd980. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->