### PR TITLE
Migrate sort graph type to common module

### DIFF
--- a/packages/server/customer-os-api/gqlgen.yml
+++ b/packages/server/customer-os-api/gqlgen.yml
@@ -68,6 +68,12 @@ models:
       - github.com/99designs/gqlgen/graphql.Int
       - github.com/99designs/gqlgen/graphql.Int64
       - github.com/99designs/gqlgen/graphql.Int32
+  SortBy:
+    model:
+      - github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model.SortBy
+  SortingDirection:
+    model:
+      - github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model.SortingDirection
   FlowStatus:
     model:
       - github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity.FlowStatus

--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -219,7 +219,7 @@ type ComplexityRoot struct {
 		Locations                     func(childComplexity int) int
 		Metadata                      func(childComplexity int) int
 		Name                          func(childComplexity int) int
-		Organizations                 func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) int
+		Organizations                 func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) int
 		Owner                         func(childComplexity int) int
 		PhoneNumbers                  func(childComplexity int) int
 		Prefix                        func(childComplexity int) int
@@ -1207,7 +1207,7 @@ type ComplexityRoot struct {
 		AccountDetails                func(childComplexity int) int
 		AppSource                     func(childComplexity int) int
 		ContactCount                  func(childComplexity int) int
-		Contacts                      func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) int
+		Contacts                      func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) int
 		Contracts                     func(childComplexity int) int
 		CreatedAt                     func(childComplexity int) int
 		CustomFields                  func(childComplexity int) int
@@ -1391,7 +1391,7 @@ type ComplexityRoot struct {
 		Contact                                    func(childComplexity int, id string) int
 		ContactByEmail                             func(childComplexity int, email string) int
 		ContactByPhone                             func(childComplexity int, e164 string) int
-		Contacts                                   func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) int
+		Contacts                                   func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) int
 		Contract                                   func(childComplexity int, id string) int
 		Contracts                                  func(childComplexity int, pagination *model.Pagination) int
 		CustomFieldTemplateList                    func(childComplexity int) int
@@ -1404,10 +1404,10 @@ type ComplexityRoot struct {
 		DashboardRetentionRate                     func(childComplexity int, period *model.DashboardPeriodInput) int
 		DashboardRevenueAtRisk                     func(childComplexity int, period *model.DashboardPeriodInput) int
 		DashboardTimeToOnboard                     func(childComplexity int, period *model.DashboardPeriodInput) int
-		DashboardViewOrganizations                 func(childComplexity int, pagination model.Pagination, where *model.Filter, sort *model.SortBy) int
-		DashboardViewRenewals                      func(childComplexity int, pagination model.Pagination, where *model.Filter, sort *model.SortBy) int
+		DashboardViewOrganizations                 func(childComplexity int, pagination model.Pagination, where *model.Filter, sort *model1.SortBy) int
+		DashboardViewRenewals                      func(childComplexity int, pagination model.Pagination, where *model.Filter, sort *model1.SortBy) int
 		Email                                      func(childComplexity int, id string) int
-		ExternalMeetings                           func(childComplexity int, externalSystemID string, externalID *string, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) int
+		ExternalMeetings                           func(childComplexity int, externalSystemID string, externalID *string, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) int
 		ExternalSystemInstances                    func(childComplexity int) int
 		Flow                                       func(childComplexity int, id string) int
 		FlowEmailVariables                         func(childComplexity int) int
@@ -1419,7 +1419,7 @@ type ComplexityRoot struct {
 		InteractionEvent                           func(childComplexity int, id string) int
 		Invoice                                    func(childComplexity int, id string) int
 		InvoiceByNumber                            func(childComplexity int, number string) int
-		Invoices                                   func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy, organizationID *string) int
+		Invoices                                   func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy, organizationID *string) int
 		Issue                                      func(childComplexity int, id string) int
 		LogEntry                                   func(childComplexity int, id string) int
 		MailstackCheckUnavailableDomains           func(childComplexity int, domains []string) int
@@ -1436,7 +1436,7 @@ type ComplexityRoot struct {
 		OrganizationByCustomerOsID                 func(childComplexity int, customerOsID string) int
 		OrganizationCheckWebsite                   func(childComplexity int, website string) int
 		OrganizationDistinctOwners                 func(childComplexity int) int
-		Organizations                              func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) int
+		Organizations                              func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) int
 		OrganizationsHiddenAfter                   func(childComplexity int, date time.Time) int
 		PhoneNumber                                func(childComplexity int, id string) int
 		Reminder                                   func(childComplexity int, id string) int
@@ -1453,10 +1453,10 @@ type ComplexityRoot struct {
 		TimelineEvents                             func(childComplexity int, ids []string) int
 		UIOrganization                             func(childComplexity int, ids string) int
 		UIOrganizations                            func(childComplexity int, ids []string) int
-		UIOrganizationsSearch                      func(childComplexity int, limit *int, where *model.Filter, sort *model.SortBy) int
+		UIOrganizationsSearch                      func(childComplexity int, limit *int, where *model.Filter, sort *model1.SortBy) int
 		User                                       func(childComplexity int, id string) int
 		UserByEmail                                func(childComplexity int, email string) int
-		Users                                      func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) int
+		Users                                      func(childComplexity int, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) int
 		WorkflowByType                             func(childComplexity int, workflowType model.WorkflowType) int
 		Workflows                                  func(childComplexity int) int
 	}
