### PR TITLE
use tx in saving contact

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/contact_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/contact_service.go
@@ -209,7 +209,7 @@ func (s *contactService) hideContactsWithGroupOrSystemGeneratedEmail(ctx context
 				AppSource: constants.AppSourceDataUpkeeper,
 			})
 
-			err = s.commonServices.ContactService.HideContact(innerCtx, record.ContactId)
+			err = s.commonServices.ContactService.HideContact(innerCtx, nil, record.ContactId)
 			if err != nil {
 				tracing.TraceErr(span, err)
 				s.log.Errorf("Error hiding contact {%s}: %s", record.ContactId, err.Error())
@@ -285,7 +285,7 @@ func (s *contactService) checkContacts(ctx context.Context) {
 			}
 
 			if saveContact {
-				_, err = s.commonServices.ContactService.Save(innerCtx, &contactEntity.Id, contactFields, false)
+				_, err = s.commonServices.ContactService.Save(innerCtx, nil, &contactEntity.Id, contactFields, false)
 				if err != nil {
 					tracing.TraceErr(span, errors.Wrap(err, "ContactService.Save"))
 					s.log.Errorf("Error updating contact {%s}: %s", contactEntity.Id, err.Error())
@@ -364,7 +364,7 @@ func (s *contactService) updateContactNamesFromEmails(ctx context.Context) {
 				saveContact = true
 			}
 			if saveContact {
-				_, err = s.commonServices.ContactService.Save(innerCtx, &record.ContactId, contactFields, false)
+				_, err = s.commonServices.ContactService.Save(innerCtx, nil, &record.ContactId, contactFields, false)
 				if err != nil {
 					tracing.TraceErr(span, errors.Wrap(err, "ContactService.Save"))
 					s.log.Errorf("Error updating contact {%s}: %s", record.ContactId, err.Error())
@@ -559,7 +559,7 @@ func (s *contactService) processLinkedInUrl(ctx context.Context, tenant, linkedi
 
 	var contactIds []string
 	if len(contactsWithLinkedin) == 0 {
-		contactId, err := s.commonServices.ContactService.CreateContactByLinkedIn(ctx, linkedinProfileUrl)
+		contactId, err := s.commonServices.ContactService.CreateContactByLinkedIn(ctx, nil, linkedinProfileUrl)
 		if err != nil {
 			tracing.TraceErr(span, err)
 			return err

--- a/packages/server/customer-os-api/graph/resolver/contact.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/contact.resolvers.go
@@ -373,7 +373,7 @@ func (r *mutationResolver) ContactUpdate(ctx context.Context, input model.Contac
 	tracing.SetDefaultResolverSpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "request.input", input)
 
-	contactId, err := r.Services.CommonServices.ContactService.Save(ctx, utils.StringPtr(input.ID), mapper.MapContactUpdateInputToContactFields(input), false)
+	contactId, err := r.Services.CommonServices.ContactService.Save(ctx, nil, utils.StringPtr(input.ID), mapper.MapContactUpdateInputToContactFields(input), false)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		graphql.AddErrorf(ctx, "Failed to update contact %s", input.ID)
@@ -450,7 +450,7 @@ func (r *mutationResolver) ContactHide(ctx context.Context, contactID string) (*
 		return &model.ActionResponse{Accepted: false}, nil
 	}
 
-	err = r.Services.CommonServices.ContactService.HideContact(ctx, contactID)
+	err = r.Services.CommonServices.ContactService.HideContact(ctx, nil, contactID)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		graphql.AddErrorf(ctx, "Error while hiding contact")

--- a/packages/server/customer-os-api/rest/customerbase/contact.go
+++ b/packages/server/customer-os-api/rest/customerbase/contact.go
@@ -242,7 +242,7 @@ func processCSVRecords(c *gin.Context, ctx context.Context, span opentracing.Spa
 func processContact(c *gin.Context, ctx context.Context, span opentracing.Span, services *service.Services, tenant string, record ContactRecord) string {
 	emailEntity, contactId := findExistingContact(c, ctx, span, services, record.Email)
 	if emailEntity == nil && contactId == "" {
-		contactId = createNewContact(c, ctx, span, services, record.LinkedInURL)
+		contactId = createNewContact(ctx, span, services, record.LinkedInURL)
 	}
 
 	if emailEntity == nil && record.Email != "" {
@@ -279,8 +279,8 @@ func findExistingContact(c *gin.Context, ctx context.Context, span opentracing.S
 	return emailEntity, ""
 }
 
-func createNewContact(c *gin.Context, ctx context.Context, span opentracing.Span, services *service.Services, linkedInURL string) string {
-	contactId, err := services.CommonServices.ContactService.CreateContactByLinkedIn(ctx, linkedInURL)
+func createNewContact(ctx context.Context, span opentracing.Span, services *service.Services, linkedInURL string) string {
+	contactId, err := services.CommonServices.ContactService.CreateContactByLinkedIn(ctx, nil, linkedInURL)
 	if err != nil {
 		tracing.TraceErr(span, errors.Wrap(err, "failed to save contact"))
 		return ""

--- a/packages/server/customer-os-api/service/contact_service.go
+++ b/packages/server/customer-os-api/service/contact_service.go
@@ -107,9 +107,9 @@ func (s *contactService) Create(ctx context.Context, contactDetails *ContactCrea
 	var err error
 
 	if (neo4jentity.SocialEntity{Url: contactDetails.SocialUrl}).IsLinkedin() {
-		contactId, err = s.services.CommonServices.ContactService.CreateContactByLinkedIn(ctx, contactDetails.SocialUrl)
+		contactId, err = s.services.CommonServices.ContactService.CreateContactByLinkedIn(ctx, nil, contactDetails.SocialUrl)
 	} else {
-		contactId, err = s.services.CommonServices.ContactService.Save(ctx, nil,
+		contactId, err = s.services.CommonServices.ContactService.Save(ctx, nil, nil,
 			data_fields.ContactFields{
 				Source:          utils.StringPtr(string(contactDetails.Source)),
 				AppSource:       utils.StringPtr(utils.StringFirstNonEmpty(contactDetails.AppSource, constants.AppSourceCustomerOsApi)),
@@ -433,7 +433,7 @@ func (s *contactService) CustomerContactCreate(ctx context.Context, data *Custom
 	result := &model.CustomerContact{}
 
 	ctx = tracing.InjectSpanContextIntoGrpcMetadata(ctx, span)
-	contactId, err := s.services.CommonServices.ContactService.Save(ctx, nil,
+	contactId, err := s.services.CommonServices.ContactService.Save(ctx, nil, nil,
 		data_fields.ContactFields{
 			FirstName:   utils.StringPtr(data.ContactEntity.FirstName),
 			LastName:    utils.StringPtr(data.ContactEntity.LastName),

--- a/packages/server/customer-os-common-module/data_fields/contact_fields.go
+++ b/packages/server/customer-os-common-module/data_fields/contact_fields.go
@@ -18,6 +18,7 @@ type ContactFields struct {
 	Description     *string               `json:"description,omitempty"`
 	Prefix          *string               `json:"prefix,omitempty"`
 	CreatedAt       *time.Time            `json:"createdAt,omitempty"`
+	Hide            *bool                 `json:"hide,omitempty"`
 }
 
 func (fields ContactFields) ExternalSystemAvailable() bool {

--- a/packages/server/customer-os-common-module/service/contact_service.go
+++ b/packages/server/customer-os-common-module/service/contact_service.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	mailsherpa "github.com/customeros/mailsherpa/mailvalidate"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/common"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/constants"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/data_fields"
@@ -23,10 +22,10 @@ import (
 )
 
 type ContactService interface {
-	Save(ctx context.Context, id *string, contactFields data_fields.ContactFields, updateOnlyIfEmpty bool) (string, error)
-	CreateContactByLinkedIn(ctx context.Context, linkedInUrl string) (string, error)
-	HideContact(ctx context.Context, contactId string) error
-	ShowContact(ctx context.Context, contactId string) error
+	Save(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, id *string, contactFields data_fields.ContactFields, updateOnlyIfEmpty bool) (string, error)
+	CreateContactByLinkedIn(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, linkedInUrl string) (string, error)
+	HideContact(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, contactId string) error
+	ShowContact(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, contactId string) error
 	GetContactById(ctx context.Context, contactId string) (*neo4jentity.ContactEntity, error)
 	LinkContactWithOrganization(ctx context.Context, contactId, organizationId, jobTitle, description, source string, primary bool, startedAt, endedAt *time.Time) error
 	CheckContactExistsWithLinkedIn(ctx context.Context, url, alias, externalId string) (bool, string, error)
@@ -45,7 +44,7 @@ func NewContactService(log logger.Logger, services *Services) ContactService {
 	}
 }
 
-func (s *contactService) Save(ctx context.Context, id *string, contactFields data_fields.ContactFields, updateOnlyIfEmpty bool) (string, error) {
+func (s *contactService) Save(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, id *string, contactFields data_fields.ContactFields, updateOnlyIfEmpty bool) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.Save")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
@@ -90,6 +89,9 @@ func (s *contactService) Save(ctx context.Context, id *string, contactFields dat
 		if utils.IfNotNilString(contactFields.AppSource) == "" {
 			contactFields.AppSource = utils.StringPtr(common.GetAppSourceFromContext(ctx))
 		}
+		if contactFields.Hide == nil {
+			contactFields.Hide = utils.BoolPtr(false)
+		}
 	} else {
 		contactId = *id
 		// validate contact exists
@@ -115,40 +117,47 @@ func (s *contactService) Save(ctx context.Context, id *string, contactFields dat
 		}
 	}
 
-	_, err = utils.ExecuteWriteInTransaction(ctx, s.services.Neo4jRepositories.Neo4jDriver, s.services.Neo4jRepositories.Database, nil, func(tx neo4j.ManagedTransaction) (any, error) {
-		innerErr := s.services.Neo4jRepositories.ContactWriteRepository.SaveContactInTx(ctx, &tx, tenant, contactId, contactFields, updateOnlyIfEmpty)
+	_, err = utils.ExecuteWriteInTransactionWithPostCommitActions(ctx, s.services.Neo4jRepositories.Neo4jDriver, s.services.Neo4jRepositories.Database, txWithPostCommit, func(txWithPostCommit *utils.TxWithPostCommit) (any, error) {
+
+		innerErr := s.services.Neo4jRepositories.ContactWriteRepository.SaveContactInTx(ctx, txWithPostCommit.Tx, tenant, contactId, contactFields, updateOnlyIfEmpty)
 		if innerErr != nil {
 			s.log.Errorf("Error while saving contact %s: %s", contactId, err.Error())
 			return nil, innerErr
 		}
+
 		if contactFields.ExternalSystemAvailable() {
-			innerErr = s.services.Neo4jRepositories.ExternalSystemWriteRepository.LinkWithEntityInTx(ctx, &tx, tenant, contactId, model.NodeLabelContact, *contactFields.ExternalSystem)
+			innerErr = s.services.Neo4jRepositories.ExternalSystemWriteRepository.LinkWithEntityInTx(ctx, txWithPostCommit.Tx, tenant, contactId, model.NodeLabelContact, *contactFields.ExternalSystem)
 			if err != nil {
 				s.log.Errorf("Error while link contact %s with external system %s: %s", contactId, contactFields.ExternalSystem.ExternalSystemId, err.Error())
 				return nil, innerErr
 			}
 		}
+
+		txWithPostCommit.AddPostCommitAction(func(ctx context.Context) error {
+			if createFlow {
+				err = s.services.RabbitMQService.PublishEvent(ctx, contactId, model.CONTACT, dto.CreateContact{contactFields})
+				if err != nil {
+					tracing.TraceErr(span, errors.Wrap(err, "unable to publish message CreateContact"))
+				}
+				utils.EventCompleted(ctx, tenant, model.CONTACT.String(), contactId, s.services.GrpcClients, utils.NewEventCompletedDetails().WithCreate())
+			} else {
+				err = s.services.RabbitMQService.PublishEvent(ctx, contactId, model.CONTACT, dto.UpdateContact{contactFields})
+				if err != nil {
+					tracing.TraceErr(span, errors.Wrap(err, "unable to publish message UpdateContact"))
+				}
+				if common.GetAppSourceFromContext(ctx) != constants.AppSourceCustomerOsApi {
+					utils.EventCompleted(ctx, tenant, model.CONTACT.String(), contactId, s.services.GrpcClients, utils.NewEventCompletedDetails().WithUpdate())
+				}
+			}
+
+			return nil
+		})
+
 		return nil, nil
 	})
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return "", err
-	}
-
-	if createFlow {
-		err = s.services.RabbitMQService.PublishEvent(ctx, contactId, model.CONTACT, dto.CreateContact{contactFields})
-		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "unable to publish message CreateContact"))
-		}
-		utils.EventCompleted(ctx, tenant, model.CONTACT.String(), contactId, s.services.GrpcClients, utils.NewEventCompletedDetails().WithCreate())
-	} else {
-		err = s.services.RabbitMQService.PublishEvent(ctx, contactId, model.CONTACT, dto.UpdateContact{contactFields})
-		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "unable to publish message UpdateContact"))
-		}
-		if common.GetAppSourceFromContext(ctx) != constants.AppSourceCustomerOsApi {
-			utils.EventCompleted(ctx, tenant, model.CONTACT.String(), contactId, s.services.GrpcClients, utils.NewEventCompletedDetails().WithUpdate())
-		}
 	}
 
 	if createFlow {
@@ -159,7 +168,7 @@ func (s *contactService) Save(ctx context.Context, id *string, contactFields dat
 	return contactId, nil
 }
 
-func (s *contactService) HideContact(ctx context.Context, contactId string) error {
+func (s *contactService) HideContact(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, contactId string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.HideContact")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
@@ -173,28 +182,30 @@ func (s *contactService) HideContact(ctx context.Context, contactId string) erro
 	}
 	tenant := common.GetTenantFromContext(ctx)
 
-	err = s.services.Neo4jRepositories.CommonWriteRepository.UpdateBoolProperty(ctx, tenant, model.NodeLabelContact, contactId, string(neo4jentity.ContactPropertyHide), true)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		s.log.Errorf("error while hiding contact %s: %s", contactId, err.Error())
-	}
-	err = s.services.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(ctx, tenant, model.NodeLabelContact, contactId, string(neo4jentity.ContactPropertyHiddenAt), utils.NowPtr())
-	if err != nil {
-		tracing.TraceErr(span, err)
-		s.log.Errorf("error while updating hidden at property for contact %s: %s", contactId, err.Error())
-	}
+	_, err = utils.ExecuteWriteInTransactionWithPostCommitActions(ctx, s.services.Neo4jRepositories.Neo4jDriver, s.services.Neo4jRepositories.Database, txWithPostCommit, func(txWithPostCommit *utils.TxWithPostCommit) (any, error) {
+		contactFields := data_fields.ContactFields{Hide: utils.BoolPtr(false)}
+		err = s.services.Neo4jRepositories.ContactWriteRepository.SaveContactInTx(ctx, txWithPostCommit.Tx, tenant, contactId, contactFields, false)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			s.log.Errorf("error while hiding contact %s: %s", contactId, err.Error())
+		}
 
-	err = s.services.RabbitMQService.PublishEvent(ctx, contactId, model.CONTACT, dto.HideContact{})
-	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "unable to publish message HideContact"))
-	}
+		txWithPostCommit.AddPostCommitAction(func(ctx context.Context) error {
+			err = s.services.RabbitMQService.PublishEvent(ctx, contactId, model.CONTACT, dto.HideContact{})
+			if err != nil {
+				tracing.TraceErr(span, errors.Wrap(err, "unable to publish message HideContact"))
+			}
 
-	utils.EventCompleted(ctx, tenant, model.CONTACT.String(), contactId, s.services.GrpcClients, utils.NewEventCompletedDetails().WithDelete())
+			utils.EventCompleted(ctx, tenant, model.CONTACT.String(), contactId, s.services.GrpcClients, utils.NewEventCompletedDetails().WithDelete())
+			return nil
+		})
+		return nil, nil
+	})
 
 	return nil
 }
 
-func (s *contactService) ShowContact(ctx context.Context, contactId string) error {
+func (s *contactService) ShowContact(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, contactId string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.ShowContact")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
@@ -208,19 +219,28 @@ func (s *contactService) ShowContact(ctx context.Context, contactId string) erro
 	}
 	tenant := common.GetTenantFromContext(ctx)
 
-	err = s.services.Neo4jRepositories.CommonWriteRepository.UpdateBoolProperty(ctx, tenant, model.NodeLabelContact, contactId, string(neo4jentity.ContactPropertyHide), false)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		s.log.Errorf("error while showing contact %s: %s", contactId, err.Error())
-		return err
-	}
+	_, err = utils.ExecuteWriteInTransactionWithPostCommitActions(ctx, s.services.Neo4jRepositories.Neo4jDriver, s.services.Neo4jRepositories.Database, txWithPostCommit, func(txWithPostCommit *utils.TxWithPostCommit) (any, error) {
+		contactFields := data_fields.ContactFields{Hide: utils.BoolPtr(true)}
+		err = s.services.Neo4jRepositories.ContactWriteRepository.SaveContactInTx(ctx, txWithPostCommit.Tx, tenant, contactId, contactFields, false)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			s.log.Errorf("error while showing contact %s: %s", contactId, err.Error())
+			return nil, err
+		}
 
-	err = s.services.RabbitMQService.PublishEvent(ctx, contactId, model.CONTACT, dto.ShowContact{})
-	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "unable to publish message ShowContact"))
-	}
+		txWithPostCommit.AddPostCommitAction(func(ctx context.Context) error {
+			err = s.services.RabbitMQService.PublishEvent(ctx, contactId, model.CONTACT, dto.ShowContact{})
+			if err != nil {
+				tracing.TraceErr(span, errors.Wrap(err, "unable to publish message ShowContact"))
+			}
 
-	utils.EventCompleted(ctx, tenant, model.CONTACT.String(), contactId, s.services.GrpcClients, utils.NewEventCompletedDetails().WithCreate())
+			utils.EventCompleted(ctx, tenant, model.CONTACT.String(), contactId, s.services.GrpcClients, utils.NewEventCompletedDetails().WithCreate())
+
+			return nil
+		})
+
+		return nil, nil
+	})
 
 	return nil
 }
@@ -385,7 +405,7 @@ func (s *contactService) CheckContactExistsWithEmail(ctx context.Context, email 
 	return len(contacts) > 0, contactId, nil
 }
 
-func (s *contactService) CreateContactByLinkedIn(ctx context.Context, linkedInUrl string) (string, error) {
+func (s *contactService) CreateContactByLinkedIn(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, linkedInUrl string) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.CreateContactByLinkedIn")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
@@ -410,57 +430,68 @@ func (s *contactService) CreateContactByLinkedIn(ctx context.Context, linkedInUr
 	// Reject contact creation if linked-in url is already used by another contact
 	if utils.IfNotNilString(linkedInUrl) != "" {
 		if (neo4jentity.SocialEntity{Url: linkedInUrl}).IsLinkedin() {
-			linkedinUsed, existingContactId, err := s.services.ContactService.CheckContactExistsWithLinkedIn(ctx, linkedInUrl, "", "")
+			linkedInAlreadyUsed, existingContactId, err := s.services.ContactService.CheckContactExistsWithLinkedIn(ctx, linkedInUrl, "", "")
 			if err != nil {
 				tracing.TraceErr(span, errors.Wrap(err, "unable to check contact exists with linkedin"))
 				return "", err
 			}
-			if linkedinUsed {
-				contactEntity, err := s.GetContactById(ctx, existingContactId)
+			if linkedInAlreadyUsed {
+				contactByLinkedInEntity, err := s.GetContactById(ctx, existingContactId)
 				if err != nil {
 					tracing.TraceErr(span, errors.Wrap(err, "unable to get contact by id"))
 					return "", err
 				}
-				if contactEntity.Hide {
-					err = s.ShowContact(ctx, existingContactId)
-					if err != nil {
-						tracing.TraceErr(span, errors.Wrap(err, "unable to show contact"))
-						return "", err
+
+				_, err = utils.ExecuteWriteInTransactionWithPostCommitActions(ctx, s.services.Neo4jRepositories.Neo4jDriver, s.services.Neo4jRepositories.Database, txWithPostCommit, func(txWithPostCommit *utils.TxWithPostCommit) (any, error) {
+					if contactByLinkedInEntity.Hide {
+						err = s.ShowContact(ctx, txWithPostCommit, existingContactId)
+						if err != nil {
+							tracing.TraceErr(span, errors.Wrap(err, "unable to show contact"))
+							return "", err
+						}
+					} else {
+						// just update contact' updatedAt
+						err = s.services.Neo4jRepositories.CommonWriteRepository.TouchEntity(ctx, txWithPostCommit.Tx, tenant, model.NodeLabelContact, existingContactId)
+						if err != nil {
+							tracing.TraceErr(span, errors.Wrap(err, "error on updating contact updatedAt"))
+						}
+						txWithPostCommit.AddPostCommitAction(func(ctx context.Context) error {
+							utils.EventCompleted(ctx, tenant, model.CONTACT.String(), existingContactId, s.services.GrpcClients, utils.NewEventCompletedDetails().WithUpdate())
+							return nil
+						})
 					}
-				} else {
-					// just update contact' updatedAt
-					err = s.services.Neo4jRepositories.CommonWriteRepository.TouchEntity(ctx, nil, tenant, model.NodeLabelContact, existingContactId)
-					if err != nil {
-						tracing.TraceErr(span, errors.Wrap(err, "error on updating contact updatedAt"))
-					}
-					utils.EventCompleted(ctx, tenant, model.CONTACT.String(), existingContactId, s.services.GrpcClients, utils.NewEventCompletedDetails().WithUpdate())
-				}
+					return nil, nil
+				})
 				return existingContactId, nil
 			}
 		}
 	}
 
-	createdContactId, err := s.Save(ctx, nil, data_fields.ContactFields{}, false)
-	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to create contact"))
-		return "", err
-	}
+	createdContactId := ""
 
-	if (neo4jentity.SocialEntity{Url: linkedInUrl}).IsLinkedin() {
-		_, err := s.services.SocialService.AddSocialToEntity(ctx, nil,
-			LinkWith{
-				Id:   createdContactId,
-				Type: model.CONTACT,
-			},
-			neo4jentity.SocialEntity{
-				Url:       linkedInUrl,
-				Source:    neo4jentity.DecodeDataSource(neo4jentity.DataSourceOpenline.String()),
-				AppSource: common.GetAppSourceFromContext(ctx),
-			})
+	_, err = utils.ExecuteWriteInTransactionWithPostCommitActions(ctx, s.services.Neo4jRepositories.Neo4jDriver, s.services.Neo4jRepositories.Database, txWithPostCommit, func(txWithPostCommit *utils.TxWithPostCommit) (any, error) {
+		createdContactId, err = s.Save(ctx, txWithPostCommit, nil, data_fields.ContactFields{}, false)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to merge social with contact"))
+			tracing.TraceErr(span, errors.Wrap(err, "failed to create contact"))
+			return "", err
 		}
-	}
+		if (neo4jentity.SocialEntity{Url: linkedInUrl}).IsLinkedin() {
+			_, err := s.services.SocialService.AddSocialToEntity(ctx, txWithPostCommit,
+				LinkWith{
+					Id:   createdContactId,
+					Type: model.CONTACT,
+				},
+				neo4jentity.SocialEntity{
+					Url:       linkedInUrl,
+					Source:    neo4jentity.DecodeDataSource(neo4jentity.DataSourceOpenline.String()),
+					AppSource: common.GetAppSourceFromContext(ctx),
+				})
+			if err != nil {
+				tracing.TraceErr(span, errors.Wrap(err, "failed to merge social with contact"))
+			}
+		}
+		return nil, nil
+	})
 
 	return createdContactId, nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/contact_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/contact_write_repository.go
@@ -90,6 +90,11 @@ func (r *contactWriteRepository) SaveContactInTx(ctx context.Context, tx *neo4j.
 			cypher += ", c.username = CASE WHEN $updateOnlyIfEmpty = false OR c.username is null OR c.username = '' THEN $username ELSE c.username END"
 			params["username"] = *data.Username
 		}
+		if data.Hide != nil {
+			cypher += ", c.hide = $hide"
+			cypher += `, c.hiddenAt = CASE WHEN $hide = true THEN datetime() ELSE null END `
+			params["hide"] = *data.Hide
+		}
 
 		span.LogFields(log.String("cypher", cypher))
 		tracing.LogObjectAsJson(span, "params", params)

--- a/packages/server/customer-os-webhooks/service/contact_service.go
+++ b/packages/server/customer-os-webhooks/service/contact_service.go
@@ -189,7 +189,7 @@ func (s *contactService) syncContact(ctx context.Context, syncMutex *sync.Mutex,
 			createContact = false
 		}
 		if createContact {
-			contactId, err = s.services.CommonServices.ContactService.Save(ctx, nil,
+			contactId, err = s.services.CommonServices.ContactService.Save(ctx, nil, nil,
 				data_fields.ContactFields{
 					Name:            utils.StringPtr(contactInput.Name),
 					FirstName:       utils.StringPtr(contactInput.FirstName),
@@ -258,7 +258,7 @@ func (s *contactService) syncContact(ctx context.Context, syncMutex *sync.Mutex,
 				ExternalSource:   contactInput.ExternalSourceEntity,
 				SyncDate:         &syncDate,
 			}
-			_, err = s.services.CommonServices.ContactService.Save(ctx, &contactId, contactFields, false)
+			_, err = s.services.CommonServices.ContactService.Save(ctx, nil, &contactId, contactFields, false)
 			if err != nil {
 				failedSync = true
 				tracing.TraceErr(span, err)

--- a/packages/server/events-subscribers/listeners/contact_listener.go
+++ b/packages/server/events-subscribers/listeners/contact_listener.go
@@ -455,7 +455,7 @@ func (c *contactListenerImpl) enrichContactWithScrapInEnrichDetails(ctx context.
 	}
 
 	if updateContact {
-		_, err := c.services.ContactService.Save(ctx, &contact.Id, contactFields, false)
+		_, err := c.services.ContactService.Save(ctx, nil, &contact.Id, contactFields, false)
 		if err != nil {
 			tracing.TraceErr(span, errors.Wrap(err, "ContactService.Save"))
 			c.log.Errorf("Error updating contact: %s", err.Error())

--- a/packages/server/user-admin-api/service/registration_service.go
+++ b/packages/server/user-admin-api/service/registration_service.go
@@ -90,7 +90,7 @@ func (s *registrationService) CreateOrganizationAndContact(ctx context.Context, 
 		}
 
 		if contactNode == nil {
-			contactId, err = s.services.CommonServices.ContactService.Save(ctx, nil, data_fields.ContactFields{}, false)
+			contactId, err = s.services.CommonServices.ContactService.Save(ctx, nil, nil, data_fields.ContactFields{}, false)
 			if err != nil {
 				tracing.TraceErr(span, err)
 				return nil, nil, err


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added transaction support to contact operations across multiple services and repositories for consistent transactional behavior.
> 
>   - **Behavior**:
>     - Updated `HideContact`, `Save`, and `CreateContactByLinkedIn` functions in `contact_service.go` to include a `txWithPostCommit` parameter for transactional operations.
>     - Modified `processLinkedInUrl` in `contact_service.go` to use `CreateContactByLinkedIn` with transaction support.
>   - **Repositories**:
>     - Updated `SaveContactInTx` in `contact_write_repository.go` to handle `hide` property with transaction.
>   - **GraphQL Resolvers**:
>     - Updated `ContactUpdate` and `ContactHide` in `contact.resolvers.go` to pass `nil` for transaction parameter.
>   - **REST API**:
>     - Updated `createNewContact` in `contact.go` to use `CreateContactByLinkedIn` with transaction support.
>   - **Webhooks**:
>     - Updated `syncContact` in `contact_service.go` to use `Save` with transaction support.
>   - **Listeners**:
>     - Updated `enrichContactWithScrapInEnrichDetails` in `contact_listener.go` to use `Save` with transaction support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3b553946ed0fde60b1c20649795f893af892afd6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->