### PR TITLE
Add toast for when LI is already used

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/socials/ContactLinkedInCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/socials/ContactLinkedInCell.tsx
@@ -35,20 +35,17 @@ export const ContactLinkedInCell = observer(
 
     const handleAddSocial = (url: string) => {
       if (!contact || url === 'Unknown' || url === '') return;
+      const formattedValue =
+        url.includes('https://www') || url.includes('linkedin.com')
+          ? getFormattedLink(url).replace(/^linkedin\.com\//, '')
+          : `company/${url}`;
 
-      contact.update((contactData) => {
-        const formattedValue =
-          url.includes('https://www') || url.includes('linkedin.com')
-            ? getFormattedLink(url).replace(/^linkedin\.com\//, '')
-            : `company/${url}`;
+      contact.value.socials.push({
+        id: crypto.randomUUID(),
+        url: `linkedin.com/${formattedValue}`,
+      } as Social);
 
-        contactData.socials.push({
-          id: crypto.randomUUID(),
-          url: `linkedin.com/${formattedValue}`,
-        } as Social);
-
-        return contactData;
-      });
+      contact.commit();
       setIsEdit(false);
     };
 
@@ -59,8 +56,8 @@ export const ContactLinkedInCell = observer(
 
       if (!linkedinId) return;
 
-      contact.update((org) => {
-        const idx = org.socials.findIndex((s) => s.id === linkedinId);
+      contact.value.socials.forEach((social) => {
+        const idx = contact.value.socials.findIndex((s) => s.id === linkedinId);
 
         if (idx !== -1) {
           const formattedValue =
@@ -68,14 +65,13 @@ export const ContactLinkedInCell = observer(
               ? getFormattedLink(url).replace(/^linkedin\.com\//, '')
               : `in/${url}`;
 
-          org.socials[idx].url = `linkedin.com/${formattedValue}`;
+          social.url = `linkedin.com/${formattedValue}`;
         }
 
         if (url === '') {
-          org.socials.splice(idx, 1);
+          contact.value.socials.splice(idx, 1);
         }
-
-        return org;
+        contact.commit();
       });
     };
 

--- a/packages/apps/frontera/src/store/Contacts/__service__/Contacts.service.ts
+++ b/packages/apps/frontera/src/store/Contacts/__service__/Contacts.service.ts
@@ -313,14 +313,27 @@ class ContactService {
           });
         }
       })
-      .with(['socials', ...P.array()], ([_]) => {
+      .with(['socials', ...P.array()], async ([_]) => {
         if (type === 'add') {
-          this.addSocial({
-            contactId: contactId!,
-            input: {
-              url: value.url,
-            },
-          });
+          try {
+            await this.addSocial({
+              contactId: contactId!,
+              input: {
+                url: value.url,
+              },
+            });
+          } catch (e) {
+            store.root.ui.toastError(
+              'This LinkedIn is already used by another contact',
+              'contact-social',
+            );
+
+            const foundIdx = store.value.socials.findIndex(
+              (social) => social.url === value.url,
+            );
+
+            store.value.socials[foundIdx].url = '';
+          }
         }
 
         if (type === 'update') {


### PR DESCRIPTION
## Proposed changes



## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add toast notification for duplicate LinkedIn URLs and refactor social link handling in `ContactLinkedInCell.tsx` and `Contacts.service.ts`.
> 
>   - **Behavior**:
>     - Adds toast notification in `Contacts.service.ts` when a LinkedIn URL is already used by another contact.
>     - Updates `handleAddSocial` and `handleUpdateSocial` in `ContactLinkedInCell.tsx` to use `contact.commit()` instead of `contact.update()`.
>   - **Error Handling**:
>     - Catches errors in `mutateOperation` in `Contacts.service.ts` when adding a social link, displays toast error if URL is duplicate.
>   - **Misc**:
>     - Minor refactoring in `ContactLinkedInCell.tsx` to streamline social link updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 32ab165a7032119bd4e0334fcfb960e6a5cc1099. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->