### PR TITLE
COS-5995: If duplicate flow is not provided by user default to `{existing-flow-name} - Take two`

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/DuplicateFlow.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/DuplicateFlow.tsx
@@ -30,11 +30,15 @@ export const DuplicateFlow = observer(() => {
       return;
     }
 
-    flows.duplicate(flowName, flow.id, {
+    const duplicateName = !flowName.trim()?.length
+      ? `${flow?.value?.name} - Take two`
+      : flowName;
+
+    flows.duplicate(duplicateName, flow.id, {
       onSuccess: (id) => {
         setIsSaving(false);
         ui.toastSuccess(
-          `${flowName} created`,
+          `${duplicateName} created`,
           `flow-duplication-success-${id}`,
         );
         ui.commandMenu.toggle('DuplicateFlow');


### PR DESCRIPTION
…

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Default duplicate flow name to `{existing-flow-name} - Take two` in `DuplicateFlow.tsx` if no name is provided.
> 
>   - **Behavior**:
>     - In `DuplicateFlow.tsx`, default duplicate flow name to `{existing-flow-name} - Take two` if no name is provided by the user.
>     - Updates success toast message to reflect the actual name used for the duplicated flow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 81645d7fd2bbdf5745e43e7ff2c5973cc5cab70c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->