### PR TITLE
COS-6065: Markdown UI improvements

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/markdownEvent/MarkdownEventPreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/markdownEvent/MarkdownEventPreviewModal.tsx
@@ -19,7 +19,7 @@ export const MarkdownEventPreviewModal = () => {
   const event = modalContent as MarkdownEventType;
 
   return (
-    <>
+    <div className='overflow-hidden rounded-xl pb-6'>
       <CardHeader className='py-4 px-6 pb-1 sticky top-0 rounded-xl bg-white z-[1]'>
         <div className='flex justify-between items-center'>
           <div className='flex mb-2 items-center'>
@@ -59,9 +59,9 @@ export const MarkdownEventPreviewModal = () => {
           </div>
         </div>
       </CardHeader>
-      <CardContent className='mt-0 max-h-[calc(100vh-60px-56px)] pb-6 pt-0 text-sm'>
+      <CardContent className='mt-0 max-h-[calc(100vh-60px-56px)] pt-0 pb-0 text-sm overflow-auto'>
         <Markdown
-          className='text-sm'
+          className='text-sm '
           components={{
             blockquote: ({ children }) => (
               <blockquote className='text-gray-500 border-l border-gray-500 pl-3'>
@@ -72,7 +72,7 @@ export const MarkdownEventPreviewModal = () => {
               <ul className='list-disc list-inside my-1'>{children}</ul>
             ),
             ol: ({ children }) => (
-              <ul className='list-decimal list-inside my-1'>{children}</ul>
+              <ol className='list-decimal list-inside my-1'>{children}</ol>
             ),
             h1: ({ children }) => (
               <h1 className='text-sm font-bold mt-1'>{children}</h1>
@@ -82,11 +82,18 @@ export const MarkdownEventPreviewModal = () => {
               <h2 className='text-sm font-medium mt-1'>{children}</h2>
             ),
             p: ({ children }) => <p className='text-sm my-1'>{children}</p>,
+            a: ({ children, href }) => {
+              return (
+                <a href={href} target='_blank' rel='noreferrer noopener'>
+                  {children}
+                </a>
+              );
+            },
           }}
         >
           {event?.content}
         </Markdown>
       </CardContent>
-    </>
+    </div>
   );
 };

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/markdownEvent/MarkdownEventStub.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/markdownEvent/MarkdownEventStub.tsx
@@ -23,9 +23,10 @@ export const MarkdownEventStub: FC<{ event: MarkdownEventType }> = ({
           'rounded-lg hover:shadow-md transition-all duration-200 ease-out',
         )}
       >
-        <CardContent className='p-3 pr-0 overflow-hidden text-sm w-full flex justify-between gap-2 '>
+        <CardContent className='p-3 pr-0 overflow-hidden text-sm w-full flex justify-between gap-2'>
           <div>
             <Markdown
+              skipHtml
               components={{
                 blockquote: ({ children }) => (
                   <blockquote className='text-gray-500 border-l border-gray-500 pl-3'>
@@ -36,7 +37,7 @@ export const MarkdownEventStub: FC<{ event: MarkdownEventType }> = ({
                   <ul className='list-disc list-inside my-1'>{children}</ul>
                 ),
                 ol: ({ children }) => (
-                  <ul className='list-decimal list-inside my-1'>{children}</ul>
+                  <ol className='list-decimal list-inside my-1'>{children}</ol>
                 ),
                 h1: ({ children }) => (
                   <h1 className='text-sm font-bold mt-1'>{children}</h1>
@@ -46,6 +47,13 @@ export const MarkdownEventStub: FC<{ event: MarkdownEventType }> = ({
                   <h2 className='text-sm font-medium mt-1'>{children}</h2>
                 ),
                 p: ({ children }) => <p className='text-sm my-1'>{children}</p>,
+                a: ({ children, href }) => {
+                  return (
+                    <a href={href} target='_blank' rel='noreferrer noopener'>
+                      {children}
+                    </a>
+                  );
+                },
               }}
             >
               {event?.content}


### PR DESCRIPTION
- scroll fix
- open link in the new tab
- added padding

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> UI improvements for markdown events include scroll fix, opening links in new tabs, and padding adjustments in `MarkdownEventPreviewModal.tsx` and `MarkdownEventStub.tsx`.
> 
>   - **UI Improvements**:
>     - `MarkdownEventPreviewModal.tsx`: Wrapped content in a `div` with `overflow-hidden` and `rounded-xl` for better layout and scrolling.
>     - `MarkdownEventStub.tsx`: Added `skipHtml` to `Markdown` component to prevent HTML rendering.
>   - **Link Handling**:
>     - Both `MarkdownEventPreviewModal.tsx` and `MarkdownEventStub.tsx`: Updated `a` tags to open links in a new tab with `target='_blank'` and `rel='noreferrer noopener'`.
>   - **List Rendering**:
>     - Corrected `ol` rendering in both `MarkdownEventPreviewModal.tsx` and `MarkdownEventStub.tsx` by changing `ul` to `ol` for ordered lists.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 42803860b2a61de8ddf3b177bdf2388543676595. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->