### PR TITLE
COS-5935: Add last updated column to organization and contact

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/columns.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/columns.tsx
@@ -1,6 +1,7 @@
 import { ContactStore } from '@store/Contacts/Contact.store';
 import { ColumnDef as ColumnDefinition } from '@tanstack/react-table';
 import { CountryCell } from '@finder/components/Columns/Cells/country';
+import { DateCell } from '@finder/components/Columns/shared/Cells/DateCell';
 import { TextCell } from '@finder/components/Columns/shared/Cells/TextCell';
 import { JobTitleCell } from '@finder/components/Columns/contacts/Cells/jobTitle';
 import { ContactFlowCell } from '@finder/components/Columns/contacts/Cells/contactFlow';
@@ -556,6 +557,27 @@ const columns: Record<string, Column> = {
       <THead<HTMLInputElement>
         title='Region'
         id={ColumnViewType.ContactsRegion}
+        {...getTHeadProps<ContactStore>(props)}
+      />
+    ),
+    skeleton: () => <Skeleton className='w-[75%] h-[14px]' />,
+  }),
+  [ColumnViewType.ContactsUpdatedAt]: columnHelper.accessor('value.updatedAt', {
+    id: ColumnViewType.ContactsUpdatedAt,
+    minSize: 150,
+    maxSize: 600,
+    enableResizing: true,
+    enableColumnFilter: false,
+    enableSorting: true,
+    cell: (props) => {
+      const lastUpdatedAt = props.getValue();
+
+      return <DateCell value={lastUpdatedAt} />;
+    },
+    header: (props) => (
+      <THead<HTMLInputElement>
+        title='Last Updated'
+        id={ColumnViewType.ContactsUpdatedAt}
         {...getTHeadProps<ContactStore>(props)}
       />
     ),

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/sortFns.ts
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/sortFns.ts
@@ -60,5 +60,8 @@ export const getContactSortFn = (columnId: string) =>
     .with(ColumnViewType.ContactsCreatedAt, () => (row: ContactStore) => {
       return row.value.createdAt;
     })
+    .with(ColumnViewType.ContactsUpdatedAt, () => (row: ContactStore) => {
+      return row.value.updatedAt;
+    })
 
     .otherwise(() => (_row: ContactStore) => false);

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/columns.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/columns.tsx
@@ -1,20 +1,20 @@
 import { CountryCell } from '@finder/components/Columns/Cells/country';
 import { OrganizationStore } from '@store/Organizations/Organization.store';
 import { OrganizationStageCell } from '@finder/components/Columns/Cells/stage';
+import { DateCell } from '@finder/components/Columns/shared/Cells/DateCell/DateCell';
 import {
   ColumnDef,
   ColumnDef as ColumnDefinition,
 } from '@tanstack/react-table';
 import { AvatarHeader } from '@finder/components/Columns/organizations/Headers/Avatar';
-import { DateCell } from '@finder/components/Columns/shared/Cells/DateCell/DateCell.tsx';
-import { getColumnConfig } from '@finder/components/Columns/shared/util/getColumnConfig.ts';
+import { getColumnConfig } from '@finder/components/Columns/shared/util/getColumnConfig';
 
-import { cn } from '@ui/utils/cn.ts';
+import { cn } from '@ui/utils/cn';
+import { Skeleton } from '@ui/feedback/Skeleton/Skeleton';
 import { createColumnHelper } from '@ui/presentation/Table';
-import { Skeleton } from '@ui/feedback/Skeleton/Skeleton.tsx';
-import { formatCurrency } from '@utils/getFormattedCurrencyNumber.ts';
+import { formatCurrency } from '@utils/getFormattedCurrencyNumber';
+import THead, { getTHeadProps } from '@ui/presentation/Table/THead';
 import { Social, TableViewDef, ColumnViewType } from '@graphql/types';
-import THead, { getTHeadProps } from '@ui/presentation/Table/THead.tsx';
 
 import {
   OwnerCell,
@@ -789,6 +789,30 @@ export const columns: Record<string, Column> = {
         <THead<HTMLInputElement>
           title='Parent Org'
           id={ColumnViewType.OrganizationsParentOrganization}
+          {...getTHeadProps<OrganizationStore>(props)}
+        />
+      ),
+      skeleton: () => <Skeleton className='w-[75%] h-[14px]' />,
+    },
+  ),
+  [ColumnViewType.OrganizationsUpdatedDate]: columnHelper.accessor(
+    'value.metadata.lastUpdated',
+    {
+      id: ColumnViewType.OrganizationsUpdatedDate,
+      minSize: 150,
+      maxSize: 600,
+      enableResizing: true,
+      enableColumnFilter: false,
+      enableSorting: true,
+      cell: (props) => {
+        const lastUpdatedAt = props.getValue();
+
+        return <DateCell value={lastUpdatedAt} />;
+      },
+      header: (props) => (
+        <THead<HTMLInputElement>
+          title='Last Updated'
+          id={ColumnViewType.OrganizationsUpdatedDate}
           {...getTHeadProps<OrganizationStore>(props)}
         />
       ),

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/sortFns.ts
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/sortFns.ts
@@ -79,6 +79,13 @@ export const getOrganizationSortFn = (columnId: string) =>
           : null,
     )
     .with(
+      ColumnViewType.OrganizationsUpdatedDate,
+      () => (row: OrganizationStore) =>
+        row.value?.metadata?.lastUpdated
+          ? new Date(row.value?.metadata?.lastUpdated)
+          : null,
+    )
+    .with(
       ColumnViewType.OrganizationsYearFounded,
       () => (row: OrganizationStore) => row.value?.yearFounded,
     )

--- a/packages/apps/frontera/src/routes/src/components/ViewSettings/EditColumns/EditColumns.tsx
+++ b/packages/apps/frontera/src/routes/src/components/ViewSettings/EditColumns/EditColumns.tsx
@@ -102,7 +102,6 @@ export const EditColumns = observer(({ type, tableId }: EditColumnsProps) => {
       ColumnViewType.ContactsSkills,
       ColumnViewType.ContactsSchools,
       ColumnViewType.ContactsExperience,
-      ColumnViewType.ContactsUpdatedAt,
       ColumnViewType.ContactsCreatedAt,
       'EMAIL_VERIFICATION_PRIMARY_EMAIL',
       ColumnViewType.ContactsEmails,

--- a/packages/apps/frontera/src/routes/src/components/ViewSettings/EditColumns/columnOptions.ts
+++ b/packages/apps/frontera/src/routes/src/components/ViewSettings/EditColumns/columnOptions.ts
@@ -48,6 +48,7 @@ export const contactsOptionsMap: Record<InvoicesColumnType | string, string> = {
   [ColumnViewType.ContactsPrimaryEmail]: 'Primary Email',
   [ColumnViewType.ContactsFlowStatus]: 'Status in Flow',
   [ColumnViewType.ContactsFlowNextAction]: 'Next Flow Action',
+  [ColumnViewType.ContactsUpdatedAt]: 'Last Updated',
 };
 
 export const invoicesHelperTextMap: Record<
@@ -110,6 +111,7 @@ export const organizationsOptionsMap: Record<
   [ColumnViewType.OrganizationsContactCount]: 'Contacts',
   [ColumnViewType.OrganizationsHeadquarters]: 'Country',
   [ColumnViewType.OrganizationsParentOrganization]: 'Parent Org',
+  [ColumnViewType.OrganizationsUpdatedDate]: 'Last Updated',
 };
 
 export const organizationsHelperTextMap: Record<
@@ -143,6 +145,7 @@ export const organizationsHelperTextMap: Record<
   [ColumnViewType.OrganizationsLtv]: 'E.g. $109,280',
   [ColumnViewType.OrganizationsHeadquarters]: 'E.g. Germany',
   [ColumnViewType.OrganizationsParentOrganization]: 'E.g. Alphabet',
+  [ColumnViewType.OrganizationsUpdatedDate]: 'E.g. 16 Sep 2024',
 };
 
 export const contactsHelperTextMap: Record<string, string> = {
@@ -169,6 +172,7 @@ export const contactsHelperTextMap: Record<string, string> = {
   [ColumnViewType.ContactsPrimaryEmail]: 'E.g. steph@acme.com',
   [ColumnViewType.ContactsFlowStatus]: 'E.g. Completed',
   [ColumnViewType.ContactsFlowNextAction]: ' E.g. Step 2/3',
+  [ColumnViewType.ContactsUpdatedAt]: 'E.g. 16 Sep 2024',
 };
 
 export const contractsMap: Record<string, string> = {

--- a/packages/apps/frontera/src/store/Organizations/__service__/getOrganization.generated.ts
+++ b/packages/apps/frontera/src/store/Organizations/__service__/getOrganization.generated.ts
@@ -23,7 +23,12 @@ export type OrganizationQuery = {
     employees?: any | null;
     yearFounded?: any | null;
     public?: boolean | null;
-    metadata: { __typename?: 'Metadata'; id: string; created: any };
+    metadata: {
+      __typename?: 'Metadata';
+      id: string;
+      created: any;
+      lastUpdated: any;
+    };
     parentCompanies: Array<{
       __typename?: 'LinkedOrganization';
       organization: {

--- a/packages/apps/frontera/src/store/Organizations/__service__/getOrganization.graphql
+++ b/packages/apps/frontera/src/store/Organizations/__service__/getOrganization.graphql
@@ -4,6 +4,7 @@ query Organization($id: ID!) {
     metadata {
       id
       created
+      lastUpdated
     }
     parentCompanies {
       organization {

--- a/packages/apps/frontera/src/store/Organizations/__service__/getOrganizations.generated.ts
+++ b/packages/apps/frontera/src/store/Organizations/__service__/getOrganizations.generated.ts
@@ -33,7 +33,12 @@ export type GetOrganizationsQuery = {
       public?: boolean | null;
       employees?: any | null;
       yearFounded?: any | null;
-      metadata: { __typename?: 'Metadata'; id: string; created: any };
+      metadata: {
+        __typename?: 'Metadata';
+        id: string;
+        created: any;
+        lastUpdated: any;
+      };
       contracts?: Array<{
         __typename?: 'Contract';
         metadata: { __typename?: 'Metadata'; id: string };
@@ -142,112 +147,8 @@ export type GetOrganizationsQuery = {
       }>;
       lastTouchpoint?: {
         __typename?: 'LastTouchpoint';
-        lastTouchPointTimelineEventId?: string | null;
         lastTouchPointAt?: any | null;
         lastTouchPointType?: Types.LastTouchpointType | null;
-        lastTouchPointTimelineEvent?:
-          | {
-              __typename: 'Action';
-              id: string;
-              actionType: Types.ActionType;
-              createdAt: any;
-              source: Types.DataSource;
-              createdBy?: {
-                __typename?: 'User';
-                id: string;
-                firstName: string;
-                lastName: string;
-              } | null;
-            }
-          | {
-              __typename: 'InteractionEvent';
-              id: string;
-              channel: string;
-              eventType?: string | null;
-              externalLinks: Array<{
-                __typename?: 'ExternalSystem';
-                type: Types.ExternalSystemType;
-              }>;
-              sentBy: Array<
-                | {
-                    __typename: 'ContactParticipant';
-                    contactParticipant: {
-                      __typename?: 'Contact';
-                      id: string;
-                      name?: string | null;
-                      firstName?: string | null;
-                      lastName?: string | null;
-                    };
-                  }
-                | {
-                    __typename: 'EmailParticipant';
-                    type?: string | null;
-                    emailParticipant: {
-                      __typename?: 'Email';
-                      id: string;
-                      email?: string | null;
-                      rawEmail?: string | null;
-                    };
-                  }
-                | {
-                    __typename: 'JobRoleParticipant';
-                    jobRoleParticipant: {
-                      __typename?: 'JobRole';
-                      contact?: {
-                        __typename?: 'Contact';
-                        id: string;
-                        name?: string | null;
-                        firstName?: string | null;
-                        lastName?: string | null;
-                      } | null;
-                    };
-                  }
-                | { __typename: 'OrganizationParticipant' }
-                | { __typename: 'PhoneNumberParticipant' }
-                | {
-                    __typename: 'UserParticipant';
-                    userParticipant: {
-                      __typename?: 'User';
-                      id: string;
-                      firstName: string;
-                      lastName: string;
-                    };
-                  }
-              >;
-            }
-          | { __typename: 'InteractionSession' }
-          | { __typename: 'Issue'; id: string; createdAt: any; updatedAt: any }
-          | {
-              __typename: 'LogEntry';
-              id: string;
-              createdBy?: {
-                __typename?: 'User';
-                lastName: string;
-                firstName: string;
-              } | null;
-            }
-          | {
-              __typename: 'Meeting';
-              id: string;
-              name?: string | null;
-              attendedBy: Array<
-                | { __typename: 'ContactParticipant' }
-                | { __typename: 'EmailParticipant' }
-                | { __typename: 'OrganizationParticipant' }
-                | { __typename: 'UserParticipant' }
-              >;
-            }
-          | {
-              __typename: 'Note';
-              id: string;
-              createdBy?: {
-                __typename?: 'User';
-                firstName: string;
-                lastName: string;
-              } | null;
-            }
-          | { __typename: 'PageView'; id: string }
-          | null;
       } | null;
     }>;
   } | null;

--- a/packages/apps/frontera/src/store/Organizations/__service__/getOrganizations.graphql
+++ b/packages/apps/frontera/src/store/Organizations/__service__/getOrganizations.graphql
@@ -16,6 +16,7 @@ query getOrganizations(
       metadata {
         id
         created
+        lastUpdated
       }
       contracts {
         metadata {
@@ -141,97 +142,8 @@ query getOrganizations(
         }
       }
       lastTouchpoint {
-        lastTouchPointTimelineEventId
         lastTouchPointAt
         lastTouchPointType
-        lastTouchPointTimelineEvent {
-          __typename
-          ... on PageView {
-            id
-          }
-          ... on Issue {
-            id
-            createdAt
-            updatedAt
-          }
-          ... on LogEntry {
-            id
-            createdBy {
-              lastName
-              firstName
-            }
-          }
-          ... on Note {
-            id
-            createdBy {
-              firstName
-              lastName
-            }
-          }
-          ... on InteractionEvent {
-            id
-            channel
-            eventType
-            externalLinks {
-              type
-            }
-            sentBy {
-              __typename
-              ... on EmailParticipant {
-                type
-                emailParticipant {
-                  id
-                  email
-                  rawEmail
-                }
-              }
-              ... on ContactParticipant {
-                contactParticipant {
-                  id
-                  name
-                  firstName
-                  lastName
-                }
-              }
-              ... on JobRoleParticipant {
-                jobRoleParticipant {
-                  contact {
-                    id
-                    name
-                    firstName
-                    lastName
-                  }
-                }
-              }
-              ... on UserParticipant {
-                userParticipant {
-                  id
-                  firstName
-                  lastName
-                }
-              }
-            }
-          }
-          ... on Meeting {
-            id
-            name
-            attendedBy {
-              __typename
-            }
-          }
-          ... on Action {
-            id
-            actionType
-            createdAt
-            source
-            actionType
-            createdBy {
-              id
-              firstName
-              lastName
-            }
-          }
-        }
       }
 
       contracts {


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 'last updated' columns to contacts and organizations with sorting and GraphQL support.
> 
>   - **Columns**:
>     - Add `ContactsUpdatedAt` column in `contacts/columns.tsx` with sorting enabled.
>     - Add `OrganizationsUpdatedDate` column in `organizations/columns.tsx` with sorting enabled.
>   - **Sorting**:
>     - Add sorting logic for `ContactsUpdatedAt` in `contacts/sortFns.ts`.
>     - Add sorting logic for `OrganizationsUpdatedDate` in `organizations/sortFns.ts`.
>   - **GraphQL**:
>     - Update `getOrganization.graphql` and `getOrganizations.graphql` to include `lastUpdated` field.
>     - Update `getOrganization.generated.ts` and `getOrganizations.generated.ts` to reflect GraphQL changes.
>   - **UI**:
>     - Update `EditColumns.tsx` and `columnOptions.ts` to include new columns in options and helper text maps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d5a34007f3c9aa0120160dfdea444a5bc9d8b5e9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->