### PR TITLE
COS-5965: Block trigger node dropdown when action node side panel is open

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/nodes/TriggerNode.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/nodes/TriggerNode.tsx
@@ -70,7 +70,7 @@ export const TriggerNode = (
             )}
           </div>
 
-          {!flowWasStarted && (
+          {!flowWasStarted && !ui.flowActionSidePanel.isOpen && (
             <IconButton
               size='xxs'
               variant='ghost'


### PR DESCRIPTION
…

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Block trigger node dropdown in `TriggerNode.tsx` when action node side panel is open.
> 
>   - **Behavior**:
>     - Update `TriggerNode` in `TriggerNode.tsx` to block trigger node dropdown when `ui.flowActionSidePanel.isOpen` is true.
>     - Ensures dropdown only appears if `flowWasStarted` is false and `flowActionSidePanel` is closed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 063e836215be9baf3973e0992d4a7d61c0cd5ccd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->