### PR TITLE
COS-5905: Fix condition to show save changes button on flows

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
@@ -12,10 +12,9 @@ import { Button } from '@ui/form/Button/Button';
 import { User01 } from '@ui/media/icons/User01';
 import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
+import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
 import { Settings03 } from '@ui/media/icons/Settings03';
-import { Tooltip } from '@ui/overlay/Tooltip/Tooltip.tsx';
 import { ChevronRight } from '@ui/media/icons/ChevronRight';
-import { FlowStatus } from '@shared/types/__generated__/graphql.types';
 
 import { FlowStatusMenu } from './components';
 
@@ -41,11 +40,10 @@ export const Header = observer(
 
     const flow = store.flows.value.get(id) as FlowStore;
 
-    const status = flow?.value?.status;
     const contactsStore = store.contacts;
     const showFinder = searchParams.get('show') === 'finder';
     const flowContactsPreset = store.tableViewDefs.flowContactsPreset;
-    const canSave = hasChanges && status === FlowStatus.On;
+    const canSave = hasChanges;
 
     useEffect(() => {
       if (!store.ui.commandMenu.isOpen) {


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies `canSave` condition in `Header.tsx` to only check `hasChanges`, affecting save button display.
> 
>   - **Behavior**:
>     - Simplifies `canSave` condition in `Header` component to only check `hasChanges`, removing dependency on `FlowStatus.On`.
>     - Affects when the save button is displayed in the flow editor.
>   - **Imports**:
>     - Removes unused `FlowStatus` import from `Header.tsx`.
>     - Adjusts `Tooltip` import path in `Header.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 98521217e0b6c86a4a7bbc4f488c41b7f897b09b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->