### PR TITLE
COS-6104: Prevent closing contract details modal on click outside

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/EditContractModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/EditContractModal.tsx
@@ -39,7 +39,7 @@ export const EditContractModal = ({
   const contractStore = store.contracts.value.get(contractId) as ContractStore;
   const contractNameInputRef = useRef<HTMLInputElement | null>(null);
 
-  const { isEditModalOpen, onEditModalClose } = useContractModalStateContext();
+  const { isEditModalOpen } = useContractModalStateContext();
 
   useEffect(() => {
     if (isEditModalOpen) {
@@ -57,7 +57,7 @@ export const EditContractModal = ({
   }, [isEditModalOpen]);
 
   return (
-    <Modal open={isEditModalOpen} onOpenChange={onEditModalClose}>
+    <Modal open={isEditModalOpen}>
       <ModalPortal>
         <ModalOverlay className='z-50' />
         <ModalContent


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents closing `EditContractModal` on outside click by removing `onOpenChange` prop in `EditContractModal.tsx`.
> 
>   - **Behavior**:
>     - Prevents closing `EditContractModal` on outside click by removing `onOpenChange` prop from `Modal` in `EditContractModal.tsx`.
>   - **Code Cleanup**:
>     - Removes unused `onEditModalClose` from `useContractModalStateContext()` in `EditContractModal.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8c99c1d6e4264de5e028eaeb075b59f525719380. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->