### PR TITLE
COS-6114: Use store sorting data for proper filter persistence, set default data if sorting in not set by user

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/FinderTable/FinderTable.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/FinderTable/FinderTable.tsx
@@ -11,7 +11,7 @@ import { useTableActions } from '@invoices/hooks/useTableActions';
 import { OpportunitiesTableActions } from '@finder/components/Actions/OpportunityActions';
 
 import { useStore } from '@shared/hooks/useStore';
-import { Invoice, TableViewType } from '@graphql/types';
+import { Invoice, TableViewType, ColumnViewType } from '@graphql/types';
 import { Table, SortingState, TableInstance } from '@ui/presentation/Table';
 import { ConfirmDeleteDialog } from '@ui/overlay/AlertDialog/ConfirmDeleteDialog';
 
@@ -38,14 +38,22 @@ export const FinderTable = observer(({ isSidePanelOpen }: FinderTableProps) => {
   const tableRef = useRef<TableInstance<object> | null>(null);
   const preset = searchParams?.get('preset');
   const tableViewDef = store.tableViewDefs.getById(preset ?? '1');
+  const contactsPreset = store.tableViewDefs.contactsPreset;
 
   const sortingData = tableViewDef?.getSorting();
-  const sorting: ColumnSort[] = [
-    {
-      id: sortingData?.id,
-      desc: sortingData?.desc,
-    },
-  ];
+  const defaultSorting =
+    preset === contactsPreset
+      ? [{ id: ColumnViewType.ContactsCreatedAt, desc: true }]
+      : [{ id: ColumnViewType.OrganizationsLastTouchpoint, desc: true }];
+
+  const sorting: ColumnSort[] = !sortingData?.id
+    ? defaultSorting
+    : [
+        {
+          id: sortingData.id,
+          desc: sortingData.desc,
+        },
+      ];
 
   const searchTerm = searchParams?.get('search');
   const { reset, targetId, isConfirming, onConfirm } = useTableActions();


### PR DESCRIPTION
…

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Default sorting logic added to `FinderTable.tsx` for cases where user sorting is not set, using `ColumnViewType` based on preset type.
> 
>   - **Behavior**:
>     - Default sorting applied in `FinderTable.tsx` when user sorting is not set.
>     - Uses `ColumnViewType.ContactsCreatedAt` for `contactsPreset` and `ColumnViewType.OrganizationsLastTouchpoint` otherwise.
>   - **Imports**:
>     - Add `ColumnViewType` to imports from `@graphql/types`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for bf734f61381210998d2129c0722fda76ccf448de. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->