### PR TITLE
COS-5949: Flows nav loses active state when navigating to a flow's editor

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/GeneralViewsSection.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/GeneralViewsSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
 import { TableViewDefStore } from '@store/TableViewDefs/TableViewDef.store.ts';
@@ -36,6 +37,8 @@ export const GeneralViewsSection = observer(
     checkIsActive,
   }: GeneralViewsSectionProps) => {
     const store = useStore();
+    const { pathname } = useLocation();
+
     const tableViewDefsList = store.tableViewDefs.toArray();
     const allOrganizationsView = tableViewDefsList.filter(
       (c) => c.value.tableId === TableIdType.Organizations && c.value.isPreset,
@@ -64,6 +67,8 @@ export const GeneralViewsSection = observer(
     const upcomingInvoices = invoicesViews[0];
     const allOrganizationsActivePreset = [allOrganizationsView?.[0]?.value?.id];
     const showInvoices = store.settings.tenant.value?.billingEnabled;
+
+    const isFlowEditorActive = pathname.includes('flow-editor');
 
     return (
       <CollapsibleSection
@@ -181,9 +186,11 @@ export const GeneralViewsSection = observer(
               onClick={() =>
                 handleItemClick(`finder?preset=${flowSequencesView?.value?.id}`)
               }
-              isActive={checkIsActive('finder', {
-                preset: flowSequencesView?.value?.id ?? '',
-              })}
+              isActive={
+                checkIsActive('finder', {
+                  preset: flowSequencesView?.value?.id ?? '',
+                }) || isFlowEditorActive
+              }
               icon={(isActive) => (
                 <Shuffle01
                   className={cn(


### PR DESCRIPTION
…
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes navigation active state loss when entering flow editor by checking `pathname` in `GeneralViewsSection`.
> 
>   - **Behavior**:
>     - Fixes active state loss in navigation when entering flow editor by checking `pathname` for 'flow-editor' in `GeneralViewsSection`.
>     - Updates `isActive` condition for `SidenavItem` related to flows to include `isFlowEditorActive`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 16a97a45b9a0ade8affc080195412574a7b57aa5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->