### PR TITLE
remove payment method type from stripe PI

### DIFF
--- a/packages/server/customer-os-common-module/service/mailstack_service.go
+++ b/packages/server/customer-os-common-module/service/mailstack_service.go
@@ -66,11 +66,8 @@ func (s *mailstackService) RegisterBuyDomainsWithMailboxes(ctx context.Context, 
 	stipePaymentDescription := fmt.Sprintf("Mailstack purchase: %d domains (%s) with usernames (%s)", len(domains), strings.Join(domains, ", "), strings.Join(usernames, ", "))
 
 	params := &stripe.PaymentIntentParams{
-		Amount:   stripe.Int64(amount),                      // Amount in cents (e.g., $20.00)
-		Currency: stripe.String(string(stripe.CurrencyUSD)), // Currency (e.g., USD)
-		PaymentMethodTypes: stripe.StringSlice([]string{
-			"card", // Allowed payment method types
-		}),
+		Amount:       stripe.Int64(amount),                      // Amount in cents (e.g., $20.00)
+		Currency:     stripe.String(string(stripe.CurrencyUSD)), // Currency (e.g., USD)
 		Description:  stripe.String(stipePaymentDescription),
 		ReceiptEmail: stripe.String(email),
 		Params: stripe.Params{


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `PaymentMethodTypes` from `stripe.PaymentIntentParams` in `RegisterBuyDomainsWithMailboxes()` to allow all payment methods by default.
> 
>   - **Behavior**:
>     - Removed `PaymentMethodTypes` from `stripe.PaymentIntentParams` in `RegisterBuyDomainsWithMailboxes()` in `mailstack_service.go`. This allows all available payment methods by default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for cb0423de1002520807b78b4d1d63a6ae2be16a70. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->