### PR TITLE
COS-6007: Fix modal context after saving email

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
@@ -146,7 +146,10 @@ export const EmailSettingsPanel = observer(() => {
 
       setTimeout(() => {
         takeSnapshot();
-        ui.commandMenu.clearContext();
+        ui.commandMenu.setContext({
+          entity: 'Flow',
+          ids: [flowId],
+        });
         sidePanelStore.clearContext();
         sidePanelStore.setOpen(false);
       }, 0);


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes context setting in `EmailSettingsPanel.tsx` after saving an email to ensure correct command menu context.
> 
>   - **Behavior**:
>     - Fixes context setting in `EmailSettingsPanel.tsx` after saving an email by updating `ui.commandMenu.setContext` with `entity: 'Flow'` and `ids: [flowId]`.
>     - Ensures `sidePanelStore.clearContext()` and `sidePanelStore.setOpen(false)` are called after setting the context.
>   - **Misc**:
>     - No changes to the logic of email content preparation or saving.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 891cec098dd8718720443eb845051a965b342708. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->