### PR TITLE
COS-6161: Add flow initial loading by id if user accessed flow editor path but flows are not bootstrapped yet

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/page.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/page.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
 import { FinderTable } from '@finder/components/FinderTable';
@@ -10,6 +10,7 @@ import { cn } from '@ui/utils/cn';
 import { Button } from '@ui/form/Button/Button';
 import { useStore } from '@shared/hooks/useStore';
 import { ViewSettings } from '@shared/components/ViewSettings';
+import { LoadingScreen } from '@shared/components/SplashScreen/components';
 import {
   TableIdType,
   TableViewType,
@@ -21,9 +22,37 @@ import { FlowSettingsPanel } from './src/components';
 
 import '@xyflow/react/dist/style.css';
 
-export const FlowEditor = () => {
+export const FlowEditor = observer(() => {
+  const store = useStore();
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const [isLoading, setIsLoading] = useState(true);
+
   const [hasNewChanges, setHasNewChanges] = useState(false);
   const [isSidePanelOpen, setIsSidePanelOpen] = useState<boolean>(false);
+
+  if (typeof id === 'undefined') {
+    navigate('/finder');
+
+    return;
+  }
+
+  useEffect(() => {
+    if (!store.flows.value.has(id) && store.flows.isLoading) {
+      setIsLoading(true);
+      store.flows.invalidateId({ id });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isLoading && store.flows.value.has(id)) {
+      setIsLoading(false);
+    }
+  }, [store.flows.value.has(id)]);
+
+  if (isLoading) {
+    return <LoadingScreen hide={false} isLoaded={false} showSplash={true} />;
+  }
 
   return (
     <ReactFlowProvider>
@@ -43,7 +72,7 @@ export const FlowEditor = () => {
       </div>
     </ReactFlowProvider>
   );
-};
+});
 
 const FlowContent = observer(
   ({

--- a/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
@@ -134,6 +134,7 @@ export const FlowBuilder = observer(
 
     const customApplyNodeChanges = useCallback(
       (changes: NodeChange[], nodes: Node[]): Node[] => {
+        if (!changes.length) return nodes;
         // reset the helper lines (clear existing lines, if any)
         setHelperLineHorizontal(undefined);
         setHelperLineVertical(undefined);
@@ -293,7 +294,7 @@ export const FlowBuilder = observer(
 
         const shouldProhibitChanges =
           changes.every((change) => change.type === 'remove') &&
-          nodes.length === changes.length;
+          nodes?.length === changes.length;
 
         if (shouldProhibitChanges) return;
         onNodesChange(changes);
@@ -305,7 +306,7 @@ export const FlowBuilder = observer(
           )
         ) {
           // avoid setting new changes flag  to true on nodes init
-          if (nodes.length !== changes.length) {
+          if (nodes?.length !== changes.length) {
             onHasNewChanges();
           }
         }

--- a/packages/apps/frontera/src/store/Flows/Flows.store.ts
+++ b/packages/apps/frontera/src/store/Flows/Flows.store.ts
@@ -99,6 +99,26 @@ export class FlowsStore implements GroupStore<Flow> {
     }
   }
 
+  async invalidateId({ id }: { id: string }) {
+    this.isLoading = true;
+
+    try {
+      const { flow } = await this.service.getFlow(id);
+
+      runInAction(() => {
+        this.load([flow]);
+      });
+    } catch (e) {
+      runInAction(() => {
+        this.error = (e as Error)?.message;
+      });
+    } finally {
+      runInAction(() => {
+        this.isLoading = false;
+      });
+    }
+  }
+
   async create(
     name: string,
     options?: { onSuccess?: (serverId: string) => void },


### PR DESCRIPTION
… 

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add flow loading by ID in `FlowEditor` if accessed directly without bootstrapped flows, with updates to `FlowsStore` and `FlowBuilder`.
> 
>   - **Behavior**:
>     - `FlowEditor` in `page.tsx` now loads a flow by ID if accessed directly without bootstrapped flows, using `invalidateId` from `FlowsStore`.
>     - Redirects to `/finder` if no `id` is present in the URL.
>     - Displays `LoadingScreen` while fetching flow data.
>   - **Store**:
>     - Adds `invalidateId` method to `FlowsStore` in `Flows.store.ts` to fetch and load a flow by ID.
>   - **Components**:
>     - `FlowBuilder` in `FlowBuilder.tsx` now prevents node changes if all nodes are being removed and handles email node additions by opening the email editor.
>     - Adds checks for node and edge changes to prevent unintended deletions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 1f6efc06726b0d4aeb6237329462f05989781a37. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->