### PR TITLE
set internal stage on create opportunity

### DIFF
--- a/packages/server/customer-os-common-module/service/opportunity_service.go
+++ b/packages/server/customer-os-common-module/service/opportunity_service.go
@@ -140,6 +140,7 @@ func (s *opportunityService) Save(ctx context.Context, tx *neo4j.ManagedTransact
 
 	var err error
 	var existing *neo4jentity.OpportunityEntity
+	createFlow := false
 
 	if organizationId == nil && opportunityId == nil {
 		err := fmt.Errorf("(OpportunityService.Save) organizationId and opportunityId are nil")
@@ -174,10 +175,14 @@ func (s *opportunityService) Save(ctx context.Context, tx *neo4j.ManagedTransact
 	}
 
 	if opportunityId == nil {
-
+		createFlow = true
 		if input.InternalType == "" {
 			input.InternalType = neo4jenum.OpportunityInternalTypeNBO.String()
 			input.UpdateInternalType = true
+		}
+		if input.InternalStage == "" {
+			input.InternalStage = neo4jenum.OpportunityInternalStageOpen.String()
+			input.UpdateInternalStage = true
 		}
 
 		if input.Currency == "" {
@@ -196,10 +201,14 @@ func (s *opportunityService) Save(ctx context.Context, tx *neo4j.ManagedTransact
 			return nil, err
 		}
 		opportunityId = &generatedId
+		span.LogKV("flow", "create")
+	} else {
+		span.LogKV("flow", "update")
 	}
+	tracing.TagEntity(span, *opportunityId)
 
 	// Changing external stage should set internal stage back to OPEN
-	if existing != nil && input.ExternalStage != "" && existing.ExternalStage != input.ExternalStage && existing.InternalStage != neo4jenum.OpportunityInternalStageOpen {
+	if !createFlow && input.ExternalStage != "" && existing.ExternalStage != input.ExternalStage && existing.InternalStage != neo4jenum.OpportunityInternalStageOpen {
 		input.InternalStage = neo4jenum.OpportunityInternalStageOpen.String()
 		input.UpdateInternalStage = true
 	}
@@ -301,7 +310,7 @@ func (s *opportunityService) Save(ctx context.Context, tx *neo4j.ManagedTransact
 	//if input.AppSource != constants.AppSourceCustomerOsApi {
 	details := utils.NewEventCompletedDetails()
 
-	if existing == nil {
+	if createFlow {
 		details.WithCreate()
 	} else {
 		details.WithUpdate()


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set default `InternalStage` to 'Open' for new opportunities in `Save()` of `opportunity_service.go` and log operation flow.
> 
>   - **Behavior**:
>     - In `Save()` of `opportunity_service.go`, set `InternalStage` to `Open` by default when creating a new opportunity.
>     - Log 'create' or 'update' flow in `Save()`.
>     - Adjust logic to reset `InternalStage` to `Open` when `ExternalStage` changes, only if not in create flow.
>   - **Misc**:
>     - Introduce `createFlow` boolean to distinguish between create and update operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c6b712aea0dbb3081f5b937998a96492ffff6248. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->