### PR TITLE
COS-5646: Send contract name update on blur instead of on keystroke

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect } from 'react';
 
 import { observer } from 'mobx-react-lite';
+import { ContractStore } from '@store/Contracts/Contract.store.ts';
 
 import { Input } from '@ui/form/Input';
 import { useStore } from '@shared/hooks/useStore';
@@ -28,7 +29,9 @@ interface ContractCardProps {
 export const ContractCard = observer(
   ({ organizationName, values }: ContractCardProps) => {
     const store = useStore();
-    const contractStore = store.contracts.value.get(values.metadata.id);
+    const contractStore = store.contracts.value.get(
+      values.metadata.id,
+    ) as ContractStore;
 
     const [isExpanded, setIsExpanded] = useState(
       !contractStore?.value?.contractSigned,
@@ -88,12 +91,20 @@ export const ContractCard = observer(
               value={contract?.contractName}
               placeholder='Add contract name'
               onFocus={(e) => e.target.select()}
+              onBlur={(e) => {
+                contractStore?.updateContractName(e.target.value);
+              }}
               className='font-semibold hover:border-none focus:border-none max-h-6 min-h-0 w-full overflow-hidden overflow-ellipsis border-0'
               onChange={(e) =>
-                contractStore?.update((prev) => ({
-                  ...prev,
-                  contractName: e.target.value,
-                }))
+                contractStore?.update(
+                  (prev) => ({
+                    ...prev,
+                    contractName: e.target.value,
+                  }),
+                  {
+                    mutate: false,
+                  },
+                )
               }
             />
 

--- a/packages/apps/frontera/src/store/Contracts/Contract.store.ts
+++ b/packages/apps/frontera/src/store/Contracts/Contract.store.ts
@@ -211,6 +211,30 @@ export class ContractStore implements Store<Contract> {
       });
   }
 
+  // this is needed because the path is not coming through correctly when contract name is updated with mutate false and then send on blur
+  // this is a fix that will work correctly until the store is migrated to the new approach - now we do not have time to do it
+  async updateContractName(contractName: string) {
+    try {
+      this.isLoading = true;
+
+      await this.service.updateContract({
+        input: {
+          contractName,
+          contractId: this.id,
+          patch: true,
+        },
+      });
+    } catch (err) {
+      runInAction(() => {
+        this.error = (err as Error)?.message;
+      });
+    } finally {
+      runInAction(() => {
+        this.isLoading = false;
+      });
+    }
+  }
+
   async updateContractValues() {
     try {
       this.isLoading = true;


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change contract name update to trigger on blur instead of keystroke in `ContractCard.tsx`.
> 
>   - **Behavior**:
>     - Change contract name update trigger from `onChange` to `onBlur` in `ContractCard.tsx`.
>     - Add `updateContractName` method in `Contract.store.ts` to handle contract name updates on blur.
>   - **Components**:
>     - Modify `ContractCard` component to use `onBlur` for contract name updates.
>   - **Stores**:
>     - Add `updateContractName` method in `ContractStore` to update contract name via service call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 042e40bac264dd8a3816c7a7f668f39cb58164a2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->