### PR TITLE
COS-5937: Command shortcuts should not be triggered in Email side panel editor

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
@@ -164,6 +164,7 @@ export const EmailSettingsPanel = observer(() => {
   return (
     <article
       onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
       className='fixed z-50 top-[0px] bottom-0 right-0 w-[400px] bg-white  border-l flex flex-col gap-4 animate-slideLeft'
     >
       <div className='flex justify-between items-center border-b border-gray-200 p-4 y-2 h-[41px]'>


### PR DESCRIPTION
…
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `onKeyDown` event handler to `EmailSettingsPanel` to prevent command shortcuts in the email side panel editor.
> 
>   - **Behavior**:
>     - Adds `onKeyDown` event handler to `EmailSettingsPanel` to stop event propagation, preventing command shortcuts in the email side panel editor.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8fbfa728bade47aa630cdf31cca6cdcc423a0593. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->