### PR TITLE
Mailstack provision in parallel

### DIFF
--- a/packages/server/events-subscribers/listeners/mailstack_listener.go
+++ b/packages/server/events-subscribers/listeners/mailstack_listener.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-postgres-repository/entity"
 	"github.com/opentracing/opentracing-go"
 	"strings"
+	"sync"
 )
 
 func Handle_MailstackProvisionBuyRequest(ctx context.Context, services *service.Services, input any) error {
@@ -38,53 +39,20 @@ func Handle_MailstackProvisionBuyRequest(ctx context.Context, services *service.
 		return nil
 	}
 
-	//buy domains
-	domains, err := services.PostgresRepositories.MailstackBuyRequestRepository.GetDomains(ctx, mailstackBuyRequest.ID)
+	err = processDomains(ctx, services, mailstackBuyRequest)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err
 	}
 
-	//TODO go routine
-
-	for _, domain := range domains {
-		// step 1 - purchase domain in namecheap
-		if domain.Status == entity.MailstackBuyRequestDomainStatusPendingProvisioning {
-			err = services.NamecheapService.PurchaseDomain(ctx, domain.Tenant, domain.Domain)
-			if err != nil {
-				tracing.TraceErr(span, err)
-				mailstackBuyRequest.Status = entity.MailstackBuyRequestStatusFailed
-				domain.Status = entity.MailstackBuyRequestDomainStatusFailed
-			} else {
-				domain.Status = entity.MailstackBuyRequestDomainStatusPendingConfiguration
-			}
-
-			err = services.PostgresRepositories.CommonRepository.UpdateProperty(ctx, domain.Tenant, entity.MailstackBuyRequestDomain{}, domain.ID, "Status", domain.Status)
-			if err != nil {
-				tracing.TraceErr(span, err)
-				return err
-			}
-		}
-
-		// step 2 - configure domain in mailstack
-		if domain.Status == entity.MailstackBuyRequestDomainStatusPendingConfiguration {
-			err = services.MailstackService.ConfigureMailstackDomain(ctx, domain.Domain, domain.RedirectWebsite)
-			if err != nil {
-				tracing.TraceErr(span, err)
-			} else {
-				domain.Status = entity.MailstackBuyRequestDomainStatusCompleted
-			}
-
-			err = services.PostgresRepositories.CommonRepository.UpdateProperty(ctx, domain.Tenant, entity.MailstackBuyRequestDomain{}, domain.ID, "Status", domain.Status)
-			if err != nil {
-				tracing.TraceErr(span, err)
-				return err
-			}
-		}
+	err = processMailboxes(ctx, services, mailstackBuyRequest)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
 	}
 
 	//reload latest state for domains
