### PR TITLE
COS-6156: Fix current flow cell after user closes cmdk without selecting flow

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/contactFlow/ContactFlowCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/contactFlow/ContactFlowCell.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, ReactElement } from 'react';
+import { useRef, ReactElement } from 'react';
 
 import { observer } from 'mobx-react-lite';
 
@@ -31,7 +31,6 @@ const icons: Record<string, ReactElement> = {
 export const ContactFlowCell = observer(
   ({ contactId }: ContactNameCellProps) => {
     const store = useStore();
-    const [isEditing, setIsEditing] = useState(false);
 
     const contactStore = store.contacts.value.get(contactId);
     const itemRef = useRef<HTMLDivElement>(null);
@@ -39,12 +38,11 @@ export const ContactFlowCell = observer(
     const contactFlows = contactStore?.flows;
 
     const open = () => {
-      setIsEditing(true);
       store.ui.commandMenu.setType('EditContactFlow');
       store.ui.commandMenu.setOpen(true);
     };
 
-    if (!contactFlows?.length && !isEditing) {
+    if (!contactFlows?.length) {
       return (
         <div
           onDoubleClick={open}


### PR DESCRIPTION
…
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `isEditing` state from `ContactFlowCell` and fixes flow cell state issue after closing command menu without selection.
> 
>   - **Behavior**:
>     - Removes `isEditing` state from `ContactFlowCell` in `ContactFlowCell.tsx`.
>     - Adjusts logic to open command menu without checking `isEditing` state.
>     - Fixes issue where flow cell state was incorrect after closing command menu without selection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 01aee1eb89eabeaf79d876021f1e385e4202c06a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->