### PR TITLE
COS-5445: If flow name is not provided by user default to "Unnamed"

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/CreateNewFlow.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/CreateNewFlow.tsx
@@ -23,7 +23,9 @@ export const CreateNewFlow = observer(() => {
   const handleConfirm = () => {
     setIsSaving(true);
 
-    flows.create(flowName, {
+    const name = flowName.trim().length > 0 ? flowName.trim() : 'Unnamed';
+
+    flows.create(name, {
       onSuccess: (id) => {
         setIsSaving(false);
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Defaults `flowName` to 'Unnamed' in `CreateNewFlow.tsx` if no name is provided.
> 
>   - **Behavior**:
>     - In `CreateNewFlow.tsx`, `handleConfirm` now defaults `flowName` to 'Unnamed' if empty.
>     - Ensures flows are created with a valid name, preventing empty names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 5dbdd9a41f18479e42e5ee20a15e411041c9de56. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->