### PR TITLE
COS-5890: User should not be able to change the structure of flow that was set to live

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
@@ -171,6 +171,13 @@ export const FlowBuilder = observer(
     );
 
     const onBeforeDelete: OnBeforeDelete = async (elements) => {
+      if (flow.value.firstStartedAt) {
+        ui.commandMenu.setType('ActiveFlowUpdateInfo');
+        ui.commandMenu.setOpen(true);
+
+        return false;
+      }
+
       const hasStartNode = elements.nodes.some(
         (e) => e.data?.action === FlowActionType.FLOW_START,
       );

--- a/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
@@ -40,6 +40,7 @@ export const Header = observer(
     const { getNodes, getEdges } = useReactFlow();
 
     const flow = store.flows.value.get(id) as FlowStore;
+
     const status = flow?.value?.status;
     const contactsStore = store.contacts;
     const showFinder = searchParams.get('show') === 'finder';

--- a/packages/apps/frontera/src/routes/flow-editor/src/edges/BasicEdge.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/edges/BasicEdge.tsx
@@ -1,4 +1,5 @@
 import { MouseEventHandler } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
 import {
@@ -21,10 +22,19 @@ export const BasicEdge: React.FC<
   const [edgePath, labelX, labelY] = getSmoothStepPath({
     ...props,
   });
-  const { ui } = useStore();
+  const { ui, flows } = useStore();
+  const flowId = useParams()?.id as string;
+  const flowWasStarted = flows.value.get(flowId)?.value?.firstStartedAt;
 
   const toggleOpen: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.stopPropagation();
+
+    if (flowWasStarted) {
+      ui.commandMenu.setType('ActiveFlowUpdateInfo');
+      ui.commandMenu.setOpen(true);
+
+      return;
+    }
 
     if (ui.flowCommandMenu.isOpen) {
       ui.flowCommandMenu.setOpen(false);

--- a/packages/apps/frontera/src/routes/flow-editor/src/nodes/TriggerNode.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/nodes/TriggerNode.tsx
@@ -1,4 +1,5 @@
 import { MouseEventHandler } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
 import { NodeProps, ViewportPortal } from '@xyflow/react';
@@ -15,7 +16,9 @@ import { DropdownCommandMenu } from '../commands/Commands';
 export const TriggerNode = (
   props: NodeProps & { data: Record<string, string> },
 ) => {
-  const { ui } = useStore();
+  const { ui, flows } = useStore();
+  const flowId = useParams()?.id as string;
+  const flowWasStarted = flows.value.get(flowId)?.value?.firstStartedAt;
 
   const handleOpen: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.stopPropagation();
@@ -65,14 +68,16 @@ export const TriggerNode = (
             )}
           </div>
 
-          <IconButton
-            size='xxs'
-            variant='ghost'
-            aria-label='Edit'
-            onClick={handleOpen}
-            icon={<ChevronDown />}
-            className='ml-2 opacity-0 group-hover:opacity-100 pointer-events-all'
-          />
+          {!flowWasStarted && (
+            <IconButton
+              size='xxs'
+              variant='ghost'
+              aria-label='Edit'
+              onClick={handleOpen}
+              icon={<ChevronDown />}
+              className='ml-2 opacity-0 group-hover:opacity-100 pointer-events-all'
+            />
+          )}
         </div>
         <Handle type='target' />
         <Handle type='source' />

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
@@ -55,6 +55,7 @@ import {
   ContactBulkCommands,
   ConfirmBulkFlowEdit,
   OrganizationCommands,
+  ActiveFlowUpdateInfo,
   RenameOpportunityName,
   ChangeBulkArrEstimate,
   UnlinkContactFromFlow,
@@ -133,6 +134,7 @@ const Commands: Record<CommandMenuType, ReactElement> = {
   ChangeFlowStatus: <ChangeFlowStatus />,
   EditContactFlow: <EditContactFlow />,
   FlowValidationMessage: <FlowValidationMessage />,
+  ActiveFlowUpdateInfo: <ActiveFlowUpdateInfo />,
   GetBrowserExtensionLink: <GetBrowserExtensionLink />,
   InstallLinkedInExtension: <InstallLinkedInExtension />,
 

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/ActiveFlowUpdateInfo.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/ActiveFlowUpdateInfo.tsx
@@ -1,0 +1,52 @@
+import { observer } from 'mobx-react-lite';
+
+import { Button } from '@ui/form/Button/Button';
+import { useStore } from '@shared/hooks/useStore';
+import { Command, CommandCancelIconButton } from '@ui/overlay/CommandMenu';
+
+export const ActiveFlowUpdateInfo = observer(() => {
+  const store = useStore();
+
+  const handleClose = () => {
+    store.ui.commandMenu.clearContext();
+    store.ui.commandMenu.setOpen(false);
+  };
+
+  return (
+    <Command>
+      <article className='relative w-full p-6 flex flex-col border-b border-b-gray-100'>
+        <div className='flex items-center justify-between'>
+          <h1 className='text-base font-semibold'>
+            Steps can’t be added or removed
+          </h1>
+          <CommandCancelIconButton onClose={handleClose} />
+        </div>
+
+        <p className='text-sm mt-2'>
+          Once a flow has gone live the first time, you can only edit content
+          and basic settings.
+          <p className='mt-2'>
+            To add or remove a step, you’d have to duplicate the flow or create
+            a new one.{' '}
+          </p>
+        </p>
+        <div className='flex justify-between gap-3 mt-6'>
+          <Button
+            size='sm'
+            variant='outline'
+            className='w-full'
+            onClick={handleClose}
+            data-test='flow-actions-confirm-stop'
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleClose();
+              }
+            }}
+          >
+            Got it
+          </Button>
+        </div>
+      </article>
+    </Command>
+  );
+});

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/index.ts
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/index.ts
@@ -6,3 +6,4 @@ export * from './ChangeFlowStatus';
 export * from './GetBrowserExtensionLink';
 export * from './InstallLinkedInExtension';
 export * from './FlowValidationMessage';
+export * from './ActiveFlowUpdateInfo';

--- a/packages/apps/frontera/src/store/Flows/Flow.store.ts
+++ b/packages/apps/frontera/src/store/Flows/Flow.store.ts
@@ -112,15 +112,6 @@ export class FlowStore implements Store<Flow> {
     { nodes, edges }: { nodes: string; edges: string },
     options?: { onError: () => void; onSuccess: () => void },
   ) {
-    if (this.value.status !== FlowStatus.Off) {
-      this.root.ui.toastError(
-        'You can only edit draft flows',
-        'update-flow-error',
-      );
-
-      return;
-    }
-
     this.isLoading = true;
 
     try {

--- a/packages/apps/frontera/src/store/Flows/__service__/getFlow.generated.ts
+++ b/packages/apps/frontera/src/store/Flows/__service__/getFlow.generated.ts
@@ -12,6 +12,7 @@ export type GetFlowQuery = {
     edges: string;
     nodes: string;
     status: Types.FlowStatus;
+    firstStartedAt?: any | null;
     metadata: { __typename?: 'Metadata'; id: string };
     senders: Array<{
       __typename?: 'FlowSender';

--- a/packages/apps/frontera/src/store/Flows/__service__/getFlow.graphql
+++ b/packages/apps/frontera/src/store/Flows/__service__/getFlow.graphql
@@ -7,6 +7,7 @@ query getFlow($id: ID!) {
     edges
     nodes
     status
+    firstStartedAt
     senders {
         metadata {
             id

--- a/packages/apps/frontera/src/store/Flows/__service__/getFlows.generated.ts
+++ b/packages/apps/frontera/src/store/Flows/__service__/getFlows.generated.ts
@@ -6,6 +6,7 @@ export type GetFlowsQuery = {
   __typename?: 'Query';
   flows: Array<{
     __typename?: 'Flow';
+    firstStartedAt?: any | null;
     name: string;
     edges: string;
     nodes: string;

--- a/packages/apps/frontera/src/store/Flows/__service__/getFlows.graphql
+++ b/packages/apps/frontera/src/store/Flows/__service__/getFlows.graphql
@@ -3,6 +3,7 @@ query getFlows {
     metadata {
       id
     }
+    firstStartedAt
     name
     edges
     nodes

--- a/packages/apps/frontera/src/store/UI/CommandMenu.store.ts
+++ b/packages/apps/frontera/src/store/UI/CommandMenu.store.ts
@@ -46,6 +46,7 @@ export type CommandMenuType =
   | 'StartFlow'
   | 'StopFlow'
   | 'EditContactFlow'
+  | 'ActiveFlowUpdateInfo'
   | 'UnlinkContactFromFlow'
   | 'ConfirmBulkFlowEdit'
   | 'ConfirmSingleFlowEdit'


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restricts modification of live flows and introduces `ActiveFlowUpdateInfo` to inform users about this restriction.
> 
>   - **Behavior**:
>     - Prevents modification of flow structure if `firstStartedAt` is set in `FlowBuilder.tsx`, `BasicEdge.tsx`, and `TriggerNode.tsx`.
>     - Displays `ActiveFlowUpdateInfo` message when modification is attempted on a live flow.
>   - **Components**:
>     - Adds `ActiveFlowUpdateInfo` component to `CommandMenu` to inform users about restrictions.
>   - **GraphQL**:
>     - Adds `firstStartedAt` field to `getFlow.graphql` and `getFlows.graphql` queries.
>   - **Stores**:
>     - Removes draft-only edit restriction in `Flow.store.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2d46a87400f9460417f55d544d00e77b91876f65. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->