### PR TITLE
COS-5964: Clicking x on the save modal should not cancel changes

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/ConfirmEmailContentChanges.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/ConfirmEmailContentChanges.tsx
@@ -16,7 +16,10 @@ export const ConfirmEmailContentChanges = observer(() => {
     store.ui.commandMenu.clearContext();
     store.ui.commandMenu.setOpen(false);
     store.ui.commandMenu.clearCallback();
+  };
 
+  const handleCancelChanges = () => {
+    handleClose();
     store.ui.flowActionSidePanel.setOpen(false);
     store.ui.flowActionSidePanel.clearContext();
   };
@@ -47,12 +50,12 @@ export const ConfirmEmailContentChanges = observer(() => {
             size='sm'
             variant='outline'
             className='w-full'
-            onClick={handleClose}
+            onClick={handleCancelChanges}
             data-test={'email-content-leave-without-saving'}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 e.stopPropagation();
-                handleClose();
+                handleCancelChanges();
               }
             }}
           >


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix 'Don't save' button in `ConfirmEmailContentChanges` to properly close side panel and clear context.
> 
>   - **Behavior**:
>     - Modify `ConfirmEmailContentChanges` component to use `handleCancelChanges` instead of `handleClose` for 'Don't save' button.
>     - `handleCancelChanges` closes the side panel and clears its context, in addition to closing the command menu.
>   - **Functions**:
>     - Add `handleCancelChanges` function to `ConfirmEmailContentChanges.tsx` to encapsulate additional side panel logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 5842c1757b53dca5a2f59639e728620daf593578. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->