### PR TITLE
COS-5672: Cmd+K should close command menu when tag option is focused

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/organization/ChangeTags.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/organization/ChangeTags.tsx
@@ -202,10 +202,21 @@ export const ChangeTags = observer(() => {
           {filteredTags?.map((tag) => (
             <CommandItem
               key={tag.id}
-              onSelect={handleSelect(tag.value)}
+              onSelect={() => {
+                handleSelect(tag.value);
+              }}
               rightAccessory={
                 newSelectedTags.has(tag.value.name) ? <Check /> : null
               }
+              onKeyDown={(e) => {
+                if (e.metaKey && e.key === 'Enter') {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  store.ui.commandMenu.setOpen(false);
+
+                  return;
+                }
+              }}
             >
               {tag.value.name}
             </CommandItem>


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Cmd+K shortcut to close command menu when tag option is focused in `ChangeTags.tsx`.
> 
>   - **Behavior**:
>     - In `ChangeTags.tsx`, added `onKeyDown` handler to `CommandItem` to close command menu with Cmd+K when a tag option is focused.
>     - Prevents default behavior and stops event propagation when Cmd+K is pressed.
>   - **Misc**:
>     - Minor refactoring of `onSelect` function to use inline arrow function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b696fb41e9e6839bb857e0b9c350c2be18019d7d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->