### PR TITLE
COS-6158: Don't allow editing email and making changes that cannot be saved when flow is live, fix condition

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/FinderTable/FinderTable.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/FinderTable/FinderTable.tsx
@@ -327,32 +327,27 @@ export const FinderTable = observer(({ isSidePanelOpen }: FinderTableProps) => {
   );
 
   const checkIfEmpty = () => {
-    if (tableId === TableIdType.FlowContacts && params.id) {
-      return store.flows.value.get(params.id)?.value.participants.length === 0;
-    }
-
     return match(tableType)
       .with(
         TableViewType.Organizations,
         () => store.organizations?.totalElements === 0,
       )
-      .with(TableViewType.Contacts, () => store.contacts?.totalElements === 0)
+      .with(TableViewType.Contacts, () => {
+        if (tableId === TableIdType.FlowContacts && params.id) {
+          return (
+            store.flows.value.get(params.id)?.value.participants.length === 0
+          );
+        }
+
+        return store.contacts?.totalElements === 0;
+      })
       .with(TableViewType.Invoices, () => store.invoices?.totalElements === 0)
       .with(TableViewType.Contracts, () => store.contracts?.totalElements === 0)
       .with(TableViewType.Flow, () => store.flows?.totalElements === 0)
       .otherwise(() => false);
   };
 
-  const checkIfLoading = () => {
-    return match(tableType)
-      .with(TableViewType.Contacts, () => store.contacts?.isLoading)
-      .with(TableViewType.Invoices, () => store.invoices?.isLoading)
-      .with(TableViewType.Contracts, () => store.contracts?.isLoading)
-      .with(TableViewType.Flow, () => store.flows?.isLoading)
-      .otherwise(() => false);
-  };
-
-  if (checkIfEmpty() || checkIfLoading()) {
+  if (checkIfEmpty()) {
     return <EmptyState />;
   }
 

--- a/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
@@ -12,21 +12,22 @@ import {
   ReactFlow,
   Background,
   MarkerType,
-  OnNodeDrag,
   NodeChange,
+  OnNodeDrag,
   getIncomers,
   getOutgoers,
-  useNodesState,
-  useEdgesState,
-  OnNodesDelete,
   OnEdgesDelete,
   OnNodesChange,
-  OnBeforeDelete,
+  OnNodesDelete,
+  useEdgesState,
+  useNodesState,
   FitViewOptions,
+  OnBeforeDelete,
   applyNodeChanges,
   SelectionDragHandler,
 } from '@xyflow/react';
 
+import { FlowStatus } from '@graphql/types';
 import { useStore } from '@shared/hooks/useStore';
 
 import { nodeTypes } from './nodes';
@@ -37,6 +38,7 @@ import { useUndoRedo, useKeyboardShortcuts } from './hooks';
 import { HelperLines, FlowBuilderToolbar } from './components';
 
 import '@xyflow/react/dist/style.css';
+
 const edgeTypes = {
   baseEdge: BasicEdge,
 };
@@ -430,7 +432,7 @@ export const FlowBuilder = observer(
               return;
             }
 
-            if (node.type === 'wait') {
+            if (node.type === 'wait' && flow.value.status === FlowStatus.Off) {
               setNodes((nds) =>
                 nds.map((n) =>
                   n.id === node.id

--- a/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
@@ -7,6 +7,7 @@ import { useReactFlow } from '@xyflow/react';
 import { FlowStore } from '@store/Flows/Flow.store';
 
 import { cn } from '@ui/utils/cn';
+import { FlowStatus } from '@graphql/types';
 import { Spinner } from '@ui/feedback/Spinner';
 import { Button } from '@ui/form/Button/Button';
 import { User01 } from '@ui/media/icons/User01';
@@ -45,7 +46,7 @@ export const Header = observer(
     const contactsStore = store.contacts;
     const showFinder = searchParams.get('show') === 'finder';
     const flowContactsPreset = store.tableViewDefs.flowContactsPreset;
-    const canSave = hasChanges;
+    const canSave = hasChanges && flow.value.status === FlowStatus.Off;
     const [showPublishChangesButton, setShowPublishChangesButton] =
       useState(false);
 

--- a/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailEditorModal.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailEditorModal.tsx
@@ -19,6 +19,7 @@ interface EmailEditorModalProps {
   flowName?: string;
   placeholder: string;
   bodyTemplate: string;
+  isReadOnly?: boolean;
   isEditorOpen: boolean;
   handleSave: () => void;
   action?: FlowActionType;
@@ -41,6 +42,7 @@ export const EmailEditorModal = observer(
     variables,
     action,
     handleSave,
+    isReadOnly,
   }: EmailEditorModalProps) => {
     const inputRef = useRef<LexicalEditor>(null);
     const editorRef = useRef<LexicalEditor>(null);
@@ -91,6 +93,7 @@ export const EmailEditorModal = observer(
                   usePlainText
                   ref={inputRef}
                   placeholder='Subject'
+                  isReadOnly={isReadOnly}
                   variableOptions={variables}
                   namespace='flow-email-editor-subject'
                   onChange={(html) => setSubject(extractPlainText(html))}
@@ -114,6 +117,7 @@ export const EmailEditorModal = observer(
               <div className='h-[60vh] mb-10'>
                 <Editor
                   ref={editorRef}
+                  isReadOnly={isReadOnly}
                   placeholder={placeholder}
                   variableOptions={variables}
                   dataTest='flow-email-editor'

--- a/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/email/EmailSettingsPanel.tsx
@@ -8,6 +8,7 @@ import { render } from '@react-email/render';
 import { FlowActionType } from '@store/Flows/types';
 
 import { cn } from '@ui/utils/cn';
+import { FlowStatus } from '@graphql/types';
 import { Button } from '@ui/form/Button/Button';
 import { Editor } from '@ui/form/Editor/Editor';
 import { IconButton } from '@ui/form/IconButton';
@@ -54,7 +55,8 @@ export const EmailSettingsPanel = observer(() => {
 
   const { takeSnapshot } = useUndoRedo();
 
-  const flow = flows.value.get(flowId)?.value?.name;
+  const flow = flows.value.get(flowId);
+  const flowName = flow?.value?.name;
 
   useEffect(() => {
     const isSubjectChanged = subject !== data?.subject;
@@ -206,7 +208,7 @@ export const EmailSettingsPanel = observer(() => {
           </div>
         </div>
 
-        <div className='px-4 overflow-y-auto min-h-[50%] h-full'>
+        <div className={cn('px-4 overflow-y-auto min-h-[50%] h-full')}>
           <Tooltip
             align='start'
             label={
@@ -228,6 +230,7 @@ export const EmailSettingsPanel = observer(() => {
                 placeholder='Subject'
                 variableOptions={variables}
                 namespace='flow-email-editor-subject'
+                isReadOnly={flow?.value?.status === FlowStatus.On}
                 onChange={(html) => setSubject(extractPlainText(html))}
                 defaultHtmlValue={convertPlainTextToHtml(subject ?? '')}
                 onKeyDown={(e) => {
@@ -262,6 +265,7 @@ export const EmailSettingsPanel = observer(() => {
               namespace='flow-email-editor'
               defaultHtmlValue={bodyTemplate}
               placeholderClassName='text-sm '
+              isReadOnly={flow?.value?.status === FlowStatus.On}
               className='text-sm cursor-text email-editor h-full'
               onChange={(e) => {
                 setBodyTemplate(e);
@@ -280,8 +284,8 @@ export const EmailSettingsPanel = observer(() => {
         {/*  Set up a test email...*/}
         {/*</Button>*/}
         <EmailEditorModal
-          flowName={flow}
           subject={subject}
+          flowName={flowName}
           action={data?.action}
           variables={variables}
           setSubject={setSubject}
@@ -291,6 +295,7 @@ export const EmailSettingsPanel = observer(() => {
           bodyTemplate={bodyTemplate}
           setBodyTemplate={setBodyTemplate}
           handleCancel={() => setFocusMode(false)}
+          isReadOnly={flow?.value?.status === FlowStatus.On}
         />
       </article>
     </div>

--- a/packages/apps/frontera/src/ui/form/Editor/Editor.tsx
+++ b/packages/apps/frontera/src/ui/form/Editor/Editor.tsx
@@ -108,6 +108,7 @@ interface EditorProps extends VariantProps<typeof contentEditableVariants> {
   dataTest?: string;
   className?: string;
   placeholder?: string;
+  isReadOnly?: boolean;
   usePlainText?: boolean;
   defaultHtmlValue?: string;
   mentionsOptions?: string[];
@@ -148,6 +149,7 @@ export const Editor = forwardRef<LexicalEditor | null, EditorProps>(
       onKeyDown,
       placeholder = 'Type something',
       showToolbarBottom = false,
+      isReadOnly = false,
     },
     ref,
   ) => {
@@ -161,6 +163,7 @@ export const Editor = forwardRef<LexicalEditor | null, EditorProps>(
       theme,
       onError,
       nodes,
+      editable: !isReadOnly,
     };
 
     const EditorPlugin = usePlainText ? PlainTextPlugin : RichTextPlugin;


### PR DESCRIPTION
… 

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent email editing and unsaved changes when flow is live, and update related components and logic.
> 
>   - **Behavior**:
>     - Prevent editing of email content in `EmailEditorModal` and `EmailSettingsPanel` when flow status is `FlowStatus.On`.
>     - Disable save functionality in `Header.tsx` when flow is live.
>   - **Components**:
>     - Add `isReadOnly` prop to `Editor` in `Editor.tsx` to control editability.
>     - Update `EmailEditorModal` and `EmailSettingsPanel` to use `isReadOnly` based on flow status.
>   - **Logic**:
>     - Modify `FlowBuilder.tsx` to check flow status before allowing node edits.
>     - Remove `checkIfLoading` function in `FinderTable.tsx` as it is no longer used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 791d44809d10e1ea45d54f16a9eca642b31cf1c0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->