### PR TITLE
COS-6135: Bottom actionbar should hide after successful action

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Actions/FlowsActions.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Actions/FlowsActions.tsx
@@ -26,7 +26,10 @@ export const FlowSequencesTableActions = ({
 
   const [targetId, setTargetId] = useState<string | null>(null);
   const selectCount = selection?.length;
-  const clearSelection = () => table.resetRowSelection();
+
+  const clearSelection = () => {
+    table.resetRowSelection();
+  };
 
   const onOpenCommandK = () => {
     if (selection.length === 1) {
@@ -47,16 +50,12 @@ export const FlowSequencesTableActions = ({
   };
 
   const handleOpen = (type: CommandMenuType, property?: string) => {
+    store.ui.commandMenu.setCallback(() => clearSelection());
+
     if (selection?.length > 1) {
       store.ui.commandMenu.setContext({
         ids: selection,
         entity: 'Flows',
-        property: property,
-      });
-    } else {
-      store.ui.commandMenu.setContext({
-        ids: [focusedId || ''],
-        entity: 'Flow',
         property: property,
       });
     }
@@ -125,7 +124,9 @@ export const FlowSequencesTableActions = ({
       handleOpen={handleOpen}
       selectCount={selectCount}
       onOpenCommandK={onOpenCommandK}
-      onHide={() => handleOpen('DeleteConfirmationModal')}
+      onHide={() => {
+        handleOpen('DeleteConfirmationModal');
+      }}
     />
   );
 };

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/shared/DeleteConfirmationModal.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/shared/DeleteConfirmationModal.tsx
@@ -131,19 +131,19 @@ export const DeleteConfirmationModal = observer(() => {
             }
           },
         });
+        context.callback?.();
+
         store.ui.commandMenu.setType('FlowHub');
         store.ui.commandMenu.clearCallback();
         store.ui.commandMenu.clearContext();
-
-        context.callback?.();
       })
       .with('Flows', () => {
         store.flows.archiveMany(context.ids);
+        context.callback?.();
         store.ui.commandMenu.setType('FlowHub');
+
         store.ui.commandMenu.clearCallback();
         store.ui.commandMenu.clearContext();
-
-        context.callback?.();
       })
       .with('TableViewDef', () => {
         store.tableViewDefs.archive(context.ids?.[0], {


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure bottom action bar hides after successful actions by setting and executing a callback to clear selection in `FlowsActions.tsx` and `DeleteConfirmationModal.tsx`.
> 
>   - **Behavior**:
>     - In `FlowsActions.tsx`, `handleOpen` now sets a callback to clear selection after opening a command menu.
>     - In `DeleteConfirmationModal.tsx`, the callback is executed after archiving flows or other entities, ensuring the action bar hides.
>   - **Functions**:
>     - `clearSelection` in `FlowsActions.tsx` is used to reset row selection.
>     - `context.callback?.()` is called in `DeleteConfirmationModal.tsx` after successful actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f40f20eabfc5ea8737e3f9d4c0332ded0e0a6a36. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->