### PR TITLE
Organization filters and sorting DONE

### DIFF
--- a/packages/server/customer-os-api/graph/resolver/organizationV2.resolvers_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/organizationV2.resolvers_it_test.go
@@ -10,6 +10,7 @@ import (
 	neo4jentity "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/enum"
 	neo4jtest "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
@@ -147,6 +148,63 @@ func TestQueryResolver_UIOrganizationsSearch_FilterByRenewalDate(t *testing.T) {
 	assertSearch(t, searchBy, []time.Time{firstOfFebruary, firstOfFebruary}, commonModel.ComparisonOperatorBetween, 3, 1)
 	assertSearch(t, searchBy, []time.Time{midOfJanuary, firstOfMarch}, commonModel.ComparisonOperatorBetween, 3, 1)
 	assertSearch(t, searchBy, []time.Time{midOfFebruary, firstOfMarch}, commonModel.ComparisonOperatorBetween, 3, 0)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_FilterByForecastArr(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{RenewalSummary: neo4jentity.RenewalSummary{ArrForecast: nil}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{RenewalSummary: neo4jentity.RenewalSummary{ArrForecast: utils.Float64Ptr(2000)}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{RenewalSummary: neo4jentity.RenewalSummary{ArrForecast: utils.Float64Ptr(2005)}})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	searchBy := model.ColumnViewTypeOrganizationsForecastArr
+
+	assertSearch(t, searchBy, "", commonModel.ComparisonOperatorIsEmpty, 3, 1)
+	assertSearch(t, searchBy, "", commonModel.ComparisonOperatorIsNotEmpty, 3, 2)
+	assertSearch(t, searchBy, 2005, commonModel.ComparisonOperatorGte, 3, 1)
+	assertSearch(t, searchBy, 2005, commonModel.ComparisonOperatorGt, 3, 0)
+	assertSearch(t, searchBy, 2004, commonModel.ComparisonOperatorLte, 3, 1)
+	assertSearch(t, searchBy, 2005, commonModel.ComparisonOperatorLte, 3, 2)
+	assertSearch(t, searchBy, 2005, commonModel.ComparisonOperatorLt, 3, 1)
+	assertSearch(t, searchBy, 2005, commonModel.ComparisonOperatorEquals, 3, 1)
+	assertSearch(t, searchBy, 2006, commonModel.ComparisonOperatorEquals, 3, 0)
+	assertSearch(t, searchBy, 2005, commonModel.ComparisonOperatorNotEquals, 3, 2)
+	assertSearch(t, searchBy, 2010, commonModel.ComparisonOperatorNotEquals, 3, 3)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_FilterByOwner(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateUserWithId(ctx, driver, tenantName, "owner1")
+	neo4jtest.CreateUserWithId(ctx, driver, tenantName, "owner2")
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1"})
+	neo4jtest.LinkNodes(ctx, driver, "owner1", "1", "OWNS")
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2"})
+	neo4jtest.LinkNodes(ctx, driver, "owner2", "2", "OWNS")
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty"})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+	require.Equal(t, 2, neo4jtest.GetCountOfNodes(ctx, driver, "User"))
+	require.Equal(t, 2, neo4jtest.GetCountOfRelationships(ctx, driver, "OWNS"))
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	searchBy := model.ColumnViewTypeOrganizationsOwner
+
+	assertSearch(t, searchBy, []string{"owner1"}, commonModel.ComparisonOperatorIn, 3, 1)
+	assertSearch(t, searchBy, []string{"owner2"}, commonModel.ComparisonOperatorIn, 3, 1)
+	assertSearch(t, searchBy, []string{"owner1", "owner2"}, commonModel.ComparisonOperatorIn, 3, 2)
 }
 
 func TestQueryResolver_UIOrganizationsSearch_FilterByLastTouchpoint(t *testing.T) {
@@ -672,8 +730,6 @@ func assertSearch(t *testing.T, filterName model.ColumnViewType, searchValue any
 		client.Var("filterName", filterName),
 		client.Var("filterValue", searchValue),
 		client.Var("filterOperation", operator),
-		client.Var("sortByField", model.ColumnViewTypeOrganizationsName),
-		client.Var("sortByDirection", commonModel.SortingDirectionAsc),
 	)
 	assertRawResponseSuccess(t, rawResponse, err)
 
@@ -689,4 +745,537 @@ func assertSearch(t *testing.T, filterName model.ColumnViewType, searchValue any
 	require.Equal(t, totalAvailable, searchResult.TotalAvailable)
 	require.Equal(t, totalElements, searchResult.TotalElements)
 	require.Equal(t, int(totalElements), len(searchResult.Ids))
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByName(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", Name: ""})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "a", Name: "a"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "b", Name: "b"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "ab", Name: "ab"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "c", Name: "c"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "aa", Name: "aa"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "abc", Name: "abc"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "ba", Name: "ba"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "z", Name: "z"})
+
+	require.Equal(t, 9, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"a", "aa", "ab", "abc", "b", "ba", "c", "z", "empty"}
+	expectedDesc := []string{"z", "c", "ba", "b", "abc", "ab", "aa", "a", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsName, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsName, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByWebsite(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", Website: ""})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "a", Website: "https://www.a"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "b", Website: "https://www.b"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "ab", Website: "https://www.ab"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "c", Website: "https://www.c"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "aa", Website: "https://www.aa"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "abc", Website: "https://www.abc"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "ba", Website: "https://www.ba"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "z", Website: "https://www.z"})
+
+	require.Equal(t, 9, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"a", "aa", "ab", "abc", "b", "ba", "c", "z", "empty"}
+	expectedDesc := []string{"z", "c", "ba", "b", "abc", "ab", "aa", "a", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsWebsite, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsWebsite, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByRelationship(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", Relationship: ""})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "a", Relationship: "a"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "b", Relationship: "b"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "ab", Relationship: "ab"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "c", Relationship: "c"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "aa", Relationship: "aa"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "abc", Relationship: "abc"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "ba", Relationship: "ba"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "z", Relationship: "z"})
+
+	require.Equal(t, 9, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"a", "aa", "ab", "abc", "b", "ba", "c", "z", "empty"}
+	expectedDesc := []string{"z", "c", "ba", "b", "abc", "ab", "aa", "a", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsRelationship, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsRelationship, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByOnboardingStatus(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", OnboardingDetails: neo4jentity.OnboardingDetails{SortingOrder: nil}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1", OnboardingDetails: neo4jentity.OnboardingDetails{SortingOrder: utils.Int64Ptr(1)}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2", OnboardingDetails: neo4jentity.OnboardingDetails{SortingOrder: utils.Int64Ptr(2)}})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"2", "1", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsOnboardingStatus, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsOnboardingStatus, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByRenewalLikelihood(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", RenewalSummary: neo4jentity.RenewalSummary{RenewalLikelihoodOrder: nil}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1", RenewalSummary: neo4jentity.RenewalSummary{RenewalLikelihoodOrder: utils.Int64Ptr(1)}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2", RenewalSummary: neo4jentity.RenewalSummary{RenewalLikelihoodOrder: utils.Int64Ptr(2)}})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"2", "1", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsRenewalLikelihood, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsRenewalLikelihood, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByRenewalDate(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	firstOfDecember := utils.FirstTimeOfMonth(2023, 12)
+	firstOfJanuary := utils.FirstTimeOfMonth(2024, 1)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", RenewalSummary: neo4jentity.RenewalSummary{NextRenewalAt: nil}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1", RenewalSummary: neo4jentity.RenewalSummary{NextRenewalAt: &firstOfDecember}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2", RenewalSummary: neo4jentity.RenewalSummary{NextRenewalAt: &firstOfJanuary}})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"2", "1", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsRenewalDate, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsRenewalDate, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByForecastArr(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", RenewalSummary: neo4jentity.RenewalSummary{ArrForecast: nil}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1", RenewalSummary: neo4jentity.RenewalSummary{ArrForecast: utils.Float64Ptr(1)}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2", RenewalSummary: neo4jentity.RenewalSummary{ArrForecast: utils.Float64Ptr(2)}})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"2", "1", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsForecastArr, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsForecastArr, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByOwner(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateUser(ctx, driver, tenantName, neo4jentity.UserEntity{Id: "owner1", FirstName: "owner1"})
+	neo4jtest.CreateUser(ctx, driver, tenantName, neo4jentity.UserEntity{Id: "owner2", FirstName: "owner2"})
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1"})
+	neo4jtest.LinkNodes(ctx, driver, "owner1", "1", "OWNS")
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2"})
+	neo4jtest.LinkNodes(ctx, driver, "owner2", "2", "OWNS")
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty"})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+	require.Equal(t, 2, neo4jtest.GetCountOfNodes(ctx, driver, "User"))
+	require.Equal(t, 2, neo4jtest.GetCountOfRelationships(ctx, driver, "OWNS"))
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"2", "1", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsOwner, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsOwner, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByLastTouchpoint(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", LastTouchpointType: nil})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "a", LastTouchpointType: utils.StringPtr("a")})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "b", LastTouchpointType: utils.StringPtr("b")})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"a", "b", "empty"}
+	expectedDesc := []string{"b", "a", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsLastTouchpoint, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsLastTouchpoint, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByLastTouchpointDate(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	firstOfDecember := utils.FirstTimeOfMonth(2023, 12)
+	firstOfJanuary := utils.FirstTimeOfMonth(2024, 1)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", LastTouchpointAt: nil})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1", LastTouchpointAt: &firstOfDecember})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2", LastTouchpointAt: &firstOfJanuary})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"2", "1", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsLastTouchpointDate, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsLastTouchpointDate, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByStage(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", Stage: ""})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "a", Stage: "a"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "b", Stage: "b"})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"a", "b", "empty"}
+	expectedDesc := []string{"b", "a", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsStage, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsStage, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByLeadsource(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", LeadSource: ""})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "a", LeadSource: "a"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "b", LeadSource: "b"})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"a", "b", "empty"}
+	expectedDesc := []string{"b", "a", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsLeadSource, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsLeadSource, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByCreatedDate(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	firstOfDecember := utils.FirstTimeOfMonth(2023, 12)
+	firstOfJanuary := utils.FirstTimeOfMonth(2024, 1)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1", CreatedAt: firstOfDecember})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2", CreatedAt: firstOfJanuary})
+
+	require.Equal(t, 2, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2"}
+	expectedDesc := []string{"2", "1"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsCreatedDate, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsCreatedDate, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByEmployeeCount(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1", Employees: 1})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2", Employees: 2})
+
+	require.Equal(t, 2, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2"}
+	expectedDesc := []string{"2", "1"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsEmployeeCount, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsEmployeeCount, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByYearFounded(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", YearFounded: nil})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1", YearFounded: utils.Int64Ptr(1)})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2", YearFounded: utils.Int64Ptr(2)})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"2", "1", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsYearFounded, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsYearFounded, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByIndustry(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", Industry: ""})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "a", Industry: "a"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "b", Industry: "b"})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"a", "b", "empty"}
+	expectedDesc := []string{"b", "a", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsIndustry, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsIndustry, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByChurnDate(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	firstOfDecember := utils.FirstTimeOfMonth(2023, 12)
+	firstOfJanuary := utils.FirstTimeOfMonth(2024, 1)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty", DerivedData: neo4jentity.DerivedData{ChurnedAt: nil}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1", DerivedData: neo4jentity.DerivedData{ChurnedAt: &firstOfDecember}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2", DerivedData: neo4jentity.DerivedData{ChurnedAt: &firstOfJanuary}})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"2", "1", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsChurnDate, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsChurnDate, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortLtv(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "a", DerivedData: neo4jentity.DerivedData{Ltv: float64(1)}})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "b", DerivedData: neo4jentity.DerivedData{Ltv: float64(2)}})
+
+	require.Equal(t, 2, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"a", "b"}
+	expectedDesc := []string{"b", "a"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsLtv, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsLtv, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByCountry(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1"})
+	neo4jtest.CreateLocation(ctx, driver, tenantName, neo4jentity.LocationEntity{Id: "l1", Country: "C1"})
+	neo4jtest.LinkNodes(ctx, driver, "1", "l1", "ASSOCIATED_WITH")
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2"})
+	neo4jtest.CreateLocation(ctx, driver, tenantName, neo4jentity.LocationEntity{Id: "l2", Country: "C2"})
+	neo4jtest.LinkNodes(ctx, driver, "2", "l2", "ASSOCIATED_WITH")
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty"})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+	require.Equal(t, 2, neo4jtest.GetCountOfNodes(ctx, driver, "Location"))
+	require.Equal(t, 2, neo4jtest.GetCountOfRelationships(ctx, driver, "ASSOCIATED_WITH"))
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"2", "1", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsCountry, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsCountry, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByCity(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1"})
+	neo4jtest.CreateLocation(ctx, driver, tenantName, neo4jentity.LocationEntity{Id: "l1", Locality: "C1"})
+	neo4jtest.LinkNodes(ctx, driver, "1", "l1", "ASSOCIATED_WITH")
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2"})
+	neo4jtest.CreateLocation(ctx, driver, tenantName, neo4jentity.LocationEntity{Id: "l2", Locality: "C2"})
+	neo4jtest.LinkNodes(ctx, driver, "2", "l2", "ASSOCIATED_WITH")
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty"})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+	require.Equal(t, 2, neo4jtest.GetCountOfNodes(ctx, driver, "Location"))
+	require.Equal(t, 2, neo4jtest.GetCountOfRelationships(ctx, driver, "ASSOCIATED_WITH"))
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"2", "1", "empty"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsCity, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsCity, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByIsPublic(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty"}) // false by default
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1", IsPublic: true})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2", IsPublic: false})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"2", "empty", "1"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsIsPublic, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsIsPublic, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByParentOrganization(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "subsidiary1"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "parent1", Name: "Parent1"})
+	neo4jtest.LinkNodes(ctx, driver, "subsidiary1", "parent1", "SUBSIDIARY_OF")
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "subsidiary2"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "parent2", Name: "Parent2"})
+	neo4jtest.LinkNodes(ctx, driver, "subsidiary2", "parent2", "SUBSIDIARY_OF")
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty"})
+
+	require.Equal(t, 5, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	sortAsc := assertSort(t, model.ColumnViewTypeOrganizationsParentOrganization, commonModel.SortingDirectionAsc)
+	assert.Equal(t, "subsidiary1", sortAsc[0])
+	assert.Equal(t, "subsidiary2", sortAsc[1])
+
+	sortDesc := assertSort(t, model.ColumnViewTypeOrganizationsParentOrganization, commonModel.SortingDirectionDesc)
+	assert.Equal(t, "subsidiary2", sortDesc[0])
+	assert.Equal(t, "subsidiary1", sortDesc[1])
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByUpdatedDate(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	firstOfDecember := utils.FirstTimeOfMonth(2023, 12)
+	firstOfJanuary := utils.FirstTimeOfMonth(2024, 1)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "empty"}) // default to now
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "1", UpdatedAt: firstOfDecember})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "2", UpdatedAt: firstOfJanuary})
+
+	require.Equal(t, 3, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+
+	expectedAsc := []string{"1", "2", "empty"}
+	expectedDesc := []string{"empty", "2", "1"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsUpdatedDate, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsUpdatedDate, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func verifySortOrder(t *testing.T, sortBy model.ColumnViewType, direction commonModel.SortingDirection, expectedOrder []string) {
+	sortedResult := assertSort(t, sortBy, direction)
+	assert.Equal(t, len(expectedOrder), len(sortedResult), "Mismatch in result length")
+	for i, expected := range expectedOrder {
+		assert.Equal(t, expected, sortedResult[i], "Mismatch at index %d", i)
+	}
+}
+
+func assertSort(t *testing.T, sortBy model.ColumnViewType, sortDirection commonModel.SortingDirection) []string {
+	rawResponse, err := c.RawPost(getQuery("organization/ui_organizations_sort"),
+		client.Var("limit", 10),
+		client.Var("sortByField", sortBy.String()),
+		client.Var("sortByDirection", sortDirection),
+	)
+	assertRawResponseSuccess(t, rawResponse, err)
+
+	var organizations struct {
+		Ui_Organizations_Search model.OrganizationSearchResult
+	}
+
+	err = decode.Decode(rawResponse.Data.(map[string]any), &organizations)
+	require.Nil(t, err)
+	require.NotNil(t, organizations)
+
+	return organizations.Ui_Organizations_Search.Ids
 }

--- a/packages/server/customer-os-api/graph/resolver/test_queries/organization/ui_organizations_search.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/organization/ui_organizations_search.txt
@@ -1,4 +1,4 @@
-query UiOrganizationsSearch($limit: Int!, $filterName: String!, $filterValue: Any!, $filterOperation: ComparisonOperator!, $sortByField: String!, $sortByDirection: SortingDirection!) {
+query UiOrganizationsSearch($limit: Int!, $filterName: String!, $filterValue: Any!, $filterOperation: ComparisonOperator!) {
   ui_organizations_search(
     limit: $limit
     where: {
@@ -8,7 +8,6 @@ query UiOrganizationsSearch($limit: Int!, $filterName: String!, $filterValue: An
         }
       ]
     }
-    sort: { by: $sortByField, direction: $sortByDirection }
   ) {
     ids
     totalElements

--- a/packages/server/customer-os-api/graph/resolver/test_queries/organization/ui_organizations_sort.txt
+++ b/packages/server/customer-os-api/graph/resolver/test_queries/organization/ui_organizations_sort.txt
@@ -1,0 +1,10 @@
+query UiOrganizationsSort($limit: Int!, $sortByField: String!, $sortByDirection: SortingDirection!) {
+  ui_organizations_search(
+    limit: $limit
+    sort: { by: $sortByField, direction: $sortByDirection }
+  ) {
+    ids
+    totalElements
+    totalAvailable
+  }
+}

--- a/packages/server/customer-os-api/graph/schemas/view.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/view.graphqls
@@ -79,35 +79,35 @@ enum ColumnViewType {
     INVOICES_INVOICE_PREVIEW
     INVOICES_ORGANIZATION
 
-    ORGANIZATIONS_AVATAR # no search
-    ORGANIZATIONS_NAME #search done
-    ORGANIZATIONS_WEBSITE #search done
-    ORGANIZATIONS_RELATIONSHIP #search done
-    ORGANIZATIONS_ONBOARDING_STATUS #search done
-    ORGANIZATIONS_RENEWAL_LIKELIHOOD #search done
-    ORGANIZATIONS_RENEWAL_DATE #search done
-    ORGANIZATIONS_FORECAST_ARR #search done
-    ORGANIZATIONS_OWNER #search done
-    ORGANIZATIONS_LAST_TOUCHPOINT #search done
-    ORGANIZATIONS_LAST_TOUCHPOINT_DATE #search done
-    ORGANIZATIONS_STAGE #search done
-    ORGANIZATIONS_CONTACT_COUNT #deprecate
-    ORGANIZATIONS_SOCIALS #search done
-    ORGANIZATIONS_LEAD_SOURCE #search done
-    ORGANIZATIONS_CREATED_DATE #search done
-    ORGANIZATIONS_EMPLOYEE_COUNT #search done
-    ORGANIZATIONS_YEAR_FOUNDED #search done
-    ORGANIZATIONS_INDUSTRY #search done
-    ORGANIZATIONS_CHURN_DATE #search done
-    ORGANIZATIONS_LTV #search done
-    ORGANIZATIONS_COUNTRY #search done
-    ORGANIZATIONS_CITY #search done
+    ORGANIZATIONS_AVATAR # no search, no sort
+    ORGANIZATIONS_NAME #search, sort done
+    ORGANIZATIONS_WEBSITE #search, sort done
+    ORGANIZATIONS_RELATIONSHIP #search, sort done
+    ORGANIZATIONS_ONBOARDING_STATUS #search, sort done
+    ORGANIZATIONS_RENEWAL_LIKELIHOOD #search, sort done
+    ORGANIZATIONS_RENEWAL_DATE #search, sort done
+    ORGANIZATIONS_FORECAST_ARR #search, sort done
+    ORGANIZATIONS_OWNER #search, sort done
+    ORGANIZATIONS_LAST_TOUCHPOINT #search, sort done
+    ORGANIZATIONS_LAST_TOUCHPOINT_DATE #search, sort done
+    ORGANIZATIONS_STAGE #search, sort done
+    ORGANIZATIONS_CONTACT_COUNT #deprecated
+    ORGANIZATIONS_SOCIALS #search done, no sort
+    ORGANIZATIONS_LEAD_SOURCE #search, sort done
+    ORGANIZATIONS_CREATED_DATE #search, sort done
+    ORGANIZATIONS_EMPLOYEE_COUNT #search, sort done
+    ORGANIZATIONS_YEAR_FOUNDED #search, sort done
+    ORGANIZATIONS_INDUSTRY #search, sort done
+    ORGANIZATIONS_CHURN_DATE #search, sort done
+    ORGANIZATIONS_LTV #search, sort done
+    ORGANIZATIONS_COUNTRY #search, sort done
+    ORGANIZATIONS_CITY #search, sort done
     ORGANIZATIONS_HEADQUARTERS #deprecated
-    ORGANIZATIONS_IS_PUBLIC #search done
-    ORGANIZATIONS_LINKEDIN_FOLLOWER_COUNT #no search
-    ORGANIZATIONS_TAGS #search done
+    ORGANIZATIONS_IS_PUBLIC #search, sort done
+    ORGANIZATIONS_LINKEDIN_FOLLOWER_COUNT #no search, no sort
+    ORGANIZATIONS_TAGS #search done, no sort
     ORGANIZATIONS_PARENT_ORGANIZATION #search done
-    ORGANIZATIONS_UPDATED_DATE #search done
+    ORGANIZATIONS_UPDATED_DATE #search, sort done
 
     CONTACTS_AVATAR
     CONTACTS_NAME

--- a/packages/server/customer-os-api/repository/dashboardV2_repository.go
+++ b/packages/server/customer-os-api/repository/dashboardV2_repository.go
@@ -45,7 +45,6 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 	parentOrganizationFilterCypher, parentOrganizationFilterParams := "", make(map[string]interface{})
 
 	ownerId := []string{}
-	ownerIncludeEmpty := false
 
 	//ORGANIZATION, EMAIL, COUNTRY, REGION, LOCALITY
 	//region organization filters
@@ -98,6 +97,12 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 			}
 			if filter.Filter.Property == model.ColumnViewTypeOrganizationsRenewalDate.String() {
 				createBetweenOrEmptyTimeFilter(filter, organizationFilter, "derivedNextRenewalAt")
+			}
+			if filter.Filter.Property == model.ColumnViewTypeOrganizationsForecastArr.String() {
+				createNumberCypherFilter(filter, organizationFilter, "renewalForecastArr")
+			}
+			if filter.Filter.Property == model.ColumnViewTypeOrganizationsOwner.String() && filter.Filter.Value.ArrayStr != nil {
+				ownerId = *filter.Filter.Value.ArrayStr
 			}
 			if filter.Filter.Property == model.ColumnViewTypeOrganizationsLastTouchpoint.String() {
 				createInOrEmptyStringFilter(filter, organizationFilter, "lastTouchpointType")
@@ -190,7 +195,7 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 	countQuery := ""
 	{
 		countQuery += fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization_%s) `, tenant)
-		if len(ownerId) > 0 || ownerIncludeEmpty {
+		if len(ownerId) > 0 {
 			countQuery += ` OPTIONAL MATCH (o)<-[:OWNS]-(owner:User) WITH *`
 		}
 		if socialFilterCypher != "" {
@@ -208,7 +213,7 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 
 		countQuery += ` WHERE (o.hide = false OR o.hide IS NULL) `
 
-		if organizationFilterCypher != "" || socialFilterCypher != "" || tagFilterCypher != "" || locationFilterCypher != "" || parentOrganizationFilterCypher != "" || len(ownerId) > 0 || ownerIncludeEmpty {
+		if organizationFilterCypher != "" || socialFilterCypher != "" || tagFilterCypher != "" || locationFilterCypher != "" || parentOrganizationFilterCypher != "" || len(ownerId) > 0 {
 			countQuery += " AND "
 		}
 
@@ -216,14 +221,8 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 		if organizationFilterCypher != "" {
 			countQueryParts = append(countQueryParts, organizationFilterCypher)
 		}
-		if len(ownerId) > 0 || ownerIncludeEmpty {
-			if len(ownerId) == 0 {
-				countQueryParts = append(countQueryParts, fmt.Sprintf(` owner.id IS NULL `))
-			} else if ownerIncludeEmpty {
-				countQueryParts = append(countQueryParts, fmt.Sprintf(` (owner.id IN $ownerId OR owner.id IS NULL) `))
-			} else {
-				countQueryParts = append(countQueryParts, fmt.Sprintf(` owner.id IN $ownerId `))
-			}
+		if len(ownerId) > 0 {
+			countQueryParts = append(countQueryParts, fmt.Sprintf(` owner.id IN $ownerId `))
 		}
 		if socialFilterCypher != "" {
 			countQueryParts = append(countQueryParts, socialFilterCypher)
@@ -246,7 +245,7 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 	//region selectQuery to fetch data
 	{
 		selectQuery += fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization_%s) `, tenant)
-		if len(ownerId) > 0 || ownerIncludeEmpty {
+		if len(ownerId) > 0 {
 			selectQuery += fmt.Sprintf(` OPTIONAL MATCH (o)<-[:OWNS]-(owner:User) WITH *`)
 		}
 		if socialFilterCypher != "" {
@@ -255,18 +254,18 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 		if tagFilterCypher != "" {
 			selectQuery += fmt.Sprintf(` OPTIONAL MATCH (o)-[:TAGGED]->(t:Tag_%s) WITH *`, tenant)
 		}
-		if locationFilterCypher != "" {
+		if locationFilterCypher != "" || (sort != nil && (sort.By == model.ColumnViewTypeOrganizationsCountry.String() || sort.By == model.ColumnViewTypeOrganizationsCity.String())) {
 			selectQuery += fmt.Sprintf(` OPTIONAL MATCH (o)-[:ASSOCIATED_WITH]->(l:Location_%s) WITH *`, tenant)
 		}
-		if parentOrganizationFilterCypher != "" {
+		if parentOrganizationFilterCypher != "" || sort != nil && sort.By == model.ColumnViewTypeOrganizationsParentOrganization.String() {
 			selectQuery += fmt.Sprintf(` OPTIONAL MATCH (o)-[:SUBSIDIARY_OF]->(po:Organization_%s) WITH *`, tenant)
 		}
-		if sort != nil && sort.By == SearchSortParamOwner {
+		if sort != nil && sort.By == model.ColumnViewTypeOrganizationsOwner.String() {
 			selectQuery += fmt.Sprintf(` OPTIONAL MATCH (o)<-[:OWNS]-(owner:User_%s) WITH *`, tenant)
 		}
 		selectQuery += ` WHERE (o.hide = false OR o.hide IS NULL) `
 
-		if organizationFilterCypher != "" || socialFilterCypher != "" || tagFilterCypher != "" || parentOrganizationFilterCypher != "" || locationFilterCypher != "" || len(ownerId) > 0 || ownerIncludeEmpty {
+		if organizationFilterCypher != "" || socialFilterCypher != "" || tagFilterCypher != "" || parentOrganizationFilterCypher != "" || locationFilterCypher != "" || len(ownerId) > 0 {
 			selectQuery += " AND "
 		}
 
@@ -274,14 +273,8 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 		if organizationFilterCypher != "" {
 			queryParts = append(queryParts, organizationFilterCypher)
 		}
-		if len(ownerId) > 0 || ownerIncludeEmpty {
-			if len(ownerId) == 0 {
-				queryParts = append(queryParts, fmt.Sprintf(` owner.id IS NULL `))
-			} else if ownerIncludeEmpty {
-				queryParts = append(queryParts, fmt.Sprintf(` (owner.id IN $ownerId OR owner.id IS NULL) `))
-			} else {
-				queryParts = append(queryParts, fmt.Sprintf(` owner.id IN $ownerId `))
-			}
+		if len(ownerId) > 0 {
+			queryParts = append(queryParts, fmt.Sprintf(` owner.id IN $ownerId `))
 		}
 		if socialFilterCypher != "" {
 			queryParts = append(queryParts, socialFilterCypher)
@@ -300,167 +293,245 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 	//endregion
 
 	// sort region
-	//aliases := " o, d, l"
-	selectQuery += " WITH o "
-	//if sort != nil && sort.By == SearchSortParamOwner {
-	//	if sort.Direction == commonmodel.SortingDirectionAsc {
-	//		selectQuery += ", CASE WHEN owner.firstName <> \"\" and not owner.firstName is null THEN owner.firstName ELSE 'ZZZZZZZZZZZZZZZZZZZ' END as OWNER_FIRST_NAME_FOR_SORTING "
-	//		selectQuery += ", CASE WHEN owner.lastName <> \"\" and not owner.lastName is null THEN owner.lastName ELSE 'ZZZZZZZZZZZZZZZZZZZ' END as OWNER_LAST_NAME_FOR_SORTING "
-	//	} else {
-	//		selectQuery += ", CASE WHEN owner.firstName <> \"\" and not owner.firstName is null THEN owner.firstName ELSE 'AAAAAAAAAAAAAAAAAAA' END as OWNER_FIRST_NAME_FOR_SORTING "
-	//		selectQuery += ", CASE WHEN owner.lastName <> \"\" and not owner.lastName is null THEN owner.lastName ELSE 'AAAAAAAAAAAAAAAAAAA' END as OWNER_LAST_NAME_FOR_SORTING "
-	//	}
-	//	aliases += ", OWNER_FIRST_NAME_FOR_SORTING, OWNER_LAST_NAME_FOR_SORTING "
-	//}
-	//if sort != nil && sort.By == SearchSortParamName {
-	//	if sort.Direction == commonmodel.SortingDirectionAsc {
-	//		selectQuery += ", CASE WHEN o.name <> \"\" and not o.name is null THEN o.name ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as NAME_FOR_SORTING "
-	//	} else {
-	//		selectQuery += ", o.name as NAME_FOR_SORTING "
-	//	}
-	//	aliases += ", NAME_FOR_SORTING "
-	//}
-	//if sort != nil && sort.By == SearchSortParamRenewalLikelihood {
-	//	if sort.Direction == commonmodel.SortingDirectionAsc {
-	//		selectQuery += ", CASE WHEN o.derivedRenewalLikelihoodOrder IS NOT NULL THEN o.derivedRenewalLikelihoodOrder ELSE 9999 END as RENEWAL_LIKELIHOOD_FOR_SORTING "
-	//	} else {
-	//		selectQuery += ", CASE WHEN o.derivedRenewalLikelihoodOrder IS NOT NULL THEN o.derivedRenewalLikelihoodOrder ELSE -1 END as RENEWAL_LIKELIHOOD_FOR_SORTING "
-	//	}
-	//	aliases += ", RENEWAL_LIKELIHOOD_FOR_SORTING "
-	//}
-	//if sort != nil && sort.By == SearchSortParamRelationship {
-	//	if sort.Direction == commonmodel.SortingDirectionAsc {
-	//		selectQuery += ", CASE WHEN o.relationship <> '' AND NOT o.relationship IS NULL THEN o.relationship ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as RELATIONSHIP_FOR_SORTING "
-	//	} else {
-	//		selectQuery += ", o.relationship as RELATIONSHIP_FOR_SORTING "
-	//	}
-	//	aliases += ", RELATIONSHIP_FOR_SORTING "
-	//}
-	//if sort != nil && sort.By == SearchSortParamStage {
-	//	if sort.Direction == commonmodel.SortingDirectionAsc {
-	//		selectQuery += ", CASE WHEN o.stage <> '' AND NOT o.stage IS NULL THEN o.stage ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as STAGE_FOR_SORTING "
-	//	} else {
-	//		selectQuery += ", o.stage as STAGE_FOR_SORTING "
-	//	}
-	//	aliases += ", STAGE_FOR_SORTING "
-	//}
-	//if sort != nil && sort.By == SearchSortParamIndustry {
-	//	if sort.Direction == commonmodel.SortingDirectionAsc {
-	//		selectQuery += ", CASE WHEN o.industry <> '' AND NOT o.industry IS NULL THEN o.industry ELSE 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ' END as STAGE_FOR_SORTING "
-	//	} else {
-	//		selectQuery += ", o.industry as INDUSTRY_FOR_SORTING "
-	//	}
-	//	aliases += ", INDUSTRY_FOR_SORTING "
-	//}
-	//if sort != nil && sort.By == SearchSortParamRenewalCycleNext {
-	//	if sort.Direction == commonmodel.SortingDirectionAsc {
-	//		selectQuery += ", CASE WHEN o.billingDetailsRenewalCycleNext IS NOT NULL THEN date(o.billingDetailsRenewalCycleNext) ELSE date('2100-01-01') END as RENEWAL_CYCLE_NEXT_FOR_SORTING "
-	//	} else {
-	//		selectQuery += ", CASE WHEN o.billingDetailsRenewalCycleNext IS NOT NULL THEN date(o.billingDetailsRenewalCycleNext) ELSE date('1900-01-01') END as RENEWAL_CYCLE_NEXT_FOR_SORTING "
-	//	}
-	//	aliases += ", RENEWAL_CYCLE_NEXT_FOR_SORTING "
-	//}
-	//if sort != nil && sort.By == SearchSortParamRenewalDate {
-	//	if sort.Direction == commonmodel.SortingDirectionAsc {
-	//		selectQuery += ", CASE WHEN o.derivedNextRenewalAt IS NOT NULL THEN date(o.derivedNextRenewalAt) ELSE date('2100-01-01') END as RENEWAL_DATE_FOR_SORTING "
-	//	} else {
-	//		selectQuery += ", CASE WHEN o.derivedNextRenewalAt IS NOT NULL THEN date(o.derivedNextRenewalAt) ELSE date('1900-01-01') END as RENEWAL_DATE_FOR_SORTING "
-	//	}
-	//	aliases += ", RENEWAL_DATE_FOR_SORTING "
-	//}
-	//if sort != nil && sort.By == SearchSortParamChurnDate {
-	//	if sort.Direction == commonmodel.SortingDirectionAsc {
-	//		selectQuery += ", CASE WHEN o.derivedChurnedAt IS NOT NULL THEN date(o.derivedChurnedAt) ELSE date('2100-01-01') END as CHURN_DATE_FOR_SORTING "
-	//	} else {
-	//		selectQuery += ", CASE WHEN o.derivedChurnedAt IS NOT NULL THEN date(o.derivedChurnedAt) ELSE date('1900-01-01') END as CHURN_DATE_FOR_SORTING "
-	//	}
-	//	aliases += ", RENEWAL_DATE_FOR_SORTING "
-	//}
-	//if sort != nil && sort.By == SearchSortParamOnboardingStatus {
-	//	if sort.Direction == commonmodel.SortingDirectionAsc {
-	//		selectQuery += ", CASE WHEN o.onboardingStatusOrder IS NOT NULL THEN o.onboardingStatusOrder ELSE 9999 END as ONBOARDING_STATUS_FOR_SORTING "
-	//		selectQuery += ", o.onboardingUpdatedAt AS ONBOARDING_UPDATED_AT_FOR_SORTING "
-	//	} else {
-	//		selectQuery += ", CASE WHEN o.onboardingStatusOrder IS NOT NULL THEN o.onboardingStatusOrder ELSE -1 END as ONBOARDING_STATUS_FOR_SORTING "
-	//		selectQuery += ", o.onboardingUpdatedAt AS ONBOARDING_UPDATED_AT_FOR_SORTING "
-	//	}
-	//	aliases += ", ONBOARDING_STATUS_FOR_SORTING, ONBOARDING_UPDATED_AT_FOR_SORTING "
-	//}
-	//if sort != nil && sort.By == SearchSortParamForecastArr {
-	//	if sort.Direction == commonmodel.SortingDirectionAsc {
-	//		selectQuery += ", CASE WHEN o.renewalForecastArr <> \"\" and o.renewalForecastArr IS NOT NULL THEN o.renewalForecastArr ELSE 9999999999999999 END as FORECAST_ARR_FOR_SORTING "
-	//	} else {
-	//		selectQuery += ", CASE WHEN o.renewalForecastArr <> \"\" and o.renewalForecastArr IS NOT NULL THEN o.renewalForecastArr ELSE 0 END as FORECAST_ARR_FOR_SORTING "
-	//	}
-	//	aliases += ", FORECAST_ARR_FOR_SORTING "
-	//}
-	//if sort != nil && sort.By == SearchSortParamOrganization {
-	//	selectQuery += " OPTIONAL MATCH (o)-[:SUBSIDIARY_OF]->(parent:Organization) WITH "
-	//	selectQuery += aliases + ", parent "
-	//}
+	sortingCypher := ""
+	aliases := ""
+
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsName.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.name <> \"\" and not o.name is null THEN toLower(o.name) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.name <> \"\" and not o.name is null THEN toLower(o.name) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsWebsite.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.website <> \"\" and not o.website is null THEN toLower(o.website) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.website <> \"\" and not o.website is null THEN toLower(o.website) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsRelationship.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.relationship <> \"\" and not o.relationship is null THEN toLower(o.relationship) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.relationship <> \"\" and not o.relationship is null THEN toLower(o.relationship) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsOnboardingStatus.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.onboardingStatusOrder <> \"\" and not o.onboardingStatusOrder is null THEN o.onboardingStatusOrder ELSE 9999 END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.onboardingStatusOrder <> \"\" and not o.onboardingStatusOrder is null THEN o.onboardingStatusOrder ELSE -1 END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsRenewalLikelihood.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.derivedRenewalLikelihoodOrder <> \"\" and not o.derivedRenewalLikelihoodOrder is null THEN o.derivedRenewalLikelihoodOrder ELSE 9999 END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.derivedRenewalLikelihoodOrder <> \"\" and not o.derivedRenewalLikelihoodOrder is null THEN o.derivedRenewalLikelihoodOrder ELSE -1 END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsRenewalDate.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.derivedNextRenewalAt <> \"\" and not o.derivedNextRenewalAt is null THEN o.derivedNextRenewalAt ELSE datetime({year:2100}) END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.derivedNextRenewalAt <> \"\" and not o.derivedNextRenewalAt is null THEN o.derivedNextRenewalAt ELSE datetime({year:1900}) END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsForecastArr.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.renewalForecastArr <> \"\" and not o.renewalForecastArr is null THEN o.renewalForecastArr ELSE 9999 END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.renewalForecastArr <> \"\" and not o.renewalForecastArr is null THEN o.renewalForecastArr ELSE -1 END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsOwner.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN owner.firstName <> \"\" and not owner.firstName is null THEN toLower(owner.firstName) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN owner.firstName <> \"\" and not owner.firstName is null THEN toLower(owner.firstName) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsLastTouchpoint.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.lastTouchpointType <> \"\" and not o.lastTouchpointType is null THEN toLower(o.lastTouchpointType) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.lastTouchpointType <> \"\" and not o.lastTouchpointType is null THEN toLower(o.lastTouchpointType) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsLastTouchpointDate.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.lastTouchpointAt <> \"\" and not o.lastTouchpointAt is null THEN o.lastTouchpointAt ELSE datetime({year:2100}) END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.lastTouchpointAt <> \"\" and not o.lastTouchpointAt is null THEN o.lastTouchpointAt ELSE datetime({year:1900}) END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsStage.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.stage <> \"\" and not o.stage is null THEN toLower(o.stage) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.stage <> \"\" and not o.stage is null THEN toLower(o.stage) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsLeadSource.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.leadSource <> \"\" and not o.leadSource is null THEN toLower(o.leadSource) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.leadSource <> \"\" and not o.leadSource is null THEN toLower(o.leadSource) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsCreatedDate.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.createdAt <> \"\" and not o.createdAt is null THEN o.createdAt ELSE datetime({year:2100}) END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.createdAt <> \"\" and not o.createdAt is null THEN o.createdAt ELSE datetime({year:1900}) END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsEmployeeCount.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.employees <> \"\" and not o.employees is null THEN o.employees ELSE 999999999 END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.employees <> \"\" and not o.employees is null THEN o.employees ELSE -1 END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsYearFounded.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.yearFounded <> \"\" and not o.yearFounded is null THEN o.yearFounded ELSE 999999999 END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.yearFounded <> \"\" and not o.yearFounded is null THEN o.yearFounded ELSE -1 END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsIndustry.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.industry <> \"\" and not o.industry is null THEN toLower(o.industry) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.industry <> \"\" and not o.industry is null THEN toLower(o.industry) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsChurnDate.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.derivedChurnedAt <> \"\" and not o.derivedChurnedAt is null THEN o.derivedChurnedAt ELSE datetime({year:2100}) END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.derivedChurnedAt <> \"\" and not o.derivedChurnedAt is null THEN o.derivedChurnedAt ELSE datetime({year:1900}) END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsLtv.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.derivedLtv <> \"\" and not o.derivedLtv is null THEN o.derivedLtv ELSE 9999999999999999 END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.derivedLtv <> \"\" and not o.derivedLtv is null THEN o.derivedLtv ELSE -9999999999999999 END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsCountry.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN l.country <> \"\" and not l.country is null THEN toLower(l.country) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN l.country <> \"\" and not l.country is null THEN toLower(l.country) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsCity.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN l.locality <> \"\" and not l.locality is null THEN toLower(l.locality) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN l.locality <> \"\" and not l.locality is null THEN toLower(l.locality) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsIsPublic.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.isPublic = true THEN 0 ELSE CASE WHEN o.isPublic = false THEN 1 ELSE 2 END END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.isPublic = false THEN 2 ELSE CASE WHEN o.isPublic = true THEN 1 ELSE 0 END END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsParentOrganization.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN po.name <> \"\" and not po.name is null THEN toLower(po.name) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN po.name <> \"\" and not po.name is null THEN toLower(po.name) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsUpdatedDate.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN o.updatedAt <> \"\" and not o.updatedAt is null THEN o.updatedAt ELSE datetime({year:2100}) END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN o.updatedAt <> \"\" and not o.updatedAt is null THEN o.updatedAt ELSE datetime({year:1900}) END as SORT_BY "
+		}
+	}
+
+	if sort != nil {
+		sortingCypher += " ORDER BY SORT_BY " + string(sort.Direction)
+	}
+
+	if len(aliases) > 0 {
+		selectQuery += " WITH *, " + aliases
+	} else {
+		selectQuery += " WITH * "
+	}
 
 	cypherSort := utils.CypherSort{}
-	//if sort != nil {
-	//	if sort.By == SearchSortParamName {
-	//		if sort.CaseSensitive != nil && *sort.CaseSensitive {
-	//			selectQuery += " ORDER BY NAME_FOR_SORTING " + string(sort.Direction)
-	//		} else {
-	//			selectQuery += " ORDER BY toLower(NAME_FOR_SORTING) " + string(sort.Direction)
-	//		}
-	//	} else if sort.By == SearchSortParamRelationship {
-	//		selectQuery += " ORDER BY RELATIONSHIP_FOR_SORTING " + string(sort.Direction)
-	//	} else if sort.By == SearchSortParamStage {
-	//		selectQuery += " ORDER BY STAGE_FOR_SORTING " + string(sort.Direction)
-	//	} else if sort.By == SearchSortParamIndustry {
-	//		selectQuery += " ORDER BY INDUSTRY_FOR_SORTING " + string(sort.Direction)
-	//	} else if sort.By == SearchSortParamOrganization {
-	//		cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce().WithAlias("parent")
-	//		cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce()
-	//		cypherSort.NewSortRule("NAME", string(sort.Direction), true, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithAlias("parent").WithDescending()
-	//		cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
-	//		selectQuery += string(cypherSort.SortingCypherFragment("o"))
-	//	} else if sort.By == SearchSortParamForecastArr {
-	//		selectQuery += " ORDER BY FORECAST_ARR_FOR_SORTING " + string(sort.Direction)
-	//	} else if sort.By == SearchSortParamRenewalLikelihood {
-	//		selectQuery += " ORDER BY RENEWAL_LIKELIHOOD_FOR_SORTING " + string(sort.Direction)
-	//	} else if sort.By == SearchSortParamOnboardingStatus {
-	//		selectQuery += " ORDER BY ONBOARDING_STATUS_FOR_SORTING " + string(sort.Direction) +
-	//			", ONBOARDING_UPDATED_AT_FOR_SORTING " + string(sort.Direction)
-	//	} else if sort.By == SearchSortParamRenewalCycleNext {
-	//		selectQuery += " ORDER BY RENEWAL_CYCLE_NEXT_FOR_SORTING " + string(sort.Direction)
-	//	} else if sort.By == SearchSortParamRenewalDate {
-	//		selectQuery += " ORDER BY RENEWAL_DATE_FOR_SORTING " + string(sort.Direction)
-	//	} else if sort.By == SearchSortParamChurnDate {
-	//		selectQuery += " ORDER BY CHURN_DATE_FOR_SORTING " + string(sort.Direction)
-	//	} else if sort.By == "DOMAIN" {
-	//		cypherSort.NewSortRule("DOMAIN", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.DomainEntity{}))
-	//		selectQuery += string(cypherSort.SortingCypherFragment("d"))
-	//	} else if sort.By == SearchSortParamLocation {
-	//		cypherSort.NewSortRule("COUNTRY", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
-	//		cypherSort.NewSortRule("REGION", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
-	//		cypherSort.NewSortRule("LOCALITY", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
-	//		selectQuery += string(cypherSort.SortingCypherFragment("l"))
-	//	} else if sort.By == "OWNER" {
-	//		if sort.CaseSensitive != nil && *sort.CaseSensitive {
-	//			selectQuery += " ORDER BY OWNER_FIRST_NAME_FOR_SORTING " + string(sort.Direction) + ", OWNER_LAST_NAME_FOR_SORTING " + string(sort.Direction)
-	//		} else {
-	//			selectQuery += " ORDER BY toLower(OWNER_FIRST_NAME_FOR_SORTING) " + string(sort.Direction) + ", toLower(OWNER_LAST_NAME_FOR_SORTING) " + string(sort.Direction)
-	//		}
-	//	} else if sort.By == SearchSortParamLastTouchpointAt || sort.By == SearchSortParamLastTouchpoint {
-	//		cypherSort.NewSortRule("LAST_TOUCHPOINT_AT", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
-	//		selectQuery += string(cypherSort.SortingCypherFragment("o"))
-	//	} else if sort.By == SearchSortParamLastTouchpointType {
-	//		cypherSort.NewSortRule("LAST_TOUCHPOINT_TYPE", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
-	//		selectQuery += string(cypherSort.SortingCypherFragment("o"))
-	//	} else if sort.By == SearchSortParamUpdatedAt {
-	//		cypherSort.NewSortRule("UPDATED_AT", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
-	//		selectQuery += string(cypherSort.SortingCypherFragment("o"))
-	//	}
-	//} else
-	//{
-	cypherSort.NewSortRule("UPDATED_AT", string(commonmodel.SortingDirectionDesc), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
-	selectQuery += string(cypherSort.SortingCypherFragment("o"))
-	//}
+	if sort != nil {
+		selectQuery += " " + sortingCypher
+		//	if sort.By == SearchSortParamName {
+		//		if sort.CaseSensitive != nil && *sort.CaseSensitive {
+		//			selectQuery += " ORDER BY NAME_FOR_SORTING " + string(sort.Direction)
+		//		} else {
+		//			selectQuery += " ORDER BY toLower(NAME_FOR_SORTING) " + string(sort.Direction)
+		//		}
+		//	} else if sort.By == SearchSortParamRelationship {
+		//		selectQuery += " ORDER BY RELATIONSHIP_FOR_SORTING " + string(sort.Direction)
+		//	} else if sort.By == SearchSortParamStage {
+		//		selectQuery += " ORDER BY STAGE_FOR_SORTING " + string(sort.Direction)
+		//	} else if sort.By == SearchSortParamIndustry {
+		//		selectQuery += " ORDER BY INDUSTRY_FOR_SORTING " + string(sort.Direction)
+		//	} else if sort.By == SearchSortParamOrganization {
+		//		cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce().WithAlias("parent")
+		//		cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithCoalesce()
+		//		cypherSort.NewSortRule("NAME", string(sort.Direction), true, reflect.TypeOf(neo4jentity.OrganizationEntity{})).WithAlias("parent").WithDescending()
+		//		cypherSort.NewSortRule("NAME", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+		//		selectQuery += string(cypherSort.SortingCypherFragment("o"))
+		//	} else if sort.By == SearchSortParamForecastArr {
+		//		selectQuery += " ORDER BY FORECAST_ARR_FOR_SORTING " + string(sort.Direction)
+		//	} else if sort.By == SearchSortParamRenewalLikelihood {
+		//		selectQuery += " ORDER BY RENEWAL_LIKELIHOOD_FOR_SORTING " + string(sort.Direction)
+		//	} else if sort.By == SearchSortParamOnboardingStatus {
+		//		selectQuery += " ORDER BY ONBOARDING_STATUS_FOR_SORTING " + string(sort.Direction) +
+		//			", ONBOARDING_UPDATED_AT_FOR_SORTING " + string(sort.Direction)
+		//	} else if sort.By == SearchSortParamRenewalCycleNext {
+		//		selectQuery += " ORDER BY RENEWAL_CYCLE_NEXT_FOR_SORTING " + string(sort.Direction)
+		//	} else if sort.By == SearchSortParamRenewalDate {
+		//		selectQuery += " ORDER BY RENEWAL_DATE_FOR_SORTING " + string(sort.Direction)
+		//	} else if sort.By == SearchSortParamChurnDate {
+		//		selectQuery += " ORDER BY CHURN_DATE_FOR_SORTING " + string(sort.Direction)
+		//	} else if sort.By == "DOMAIN" {
+		//		cypherSort.NewSortRule("DOMAIN", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.DomainEntity{}))
+		//		selectQuery += string(cypherSort.SortingCypherFragment("d"))
+		//	} else if sort.By == SearchSortParamLocation {
+		//		cypherSort.NewSortRule("COUNTRY", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
+		//		cypherSort.NewSortRule("REGION", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
+		//		cypherSort.NewSortRule("LOCALITY", string(sort.Direction), *sort.CaseSensitive, reflect.TypeOf(neo4jentity.LocationEntity{}))
+		//		selectQuery += string(cypherSort.SortingCypherFragment("l"))
+		//	} else if sort.By == "OWNER" {
+		//		if sort.CaseSensitive != nil && *sort.CaseSensitive {
+		//			selectQuery += " ORDER BY OWNER_FIRST_NAME_FOR_SORTING " + string(sort.Direction) + ", OWNER_LAST_NAME_FOR_SORTING " + string(sort.Direction)
+		//		} else {
+		//			selectQuery += " ORDER BY toLower(OWNER_FIRST_NAME_FOR_SORTING) " + string(sort.Direction) + ", toLower(OWNER_LAST_NAME_FOR_SORTING) " + string(sort.Direction)
+		//		}
+		//	} else if sort.By == SearchSortParamLastTouchpointAt || sort.By == SearchSortParamLastTouchpoint {
+		//		cypherSort.NewSortRule("LAST_TOUCHPOINT_AT", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+		//		selectQuery += string(cypherSort.SortingCypherFragment("o"))
+		//	} else if sort.By == SearchSortParamLastTouchpointType {
+		//		cypherSort.NewSortRule("LAST_TOUCHPOINT_TYPE", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+		//		selectQuery += string(cypherSort.SortingCypherFragment("o"))
+		//	} else if sort.By == SearchSortParamUpdatedAt {
+		//		cypherSort.NewSortRule("UPDATED_AT", string(sort.Direction), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+		//		selectQuery += string(cypherSort.SortingCypherFragment("o"))
+		//	}
+
+		//TODO default sort if empty sort
+	} else {
+		cypherSort.NewSortRule("UPDATED_AT", string(commonmodel.SortingDirectionDesc), false, reflect.TypeOf(neo4jentity.OrganizationEntity{}))
+		selectQuery += string(cypherSort.SortingCypherFragment("o"))
+	}
 
 	// end sort region
 	selectQuery += fmt.Sprintf(` RETURN distinct(o.id) `)

--- a/packages/server/customer-os-neo4j-repository/test/neo4j_data_helper.go
+++ b/packages/server/customer-os-neo4j-repository/test/neo4j_data_helper.go
@@ -284,7 +284,7 @@ func CreateOrganization(ctx context.Context, driver *neo4j.DriverWithContext, te
 		"description":                   organization.Description,
 		"website":                       organization.Website,
 		"industry":                      organization.Industry,
-		"isPublic":                      organization.IsPublic,
+		"isPublic":                      utils.BoolDefaultIfNil(organization.IsPublic, false),
 		"subIndustry":                   organization.SubIndustry,
 		"industryGroup":                 organization.IndustryGroup,
 		"targetAudience":                organization.TargetAudience,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added filtering and sorting capabilities for organizations in the customer OS API with extensive tests and GraphQL updates.
> 
>   - **Behavior**:
>     - Added filtering and sorting capabilities for organizations in `organizationV2.resolvers_it_test.go`.
>     - Implemented tests for filtering by name, website, relationship, onboarding status, renewal likelihood, renewal date, forecast ARR, owner, last touchpoint, stage, socials, lead source, created date, employee count, year founded, industry, churn date, LTV, country, city, is public, tags, parent organization, and updated date.
>     - Implemented tests for sorting by name, website, relationship, onboarding status, renewal likelihood, renewal date, forecast ARR, owner, last touchpoint, stage, lead source, created date, employee count, year founded, industry, churn date, LTV, country, city, is public, parent organization, and updated date.
>   - **GraphQL**:
>     - Updated `ui_organizations_search.txt` to remove sorting parameters.
>     - Added `ui_organizations_sort.txt` for sorting queries.
>     - Updated `view.graphqls` to reflect new sorting capabilities.
>   - **Repository**:
>     - Modified `dashboardV2_repository.go` to handle new filtering and sorting logic.
>     - Removed unused variables and streamlined query construction.
>   - **Test Data**:
>     - Updated `neo4j_data_helper.go` to support new test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for be7a48a0ad44a91d98a9021d2f92cfc748385c72. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->