### PR TITLE
COS-6157: Add empty table state to flow contacts

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/EmptyState/EmptyState.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/EmptyState/EmptyState.tsx
@@ -104,6 +104,18 @@ export const EmptyState = observer(() => {
             store.ui.commandMenu.setOpen(true);
           },
         };
+      case TableIdType.FlowContacts:
+        return {
+          title: 'No contacts yet',
+          description:
+            'Add contacts to start scheduling messages. Once live, the flow will automatically schedule contacts when the trigger conditions are met.',
+          buttonLabel: 'Add contacts',
+          dataTest: 'flow-add-contacts',
+          onClick: () => {
+            store.ui.commandMenu.setType('AddContactsToFlow');
+            store.ui.commandMenu.setOpen(true);
+          },
+        };
       default:
         return {
           title: "We couldn't find any organizations",

--- a/packages/apps/frontera/src/routes/finder/src/components/FinderTable/FinderTable.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/FinderTable/FinderTable.tsx
@@ -11,9 +11,14 @@ import { useTableActions } from '@invoices/hooks/useTableActions';
 import { OpportunitiesTableActions } from '@finder/components/Actions/OpportunityActions';
 
 import { useStore } from '@shared/hooks/useStore';
-import { Invoice, TableViewType, ColumnViewType } from '@graphql/types';
 import { Table, SortingState, TableInstance } from '@ui/presentation/Table';
 import { ConfirmDeleteDialog } from '@ui/overlay/AlertDialog/ConfirmDeleteDialog';
+import {
+  Invoice,
+  TableIdType,
+  TableViewType,
+  ColumnViewType,
+} from '@graphql/types';
 
 import { SidePanel } from '../SidePanel';
 import { EmptyState } from '../EmptyState/EmptyState';
@@ -62,6 +67,7 @@ export const FinderTable = observer(({ isSidePanelOpen }: FinderTableProps) => {
 
   const tableType =
     tableViewDef?.value?.tableType || TableViewType.Organizations;
+  const tableId = tableViewDef?.value?.tableId || TableIdType.Organizations;
 
   const columns = computeFinderColumns(store, {
     tableType,
@@ -321,6 +327,10 @@ export const FinderTable = observer(({ isSidePanelOpen }: FinderTableProps) => {
   );
 
   const checkIfEmpty = () => {
+    if (tableId === TableIdType.FlowContacts && params.id) {
+      return store.flows.value.get(params.id)?.value.participants.length === 0;
+    }
+
     return match(tableType)
       .with(
         TableViewType.Organizations,
@@ -342,7 +352,7 @@ export const FinderTable = observer(({ isSidePanelOpen }: FinderTableProps) => {
       .otherwise(() => false);
   };
 
-  if (checkIfEmpty() && checkIfLoading()) {
+  if (checkIfEmpty() || checkIfLoading()) {
     return <EmptyState />;
   }
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add empty state handling for FlowContacts table in FinderTable component.
> 
>   - **Behavior**:
>     - Add empty state for `FlowContacts` in `EmptyState.tsx` with title, description, button, and click handler.
>     - Update `checkIfEmpty()` in `FinderTable.tsx` to handle `FlowContacts` by checking if participants are empty.
>   - **Misc**:
>     - Import `TableIdType` in `FinderTable.tsx` for `FlowContacts` handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b456c5c262a3a8c95e4207c4e0a1f8d6972d6840. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->