### PR TITLE
COS-6001: Show the flow settings panel when user enters empty flow

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/page.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
@@ -68,6 +68,15 @@ const FlowContent = observer(
     const tableId = tableViewDef?.value.tableId;
 
     const tableType = tableViewDef?.value?.tableType;
+
+    useEffect(() => {
+      const nodes = getNodes();
+
+      // open settings
+      if (nodes.length === 2) {
+        setIsSidePanelOpen(true);
+      }
+    }, []);
 
     return (
       <>

--- a/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
@@ -272,6 +272,20 @@ export const FlowBuilder = observer(
       takeSnapshot();
     }, [takeSnapshot]);
 
+    const handleOpenEmailEditor = useCallback((node: Node) => {
+      onToggleSidePanel(false);
+
+      store.ui.flowActionSidePanel.setOpen(true);
+      store.ui.flowActionSidePanel.setType('EmailAction');
+      store.ui.flowActionSidePanel.setContext({
+        ...store.ui.flowActionSidePanel.context,
+        id: node.id,
+        // @ts-expect-error to do improve types on flowActionSidePanel
+
+        node: node,
+      });
+    }, []);
+
     const onNodesChangeHandler = useCallback(
       (changes: NodeChange[]) => {
         // this is hack to prevent removing initial edges automatically for some unknown yet reason
@@ -295,27 +309,18 @@ export const FlowBuilder = observer(
           }
         }
 
-        // Check if we need to open the side panel
-        const shouldOpenSidePanel = changes.some((change) => {
-          if (
+        // Open email editor when new node is added
+        const newEmailNode = changes.find(
+          (change: NodeChange): change is NodeChange & { item: Node } =>
             change.type === 'add' &&
-            change.item.type === 'action' &&
-            change.item.data.action === 'EMAIL_NEW'
-          ) {
-            // Check if this is the first email action
-            const existingEmailNodes = nodes.filter(
-              (node) =>
-                node.type === 'action' && node.data.action === 'EMAIL_NEW',
-            );
+            'item' in change &&
+            change.item?.type === 'action' &&
+            (change.item?.data?.action === 'EMAIL_NEW' ||
+              change.item?.data?.action === 'EMAIL_REPLY'),
+        );
 
-            return existingEmailNodes.length === 0;
-          }
-
-          return false;
-        });
-
-        if (shouldOpenSidePanel) {
-          onToggleSidePanel(true);
+        if (newEmailNode) {
+          handleOpenEmailEditor(newEmailNode.item);
         }
       },
       [nodes, onNodesChange],
@@ -464,15 +469,7 @@ export const FlowBuilder = observer(
               ['EMAIL_NEW', 'EMAIL_REPLY'].includes(node.data.action as string)
             ) {
               event.stopPropagation();
-              store.ui.flowActionSidePanel.setOpen(true);
-              store.ui.flowActionSidePanel.setType('EmailAction');
-              store.ui.flowActionSidePanel.setContext({
-                ...store.ui.flowActionSidePanel.context,
-                id: node.id,
-                // @ts-expect-error to do improve types on flowActionSidePanel
-
-                node: node,
-              });
+              handleOpenEmailEditor(node);
 
               return;
             }


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Open flow settings panel on entering empty flow and streamline email editor opening in `FlowBuilder.tsx`.
> 
>   - **Behavior**:
>     - In `page.tsx`, use `useEffect` to open settings panel if `getNodes()` returns exactly two nodes.
>     - In `FlowBuilder.tsx`, open email editor when a new node of type `EMAIL_NEW` or `EMAIL_REPLY` is added using `handleOpenEmailEditor()`.
>   - **Functions**:
>     - Add `handleOpenEmailEditor()` in `FlowBuilder.tsx` to centralize logic for opening email editor.
>     - Modify `onNodesChangeHandler()` in `FlowBuilder.tsx` to use `handleOpenEmailEditor()` for new email nodes.
>   - **Misc**:
>     - Import `useEffect` in `page.tsx` to manage side panel state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 24bf1f26323841aba26e80872a7ae61d79cf02d2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->