### PR TITLE
COS-5911: Don't allow to update subject of email reply

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
@@ -195,31 +195,49 @@ export const EmailSettingsPanel = observer(() => {
       </div>
 
       <div className='px-4'>
-        <div>
-          <Editor
-            size='md'
-            usePlainText
-            ref={inputRef}
-            placeholder='Subject'
-            namespace='flow-email-editor-subject'
-            onChange={(html) => setSubject(extractPlainText(html))}
-            defaultHtmlValue={convertPlainTextToHtml(subject ?? '')}
-            placeholderClassName='text-sm font-medium h-auto cursor-text'
-            onKeyDown={(e) => {
-              if (e.key === 'Tab') {
-                e.preventDefault();
-                editorRef.current?.focus();
-              }
-            }}
-            className={cn(
-              `text-sm font-medium h-auto cursor-text email-editor-subject`,
-              {
-                'pointer-events-none text-gray-400':
-                  data?.action === FlowActionType.EMAIL_REPLY,
-              },
-            )}
-          />
-        </div>
+        <Tooltip
+          label={
+            data?.action === FlowActionType.EMAIL_REPLY
+              ? `The subject will start with 'RE:' followed by the original subject (this can't be changed)`
+              : ''
+          }
+        >
+          <div
+            className={cn({
+              'cursor-not-allowed': data?.action === FlowActionType.EMAIL_REPLY,
+            })}
+          >
+            <Editor
+              size='md'
+              usePlainText
+              ref={inputRef}
+              placeholder='Subject'
+              namespace='flow-email-editor-subject'
+              onChange={(html) => setSubject(extractPlainText(html))}
+              defaultHtmlValue={convertPlainTextToHtml(subject ?? '')}
+              onKeyDown={(e) => {
+                if (e.key === 'Tab') {
+                  e.preventDefault();
+                  editorRef.current?.focus();
+                }
+              }}
+              placeholderClassName={cn(
+                'text-sm font-medium h-auto cursor-text',
+                {
+                  'pointer-events-none text-gray-400':
+                    data?.action === FlowActionType.EMAIL_REPLY,
+                },
+              )}
+              className={cn(
+                `text-sm font-medium h-auto cursor-text email-editor-subject`,
+                {
+                  'pointer-events-none text-gray-400':
+                    data?.action === FlowActionType.EMAIL_REPLY,
+                },
+              )}
+            />
+          </div>
+        </Tooltip>
 
         <Editor
           ref={editorRef}

--- a/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
@@ -196,9 +196,10 @@ export const EmailSettingsPanel = observer(() => {
 
       <div className='px-4'>
         <Tooltip
+          align='start'
           label={
             data?.action === FlowActionType.EMAIL_REPLY
-              ? `The subject will start with 'RE:' followed by the original subject (this can't be changed)`
+              ? `Reply to email subjects can't be edited`
               : ''
           }
         >

--- a/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
@@ -183,12 +183,12 @@ export const EmailSettingsPanel = observer(() => {
         <div className='flex gap-2'>
           <div>
             <Button size='xs' variant='ghost' onClick={handleCancel}>
-              Cancel
+              Cancel changes
             </Button>
           </div>
           <div>
             <Button size='xs' variant='outline' onClick={handleSave}>
-              Save changes
+              Save email
             </Button>
           </div>
         </div>

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/StartFlow.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/StartFlow.tsx
@@ -46,9 +46,7 @@ export const StartFlow = observer(() => {
     <Command>
       <article className='relative w-full p-6 flex flex-col border-b border-b-gray-100'>
         <div className='flex items-center justify-between'>
-          <h1 className='text-base font-semibold'>
-            Start flow '{flow?.value.name}'?
-          </h1>
+          <h1 className='text-base font-semibold'>Start {flow?.value.name}?</h1>
           <CommandCancelIconButton onClose={handleClose} />
         </div>
 

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/StopFlow.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/StopFlow.tsx
@@ -36,21 +36,17 @@ export const StopFlow = observer(() => {
     <Command>
       <article className='relative w-full p-6 flex flex-col border-b border-b-gray-100'>
         <div className='flex items-center justify-between'>
-          <h1 className='text-base font-semibold'>
-            Stop flow '{flow?.value.name}'?
-          </h1>
+          <h1 className='text-base font-semibold'>Stop {flow?.value.name}?</h1>
           <CommandCancelIconButton onClose={handleClose} />
         </div>
 
         {/* todo update when we support multiple record types*/}
         <p className='text-sm mt-2'>
-          This will stop all upcoming steps for your active
-          {flow?.value.participants?.length === 1 ? 'contact' : 'contacts'} from
-          taking place.
+          This will stop all upcoming steps for your active contacts from taking
+          place.
           <p className='mt-2'>
-            When you start the flow again,{' '}
-            {flow?.value.participants?.length === 1 ? 'contact' : 'contacts'}{' '}
-            will pick up from the last completed step on a new schedule.
+            When you start the flow again, contacts will pick up from the last
+            completed step on a new schedule.
           </p>
         </p>
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Disables subject editing for email replies in `EmailSettingsPanel` and updates text in `StartFlow.tsx` and `StopFlow.tsx`.
> 
>   - **Behavior**:
>     - Disables subject editing in `EmailSettingsPanel` when `data?.action` is `FlowActionType.EMAIL_REPLY`.
>     - Adds tooltip explaining subject starts with 'RE:' and is unchangeable for email replies.
>   - **UI**:
>     - Adds `Tooltip` around subject `Editor` in `EmailSettingsPanel` to show explanation.
>     - Applies `cursor-not-allowed` and `pointer-events-none` styles to subject `Editor` when action is EMAIL_REPLY.
>   - **Text Changes**:
>     - Updates text in `StartFlow.tsx` and `StopFlow.tsx` to remove unnecessary quotes and simplify participant count logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for e0855ac3a3d88659f4b99638a21224829f27644f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->