### PR TITLE
COS-6046: Fixed: Copy/paste variables are not identified as variables

### DIFF
--- a/packages/apps/frontera/src/ui/form/Editor/plugins/PastePlugin.tsx
+++ b/packages/apps/frontera/src/ui/form/Editor/plugins/PastePlugin.tsx
@@ -8,27 +8,10 @@ import {
   PASTE_COMMAND,
   $createTextNode,
   $isRangeSelection,
-  $createParagraphNode,
 } from 'lexical';
 
 import { isValidUrl } from '@utils/urlValidation';
-
-const ALLOWED_TAGS = [
-  'ul',
-  'ol',
-  'p',
-  'div',
-  'span',
-  'a',
-  'strong',
-  'em',
-  's',
-  'blockquote',
-  'i',
-  'b',
-  'u',
-  'li', // Additional text formatting tags
-];
+import { convertPlainTextToHtml } from '@ui/form/Editor/utils/convertPlainTextToHtml';
 
 export function LinkPastePlugin() {
   const [editor] = useLexicalComposerContext();
@@ -57,58 +40,14 @@ export function LinkPastePlugin() {
             if (htmlData) {
               const parser = new DOMParser();
               const doc = parser.parseFromString(htmlData, 'text/html');
-
-              const filterNode = (node: Node): DocumentFragment => {
-                const fragment = document.createDocumentFragment();
-
-                if (node.nodeType === Node.TEXT_NODE) {
-                  fragment.appendChild(node.cloneNode(true));
-                } else if (node.nodeType === Node.ELEMENT_NODE) {
-                  const element = node as HTMLElement;
-                  const tagName = element.tagName.toLowerCase();
-
-                  if (ALLOWED_TAGS.includes(tagName)) {
-                    const newElement = document.createElement(tagName);
-
-                    if (tagName === 'a') {
-                      const href = element.getAttribute('href');
-
-                      if (href) newElement.setAttribute('href', href);
-                    }
-
-                    Array.from(element.childNodes).forEach((child) => {
-                      newElement.appendChild(filterNode(child));
-                    });
-
-                    fragment.appendChild(newElement);
-                  } else {
-                    Array.from(element.childNodes).forEach((child) => {
-                      fragment.appendChild(filterNode(child));
-                    });
-                  }
-                }
-
-                return fragment;
-              };
-
-              const filteredBody = filterNode(doc.body);
-              const newDoc = document.implementation.createHTMLDocument();
-
-              newDoc.body.appendChild(filteredBody);
-
-              const nodes = $generateNodesFromDOM(editor, newDoc);
+              const nodes = $generateNodesFromDOM(editor, doc);
 
               selection.insertNodes(nodes);
             } else {
-              const lines = pastedData.split('\n');
-              const nodes = lines.map((line) => {
-                const paragraphNode = $createParagraphNode();
-                const textNode = $createTextNode(line);
-
-                paragraphNode.append(textNode);
-
-                return paragraphNode;
-              });
+              const htmlData = convertPlainTextToHtml(pastedData);
+              const parser = new DOMParser();
+              const doc = parser.parseFromString(htmlData, 'text/html');
+              const nodes = $generateNodesFromDOM(editor, doc);
 
               selection.insertNodes(nodes);
             }


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes variable identification in `LinkPastePlugin` by simplifying HTML parsing and using `convertPlainTextToHtml`.
> 
>   - **Behavior**:
>     - Fixes issue where pasted variables were not identified as variables in `LinkPastePlugin`.
>     - Removes `filterNode` function and `ALLOWED_TAGS` array, simplifying HTML parsing.
>     - Uses `convertPlainTextToHtml` for converting plain text to HTML before parsing.
>   - **Functions**:
>     - Updates `handlePaste` in `LinkPastePlugin` to use `convertPlainTextToHtml` for non-HTML clipboard data.
>     - Removes custom filtering logic for HTML content, directly using `$generateNodesFromDOM`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 495a13d03b4d2f8d4c2ab88af8ac1ef221b346be. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->