### PR TITLE
COS-6008: Do not set isLoading on duplicate flow action

### DIFF
--- a/packages/apps/frontera/src/store/Flows/Flows.store.ts
+++ b/packages/apps/frontera/src/store/Flows/Flows.store.ts
@@ -168,8 +168,6 @@ export class FlowsStore implements GroupStore<Flow> {
     id: string,
     options?: { onSuccess?: (serverId: string) => void },
   ) {
-    this.isLoading = true;
-
     const originFlow = this.value.get(id);
     const newFlow = new FlowStore(this.root, this.transport);
     const tempId = newFlow.value.metadata.id;
@@ -229,8 +227,6 @@ export class FlowsStore implements GroupStore<Flow> {
         this.error = (e as Error)?.message;
         this.value.delete(tempId);
       });
-    } finally {
-      this.isLoading = false;
     }
   }
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `isLoading` state changes in `duplicate()` in `Flows.store.ts` to avoid unnecessary loading state updates.
> 
>   - **Behavior**:
>     - Remove setting `isLoading` to `true` and `false` in `duplicate()` in `Flows.store.ts` to prevent unnecessary loading state changes during duplicate flow action.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 43af18e692e304b43c0a9fef2595579f1c2b538e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->