### PR TITLE
Alex/cos 6068 do not throw error on add same social to organization

### DIFF
--- a/packages/server/customer-os-api/rest/events/fathom.go
+++ b/packages/server/customer-os-api/rest/events/fathom.go
@@ -53,10 +53,10 @@ func FathomZapier(services *service.Services) gin.HandlerFunc {
 			return
 		}
 
-		//if !strings.EqualFold(c.Request.UserAgent(), "Zapier") {
-		//	rest.SendError(c, span, http.StatusForbidden, rest.ErrForbidden)
-		//	return
-		//}
+		if !strings.EqualFold(c.Request.UserAgent(), "Zapier") {
+			rest.SendError(c, span, http.StatusForbidden, rest.ErrForbidden)
+			return
+		}
 
 		handleFathomAISummaryZapier(httpContext)
 	}

--- a/packages/server/customer-os-api/rest/events/fathom.go
+++ b/packages/server/customer-os-api/rest/events/fathom.go
@@ -53,10 +53,10 @@ func FathomZapier(services *service.Services) gin.HandlerFunc {
 			return
 		}
 
-		if !strings.EqualFold(c.Request.UserAgent(), "Zapier") {
-			rest.SendError(c, span, http.StatusForbidden, rest.ErrForbidden)
-			return
-		}
+		//if !strings.EqualFold(c.Request.UserAgent(), "Zapier") {
+		//	rest.SendError(c, span, http.StatusForbidden, rest.ErrForbidden)
+		//	return
+		//}
 
 		handleFathomAISummaryZapier(httpContext)
 	}

--- a/packages/server/customer-os-common-module/service/social_service.go
+++ b/packages/server/customer-os-common-module/service/social_service.go
@@ -224,14 +224,20 @@ func (s *socialService) AddSocialToEntity(ctx context.Context, txWithPostCommit 
 					// use identifier as alias
 					alias = socialEntity.ExtractLinkedinCompanyIdentifierFromUrl()
 				}
-				orgs, err := s.services.Neo4jRepositories.OrganizationReadRepository.GetOrganizationsByLinkedIn(ctx, tenant, socialUrl, alias, socialEntity.ExternalId)
+				orgsDbNodes, err := s.services.Neo4jRepositories.OrganizationReadRepository.GetOrganizationsByLinkedIn(ctx, tenant, socialUrl, alias, socialEntity.ExternalId)
 				if err != nil {
 					tracing.TraceErr(span, err)
 					return "", err
 				}
-				if len(orgs) > 0 {
-					err = errors.Errorf("linkedin url %s already used by organization %s", socialUrl, orgs[0].Props["id"])
-					return "", err
+				if len(orgsDbNodes) > 0 {
+					if orgsDbNodes[0].Props["id"] == linkWith.Id {
+						// social already linked to organization
+						span.LogFields(log.Bool("result.alreadyLinked", true))
+						return "", nil
+					} else {
+						err = errors.Errorf("linkedin url %s already used by organization %s", socialUrl, orgsDbNodes[0].Props["id"])
+						return "", err
+					}
 				}
 			} else if linkWith.Type == model.CONTACT {
 				linkedInUsed, existingContactId, err := s.services.ContactService.CheckContactExistsWithLinkedIn(ctx, socialUrl, socialEntity.Alias, socialEntity.ExternalId)
@@ -240,8 +246,14 @@ func (s *socialService) AddSocialToEntity(ctx context.Context, txWithPostCommit 
 					return "", err
 				}
 				if linkedInUsed {
-					err = errors.Errorf("linkedin url %s already used by contact %s", socialUrl, existingContactId)
-					return "", err
+					if existingContactId == linkWith.Id {
+						// social already linked to contact
+						span.LogFields(log.Bool("result.alreadyLinked", true))
+						return "", nil
+					} else {
+						err = errors.Errorf("linkedin url %s already used by contact %s", socialUrl, existingContactId)
+						return "", err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent errors when adding a social link already associated with an entity and normalize JSON booleans in `fathom.go`.
> 
>   - **Behavior**:
>     - In `social_service.go`, `AddSocialToEntity()` now checks if a LinkedIn URL is already linked to the same organization or contact and returns without error if true.
>     - In `fathom.go`, `cleanFathomJsonPayload()` now replaces `: True` and `: False` with lowercase `true` and `false` in JSON strings.
>   - **Functions**:
>     - `AddSocialToEntity()` in `social_service.go` updated to handle already linked social URLs without error.
>     - `cleanFathomJsonPayload()` in `fathom.go` updated for JSON boolean normalization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for bc20141f3b0bb62d67745940c73028f632c75bb1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->