### PR TITLE
Fix new SLI version creation

### DIFF
--- a/packages/server/customer-os-api/service/service_line_item_service.go
+++ b/packages/server/customer-os-api/service/service_line_item_service.go
@@ -302,6 +302,8 @@ func (s *serviceLineItemService) NewVersion(ctx context.Context, data ServiceLin
 		return "", err
 	}
 
+	neo4jrepository.WaitForNodeCreatedInNeo4j(ctx, s.repositories.Neo4jRepositories, response.Id, model2.NodeLabelServiceLineItem, span)
+
 	return response.Id, err
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a call to `neo4jrepository.WaitForNodeCreatedInNeo4j()` in `NewVersion()` to ensure Neo4j node creation before proceeding.
> 
>   - **Behavior**:
>     - Adds `neo4jrepository.WaitForNodeCreatedInNeo4j()` call in `NewVersion()` in `service_line_item_service.go` to ensure the node is created in Neo4j before proceeding.
>   - **Misc**:
>     - No other changes or refactoring in the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a92d7678ce04da3fc8a7826075f7e6c032c6f004. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->