-	domains, err = services.PostgresRepositories.MailstackBuyRequestRepository.GetDomains(ctx, mailstackBuyRequest.ID)
+	domains, err := services.PostgresRepositories.MailstackBuyRequestRepository.GetDomains(ctx, mailstackBuyRequest.ID)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err
@@ -116,13 +84,141 @@ func Handle_MailstackProvisionBuyRequest(ctx context.Context, services *service.
 
 	// mark buy request as completed or failed
 	if mailstackBuyRequest.Status == entity.MailstackBuyRequestStatusPending {
-		mailstackBuyRequest.Status = entity.MailstackBuyRequestStatusCompleted
-	}
-	_, err = services.PostgresRepositories.MailstackBuyRequestRepository.Store(ctx, nil, mailstackBuyRequest)
-	if err != nil {
-		tracing.TraceErr(span, err)
+
+		completed := true
+
+		for _, domain := range domains {
+			if domain.Status != entity.MailstackBuyRequestDomainStatusCompleted {
+				completed = false
+			}
+		}
+
+		if completed {
+			mailstackBuyRequest.Status = entity.MailstackBuyRequestStatusCompleted
+		}
+
+		_, err = services.PostgresRepositories.MailstackBuyRequestRepository.Store(ctx, nil, mailstackBuyRequest)
+		if err != nil {
+			tracing.TraceErr(span, err)
+		}
 	}
 
+	return nil
+}
+
+func processDomains(ctx context.Context, services *service.Services, mailstackBuyRequest *entity.MailstackBuyRequest) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Listeners.Handle_MailstackProvisionBuyRequest.processDomains")
+	defer span.Finish()
+	tracing.SetDefaultListenerSpanTags(ctx, span)
+
+	domains, err := services.PostgresRepositories.MailstackBuyRequestRepository.GetDomains(ctx, mailstackBuyRequest.ID)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 5) // Semaphore to limit to 5 goroutines
+
+	for _, domain := range domains {
+		wg.Add(1)
+
+		// Create a new scope to avoid data races on the `domain` variable
+		go func(domain *entity.MailstackBuyRequestDomain) {
+			defer wg.Done()
+
+			sem <- struct{}{}        // Acquire semaphore
+			defer func() { <-sem }() // Release semaphore
+
+			// Step 1 - Purchase domain in Namecheap
+			if domain.Status == entity.MailstackBuyRequestDomainStatusPendingProvisioning {
+				err := services.NamecheapService.PurchaseDomain(ctx, domain.Tenant, domain.Domain)
+				if err != nil {
+					tracing.TraceErr(span, err)
+					mailstackBuyRequest.Status = entity.MailstackBuyRequestStatusFailed
+					domain.Status = entity.MailstackBuyRequestDomainStatusFailed
+				} else {
+					domain.Status = entity.MailstackBuyRequestDomainStatusPendingConfiguration
+				}
+
+				err = services.PostgresRepositories.CommonRepository.UpdateProperty(ctx, domain.Tenant, entity.MailstackBuyRequestDomain{}, domain.ID, "Status", domain.Status)
+				if err != nil {
+					tracing.TraceErr(span, err)
+					return // Exit the goroutine on error
+				}
+			}
+
+			// Step 2 - Configure domain in Mailstack
+			if domain.Status == entity.MailstackBuyRequestDomainStatusPendingConfiguration {
+				err := services.MailstackService.ConfigureMailstackDomain(ctx, domain.Domain, domain.RedirectWebsite)
+				if err != nil {
+					tracing.TraceErr(span, err)
+				} else {
+					domain.Status = entity.MailstackBuyRequestDomainStatusCompleted
+				}
+
+				err = services.PostgresRepositories.CommonRepository.UpdateProperty(ctx, domain.Tenant, entity.MailstackBuyRequestDomain{}, domain.ID, "Status", domain.Status)
+				if err != nil {
+					tracing.TraceErr(span, err)
+					return // Exit the goroutine on error
+				}
+			}
+		}(domain)
+	}
+
+	wg.Wait() // Wait for all goroutines to finish
+	return nil
+}
+
+func processMailboxes(ctx context.Context, services *service.Services, mailstackBuyRequest *entity.MailstackBuyRequest) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Listeners.Handle_MailstackProvisionBuyRequest.processMailboxes")
+	defer span.Finish()
+	tracing.SetDefaultListenerSpanTags(ctx, span)
+
+	domains, err := services.PostgresRepositories.MailstackBuyRequestRepository.GetDomains(ctx, mailstackBuyRequest.ID)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 4) // Semaphore to limit to 4 goroutines
+
+	for _, domain := range domains {
+		if domain.Status != entity.MailstackBuyRequestDomainStatusCompleted {
+			continue
+		}
+
+		wg.Add(1)
+
+		// Create a new scope to avoid data races on the `domain` variable
+		go func(domain *entity.MailstackBuyRequestDomain) {
+			defer wg.Done()
+
+			sem <- struct{}{}        // Acquire semaphore
+			defer func() { <-sem }() // Release semaphore
+
+			mailboxes, err := services.PostgresRepositories.TenantSettingsMailboxRepository.GetAllByDomain(ctx, domain.Domain)
+			if err != nil {
+				tracing.TraceErr(span, err)
+				return // Exit the goroutine on error
+			}
+
+			for _, mailbox := range mailboxes {
+				if mailbox.Status != entity.MailboxStatusPendingProvisioning {
+					continue
+				}
+
+				err := services.RabbitMQService.PublishEvent(ctx, mailbox.ID, model.MAILBOX, dto.MailstackProvisionMailbox{})
+				if err != nil {
+					tracing.TraceErr(span, err)
+					return
+				}
+			}
+		}(domain)
+	}
+
+	wg.Wait() // Wait for all goroutines to finish
 	return nil
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Parallelized domain and mailbox provisioning in `mailstack_listener.go` using goroutines and semaphores for improved efficiency.
> 
>   - **Concurrency**:
>     - Introduced `processDomains` and `processMailboxes` functions in `mailstack_listener.go` to handle domain and mailbox provisioning in parallel using goroutines.
>     - Utilized semaphores to limit concurrency to 5 for domains and 4 for mailboxes.
>   - **Behavior**:
>     - Domains are purchased and configured in parallel if their status is `PendingProvisioning` or `PendingConfiguration`.
>     - Mailboxes are provisioned in parallel if their domain status is `Completed` and mailbox status is `PendingProvisioning`.
>   - **Error Handling**:
>     - Errors in domain and mailbox processing are traced and logged, with goroutines exiting on error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7813513ae6a10f15d015c1b5ecb839aeb457af91. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->