### PR TITLE
COS-5627: Allow orgs set as customer to be moved directly to prospect

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/relationship/OrganizationRelationship.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/relationship/OrganizationRelationship.tsx
@@ -96,9 +96,6 @@ export const OrganizationRelationshipCell = observer(
               .filter(
                 (option) =>
                   !(
-                    value?.label === 'Customer' && option.label === 'Prospect'
-                  ) &&
-                  !(
                     value?.label === 'Not a Fit' && option.label === 'Prospect'
                   ),
               )

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/organization/ChangeRelationship.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/organization/ChangeRelationship.tsx
@@ -94,10 +94,6 @@ export const ChangeRelationship = observer(() => {
       relationshipOptions.filter(
         (option) =>
           !(
-            selectedRelationshipOption?.label === 'Customer' &&
-            option.label === 'Prospect'
-          ) &&
-          !(
             selectedRelationshipOption?.label === 'Not a fit' &&
             option.label === 'Prospect'
           ),

--- a/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
+++ b/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
@@ -512,24 +512,10 @@ export class OrganizationsStore extends SyncableGroup<
     relationship: OrganizationRelationship,
     mutate = true,
   ) => {
-    let invalidCustomerStageCount = 0;
-
     ids.forEach((id) => {
       const organization = this.value.get(id);
 
       if (!organization) return;
-
-      if (
-        organization.value.relationship === OrganizationRelationship.Customer &&
-        ![
-          OrganizationRelationship.FormerCustomer,
-          OrganizationRelationship.NotAFit,
-        ].includes(relationship)
-      ) {
-        invalidCustomerStageCount++;
-
-        return; // Do not update if current is customer and new is not formet customer or not a fit
-      }
 
       organization.value.relationship = relationship;
       organization.value.stage =
@@ -537,15 +523,6 @@ export class OrganizationsStore extends SyncableGroup<
 
       organization.commit({ syncOnly: !mutate });
     });
-
-    if (invalidCustomerStageCount) {
-      this.root.ui.toastError(
-        `${invalidCustomerStageCount} customer${
-          invalidCustomerStageCount > 1 ? 's' : ''
-        } remain unchanged`,
-        'stage-update-failed-due-to-relationship-mismatch',
-      );
-    }
   };
 
   updateHealth = (


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow organizations with 'Customer' relationship to be moved directly to 'Prospect' by removing restrictive conditions.
> 
>   - **Behavior**:
>     - Allow organizations with 'Customer' relationship to be moved directly to 'Prospect'.
>     - Removed condition preventing 'Customer' to 'Prospect' transition in `OrganizationRelationshipCell` and `ChangeRelationship`.
>   - **Store Logic**:
>     - Removed logic in `updateRelationship` in `Organizations.store.ts` that prevented updating 'Customer' to 'Prospect'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 51002b1a1bfed1346591dde73118f640e9eb953c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->