### PR TITLE
Fix send emails

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/cron/cron.go
+++ b/packages/runner/customer-os-data-upkeeper/cron/cron.go
@@ -283,7 +283,7 @@ func StartCron(cont *container.Container) *cron.Cron {
 	}
 
 	err = c.AddFunc(cont.Cfg.Cron.CronScheduleSendEmails, func() {
-		//lockAndRunJob(cont, sendEmailsGroup, sendEmails)
+		lockAndRunJob(cont, sendEmailsGroup, sendEmails)
 	})
 	if err != nil {
 		cont.Log.Fatalf("Could not add cron job %s: %v", "sendEmails", err.Error())


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Re-enables the `sendEmails` cron job in `cron.go` by uncommenting the `lockAndRunJob` call for `sendEmailsGroup`.
> 
>   - **Behavior**:
>     - Re-enables the `sendEmails` cron job in `cron.go` by uncommenting the `lockAndRunJob` call for `sendEmailsGroup`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3e8da09934c826d5963f7c7d34ef5d48e5491b62. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->