### PR TITLE
Expose test mailbox in API + auto create when missing

### DIFF
--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -1321,6 +1321,7 @@ type ComplexityRoot struct {
 		Flow                               func(childComplexity int, id string) int
 		FlowEmailVariables                 func(childComplexity int) int
 		FlowParticipant                    func(childComplexity int, id string) int
+		FlowTestEmailSender                func(childComplexity int) int
 		Flows                              func(childComplexity int) int
 		GcliSearch                         func(childComplexity int, keyword string, limit *int) int
 		GlobalCache                        func(childComplexity int) int
@@ -1961,6 +1962,7 @@ type QueryResolver interface {
 	Flows(ctx context.Context) ([]*model.Flow, error)
 	FlowParticipant(ctx context.Context, id string) (*model.FlowParticipant, error)
 	FlowEmailVariables(ctx context.Context) ([]*model.EmailVariableEntity, error)
+	FlowTestEmailSender(ctx context.Context) (string, error)
 	InteractionEvent(ctx context.Context, id string) (*model.InteractionEvent, error)
 	Invoice(ctx context.Context, id string) (*model.Invoice, error)
 	Invoices(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy, organizationID *string) (*model.InvoicesPage, error)
@@ -9738,6 +9740,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.FlowParticipant(childComplexity, args["id"].(string)), true
 
+	case "Query.flow_testEmailSender":
+		if e.complexity.Query.FlowTestEmailSender == nil {
+			break
+		}
+
+		return e.complexity.Query.FlowTestEmailSender(childComplexity), true
+
 	case "Query.flows":
 		if e.complexity.Query.Flows == nil {
 			break
@@ -13119,6 +13128,7 @@ enum ComparisonOperator {
 
     flowParticipant(id: ID!): FlowParticipant! @hasRole(roles: [ADMIN, USER]) @hasTenant
     flow_emailVariables: [EmailVariableEntity!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
+    flow_testEmailSender: String! @hasRole(roles: [ADMIN, USER]) @hasTenant
 }
 
 extend type Mutation {
@@ -13272,6 +13282,7 @@ enum FlowParticipantStatus {
     IN_PROGRESS
     COMPLETED
     GOAL_ACHIEVED
+    ERROR
 }
 
 type EmailVariableEntity {
@@ -85006,6 +85017,84 @@ func (ec *executionContext) fieldContext_Query_flow_emailVariables(_ context.Con
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_flow_testEmailSender(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_flow_testEmailSender(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Query().FlowTestEmailSender(rctx)
+		}
+
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			roles, err := ec.unmarshalNRole2ᚕgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐRoleᚄ(ctx, []interface{}{"ADMIN", "USER"})
+			if err != nil {
+				var zeroVal string
+				return zeroVal, err
+			}
+			if ec.directives.HasRole == nil {
+				var zeroVal string
+				return zeroVal, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, roles)
+		}
+		directive2 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.HasTenant == nil {
+				var zeroVal string
+				return zeroVal, errors.New("directive hasTenant is not implemented")
+			}
+			return ec.directives.HasTenant(ctx, nil, directive1)
+		}
+
+		tmp, err := directive2(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(string); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_flow_testEmailSender(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_interactionEvent(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_interactionEvent(ctx, field)
 	if err != nil {
@@ -117284,6 +117373,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_flow_emailVariables(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "flow_testEmailSender":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_flow_testEmailSender(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/packages/server/customer-os-api/graph/resolver/flow.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/flow.resolvers.go
@@ -23,7 +23,7 @@ import (
 	neo4jentity "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/repository"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // Participants is the resolver for the participants field.
@@ -621,6 +621,46 @@ func (r *queryResolver) FlowEmailVariables(ctx context.Context) ([]*model.EmailV
 	})
 
 	return emailVariables, nil
+}
+
+// FlowTestEmailSender is the resolver for the flow_testEmailSender field.
+func (r *queryResolver) FlowTestEmailSender(ctx context.Context) (string, error) {
+	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "FlowResolver.FlowTestEmailSender", graphql.GetOperationContext(ctx))
+	defer span.Finish()
+	tracing.SetDefaultResolverSpanTags(ctx, span)
+
+	tenant := common.GetTenantFromContext(ctx)
+
+	testEmailAddress, err := r.Services.Repositories.Neo4jRepositories.EmailReadRepository.GetTestEmailForFlows(ctx, tenant)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		graphql.AddErrorf(ctx, "")
+		return "", err
+	}
+
+	if testEmailAddress == "" {
+		err := r.Services.CommonServices.RegistrationService.PrepareDefaultTenantSetup(ctx, common.GetUserEmailFromContext(ctx))
+		if err != nil {
+			tracing.TraceErr(span, err)
+			graphql.AddErrorf(ctx, "")
+			return "", err
+		}
+
+		testEmailAddress, err = r.Services.Repositories.Neo4jRepositories.EmailReadRepository.GetTestEmailForFlows(ctx, tenant)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			graphql.AddErrorf(ctx, "")
+			return "", err
+		}
+
+		if testEmailAddress == "" {
+			tracing.TraceErr(span, err)
+			graphql.AddErrorf(ctx, "")
+			return "", fmt.Errorf("Test email address not found")
+		}
+	}
+
+	return testEmailAddress, nil
 }
 
 // Flow returns generated.FlowResolver implementation.

--- a/packages/server/customer-os-api/graph/schemas/flow.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/flow.graphqls
@@ -4,6 +4,7 @@ extend type Query {
 
     flowParticipant(id: ID!): FlowParticipant! @hasRole(roles: [ADMIN, USER]) @hasTenant
     flow_emailVariables: [EmailVariableEntity!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
+    flow_testEmailSender: String! @hasRole(roles: [ADMIN, USER]) @hasTenant
 }
 
 extend type Mutation {

--- a/packages/server/customer-os-common-module/service/registration_service.go
+++ b/packages/server/customer-os-common-module/service/registration_service.go
@@ -7,12 +7,16 @@ import (
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/tracing"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
+	neo4jentity "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/mapper"
 	"github.com/opentracing/opentracing-go"
 	"strings"
 )
 
 type RegistrationService interface {
 	PrepareDefaultTenantSetup(ctx context.Context, loggedInUserEmail string) error
+	ConfigureTestMailbox(ctx context.Context) error
+	CreatePostmarkServer(ctx context.Context) error
 }
 
 type registrationService struct {
@@ -37,10 +41,57 @@ func (s *registrationService) PrepareDefaultTenantSetup(ctx context.Context, log
 		tracing.TraceErr(span, err)
 		return err
 	}
+
+	err = s.ConfigureTestMailbox(ctx)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	err = s.CreatePostmarkServer(ctx)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	return nil
+}
+
+func (s *registrationService) ConfigureTestMailbox(ctx context.Context) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "RegistrationService.ConfigureTestMailbox")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	// validate tenant
+	err := common.ValidateTenant(ctx)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
 	tenant := common.GetTenantFromContext(ctx)
 
-	// Step 1 - Create default user
-	testUserId, err := s.services.UserService.CreateTestUser(ctx, "Test", "Sender")
+	var testUserId string
+
+	existingTestUser, err := s.services.Neo4jRepositories.UserReadRepository.FindTestUser(ctx)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	if existingTestUser == nil {
+		testUserId, err = s.services.UserService.CreateUser(ctx, neo4jentity.UserEntity{
+			FirstName: "Test",
+			LastName:  "Sender",
+			Test:      true,
+		})
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
+	} else {
+		testUserId = mapper.MapDbNodeToUserEntity(existingTestUser).Id
+	}
+
 	span.LogKV("result.testUserId", testUserId)
 	if err != nil {
 		tracing.TraceErr(span, err)
@@ -61,22 +112,46 @@ func (s *registrationService) PrepareDefaultTenantSetup(ctx context.Context, log
 	}
 	span.LogKV("result.testEmailId", testEmailId)
 
+	mailbox, err := s.services.PostgresRepositories.TenantSettingsMailboxRepository.GetByMailbox(ctx, mailboxAddress)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	if mailbox == nil {
+		// Step 4 - Register mailbox in opensrs
+		password := utils.GenerateLowerAlpha(1) + utils.GenerateKey(11, false)
+		username := strings.ToLower(tenant)
+		forwardingTo := []string{fmt.Sprintf("bcc@%s.customeros.ai", strings.ToLower(tenant))}
+		err = s.services.MailboxService.AddMailbox(ctx, TEST_MAILBOX_DOMAIN, username, password, mailboxAddress, true, true, forwardingTo)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
+	}
+
+	span.LogKV("result.mailbox", mailboxAddress)
+
+	return nil
+}
+
+func (s *registrationService) CreatePostmarkServer(ctx context.Context) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "RegistrationService.CreatePostmarkServer")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	// validate tenant
+	err := common.ValidateTenant(ctx)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
 	// Step 3 - Create postmark server for the tenant
 	err = s.services.PostmarkService.CreateServer(ctx)
 	if err != nil {
 		tracing.TraceErr(span, err)
 	}
-
-	// Step 4 - Register mailbox in opensrs
-	password := utils.GenerateLowerAlpha(1) + utils.GenerateKey(11, false)
-	username := strings.ToLower(tenant)
-	forwardingTo := []string{fmt.Sprintf("bcc@%s.customeros.ai", strings.ToLower(tenant))}
-	err = s.services.MailboxService.AddMailbox(ctx, TEST_MAILBOX_DOMAIN, username, password, mailboxAddress, true, true, forwardingTo)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return err
-	}
-	span.LogKV("result.mailbox", mailboxAddress)
 
 	return nil
 }

--- a/packages/server/customer-os-common-module/service/user_service.go
+++ b/packages/server/customer-os-common-module/service/user_service.go
@@ -16,7 +16,6 @@ type UserService interface {
 	GetAllUsersForTenant(ctx context.Context, tenant string) ([]*neo4jentity.UserEntity, error)
 	FindUserByEmail(parentCtx context.Context, email string) (*neo4jentity.UserEntity, error)
 	CreateUser(ctx context.Context, userEntity neo4jentity.UserEntity) (string, error)
-	CreateTestUser(ctx context.Context, firstName, lastName string) (string, error)
 }
 
 type userService struct {
@@ -100,16 +99,4 @@ func (s *userService) CreateUser(ctx context.Context, userEntity neo4jentity.Use
 	}
 
 	return userId, nil
-}
-
-func (s *userService) CreateTestUser(ctx context.Context, firstName, lastName string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserService.CreateTestUser")
-	defer span.Finish()
-	span.LogKV("firstName", firstName, "lastName", lastName)
-
-	return s.CreateUser(ctx, neo4jentity.UserEntity{
-		FirstName: firstName,
-		LastName:  lastName,
-		Test:      true,
-	})
 }

--- a/packages/server/customer-os-neo4j-repository/repository/email_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/email_read_repository.go
@@ -29,6 +29,7 @@ type EmailReadRepository interface {
 	IsLinkedToEntityByEmailAddress(ctx context.Context, tenant, email, entityId string, entityType neo4jenum.EntityType) (bool, error)
 	GetOrphanEmailNodes(ctx context.Context, limit, hoursFromLastUpdate int) ([]TenantAndEmailId, error)
 	IsOrphanEmail(ctx context.Context, tenant, emailId string) (bool, error)
+	GetTestEmailForFlows(ctx context.Context, tenant string) (string, error)
 }
 
 type emailReadRepository struct {
@@ -466,4 +467,39 @@ func (r *emailReadRepository) IsOrphanEmail(ctx context.Context, tenant, emailId
 		return false, err
 	}
 	return result.(bool), err
+}
+
+func (r *emailReadRepository) GetTestEmailForFlows(ctx context.Context, tenant string) (string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailReadRepository.GetTestEmailForFlows")
+	defer span.Finish()
+	tracing.TagComponentNeo4jRepository(span)
+	tracing.TagTenant(span, tenant)
+
+	cypher := fmt.Sprintf(`match (t:Tenant{name:$tenant})--(e:Email_%s) where e.rawEmail =~ ".*testcustomeros.com" return e.rawEmail`, tenant)
+	params := map[string]any{
+		"tenant": tenant,
+	}
+	span.LogFields(log.String("cypher", cypher))
+	tracing.LogObjectAsJson(span, "params", params)
+
+	session := r.prepareReadSession(ctx)
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
+			return nil, err
+		} else {
+			return queryResult.Collect(ctx)
+		}
+	})
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", err
+	}
+	if len(result.([]*db.Record)) == 0 {
+		span.LogFields(log.Bool("result.found", false))
+		return "", nil
+	}
+	span.LogFields(log.String("result", result.([]*db.Record)[0].Values[0].(string)))
+	return result.([]*db.Record)[0].Values[0].(string), err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/user_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/user_read_repository.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/common"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/tracing"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
 	"github.com/opentracing/opentracing-go"
@@ -16,6 +17,7 @@ type UserReadRepository interface {
 	GetByIds(ctx context.Context, tenant string, ids []string) ([]*dbtype.Node, error)
 	GetUserById(ctx context.Context, tenant, userId string) (*dbtype.Node, error)
 	FindFirstUserWithRolesByEmail(ctx context.Context, email string) (string, string, []string, error)
+	FindTestUser(ctx context.Context) (*dbtype.Node, error)
 	GetFirstUserByEmail(ctx context.Context, tenant, email string) (*dbtype.Node, error)
 	GetAllOwnersForOrganizations(ctx context.Context, tenant string, organizationIDs []string) ([]*utils.DbNodeAndId, error)
 	GetOwnerForOrganization(ctx context.Context, tenant, organizationId string) (*dbtype.Node, error)
@@ -194,6 +196,46 @@ func (r *userReadRepository) GetFirstUserByEmail(ctx context.Context, tenant, em
 	params := map[string]any{
 		"tenant": tenant,
 		"email":  email,
+	}
+	span.LogFields(log.String("cypher", cypher))
+	tracing.LogObjectAsJson(span, "params", params)
+
+	session := r.prepareReadSession(ctx)
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
+			return nil, err
+		} else {
+			return utils.ExtractFirstRecordFirstValueAsDbNodePtr(ctx, queryResult, err)
+		}
+	})
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+
+	if result == nil {
+		span.LogFields(log.Bool("result.found", false))
+		return nil, nil
+	}
+
+	span.LogFields(log.Bool("result.found", true))
+	return result.(*dbtype.Node), nil
+}
+
+func (r *userReadRepository) FindTestUser(ctx context.Context) (*dbtype.Node, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "UserRepository.FindTestUser")
+	defer span.Finish()
+	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+
+	tenant := common.GetTenantFromContext(ctx)
+
+	cypher := `MATCH (:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)
+			WHERE u.test = true and u.firstName = "Test" and u.lastName = "Sender"
+			RETURN u limit 1`
+	params := map[string]any{
+		"tenant": tenant,
 	}
 	span.LogFields(log.String("cypher", cypher))
 	tracing.LogObjectAsJson(span, "params", params)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `flow_testEmailSender` query to GraphQL API and auto-create test mailbox if missing, with updates to services and repositories.
> 
>   - **GraphQL API**:
>     - Add `flow_testEmailSender` query in `flow.graphqls` to expose test email sender.
>     - Implement resolver `FlowTestEmailSender` in `flow.resolvers.go` to fetch or create test email.
>   - **Service Enhancements**:
>     - Update `RegistrationService` in `registration_service.go` to include `ConfigureTestMailbox` and `CreatePostmarkServer` methods.
>     - Automatically create test mailbox if missing during `PrepareDefaultTenantSetup`.
>   - **Repository Updates**:
>     - Add `GetTestEmailForFlows` method in `email_read_repository.go` to fetch test emails.
>     - Add `FindTestUser` method in `user_read_repository.go` to locate test users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 094e45122a5d4a6392ec3bc3b74f03cf58b7f000. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->