@@ -1707,7 +1707,7 @@ type CommentResolver interface {
 type ContactResolver interface {
 	Tags(ctx context.Context, obj *model.Contact) ([]*model.Tag, error)
 	JobRoles(ctx context.Context, obj *model.Contact) ([]*model.JobRole, error)
-	Organizations(ctx context.Context, obj *model.Contact, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.OrganizationPage, error)
+	Organizations(ctx context.Context, obj *model.Contact, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) (*model.OrganizationPage, error)
 	LatestOrganizationWithJobRole(ctx context.Context, obj *model.Contact) (*model.OrganizationWithJobRole, error)
 	PhoneNumbers(ctx context.Context, obj *model.Contact) ([]*model.PhoneNumber, error)
 	Emails(ctx context.Context, obj *model.Contact) ([]*model.Email, error)
@@ -2020,7 +2020,7 @@ type OrganizationResolver interface {
 
 	TimelineEvents(ctx context.Context, obj *model.Organization, from *time.Time, size int, timelineEventTypes []model.TimelineEventType) ([]model.TimelineEvent, error)
 
-	Contacts(ctx context.Context, obj *model.Organization, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.ContactsPage, error)
+	Contacts(ctx context.Context, obj *model.Organization, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) (*model.ContactsPage, error)
 	JobRoles(ctx context.Context, obj *model.Organization) ([]*model.JobRole, error)
 	Emails(ctx context.Context, obj *model.Organization) ([]*model.Email, error)
 	PhoneNumbers(ctx context.Context, obj *model.Organization) ([]*model.PhoneNumber, error)
@@ -2049,14 +2049,14 @@ type QueryResolver interface {
 	BankAccounts(ctx context.Context) ([]*model.BankAccount, error)
 	GlobalCache(ctx context.Context) (*model.GlobalCache, error)
 	Contact(ctx context.Context, id string) (*model.Contact, error)
-	Contacts(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.ContactsPage, error)
+	Contacts(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) (*model.ContactsPage, error)
 	ContactByEmail(ctx context.Context, email string) (*model.Contact, error)
 	ContactByPhone(ctx context.Context, e164 string) (*model.Contact, error)
 	Contract(ctx context.Context, id string) (*model.Contract, error)
 	Contracts(ctx context.Context, pagination *model.Pagination) (*model.ContractPage, error)
 	CustomFieldTemplateList(ctx context.Context) ([]*model.CustomFieldTemplate, error)
-	DashboardViewOrganizations(ctx context.Context, pagination model.Pagination, where *model.Filter, sort *model.SortBy) (*model.OrganizationPage, error)
-	DashboardViewRenewals(ctx context.Context, pagination model.Pagination, where *model.Filter, sort *model.SortBy) (*model.RenewalsPage, error)
+	DashboardViewOrganizations(ctx context.Context, pagination model.Pagination, where *model.Filter, sort *model1.SortBy) (*model.OrganizationPage, error)
+	DashboardViewRenewals(ctx context.Context, pagination model.Pagination, where *model.Filter, sort *model1.SortBy) (*model.RenewalsPage, error)
 	DashboardCustomerMap(ctx context.Context) ([]*model.DashboardCustomerMap, error)
 	DashboardMRRPerCustomer(ctx context.Context, period *model.DashboardPeriodInput) (*model.DashboardMRRPerCustomer, error)
 	DashboardGrossRevenueRetention(ctx context.Context, period *model.DashboardPeriodInput) (*model.DashboardGrossRevenueRetention, error)
@@ -2075,7 +2075,7 @@ type QueryResolver interface {
 	FlowTestEmailSender(ctx context.Context) (string, error)
 	InteractionEvent(ctx context.Context, id string) (*model.InteractionEvent, error)
 	Invoice(ctx context.Context, id string) (*model.Invoice, error)
-	Invoices(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy, organizationID *string) (*model.InvoicesPage, error)
+	Invoices(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy, organizationID *string) (*model.InvoicesPage, error)
 	InvoiceByNumber(ctx context.Context, number string) (*model.Invoice, error)
 	Issue(ctx context.Context, id string) (*model.Issue, error)
 	LogEntry(ctx context.Context, id string) (*model.LogEntry, error)
@@ -2086,10 +2086,10 @@ type QueryResolver interface {
 	MailstackMailboxes(ctx context.Context) ([]*model.Mailbox, error)
 	MailstackRegisteredBuyDomainsWithMailboxes(ctx context.Context) ([]*model.MailstackBuyRequest, error)
 	Meeting(ctx context.Context, id string) (*model.Meeting, error)
-	ExternalMeetings(ctx context.Context, externalSystemID string, externalID *string, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.MeetingsPage, error)
+	ExternalMeetings(ctx context.Context, externalSystemID string, externalID *string, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) (*model.MeetingsPage, error)
 	Opportunity(ctx context.Context, id string) (*model.Opportunity, error)
 	OpportunitiesLinkedToOrganizations(ctx context.Context, pagination *model.Pagination) (*model.OpportunityPage, error)
-	Organizations(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.OrganizationPage, error)
+	Organizations(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) (*model.OrganizationPage, error)
 	Organization(ctx context.Context, id string) (*model.Organization, error)
 	OrganizationByCustomerOsID(ctx context.Context, customerOsID string) (*model.Organization, error)
 	OrganizationByCustomID(ctx context.Context, customID string) (*model.Organization, error)
@@ -2098,7 +2098,7 @@ type QueryResolver interface {
 	OrganizationsHiddenAfter(ctx context.Context, date time.Time) ([]string, error)
 	UIOrganization(ctx context.Context, ids string) (*model.OrganizationUIDetails, error)
 	UIOrganizations(ctx context.Context, ids []string) ([]*model.OrganizationUIDetails, error)
-	UIOrganizationsSearch(ctx context.Context, limit *int, where *model.Filter, sort *model.SortBy) (*model.OrganizationSearchResult, error)
+	UIOrganizationsSearch(ctx context.Context, limit *int, where *model.Filter, sort *model1.SortBy) (*model.OrganizationSearchResult, error)
 	PhoneNumber(ctx context.Context, id string) (*model.PhoneNumber, error)
 	Reminder(ctx context.Context, id string) (*model.Reminder, error)
 	RemindersForOrganization(ctx context.Context, organizationID string, dismissed *bool) ([]*model.Reminder, error)
@@ -2113,7 +2113,7 @@ type QueryResolver interface {
 	TenantSettings(ctx context.Context) (*model.TenantSettings, error)
 	BillableInfo(ctx context.Context) (*model.TenantBillableInfo, error)
 	TimelineEvents(ctx context.Context, ids []string) ([]model.TimelineEvent, error)
-	Users(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.UserPage, error)
+	Users(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) (*model.UserPage, error)
 	User(ctx context.Context, id string) (*model.User, error)
 	UserByEmail(ctx context.Context, email string) (*model.User, error)
 	TableViewDefs(ctx context.Context) ([]*model.TableViewDef, error)
@@ -2926,7 +2926,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Contact.Organizations(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model.SortBy)), true
+		return e.complexity.Contact.Organizations(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model1.SortBy)), true
 
 	case "Contact.owner":
 		if e.complexity.Contact.Owner == nil {
@@ -9002,7 +9002,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Organization.Contacts(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model.SortBy)), true
+		return e.complexity.Organization.Contacts(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model1.SortBy)), true
 
 	case "Organization.contracts":
 		if e.complexity.Organization.Contracts == nil {
@@ -10136,7 +10136,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Contacts(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model.SortBy)), true
+		return e.complexity.Query.Contacts(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model1.SortBy)), true
 
 	case "Query.contract":
 		if e.complexity.Query.Contract == nil {
@@ -10282,7 +10282,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.DashboardViewOrganizations(childComplexity, args["pagination"].(model.Pagination), args["where"].(*model.Filter), args["sort"].(*model.SortBy)), true
+		return e.complexity.Query.DashboardViewOrganizations(childComplexity, args["pagination"].(model.Pagination), args["where"].(*model.Filter), args["sort"].(*model1.SortBy)), true
 
 	case "Query.dashboardView_Renewals":
 		if e.complexity.Query.DashboardViewRenewals == nil {
@@ -10294,7 +10294,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.DashboardViewRenewals(childComplexity, args["pagination"].(model.Pagination), args["where"].(*model.Filter), args["sort"].(*model.SortBy)), true
+		return e.complexity.Query.DashboardViewRenewals(childComplexity, args["pagination"].(model.Pagination), args["where"].(*model.Filter), args["sort"].(*model1.SortBy)), true
 
 	case "Query.email":
 		if e.complexity.Query.Email == nil {
@@ -10318,7 +10318,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ExternalMeetings(childComplexity, args["externalSystemId"].(string), args["externalId"].(*string), args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model.SortBy)), true
+		return e.complexity.Query.ExternalMeetings(childComplexity, args["externalSystemId"].(string), args["externalId"].(*string), args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model1.SortBy)), true
 
 	case "Query.externalSystemInstances":
 		if e.complexity.Query.ExternalSystemInstances == nil {
@@ -10437,7 +10437,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Invoices(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model.SortBy), args["organizationId"].(*string)), true
+		return e.complexity.Query.Invoices(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model1.SortBy), args["organizationId"].(*string)), true
 
 	case "Query.issue":
 		if e.complexity.Query.Issue == nil {
@@ -10616,7 +10616,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Organizations(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model.SortBy)), true
+		return e.complexity.Query.Organizations(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model1.SortBy)), true
 
 	case "Query.organizations_HiddenAfter":
 		if e.complexity.Query.OrganizationsHiddenAfter == nil {
@@ -10795,7 +10795,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.UIOrganizationsSearch(childComplexity, args["limit"].(*int), args["where"].(*model.Filter), args["sort"].(*model.SortBy)), true
+		return e.complexity.Query.UIOrganizationsSearch(childComplexity, args["limit"].(*int), args["where"].(*model.Filter), args["sort"].(*model1.SortBy)), true
 
 	case "Query.user":
 		if e.complexity.Query.User == nil {
@@ -10831,7 +10831,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Users(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model.SortBy)), true
+		return e.complexity.Query.Users(childComplexity, args["pagination"].(*model.Pagination), args["where"].(*model.Filter), args["sort"].([]*model1.SortBy)), true
 
 	case "Query.workflow_ByType":
 		if e.complexity.Query.WorkflowByType == nil {
@@ -16714,22 +16714,22 @@ func (ec *executionContext) field_Contact_organizations_argsWhere(
 func (ec *executionContext) field_Contact_organizations_argsSort(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) ([]*model.SortBy, error) {
+) ([]*model1.SortBy, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["sort"]
 	if !ok {
-		var zeroVal []*model.SortBy
+		var zeroVal []*model1.SortBy
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
 	if tmp, ok := rawArgs["sort"]; ok {
-		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortByᚄ(ctx, tmp)
+		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortByᚄ(ctx, tmp)
 	}
 
-	var zeroVal []*model.SortBy
+	var zeroVal []*model1.SortBy
 	return zeroVal, nil
 }
 
@@ -24628,22 +24628,22 @@ func (ec *executionContext) field_Organization_contacts_argsWhere(
 func (ec *executionContext) field_Organization_contacts_argsSort(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) ([]*model.SortBy, error) {
+) ([]*model1.SortBy, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["sort"]
 	if !ok {
-		var zeroVal []*model.SortBy
+		var zeroVal []*model1.SortBy
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
 	if tmp, ok := rawArgs["sort"]; ok {
-		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortByᚄ(ctx, tmp)
+		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortByᚄ(ctx, tmp)
 	}
 
-	var zeroVal []*model.SortBy
+	var zeroVal []*model1.SortBy
 	return zeroVal, nil
 }
 
@@ -24992,22 +24992,22 @@ func (ec *executionContext) field_Query_contacts_argsWhere(
 func (ec *executionContext) field_Query_contacts_argsSort(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) ([]*model.SortBy, error) {
+) ([]*model1.SortBy, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["sort"]
 	if !ok {
-		var zeroVal []*model.SortBy
+		var zeroVal []*model1.SortBy
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
 	if tmp, ok := rawArgs["sort"]; ok {
-		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortByᚄ(ctx, tmp)
+		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortByᚄ(ctx, tmp)
 	}
 
-	var zeroVal []*model.SortBy
+	var zeroVal []*model1.SortBy
 	return zeroVal, nil
 }
 
@@ -25142,22 +25142,22 @@ func (ec *executionContext) field_Query_dashboardView_Organizations_argsWhere(
 func (ec *executionContext) field_Query_dashboardView_Organizations_argsSort(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) (*model.SortBy, error) {
+) (*model1.SortBy, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["sort"]
 	if !ok {
-		var zeroVal *model.SortBy
+		var zeroVal *model1.SortBy
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
 	if tmp, ok := rawArgs["sort"]; ok {
-		return ec.unmarshalOSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortBy(ctx, tmp)
+		return ec.unmarshalOSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortBy(ctx, tmp)
 	}
 
-	var zeroVal *model.SortBy
+	var zeroVal *model1.SortBy
 	return zeroVal, nil
 }
 
@@ -25228,22 +25228,22 @@ func (ec *executionContext) field_Query_dashboardView_Renewals_argsWhere(
 func (ec *executionContext) field_Query_dashboardView_Renewals_argsSort(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) (*model.SortBy, error) {
+) (*model1.SortBy, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["sort"]
 	if !ok {
-		var zeroVal *model.SortBy
+		var zeroVal *model1.SortBy
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
 	if tmp, ok := rawArgs["sort"]; ok {
-		return ec.unmarshalOSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortBy(ctx, tmp)
+		return ec.unmarshalOSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortBy(ctx, tmp)
 	}
 
-	var zeroVal *model.SortBy
+	var zeroVal *model1.SortBy
 	return zeroVal, nil
 }
 
@@ -25656,22 +25656,22 @@ func (ec *executionContext) field_Query_externalMeetings_argsWhere(
 func (ec *executionContext) field_Query_externalMeetings_argsSort(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) ([]*model.SortBy, error) {
+) ([]*model1.SortBy, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["sort"]
 	if !ok {
-		var zeroVal []*model.SortBy
+		var zeroVal []*model1.SortBy
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
 	if tmp, ok := rawArgs["sort"]; ok {
-		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortByᚄ(ctx, tmp)
+		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortByᚄ(ctx, tmp)
 	}
 
-	var zeroVal []*model.SortBy
+	var zeroVal []*model1.SortBy
 	return zeroVal, nil
 }
 
@@ -25966,22 +25966,22 @@ func (ec *executionContext) field_Query_invoices_argsWhere(
 func (ec *executionContext) field_Query_invoices_argsSort(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) ([]*model.SortBy, error) {
+) ([]*model1.SortBy, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["sort"]
 	if !ok {
-		var zeroVal []*model.SortBy
+		var zeroVal []*model1.SortBy
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
 	if tmp, ok := rawArgs["sort"]; ok {
-		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortByᚄ(ctx, tmp)
+		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortByᚄ(ctx, tmp)
 	}
 
-	var zeroVal []*model.SortBy
+	var zeroVal []*model1.SortBy
 	return zeroVal, nil
 }
 
@@ -26458,22 +26458,22 @@ func (ec *executionContext) field_Query_organizations_argsWhere(
 func (ec *executionContext) field_Query_organizations_argsSort(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) ([]*model.SortBy, error) {
+) ([]*model1.SortBy, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["sort"]
 	if !ok {
-		var zeroVal []*model.SortBy
+		var zeroVal []*model1.SortBy
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
 	if tmp, ok := rawArgs["sort"]; ok {
-		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortByᚄ(ctx, tmp)
+		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortByᚄ(ctx, tmp)
 	}
 
-	var zeroVal []*model.SortBy
+	var zeroVal []*model1.SortBy
 	return zeroVal, nil
 }
 
@@ -26891,22 +26891,22 @@ func (ec *executionContext) field_Query_ui_organizations_search_argsWhere(
 func (ec *executionContext) field_Query_ui_organizations_search_argsSort(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) (*model.SortBy, error) {
+) (*model1.SortBy, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["sort"]
 	if !ok {
-		var zeroVal *model.SortBy
+		var zeroVal *model1.SortBy
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
 	if tmp, ok := rawArgs["sort"]; ok {
-		return ec.unmarshalOSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortBy(ctx, tmp)
+		return ec.unmarshalOSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortBy(ctx, tmp)
 	}
 
-	var zeroVal *model.SortBy
+	var zeroVal *model1.SortBy
 	return zeroVal, nil
 }
 
@@ -27041,22 +27041,22 @@ func (ec *executionContext) field_Query_users_argsWhere(
 func (ec *executionContext) field_Query_users_argsSort(
 	ctx context.Context,
 	rawArgs map[string]interface{},
-) ([]*model.SortBy, error) {
+) ([]*model1.SortBy, error) {
 	// We won't call the directive if the argument is null.
 	// Set call_argument_directives_with_null to true to call directives
 	// even if the argument is null.
 	_, ok := rawArgs["sort"]
 	if !ok {
-		var zeroVal []*model.SortBy
+		var zeroVal []*model1.SortBy
 		return zeroVal, nil
 	}
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
 	if tmp, ok := rawArgs["sort"]; ok {
-		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortByᚄ(ctx, tmp)
+		return ec.unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortByᚄ(ctx, tmp)
 	}
 
-	var zeroVal []*model.SortBy
+	var zeroVal []*model1.SortBy
 	return zeroVal, nil
 }
 
@@ -32002,7 +32002,7 @@ func (ec *executionContext) _Contact_organizations(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Contact().Organizations(rctx, obj, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model.SortBy))
+		return ec.resolvers.Contact().Organizations(rctx, obj, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model1.SortBy))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -81490,7 +81490,7 @@ func (ec *executionContext) _Organization_contacts(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Organization().Contacts(rctx, obj, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model.SortBy))
+		return ec.resolvers.Organization().Contacts(rctx, obj, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model1.SortBy))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -87654,7 +87654,7 @@ func (ec *executionContext) _Query_contacts(ctx context.Context, field graphql.C
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Contacts(rctx, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model.SortBy))
+		return ec.resolvers.Query().Contacts(rctx, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model1.SortBy))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -88353,7 +88353,7 @@ func (ec *executionContext) _Query_dashboardView_Organizations(ctx context.Conte
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().DashboardViewOrganizations(rctx, fc.Args["pagination"].(model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].(*model.SortBy))
+		return ec.resolvers.Query().DashboardViewOrganizations(rctx, fc.Args["pagination"].(model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].(*model1.SortBy))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -88415,7 +88415,7 @@ func (ec *executionContext) _Query_dashboardView_Renewals(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().DashboardViewRenewals(rctx, fc.Args["pagination"].(model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].(*model.SortBy))
+		return ec.resolvers.Query().DashboardViewRenewals(rctx, fc.Args["pagination"].(model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].(*model1.SortBy))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -89907,7 +89907,7 @@ func (ec *executionContext) _Query_invoices(ctx context.Context, field graphql.C
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Invoices(rctx, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model.SortBy), fc.Args["organizationId"].(*string))
+		return ec.resolvers.Query().Invoices(rctx, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model1.SortBy), fc.Args["organizationId"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -90954,7 +90954,7 @@ func (ec *executionContext) _Query_externalMeetings(ctx context.Context, field g
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().ExternalMeetings(rctx, fc.Args["externalSystemId"].(string), fc.Args["externalId"].(*string), fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model.SortBy))
+		return ec.resolvers.Query().ExternalMeetings(rctx, fc.Args["externalSystemId"].(string), fc.Args["externalId"].(*string), fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model1.SortBy))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -91267,7 +91267,7 @@ func (ec *executionContext) _Query_organizations(ctx context.Context, field grap
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Query().Organizations(rctx, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model.SortBy))
+			return ec.resolvers.Query().Organizations(rctx, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model1.SortBy))
 		}
 
 		directive1 := func(ctx context.Context) (interface{}, error) {
@@ -92724,7 +92724,7 @@ func (ec *executionContext) _Query_ui_organizations_search(ctx context.Context, 
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Query().UIOrganizationsSearch(rctx, fc.Args["limit"].(*int), fc.Args["where"].(*model.Filter), fc.Args["sort"].(*model.SortBy))
+			return ec.resolvers.Query().UIOrganizationsSearch(rctx, fc.Args["limit"].(*int), fc.Args["where"].(*model.Filter), fc.Args["sort"].(*model1.SortBy))
 		}
 
 		directive1 := func(ctx context.Context) (interface{}, error) {
@@ -94150,7 +94150,7 @@ func (ec *executionContext) _Query_users(ctx context.Context, field graphql.Coll
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Users(rctx, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model.SortBy))
+		return ec.resolvers.Query().Users(rctx, fc.Args["pagination"].(*model.Pagination), fc.Args["where"].(*model.Filter), fc.Args["sort"].([]*model1.SortBy))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -110231,8 +110231,8 @@ func (ec *executionContext) unmarshalInputSocialUpdateInput(ctx context.Context,
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputSortBy(ctx context.Context, obj interface{}) (model.SortBy, error) {
-	var it model.SortBy
+func (ec *executionContext) unmarshalInputSortBy(ctx context.Context, obj interface{}) (model1.SortBy, error) {
+	var it model1.SortBy
 	asMap := map[string]interface{}{}
 	for k, v := range obj.(map[string]interface{}) {
 		asMap[k] = v
@@ -110261,7 +110261,7 @@ func (ec *executionContext) unmarshalInputSortBy(ctx context.Context, obj interf
 			it.By = data
 		case "direction":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
-			data, err := ec.unmarshalNSortingDirection2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortingDirection(ctx, v)
+			data, err := ec.unmarshalNSortingDirection2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortingDirection(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -131181,19 +131181,25 @@ func (ec *executionContext) unmarshalNSocialUpdateInput2githubᚗcomᚋopenline�
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortBy(ctx context.Context, v interface{}) (*model.SortBy, error) {
+func (ec *executionContext) unmarshalNSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortBy(ctx context.Context, v interface{}) (*model1.SortBy, error) {
 	res, err := ec.unmarshalInputSortBy(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNSortingDirection2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortingDirection(ctx context.Context, v interface{}) (model.SortingDirection, error) {
-	var res model.SortingDirection
-	err := res.UnmarshalGQL(v)
+func (ec *executionContext) unmarshalNSortingDirection2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortingDirection(ctx context.Context, v interface{}) (model1.SortingDirection, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := model1.SortingDirection(tmp)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNSortingDirection2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortingDirection(ctx context.Context, sel ast.SelectionSet, v model.SortingDirection) graphql.Marshaler {
-	return v
+func (ec *executionContext) marshalNSortingDirection2githubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortingDirection(ctx context.Context, sel ast.SelectionSet, v model1.SortingDirection) graphql.Marshaler {
+	res := graphql.MarshalString(string(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {
@@ -133489,7 +133495,7 @@ func (ec *executionContext) unmarshalOServiceLineItemBulkUpdateItem2ᚖgithubᚗ
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortByᚄ(ctx context.Context, v interface{}) ([]*model.SortBy, error) {
+func (ec *executionContext) unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortByᚄ(ctx context.Context, v interface{}) ([]*model1.SortBy, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -133498,10 +133504,10 @@ func (ec *executionContext) unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑai�
 		vSlice = graphql.CoerceList(v)
 	}
 	var err error
-	res := make([]*model.SortBy, len(vSlice))
+	res := make([]*model1.SortBy, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortBy(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortBy(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
@@ -133509,7 +133515,7 @@ func (ec *executionContext) unmarshalOSortBy2ᚕᚖgithubᚗcomᚋopenlineᚑai�
 	return res, nil
 }
 
-func (ec *executionContext) unmarshalOSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐSortBy(ctx context.Context, v interface{}) (*model.SortBy, error) {
+func (ec *executionContext) unmarshalOSortBy2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortBy(ctx context.Context, v interface{}) (*model1.SortBy, error) {
 	if v == nil {
 		return nil, nil
 	}

--- a/packages/server/customer-os-api/graph/model/models_gen.go
+++ b/packages/server/customer-os-api/graph/model/models_gen.go
@@ -2574,12 +2574,6 @@ type SocialUpdateInput struct {
 	URL string `json:"url"`
 }
 
-type SortBy struct {
-	By            string           `json:"by"`
-	Direction     SortingDirection `json:"direction"`
-	CaseSensitive *bool            `json:"caseSensitive,omitempty"`
-}
-
 type State struct {
 	ID      string   `json:"id"`
 	Country *Country `json:"country"`
@@ -5013,47 +5007,6 @@ func (e *Role) UnmarshalGQL(v interface{}) error {
 }
 
 func (e Role) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-type SortingDirection string
-
-const (
-	SortingDirectionAsc  SortingDirection = "ASC"
-	SortingDirectionDesc SortingDirection = "DESC"
-)
-
-var AllSortingDirection = []SortingDirection{
-	SortingDirectionAsc,
-	SortingDirectionDesc,
-}
-
-func (e SortingDirection) IsValid() bool {
-	switch e {
-	case SortingDirectionAsc, SortingDirectionDesc:
-		return true
-	}
-	return false
-}
-
-func (e SortingDirection) String() string {
-	return string(e)
-}
-
-func (e *SortingDirection) UnmarshalGQL(v interface{}) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = SortingDirection(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid SortingDirection", str)
-	}
-	return nil
-}
-
-func (e SortingDirection) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/packages/server/customer-os-api/graph/resolver/contact.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/contact.resolvers.go
@@ -62,7 +62,7 @@ func (r *contactResolver) JobRoles(ctx context.Context, obj *model.Contact) ([]*
 }
 
 // Organizations is the resolver for the organizations field.
-func (r *contactResolver) Organizations(ctx context.Context, obj *model.Contact, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.OrganizationPage, error) {
+func (r *contactResolver) Organizations(ctx context.Context, obj *model.Contact, pagination *model.Pagination, where *model.Filter, sort []*commonmodel.SortBy) (*model.OrganizationPage, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "ContactResolver.Organizations", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)
@@ -935,7 +935,7 @@ func (r *queryResolver) Contact(ctx context.Context, id string) (*model.Contact,
 }
 
 // Contacts is the resolver for the contacts field.
-func (r *queryResolver) Contacts(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.ContactsPage, error) {
+func (r *queryResolver) Contacts(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*commonmodel.SortBy) (*model.ContactsPage, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.Contacts", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)

--- a/packages/server/customer-os-api/graph/resolver/dashboard.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/dashboard.resolvers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/service"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/tracing"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/common"
+	model1 "github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/opentracing/opentracing-go/log"
@@ -45,7 +46,7 @@ func (r *dashboardCustomerMapResolver) Organization(ctx context.Context, obj *mo
 }
 
 // DashboardViewOrganizations is the resolver for the dashboardView_Organizations field.
-func (r *queryResolver) DashboardViewOrganizations(ctx context.Context, pagination model.Pagination, where *model.Filter, sort *model.SortBy) (*model.OrganizationPage, error) {
+func (r *queryResolver) DashboardViewOrganizations(ctx context.Context, pagination model.Pagination, where *model.Filter, sort *model1.SortBy) (*model.OrganizationPage, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.DashboardViewOrganizations", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)
@@ -84,7 +85,7 @@ func (r *queryResolver) DashboardViewOrganizations(ctx context.Context, paginati
 }
 
 // DashboardViewRenewals is the resolver for the dashboardView_Renewals field.
-func (r *queryResolver) DashboardViewRenewals(ctx context.Context, pagination model.Pagination, where *model.Filter, sort *model.SortBy) (*model.RenewalsPage, error) {
+func (r *queryResolver) DashboardViewRenewals(ctx context.Context, pagination model.Pagination, where *model.Filter, sort *model1.SortBy) (*model.RenewalsPage, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.DashboardViewRenewals", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)

--- a/packages/server/customer-os-api/graph/resolver/invoice.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/invoice.resolvers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/mapper"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/tracing"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/common"
+	model1 "github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model"
 	commonService "github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/service"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
@@ -391,7 +392,7 @@ func (r *queryResolver) Invoice(ctx context.Context, id string) (*model.Invoice,
 }
 
 // Invoices is the resolver for the invoices field.
-func (r *queryResolver) Invoices(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy, organizationID *string) (*model.InvoicesPage, error) {
+func (r *queryResolver) Invoices(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy, organizationID *string) (*model.InvoicesPage, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "InvoiceResolver.Invoices", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)

--- a/packages/server/customer-os-api/graph/resolver/meeting.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/meeting.resolvers.go
@@ -415,7 +415,7 @@ func (r *queryResolver) Meeting(ctx context.Context, id string) (*model.Meeting,
 }
 
 // ExternalMeetings is the resolver for the externalMeetings field.
-func (r *queryResolver) ExternalMeetings(ctx context.Context, externalSystemID string, externalID *string, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.MeetingsPage, error) {
+func (r *queryResolver) ExternalMeetings(ctx context.Context, externalSystemID string, externalID *string, pagination *model.Pagination, where *model.Filter, sort []*commonModel.SortBy) (*model.MeetingsPage, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.Meetings", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)

--- a/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organization.resolvers.go
@@ -760,7 +760,7 @@ func (r *organizationResolver) TimelineEvents(ctx context.Context, obj *model.Or
 }
 
 // Contacts is the resolver for the contacts field.
-func (r *organizationResolver) Contacts(ctx context.Context, obj *model.Organization, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.ContactsPage, error) {
+func (r *organizationResolver) Contacts(ctx context.Context, obj *model.Organization, pagination *model.Pagination, where *model.Filter, sort []*commonmodel.SortBy) (*model.ContactsPage, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "OrganizationResolver.Contacts", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)
@@ -980,7 +980,7 @@ func (r *organizationResolver) SubsidiaryOf(ctx context.Context, obj *model.Orga
 }
 
 // Organizations is the resolver for the organizations field.
-func (r *queryResolver) Organizations(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.OrganizationPage, error) {
+func (r *queryResolver) Organizations(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*commonmodel.SortBy) (*model.OrganizationPage, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.Organizations", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)

--- a/packages/server/customer-os-api/graph/resolver/organizationV2.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organizationV2.resolvers.go
@@ -207,7 +207,7 @@ func (r *queryResolver) UIOrganizations(ctx context.Context, ids []string) ([]*m
 }
 
 // UIOrganizationsSearch is the resolver for the ui_organizations_search field.
-func (r *queryResolver) UIOrganizationsSearch(ctx context.Context, limit *int, where *model.Filter, sort *model.SortBy) (*model.OrganizationSearchResult, error) {
+func (r *queryResolver) UIOrganizationsSearch(ctx context.Context, limit *int, where *model.Filter, sort *commonModel.SortBy) (*model.OrganizationSearchResult, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.UIOrganizationsSearch", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)

--- a/packages/server/customer-os-api/graph/resolver/user.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/user.resolvers.go
@@ -179,7 +179,7 @@ func (r *mutationResolver) CustomerUserAddJobRole(ctx context.Context, id string
 }
 
 // Users is the resolver for the users field.
-func (r *queryResolver) Users(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model.SortBy) (*model.UserPage, error) {
+func (r *queryResolver) Users(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*commonModel.SortBy) (*model.UserPage, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.Users", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)

--- a/packages/server/customer-os-api/repository/dashboard_repository.go
+++ b/packages/server/customer-os-api/repository/dashboard_repository.go
@@ -7,6 +7,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/graph/model"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/mapper"
+	commonmodel "github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/tracing"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
@@ -51,9 +52,9 @@ const (
 
 type DashboardRepository interface {
 	//deprecated
-	GetDashboardViewOrganizationData(ctx context.Context, tenant string, skip, limit int, where *model.Filter, sort *model.SortBy) (*utils.DbNodesWithTotalCount, error)
-	GetDashboardViewOrganizationDataV2(ctx context.Context, tenant string, limit int, where *model.Filter, sort *model.SortBy) (*utils.StringsWithTotalCount, error)
-	GetDashboardViewRenewalData(ctx context.Context, tenant string, skip, limit int, where *model.Filter, sort *model.SortBy) (*utils.RecordsWithTotalCount, error)
+	GetDashboardViewOrganizationData(ctx context.Context, tenant string, skip, limit int, where *model.Filter, sort *commonmodel.SortBy) (*utils.DbNodesWithTotalCount, error)
+	GetDashboardViewOrganizationDataV2(ctx context.Context, tenant string, limit int, where *model.Filter, sort *commonmodel.SortBy) (*utils.StringsWithTotalCount, error)
+	GetDashboardViewRenewalData(ctx context.Context, tenant string, skip, limit int, where *model.Filter, sort *commonmodel.SortBy) (*utils.RecordsWithTotalCount, error)
 	GetDashboardNewCustomersData(ctx context.Context, tenant string, startDate, endDate time.Time) ([]map[string]interface{}, error)
 	GetDashboardCustomerMapData(ctx context.Context, tenant string) ([]map[string]interface{}, error)
 	GetDashboardRevenueAtRiskData(ctx context.Context, tenant string, startDate, endDate time.Time) ([]map[string]interface{}, error)
@@ -94,7 +95,7 @@ func createStringCypherFilterWithValueOrEmpty(filter *model.FilterItem, property
 	}
 }
 
-func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Context, tenant string, skip, limit int, where *model.Filter, sort *model.SortBy) (*utils.DbNodesWithTotalCount, error) {
+func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Context, tenant string, skip, limit int, where *model.Filter, sort *commonmodel.SortBy) (*utils.DbNodesWithTotalCount, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "DashboardRepository.GetDashboardViewOrganizationData")
 	defer span.Finish()
 	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
@@ -334,7 +335,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 	aliases := " o, d, l"
 	query += " WITH o, d, l "
 	if sort != nil && sort.By == SearchSortParamOwner {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			query += ", CASE WHEN owner.firstName <> \"\" and not owner.firstName is null THEN owner.firstName ELSE 'ZZZZZZZZZZZZZZZZZZZ' END as OWNER_FIRST_NAME_FOR_SORTING "
 			query += ", CASE WHEN owner.lastName <> \"\" and not owner.lastName is null THEN owner.lastName ELSE 'ZZZZZZZZZZZZZZZZZZZ' END as OWNER_LAST_NAME_FOR_SORTING "
 		} else {
@@ -344,7 +345,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		aliases += ", OWNER_FIRST_NAME_FOR_SORTING, OWNER_LAST_NAME_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamName {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			query += ", CASE WHEN o.name <> \"\" and not o.name is null THEN o.name ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as NAME_FOR_SORTING "
 		} else {
 			query += ", o.name as NAME_FOR_SORTING "
@@ -352,7 +353,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		aliases += ", NAME_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamRenewalLikelihood {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			query += ", CASE WHEN o.derivedRenewalLikelihoodOrder IS NOT NULL THEN o.derivedRenewalLikelihoodOrder ELSE 9999 END as RENEWAL_LIKELIHOOD_FOR_SORTING "
 		} else {
 			query += ", CASE WHEN o.derivedRenewalLikelihoodOrder IS NOT NULL THEN o.derivedRenewalLikelihoodOrder ELSE -1 END as RENEWAL_LIKELIHOOD_FOR_SORTING "
@@ -360,7 +361,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		aliases += ", RENEWAL_LIKELIHOOD_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamRelationship {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			query += ", CASE WHEN o.relationship <> '' AND NOT o.relationship IS NULL THEN o.relationship ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as RELATIONSHIP_FOR_SORTING "
 		} else {
 			query += ", o.relationship as RELATIONSHIP_FOR_SORTING "
@@ -368,7 +369,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		aliases += ", RELATIONSHIP_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamStage {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			query += ", CASE WHEN o.stage <> '' AND NOT o.stage IS NULL THEN o.stage ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as STAGE_FOR_SORTING "
 		} else {
 			query += ", o.stage as STAGE_FOR_SORTING "
@@ -376,7 +377,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		aliases += ", STAGE_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamIndustry {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			query += ", CASE WHEN o.industry <> '' AND NOT o.industry IS NULL THEN o.industry ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as STAGE_FOR_SORTING "
 		} else {
 			query += ", o.industry as INDUSTRY_FOR_SORTING "
@@ -384,7 +385,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		aliases += ", INDUSTRY_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamRenewalCycleNext {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			query += ", CASE WHEN o.billingDetailsRenewalCycleNext IS NOT NULL THEN date(o.billingDetailsRenewalCycleNext) ELSE date('2100-01-01') END as RENEWAL_CYCLE_NEXT_FOR_SORTING "
 		} else {
 			query += ", CASE WHEN o.billingDetailsRenewalCycleNext IS NOT NULL THEN date(o.billingDetailsRenewalCycleNext) ELSE date('1900-01-01') END as RENEWAL_CYCLE_NEXT_FOR_SORTING "
@@ -392,7 +393,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		aliases += ", RENEWAL_CYCLE_NEXT_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamRenewalDate {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			query += ", CASE WHEN o.derivedNextRenewalAt IS NOT NULL THEN date(o.derivedNextRenewalAt) ELSE date('2100-01-01') END as RENEWAL_DATE_FOR_SORTING "
 		} else {
 			query += ", CASE WHEN o.derivedNextRenewalAt IS NOT NULL THEN date(o.derivedNextRenewalAt) ELSE date('1900-01-01') END as RENEWAL_DATE_FOR_SORTING "
@@ -400,7 +401,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		aliases += ", RENEWAL_DATE_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamChurnDate {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			query += ", CASE WHEN o.derivedChurnedAt IS NOT NULL THEN date(o.derivedChurnedAt) ELSE date('2100-01-01') END as CHURN_DATE_FOR_SORTING "
 		} else {
 			query += ", CASE WHEN o.derivedChurnedAt IS NOT NULL THEN date(o.derivedChurnedAt) ELSE date('1900-01-01') END as CHURN_DATE_FOR_SORTING "
@@ -408,7 +409,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		aliases += ", RENEWAL_DATE_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamOnboardingStatus {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			query += ", CASE WHEN o.onboardingStatusOrder IS NOT NULL THEN o.onboardingStatusOrder ELSE 9999 END as ONBOARDING_STATUS_FOR_SORTING "
 			query += ", o.onboardingUpdatedAt AS ONBOARDING_UPDATED_AT_FOR_SORTING "
 		} else {
@@ -418,7 +419,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		aliases += ", ONBOARDING_STATUS_FOR_SORTING, ONBOARDING_UPDATED_AT_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamForecastArr {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			query += ", CASE WHEN o.renewalForecastArr <> \"\" and o.renewalForecastArr IS NOT NULL THEN o.renewalForecastArr ELSE 9999999999999999 END as FORECAST_ARR_FOR_SORTING "
 		} else {
 			query += ", CASE WHEN o.renewalForecastArr <> \"\" and o.renewalForecastArr IS NOT NULL THEN o.renewalForecastArr ELSE 0 END as FORECAST_ARR_FOR_SORTING "
@@ -445,10 +446,10 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		} else if sort.By == SearchSortParamIndustry {
 			query += " ORDER BY INDUSTRY_FOR_SORTING " + string(sort.Direction)
 		} else if sort.By == SearchSortParamOrganization {
-			cypherSort.NewSortRule("NAME", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce().WithAlias("parent")
-			cypherSort.NewSortRule("NAME", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce()
-			cypherSort.NewSortRule("NAME", sort.Direction.String(), true, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithAlias("parent").WithDescending()
-			cypherSort.NewSortRule("NAME", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+			cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce().WithAlias("parent")
+			cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce()
+			cypherSort.NewSortRule("NAME", string(sort.Direction), true, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithAlias("parent").WithDescending()
+			cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 			query += string(cypherSort.SortingCypherFragment("o"))
 		} else if sort.By == SearchSortParamForecastArr {
 			query += " ORDER BY FORECAST_ARR_FOR_SORTING " + string(sort.Direction)
@@ -464,12 +465,12 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 		} else if sort.By == SearchSortParamChurnDate {
 			query += " ORDER BY CHURN_DATE_FOR_SORTING " + string(sort.Direction)
 		} else if sort.By == "DOMAIN" {
-			cypherSort.NewSortRule("DOMAIN", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.DomainEntity{}))
+			cypherSort.NewSortRule("DOMAIN", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.DomainEntity{}))
 			query += string(cypherSort.SortingCypherFragment("d"))
 		} else if sort.By == SearchSortParamLocation {
-			cypherSort.NewSortRule("COUNTRY", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
-			cypherSort.NewSortRule("REGION", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
-			cypherSort.NewSortRule("LOCALITY", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
+			cypherSort.NewSortRule("COUNTRY", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
+			cypherSort.NewSortRule("REGION", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
+			cypherSort.NewSortRule("LOCALITY", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
 			query += string(cypherSort.SortingCypherFragment("l"))
 		} else if sort.By == "OWNER" {
 			if sort.CaseSensitive != nil && *sort.CaseSensitive {
@@ -478,17 +479,17 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 				query += " ORDER BY toLower(OWNER_FIRST_NAME_FOR_SORTING) " + string(sort.Direction) + ", toLower(OWNER_LAST_NAME_FOR_SORTING) " + string(sort.Direction)
 			}
 		} else if sort.By == SearchSortParamLastTouchpointAt || sort.By == SearchSortParamLastTouchpoint {
-			cypherSort.NewSortRule("LAST_TOUCHPOINT_AT", sort.Direction.String(), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+			cypherSort.NewSortRule("LAST_TOUCHPOINT_AT", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 			query += string(cypherSort.SortingCypherFragment("o"))
 		} else if sort.By == SearchSortParamLastTouchpointType {
-			cypherSort.NewSortRule("LAST_TOUCHPOINT_TYPE", sort.Direction.String(), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+			cypherSort.NewSortRule("LAST_TOUCHPOINT_TYPE", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 			query += string(cypherSort.SortingCypherFragment("o"))
 		} else if sort.By == SearchSortParamUpdatedAt {
-			cypherSort.NewSortRule("UPDATED_AT", sort.Direction.String(), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+			cypherSort.NewSortRule("UPDATED_AT", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 			query += string(cypherSort.SortingCypherFragment("o"))
 		}
 	} else {
-		cypherSort.NewSortRule("UPDATED_AT", string(model.SortingDirectionDesc), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+		cypherSort.NewSortRule("UPDATED_AT", string(commonmodel.SortingDirectionDesc), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 		query += string(cypherSort.SortingCypherFragment("o"))
 	}
 	// end sort region
@@ -516,7 +517,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationData(ctx context.Conte
 	return dbNodesWithTotalCount, nil
 }
 
-func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Context, tenant string, limit int, where *model.Filter, sort *model.SortBy) (*utils.StringsWithTotalCount, error) {
+func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Context, tenant string, limit int, where *model.Filter, sort *commonmodel.SortBy) (*utils.StringsWithTotalCount, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "DashboardRepository.GetDashboardViewOrganizationDataV2")
 	defer span.Finish()
 	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
@@ -736,7 +737,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 	aliases := " o, d, l"
 	selectQuery += " WITH o, d, l "
 	if sort != nil && sort.By == SearchSortParamOwner {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			selectQuery += ", CASE WHEN owner.firstName <> \"\" and not owner.firstName is null THEN owner.firstName ELSE 'ZZZZZZZZZZZZZZZZZZZ' END as OWNER_FIRST_NAME_FOR_SORTING "
 			selectQuery += ", CASE WHEN owner.lastName <> \"\" and not owner.lastName is null THEN owner.lastName ELSE 'ZZZZZZZZZZZZZZZZZZZ' END as OWNER_LAST_NAME_FOR_SORTING "
 		} else {
@@ -746,7 +747,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		aliases += ", OWNER_FIRST_NAME_FOR_SORTING, OWNER_LAST_NAME_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamName {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			selectQuery += ", CASE WHEN o.name <> \"\" and not o.name is null THEN o.name ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as NAME_FOR_SORTING "
 		} else {
 			selectQuery += ", o.name as NAME_FOR_SORTING "
@@ -754,7 +755,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		aliases += ", NAME_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamRenewalLikelihood {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			selectQuery += ", CASE WHEN o.derivedRenewalLikelihoodOrder IS NOT NULL THEN o.derivedRenewalLikelihoodOrder ELSE 9999 END as RENEWAL_LIKELIHOOD_FOR_SORTING "
 		} else {
 			selectQuery += ", CASE WHEN o.derivedRenewalLikelihoodOrder IS NOT NULL THEN o.derivedRenewalLikelihoodOrder ELSE -1 END as RENEWAL_LIKELIHOOD_FOR_SORTING "
@@ -762,7 +763,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		aliases += ", RENEWAL_LIKELIHOOD_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamRelationship {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			selectQuery += ", CASE WHEN o.relationship <> '' AND NOT o.relationship IS NULL THEN o.relationship ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as RELATIONSHIP_FOR_SORTING "
 		} else {
 			selectQuery += ", o.relationship as RELATIONSHIP_FOR_SORTING "
@@ -770,7 +771,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		aliases += ", RELATIONSHIP_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamStage {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			selectQuery += ", CASE WHEN o.stage <> '' AND NOT o.stage IS NULL THEN o.stage ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as STAGE_FOR_SORTING "
 		} else {
 			selectQuery += ", o.stage as STAGE_FOR_SORTING "
@@ -778,7 +779,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		aliases += ", STAGE_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamIndustry {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			selectQuery += ", CASE WHEN o.industry <> '' AND NOT o.industry IS NULL THEN o.industry ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as STAGE_FOR_SORTING "
 		} else {
 			selectQuery += ", o.industry as INDUSTRY_FOR_SORTING "
@@ -786,7 +787,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		aliases += ", INDUSTRY_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamRenewalCycleNext {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			selectQuery += ", CASE WHEN o.billingDetailsRenewalCycleNext IS NOT NULL THEN date(o.billingDetailsRenewalCycleNext) ELSE date('2100-01-01') END as RENEWAL_CYCLE_NEXT_FOR_SORTING "
 		} else {
 			selectQuery += ", CASE WHEN o.billingDetailsRenewalCycleNext IS NOT NULL THEN date(o.billingDetailsRenewalCycleNext) ELSE date('1900-01-01') END as RENEWAL_CYCLE_NEXT_FOR_SORTING "
@@ -794,7 +795,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		aliases += ", RENEWAL_CYCLE_NEXT_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamRenewalDate {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			selectQuery += ", CASE WHEN o.derivedNextRenewalAt IS NOT NULL THEN date(o.derivedNextRenewalAt) ELSE date('2100-01-01') END as RENEWAL_DATE_FOR_SORTING "
 		} else {
 			selectQuery += ", CASE WHEN o.derivedNextRenewalAt IS NOT NULL THEN date(o.derivedNextRenewalAt) ELSE date('1900-01-01') END as RENEWAL_DATE_FOR_SORTING "
@@ -802,7 +803,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		aliases += ", RENEWAL_DATE_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamChurnDate {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			selectQuery += ", CASE WHEN o.derivedChurnedAt IS NOT NULL THEN date(o.derivedChurnedAt) ELSE date('2100-01-01') END as CHURN_DATE_FOR_SORTING "
 		} else {
 			selectQuery += ", CASE WHEN o.derivedChurnedAt IS NOT NULL THEN date(o.derivedChurnedAt) ELSE date('1900-01-01') END as CHURN_DATE_FOR_SORTING "
@@ -810,7 +811,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		aliases += ", RENEWAL_DATE_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamOnboardingStatus {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			selectQuery += ", CASE WHEN o.onboardingStatusOrder IS NOT NULL THEN o.onboardingStatusOrder ELSE 9999 END as ONBOARDING_STATUS_FOR_SORTING "
 			selectQuery += ", o.onboardingUpdatedAt AS ONBOARDING_UPDATED_AT_FOR_SORTING "
 		} else {
@@ -820,7 +821,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		aliases += ", ONBOARDING_STATUS_FOR_SORTING, ONBOARDING_UPDATED_AT_FOR_SORTING "
 	}
 	if sort != nil && sort.By == SearchSortParamForecastArr {
-		if sort.Direction == model.SortingDirectionAsc {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
 			selectQuery += ", CASE WHEN o.renewalForecastArr <> \"\" and o.renewalForecastArr IS NOT NULL THEN o.renewalForecastArr ELSE 9999999999999999 END as FORECAST_ARR_FOR_SORTING "
 		} else {
 			selectQuery += ", CASE WHEN o.renewalForecastArr <> \"\" and o.renewalForecastArr IS NOT NULL THEN o.renewalForecastArr ELSE 0 END as FORECAST_ARR_FOR_SORTING "
@@ -847,10 +848,10 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		} else if sort.By == SearchSortParamIndustry {
 			selectQuery += " ORDER BY INDUSTRY_FOR_SORTING " + string(sort.Direction)
 		} else if sort.By == SearchSortParamOrganization {
-			cypherSort.NewSortRule("NAME", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce().WithAlias("parent")
-			cypherSort.NewSortRule("NAME", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce()
-			cypherSort.NewSortRule("NAME", sort.Direction.String(), true, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithAlias("parent").WithDescending()
-			cypherSort.NewSortRule("NAME", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+			cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce().WithAlias("parent")
+			cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce()
+			cypherSort.NewSortRule("NAME", string(sort.Direction), true, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithAlias("parent").WithDescending()
+			cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 			selectQuery += string(cypherSort.SortingCypherFragment("o"))
 		} else if sort.By == SearchSortParamForecastArr {
 			selectQuery += " ORDER BY FORECAST_ARR_FOR_SORTING " + string(sort.Direction)
@@ -866,12 +867,12 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 		} else if sort.By == SearchSortParamChurnDate {
 			selectQuery += " ORDER BY CHURN_DATE_FOR_SORTING " + string(sort.Direction)
 		} else if sort.By == "DOMAIN" {
-			cypherSort.NewSortRule("DOMAIN", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.DomainEntity{}))
+			cypherSort.NewSortRule("DOMAIN", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.DomainEntity{}))
 			selectQuery += string(cypherSort.SortingCypherFragment("d"))
 		} else if sort.By == SearchSortParamLocation {
-			cypherSort.NewSortRule("COUNTRY", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
-			cypherSort.NewSortRule("REGION", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
-			cypherSort.NewSortRule("LOCALITY", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
+			cypherSort.NewSortRule("COUNTRY", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
+			cypherSort.NewSortRule("REGION", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
+			cypherSort.NewSortRule("LOCALITY", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
 			selectQuery += string(cypherSort.SortingCypherFragment("l"))
 		} else if sort.By == "OWNER" {
 			if sort.CaseSensitive != nil && *sort.CaseSensitive {
@@ -880,17 +881,17 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 				selectQuery += " ORDER BY toLower(OWNER_FIRST_NAME_FOR_SORTING) " + string(sort.Direction) + ", toLower(OWNER_LAST_NAME_FOR_SORTING) " + string(sort.Direction)
 			}
 		} else if sort.By == SearchSortParamLastTouchpointAt || sort.By == SearchSortParamLastTouchpoint {
-			cypherSort.NewSortRule("LAST_TOUCHPOINT_AT", sort.Direction.String(), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+			cypherSort.NewSortRule("LAST_TOUCHPOINT_AT", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 			selectQuery += string(cypherSort.SortingCypherFragment("o"))
 		} else if sort.By == SearchSortParamLastTouchpointType {
-			cypherSort.NewSortRule("LAST_TOUCHPOINT_TYPE", sort.Direction.String(), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+			cypherSort.NewSortRule("LAST_TOUCHPOINT_TYPE", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 			selectQuery += string(cypherSort.SortingCypherFragment("o"))
 		} else if sort.By == SearchSortParamUpdatedAt {
-			cypherSort.NewSortRule("UPDATED_AT", sort.Direction.String(), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+			cypherSort.NewSortRule("UPDATED_AT", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 			selectQuery += string(cypherSort.SortingCypherFragment("o"))
 		}
 	} else {
-		cypherSort.NewSortRule("UPDATED_AT", string(model.SortingDirectionDesc), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+		cypherSort.NewSortRule("UPDATED_AT", string(commonmodel.SortingDirectionDesc), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 		selectQuery += string(cypherSort.SortingCypherFragment("o"))
 	}
 	// end sort region
@@ -982,7 +983,7 @@ func (r *dashboardRepository) GetDashboardViewOrganizationDataV2(ctx context.Con
 	return stringsWithTotalCount, nil
 }
 
-func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, tenant string, skip, limit int, where *model.Filter, sort *model.SortBy) (*utils.RecordsWithTotalCount, error) {
+func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, tenant string, skip, limit int, where *model.Filter, sort *commonmodel.SortBy) (*utils.RecordsWithTotalCount, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "DashboardRepository.GetDashboardViewRenewalData")
 	defer span.Finish()
 	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
@@ -1260,7 +1261,7 @@ func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, t
 		aliases := " o, contract, op, owner"
 		query += " WITH o, contract, op, owner "
 		if sort != nil && sort.By == SearchSortParamOwner {
-			if sort.Direction == model.SortingDirectionAsc {
+			if sort.Direction == commonmodel.SortingDirectionAsc {
 				query += ", CASE WHEN owner.firstName <> \"\" and not owner.firstName is null THEN owner.firstName ELSE 'ZZZZZZZZZZZZZZZZZZZ' END as OWNER_FIRST_NAME_FOR_SORTING "
 				query += ", CASE WHEN owner.lastName <> \"\" and not owner.lastName is null THEN owner.lastName ELSE 'ZZZZZZZZZZZZZZZZZZZ' END as OWNER_LAST_NAME_FOR_SORTING "
 			} else {
@@ -1270,7 +1271,7 @@ func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, t
 			aliases += ", OWNER_FIRST_NAME_FOR_SORTING, OWNER_LAST_NAME_FOR_SORTING "
 		}
 		if sort != nil && sort.By == SearchSortParamName {
-			if sort.Direction == model.SortingDirectionAsc {
+			if sort.Direction == commonmodel.SortingDirectionAsc {
 				query += ", CASE WHEN o.name <> \"\" and not o.name is null THEN o.name ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as NAME_FOR_SORTING "
 			} else {
 				query += ", o.name as NAME_FOR_SORTING "
@@ -1278,7 +1279,7 @@ func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, t
 			aliases += ", NAME_FOR_SORTING "
 		}
 		if sort != nil && sort.By == SearchSortParamRenewalLikelihood {
-			if sort.Direction == model.SortingDirectionAsc {
+			if sort.Direction == commonmodel.SortingDirectionAsc {
 				query += ", CASE WHEN op.renewalLikelihood IS NOT NULL THEN op.renewalLikelihood ELSE 9999 END as RENEWAL_LIKELIHOOD_FOR_SORTING "
 			} else {
 				query += ", CASE WHEN op.renewalLikelihood IS NOT NULL THEN op.renewalLikelihood ELSE -1 END as RENEWAL_LIKELIHOOD_FOR_SORTING "
@@ -1286,7 +1287,7 @@ func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, t
 			aliases += ", RENEWAL_LIKELIHOOD_FOR_SORTING "
 		}
 		if sort != nil && sort.By == SearchSortParamRenewalCycleNext {
-			if sort.Direction == model.SortingDirectionAsc {
+			if sort.Direction == commonmodel.SortingDirectionAsc {
 				query += ", CASE WHEN op.renewedAt IS NOT NULL THEN date(op.renewedAt) ELSE date('2100-01-01') END as RENEWAL_CYCLE_NEXT_FOR_SORTING "
 			} else {
 				query += ", CASE WHEN op.renewedAt IS NOT NULL THEN date(op.renewedAt) ELSE date('1900-01-01') END as RENEWAL_CYCLE_NEXT_FOR_SORTING "
@@ -1294,7 +1295,7 @@ func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, t
 			aliases += ", RENEWAL_CYCLE_NEXT_FOR_SORTING "
 		}
 		if sort != nil && sort.By == SearchSortParamRenewalDate {
-			if sort.Direction == model.SortingDirectionAsc {
+			if sort.Direction == commonmodel.SortingDirectionAsc {
 				query += ", CASE WHEN op.renewedAt IS NOT NULL THEN date(op.renewedAt) ELSE date('2100-01-01') END as RENEWAL_DATE_FOR_SORTING "
 			} else {
 				query += ", CASE WHEN op.renewedAt IS NOT NULL THEN date(op.renewedAt) ELSE date('1900-01-01') END as RENEWAL_DATE_FOR_SORTING "
@@ -1302,7 +1303,7 @@ func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, t
 			aliases += ", RENEWAL_DATE_FOR_SORTING "
 		}
 		if sort != nil && sort.By == SearchSortParamContractLengthInMonths {
-			if sort.Direction == model.SortingDirectionAsc {
+			if sort.Direction == commonmodel.SortingDirectionAsc {
 				query += ", CASE WHEN contract.lengthInMonths IS NOT NULL AND contract.lengthInMonths > 0 THEN contract.lengthInMonths ELSE 9999 END as CONTRACT_LENGTH_FOR_SORTING "
 			} else {
 				query += ", CASE WHEN contract.lengthInMonths IS NOT NULL THEN contract.lengthInMonths ELSE -1 END as CONTRACT_LENGTH_FOR_SORTING "
@@ -1310,7 +1311,7 @@ func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, t
 			aliases += ", RENEWAL_LIKELIHOOD_FOR_SORTING "
 		}
 		if sort != nil && sort.By == SearchSortParamOnboardingStatus {
-			if sort.Direction == model.SortingDirectionAsc {
+			if sort.Direction == commonmodel.SortingDirectionAsc {
 				query += ", CASE WHEN o.onboardingStatusOrder IS NOT NULL THEN o.onboardingStatusOrder ELSE 9999 END as ONBOARDING_STATUS_FOR_SORTING "
 				query += ", o.onboardingUpdatedAt AS ONBOARDING_UPDATED_AT_FOR_SORTING "
 			} else {
@@ -1320,7 +1321,7 @@ func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, t
 			aliases += ", ONBOARDING_STATUS_FOR_SORTING, ONBOARDING_UPDATED_AT_FOR_SORTING "
 		}
 		if sort != nil && sort.By == SearchSortParamForecastArr {
-			if sort.Direction == model.SortingDirectionAsc {
+			if sort.Direction == commonmodel.SortingDirectionAsc {
 				query += ", CASE WHEN op.maxAmount <> \"\" and op.maxAmount IS NOT NULL THEN op.maxAmount ELSE 9999999999999999 END as FORECAST_ARR_FOR_SORTING "
 			} else {
 				query += ", CASE WHEN op.maxAmount <> \"\" and op.maxAmount IS NOT NULL THEN op.maxAmount ELSE 0 END as FORECAST_ARR_FOR_SORTING "
@@ -1337,10 +1338,10 @@ func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, t
 			if sort.By == SearchSortParamName {
 				query += " ORDER BY NAME_FOR_SORTING " + string(sort.Direction)
 			} else if sort.By == SearchSortParamOrganization {
-				cypherSort.NewSortRule("NAME", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce().WithAlias("parent")
-				cypherSort.NewSortRule("NAME", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce()
-				cypherSort.NewSortRule("NAME", sort.Direction.String(), true, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithAlias("parent").WithDescending()
-				cypherSort.NewSortRule("NAME", sort.Direction.String(), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+				cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce().WithAlias("parent")
+				cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce()
+				cypherSort.NewSortRule("NAME", string(sort.Direction), true, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithAlias("parent").WithDescending()
+				cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 				query += string(cypherSort.SortingCypherFragment("o"))
 			} else if sort.By == SearchSortParamForecastArr {
 				query += " ORDER BY FORECAST_ARR_FOR_SORTING " + string(sort.Direction)
@@ -1356,19 +1357,19 @@ func (r *dashboardRepository) GetDashboardViewRenewalData(ctx context.Context, t
 			} else if sort.By == "OWNER" {
 				query += " ORDER BY OWNER_FIRST_NAME_FOR_SORTING " + string(sort.Direction) + ", OWNER_LAST_NAME_FOR_SORTING " + string(sort.Direction)
 			} else if sort.By == SearchSortParamLastTouchpointAt || sort.By == SearchSortParamLastTouchpoint {
-				cypherSort.NewSortRule("LAST_TOUCHPOINT_AT", sort.Direction.String(), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+				cypherSort.NewSortRule("LAST_TOUCHPOINT_AT", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 				query += string(cypherSort.SortingCypherFragment("o"))
 			} else if sort.By == SearchSortParamLastTouchpointType {
-				cypherSort.NewSortRule("LAST_TOUCHPOINT_TYPE", sort.Direction.String(), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+				cypherSort.NewSortRule("LAST_TOUCHPOINT_TYPE", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 				query += string(cypherSort.SortingCypherFragment("o"))
 			} else if sort.By == SearchSortParamContractLengthInMonths {
 				query += " ORDER BY CONTRACT_LENGTH_FOR_SORTING " + string(sort.Direction)
 			} else if sort.By == SearchSortParamUpdatedAt {
-				cypherSort.NewSortRule("UPDATED_AT", sort.Direction.String(), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+				cypherSort.NewSortRule("UPDATED_AT", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 				query += string(cypherSort.SortingCypherFragment("o"))
 			}
 		} else {
-			cypherSort.NewSortRule("UPDATED_AT", string(model.SortingDirectionDesc), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+			cypherSort.NewSortRule("UPDATED_AT", string(commonmodel.SortingDirectionDesc), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
 			query += string(cypherSort.SortingCypherFragment("o"))
 		}
 		// end sort region

--- a/packages/server/customer-os-api/service/contact_service.go
+++ b/packages/server/customer-os-api/service/contact_service.go
@@ -31,11 +31,11 @@ type ContactService interface {
 	GetById(ctx context.Context, id string) (*neo4jentity.ContactEntity, error)
 	GetFirstContactByEmail(ctx context.Context, email string) (*neo4jentity.ContactEntity, error)
 	GetFirstContactByPhoneNumber(ctx context.Context, phoneNumber string) (*neo4jentity.ContactEntity, error)
-	FindAll(ctx context.Context, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error)
+	FindAll(ctx context.Context, page, limit int, filter *model.Filter, sortBy []*commonModel.SortBy) (*utils.Pagination, error)
 	PermanentDelete(ctx context.Context, id string) (bool, error)
 	RestoreFromArchive(ctx context.Context, contactId string) (bool, error)
 	GetContactsForJobRoles(ctx context.Context, jobRoleIds []string) (*neo4jentity.ContactEntities, error)
-	GetContactsForOrganization(ctx context.Context, organizationId string, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error)
+	GetContactsForOrganization(ctx context.Context, organizationId string, page, limit int, filter *model.Filter, sortBy []*commonModel.SortBy) (*utils.Pagination, error)
 	Merge(ctx context.Context, primaryContactId, mergedContactId string) error
 	GetContactsForEmails(ctx context.Context, emailIds []string) (*neo4jentity.ContactEntities, error)
 	GetContactsForPhoneNumbers(ctx context.Context, phoneNumberIds []string) (*neo4jentity.ContactEntities, error)
@@ -234,7 +234,7 @@ func (s *contactService) GetFirstContactByPhoneNumber(ctx context.Context, phone
 	return neo4jmapper.MapDbNodeToContactEntity(dbNodes[0]), nil
 }
 
-func (s *contactService) FindAll(ctx context.Context, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error) {
+func (s *contactService) FindAll(ctx context.Context, page, limit int, filter *model.Filter, sortBy []*commonModel.SortBy) (*utils.Pagination, error) {
 	session := utils.NewNeo4jReadSession(ctx, s.getNeo4jDriver())
 	defer session.Close(ctx)
 
@@ -291,7 +291,7 @@ func (s *contactService) GetContactsForJobRoles(ctx context.Context, jobRoleIds 
 	return &contactEntities, nil
 }
 
-func (s *contactService) GetContactsForOrganization(ctx context.Context, organizationId string, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error) {
+func (s *contactService) GetContactsForOrganization(ctx context.Context, organizationId string, page, limit int, filter *model.Filter, sortBy []*commonModel.SortBy) (*utils.Pagination, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.GetContactsForOrganization")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)

--- a/packages/server/customer-os-api/service/dashboard_service.go
+++ b/packages/server/customer-os-api/service/dashboard_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/repository"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/common"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/logger"
+	commonModel "github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/tracing"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
@@ -23,14 +24,14 @@ import (
 
 type DashboardViewOrganizationsRequest struct {
 	Where *model.Filter
-	Sort  *model.SortBy
+	Sort  *commonModel.SortBy
 	Page  int
 	Limit int
 }
 
 type DashboardViewRenewalsRequest struct {
 	Where *model.Filter
-	Sort  *model.SortBy
+	Sort  *commonModel.SortBy
 	Page  int
 	Limit int
 }

--- a/packages/server/customer-os-api/service/invoice_service.go
+++ b/packages/server/customer-os-api/service/invoice_service.go
@@ -35,7 +35,7 @@ const (
 
 type InvoiceService interface {
 	CountInvoices(ctx context.Context, tenant, organizationId string, where *model.Filter) (int64, error)
-	GetInvoices(ctx context.Context, organizationId string, page, limit int, where *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error)
+	GetInvoices(ctx context.Context, organizationId string, page, limit int, where *model.Filter, sortBy []*model2.SortBy) (*utils.Pagination, error)
 	UpdateInvoice(ctx context.Context, input model.InvoiceUpdateInput) error
 }
 type invoiceService struct {
@@ -128,7 +128,7 @@ func (s *invoiceService) CountInvoices(ctx context.Context, tenant, organization
 	return s.repositories.Neo4jRepositories.InvoiceReadRepository.CountInvoices(ctx, tenant, filter, params)
 }
 
-func (s *invoiceService) GetInvoices(ctx context.Context, organizationId string, page, limit int, where *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error) {
+func (s *invoiceService) GetInvoices(ctx context.Context, organizationId string, page, limit int, where *model.Filter, sortBy []*model2.SortBy) (*utils.Pagination, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceService.GetInvoices")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
@@ -144,10 +144,10 @@ func (s *invoiceService) GetInvoices(ctx context.Context, organizationId string,
 	}
 
 	if len(sortBy) == 0 {
-		sortBy = []*model.SortBy{
+		sortBy = []*model2.SortBy{
 			{
 				By:        "INVOICE_DUE_DATE",
-				Direction: model.SortingDirectionDesc,
+				Direction: model2.SortingDirectionDesc,
 			},
 		}
 	}

--- a/packages/server/customer-os-api/service/meeting_service.go
+++ b/packages/server/customer-os-api/service/meeting_service.go
@@ -37,7 +37,7 @@ type MeetingService interface {
 	GetMeetingsForInteractionEvents(ctx context.Context, ids []string) (*entity.MeetingEntities, error)
 	GetParticipantsForMeetings(ctx context.Context, ids []string, relation entity.MeetingRelation) (*neo4jentity.MeetingParticipants, error)
 
-	FindAll(ctx context.Context, externalSystemID string, externalID *string, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error)
+	FindAll(ctx context.Context, externalSystemID string, externalID *string, page, limit int, filter *model.Filter, sortBy []*commonModel.SortBy) (*utils.Pagination, error)
 }
 
 type MeetingParticipant struct {
@@ -373,7 +373,7 @@ func (s *meetingService) GetMeetingsForInteractionEvents(ctx context.Context, id
 	return &meetingEntities, nil
 }
 
-func (s *meetingService) FindAll(ctx context.Context, externalSystemID string, externalID *string, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error) {
+func (s *meetingService) FindAll(ctx context.Context, externalSystemID string, externalID *string, page, limit int, filter *model.Filter, sortBy []*commonModel.SortBy) (*utils.Pagination, error) {
 	session := utils.NewNeo4jReadSession(ctx, s.getNeo4jDriver())
 	defer session.Close(ctx)
 

--- a/packages/server/customer-os-api/service/organization_service.go
+++ b/packages/server/customer-os-api/service/organization_service.go
@@ -34,8 +34,8 @@ type OrganizationService interface {
 	GetByCustomerOsId(ctx context.Context, customerOsId string) (*neo4jentity.OrganizationEntity, error)
 	GetByReferenceId(ctx context.Context, referenceId string) (*neo4jentity.OrganizationEntity, error)
 	ExistsById(ctx context.Context, organizationId string) (bool, error)
-	FindAll(ctx context.Context, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error)
-	GetOrganizationsForContact(ctx context.Context, contactId string, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error)
+	FindAll(ctx context.Context, page, limit int, filter *model.Filter, sortBy []*commonmodel.SortBy) (*utils.Pagination, error)
+	GetOrganizationsForContact(ctx context.Context, contactId string, page, limit int, filter *model.Filter, sortBy []*commonmodel.SortBy) (*utils.Pagination, error)
 	Merge(ctx context.Context, primaryOrganizationId, mergedOrganizationId string) error
 	GetOrganizationsForEmails(ctx context.Context, emailIds []string) (*neo4jentity.OrganizationEntities, error)
 	GetOrganizationsForPhoneNumbers(ctx context.Context, phoneNumberIds []string) (*neo4jentity.OrganizationEntities, error)
@@ -95,7 +95,7 @@ func (s *organizationService) ExistsById(ctx context.Context, organizationId str
 	return s.repositories.Neo4jRepositories.CommonReadRepository.ExistsById(ctx, common.GetTenantFromContext(ctx), organizationId, commonmodel.NodeLabelOrganization)
 }
 
-func (s *organizationService) FindAll(ctx context.Context, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error) {
+func (s *organizationService) FindAll(ctx context.Context, page, limit int, filter *model.Filter, sortBy []*commonmodel.SortBy) (*utils.Pagination, error) {
 	var paginatedResult = utils.Pagination{
 		Limit: limit,
 		Page:  page,
@@ -129,7 +129,7 @@ func (s *organizationService) FindAll(ctx context.Context, page, limit int, filt
 	return &paginatedResult, nil
 }
 
-func (s *organizationService) GetOrganizationsForContact(ctx context.Context, contactId string, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error) {
+func (s *organizationService) GetOrganizationsForContact(ctx context.Context, contactId string, page, limit int, filter *model.Filter, sortBy []*commonmodel.SortBy) (*utils.Pagination, error) {
 	var paginatedResult = utils.Pagination{
 		Limit: limit,
 		Page:  page,

--- a/packages/server/customer-os-api/service/sort_builder.go
+++ b/packages/server/customer-os-api/service/sort_builder.go
@@ -1,18 +1,18 @@
 package service
 
 import (
-	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/graph/model"
+	commonModel "github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
 	"github.com/pkg/errors"
 	"reflect"
 	"strings"
 )
 
-func buildSort(sortBy []*model.SortBy, T reflect.Type) (*utils.CypherSort, error) {
+func buildSort(sortBy []*commonModel.SortBy, T reflect.Type) (*utils.CypherSort, error) {
 	transformedSorting := new(utils.CypherSort)
 	if sortBy != nil {
 		for _, v := range sortBy {
-			orderBy := transformedSorting.NewSortRule(v.By, v.Direction.String(), utils.IfNotNilBool(v.CaseSensitive), T)
+			orderBy := transformedSorting.NewSortRule(v.By, string(v.Direction), utils.IfNotNilBool(v.CaseSensitive), T)
 			if !orderBy.IsValid() {
 				return nil, errors.New("Invalid sorting rule")
 			}
@@ -34,7 +34,7 @@ type SortMultipleEntitiesDefinitionDefault struct {
 	DescDefault  string
 }
 
-func buildSortMultipleEntities(sortBy []*model.SortBy, mapping []SortMultipleEntitiesDefinition) (*utils.Cypher, error) {
+func buildSortMultipleEntities(sortBy []*commonModel.SortBy, mapping []SortMultipleEntitiesDefinition) (*utils.Cypher, error) {
 	transformedSorting := new(utils.CypherSort)
 
 	if sortBy != nil {
@@ -57,7 +57,7 @@ func buildSortMultipleEntities(sortBy []*model.SortBy, mapping []SortMultipleEnt
 				return nil, errors.New("Entity not found in mapping")
 			}
 
-			orderBy := transformedSorting.NewSortRule(sort, v.Direction.String(), utils.IfNotNilBool(v.CaseSensitive), mappingFound.EntityMapping)
+			orderBy := transformedSorting.NewSortRule(sort, string(v.Direction), utils.IfNotNilBool(v.CaseSensitive), mappingFound.EntityMapping)
 			if !orderBy.IsValid() {
 				return nil, errors.New("Invalid sorting rule")
 			}
@@ -65,7 +65,7 @@ func buildSortMultipleEntities(sortBy []*model.SortBy, mapping []SortMultipleEnt
 			var defaultIfNil string
 			for _, value := range mappingFound.EntityDefaults {
 				if value.PropertyName == sort {
-					if v.Direction.String() == "ASC" {
+					if string(v.Direction) == "ASC" {
 						defaultIfNil = value.AscDefault
 					} else {
 						defaultIfNil = value.DescDefault

--- a/packages/server/customer-os-api/service/user_service.go
+++ b/packages/server/customer-os-api/service/user_service.go
@@ -32,7 +32,7 @@ import (
 type UserService interface {
 	Create(ctx context.Context, UserEntity neo4jentity.UserEntity) (string, error)
 	Update(ctx context.Context, userId, firstName, lastName string, name, timezone, profilePhotoURL *string) (*neo4jentity.UserEntity, error)
-	GetAll(ctx context.Context, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error)
+	GetAll(ctx context.Context, page, limit int, filter *model.Filter, sortBy []*model2.SortBy) (*utils.Pagination, error)
 
 	AddRole(ctx context.Context, userId string, role model.Role) (*neo4jentity.UserEntity, error)
 	AddRoleInTenant(ctx context.Context, userId string, tenant string, role model.Role) (*neo4jentity.UserEntity, error)
@@ -295,7 +295,7 @@ func (s *userService) RemoveRoleInTenant(parentCtx context.Context, userId strin
 	return s.services.CommonServices.UserService.GetById(ctx, userId)
 }
 
-func (s *userService) GetAll(parentCtx context.Context, page, limit int, filter *model.Filter, sortBy []*model.SortBy) (*utils.Pagination, error) {
+func (s *userService) GetAll(parentCtx context.Context, page, limit int, filter *model.Filter, sortBy []*model2.SortBy) (*utils.Pagination, error) {
 	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserService.GetAll")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)

--- a/packages/server/customer-os-common-module/model/sort.go
+++ b/packages/server/customer-os-common-module/model/sort.go
@@ -1,0 +1,14 @@
+package model
+
+type SortBy struct {
+	By            string           `json:"by"`
+	Direction     SortingDirection `json:"direction"`
+	CaseSensitive *bool            `json:"caseSensitive,omitempty"`
+}
+
+type SortingDirection string
+
+const (
+	SortingDirectionAsc  SortingDirection = "ASC"
+	SortingDirectionDesc SortingDirection = "DESC"
+)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Migrate `SortBy` and `SortingDirection` types to `customer-os-common-module` and update references across the codebase.
> 
>   - **Behavior**:
>     - Migrate `SortBy` and `SortingDirection` types to `customer-os-common-module`.
>     - Update references to `SortBy` and `SortingDirection` in `gqlgen.yml`, `generated.go`, and `models_gen.go`.
>   - **Service Updates**:
>     - Update `contact_service.go`, `dashboard_service.go`, `invoice_service.go`, `meeting_service.go`, `organization_service.go`, `user_service.go` to use `commonModel.SortBy`.
>     - Modify `sort_builder.go` to use `commonModel.SortBy`.
>   - **Model Changes**:
>     - Remove `SortBy` and `SortingDirection` from `models_gen.go`.
>     - Add `sort.go` in `customer-os-common-module` with `SortBy` and `SortingDirection` definitions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7869927b38963de941dd325324b5690f488d444b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->