### PR TITLE
COS-5950: Reduce the time for toasts to stay open to 5 seconds

### DIFF
--- a/packages/apps/frontera/src/ui/presentation/Toast/toastError.tsx
+++ b/packages/apps/frontera/src/ui/presentation/Toast/toastError.tsx
@@ -9,6 +9,7 @@ export const toastError = (text: string, id: string) => {
   return toast.error(text, {
     toastId: id,
     icon: ExclamationWaves,
+    autoClose: 5000,
     closeButton: ({ closeToast }) => (
       <IconButton
         variant='ghost'

--- a/packages/apps/frontera/src/ui/presentation/Toast/toastSuccess.tsx
+++ b/packages/apps/frontera/src/ui/presentation/Toast/toastSuccess.tsx
@@ -9,6 +9,7 @@ export const toastSuccess = (text: string, id: string) => {
   return toast.success(text, {
     toastId: id,
     icon: CheckWaves,
+    autoClose: 5000,
     closeButton: ({ closeToast }) => (
       <IconButton
         variant='ghost'


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `autoClose` to 5000ms for toast notifications in `toastError.tsx` and `toastSuccess.tsx`.
> 
>   - **Behavior**:
>     - Set `autoClose` to 5000ms for `toastError` in `toastError.tsx` and `toastSuccess` in `toastSuccess.tsx`.
>   - **Files Affected**:
>     - `toastError.tsx`
>     - `toastSuccess.tsx`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 42ce0d7deae30a6a2c67deffb5ef2f317d10e547. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->