### PR TITLE
COS-6077: Time format is incorrect on next action tooltip

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/nextFlowAction/NextFlowAction.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/nextFlowAction/NextFlowAction.tsx
@@ -2,12 +2,11 @@ import { useRef, ReactElement } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { Node } from '@xyflow/react';
-import { toZonedTime } from 'date-fns-tz';
 import { observer } from 'mobx-react-lite';
+import { format, toZonedTime } from 'date-fns-tz';
 import { FlowActionType } from '@store/Flows/types';
-import { FlowStore } from '@store/Flows/Flow.store.ts';
+import { FlowStore } from '@store/Flows/Flow.store';
 
-import { DateTimeUtils } from '@utils/date.ts';
 import { Mail01 } from '@ui/media/icons/Mail01';
 import { useStore } from '@shared/hooks/useStore';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
@@ -37,7 +36,7 @@ const TOOLTIP_MESSAGE: Record<string, (date: string) => string> = {
 
 export const NextFlowAction = observer(
   ({ contactID }: { contactID: string }) => {
-    const { flows } = useStore();
+    const { flows, contacts } = useStore();
     const { id } = useParams<{ id: string }>();
     const itemRef = useRef<HTMLDivElement>(null);
 
@@ -54,6 +53,8 @@ export const NextFlowAction = observer(
     if (!contact?.executions?.length || !flowStore?.value?.nodes) {
       return <span className='text-grayModern-400'>None</span>;
     }
+
+    const contactTimezone = contacts?.value?.get(contactID)?.value?.timezone;
 
     // Process flow data
     const nodes = flowStore.parsedNodes;
@@ -77,12 +78,27 @@ export const NextFlowAction = observer(
       (e: ExtendedNode) => e.internalId === nextAction?.action?.metadata?.id,
     );
     const nextActionDate = nextAction.scheduledAt;
-    const utcScheduledAt = toZonedTime(nextActionDate, 'UTC').toUTCString();
 
-    const formattedDate = DateTimeUtils.format(
-      utcScheduledAt,
-      'd MMM y, hh:mm',
+    const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    const userTimezoneScheduledAt = toZonedTime(nextActionDate, userTimezone);
+    const contactTimezoneScheduledAt =
+      contactTimezone && toZonedTime(nextActionDate, contactTimezone);
+
+    const formattedDate = format(
+      userTimezoneScheduledAt,
+      'd MMM y, HH:mm zzz',
+      {
+        timeZone: userTimezone,
+      },
     );
+
+    const formattedDateContact =
+      contactTimezone &&
+      contactTimezoneScheduledAt &&
+      format(contactTimezoneScheduledAt, 'HH:mm zzz', {
+        timeZone: contactTimezone,
+      });
 
     if (typeof nextActionNode?.data?.action !== 'string') {
       return null;
@@ -97,6 +113,7 @@ export const NextFlowAction = observer(
           <div className='space-y-1'>
             <div className='flex gap-1'>
               {TOOLTIP_MESSAGE[nextActionNode.data.action](formattedDate)}
+              {formattedDateContact && <span>({formattedDateContact})</span>}
             </div>
           </div>
         }


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes time format in `NextFlowAction` tooltip to display in both user's and contact's timezones using `date-fns-tz`.
> 
>   - **Behavior**:
>     - Fixes time format in `NextFlowAction` tooltip to display in user's and contact's timezones.
>     - Uses `format` and `toZonedTime` from `date-fns-tz` to handle timezone conversion.
>   - **Code Changes**:
>     - Adds `contactTimezone` retrieval from `contacts` store.
>     - Formats `nextActionDate` for both user and contact timezones.
>     - Updates tooltip to show both formatted times if available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 581ea891319b4ce052c816a4bd1e056f42f71cc6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->