### PR TITLE
Fix send email

### DIFF
--- a/packages/server/customer-os-common-module/service/mail_sender.go
+++ b/packages/server/customer-os-common-module/service/mail_sender.go
@@ -35,10 +35,6 @@ func (s *mailService) SendMail(ctx context.Context, emailMessage *postgresentity
 		return err
 	}
 
-	if err := s.setFromName(ctx, span, emailMessage); err != nil {
-		return err
-	}
-
 	if err := s.sendEmailBasedOnProvider(ctx, span, emailMessage, oauthToken); err != nil {
 		return err
 	}
@@ -136,24 +132,6 @@ func (s *mailService) setReplyReferences(emailMessage *postgresentity.EmailMessa
 		emailMessage.ProviderReferences = emailChannelData.ProviderMessageId
 	}
 	emailMessage.ProviderInReplyTo = emailChannelData.ProviderMessageId
-}
-
-func (s *mailService) setFromName(ctx context.Context, span opentracing.Span, emailMessage *postgresentity.EmailMessage) error {
-	userNode, err := s.services.Neo4jRepositories.UserReadRepository.GetFirstUserByEmail(ctx, emailMessage.Tenant, emailMessage.From)
-	if err != nil {
-		err = errors.Wrap(err, "failed to get first user by email")
-		tracing.TraceErr(span, err)
-		return err
-	}
-	if userNode == nil {
-		err := errors.New("user not found")
-		tracing.TraceErr(span, err)
-		return err
-	}
-
-	user := neo4jmapper.MapDbNodeToUserEntity(userNode)
-	emailMessage.FromName = user.FirstName + " " + user.LastName
-	return nil
 }
 
 func (s *mailService) sendEmailBasedOnProvider(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `setFromName` function from `mailService` in `mail_sender.go`, simplifying email sending by eliminating Neo4j query for sender's name.
> 
>   - **Behavior**:
>     - Removed `setFromName` function from `mailService` in `mail_sender.go`, which set `FromName` in `EmailMessage` by querying Neo4j.
>     - `SendMail` no longer calls `setFromName`, simplifying email sending process.
>   - **Misc**:
>     - Removed unused imports related to `setFromName` functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 056a5fd49212a1d70cea71988e05f6be8fb03b58. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->