### PR TITLE
org domain is required to find email

### DIFF
--- a/packages/server/customer-os-api/graph/resolver/contact.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/contact.resolvers.go
@@ -670,7 +670,7 @@ func (r *mutationResolver) ContactFindWorkEmail(ctx context.Context, contactID s
 		orgDomain = *domain
 	}
 
-	if orgName == "" && orgDomain == "" {
+	if orgDomain == "" {
 		tracing.TraceErr(span, errors.New("cannot find email for contact without domain"))
 		graphql.AddErrorf(ctx, "Missing domain for contact")
 		return &model.ActionResponse{Accepted: false}, nil


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `ContactFindWorkEmail` to require `orgDomain` for email search, logging error if missing.
> 
>   - **Behavior**:
>     - In `ContactFindWorkEmail` function, removed check for `orgName` being empty. Now only `orgDomain` is required to proceed.
>     - If `orgDomain` is empty, logs an error and returns a response indicating a missing domain.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8206bb7e6385a4dac1aac4a157f4d22a8bb77338. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->