### PR TITLE
Fix sending reminders

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/organization_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/organization_service.go
@@ -568,8 +568,9 @@ func (s *organizationService) SendReminders() {
 	}
 
 	for _, reminderNode := range readyToSendNodes {
+		tenant := model.GetTenantFromLabels(reminderNode.Labels, model.NodeLabelReminder)
 		innerCtx := common.WithCustomContext(ctx, &common.CustomContext{
-			Tenant:    model.GetTenantFromLabels(reminderNode.Labels, model.NodeLabelReminder),
+			Tenant:    tenant,
 			AppSource: constants.AppSourceDataUpkeeper,
 		})
 
@@ -578,6 +579,13 @@ func (s *organizationService) SendReminders() {
 		if err != nil {
 			tracing.TraceErr(span, err)
 			s.log.Errorf("Error sending reminder {%s}: %s", reminder.Id, err.Error())
+			return
+		}
+
+		err = s.commonServices.ReminderService.UpdateReminder(ctx, tenant, reminder.Id, nil, nil, nil, utils.BoolPtr(true))
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return
 		}
 	}
 }

--- a/packages/server/customer-os-api/graph/resolver/reminders.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/reminders.resolvers.go
@@ -39,7 +39,7 @@ func (r *mutationResolver) ReminderUpdate(ctx context.Context, input model.Remin
 	tracing.SetDefaultResolverSpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "request.input", input)
 
-	err := r.Services.CommonServices.ReminderService.UpdateReminder(ctx, common.GetTenantFromContext(ctx), input.ID, input.Content, input.DueDate, input.Dismissed)
+	err := r.Services.CommonServices.ReminderService.UpdateReminder(ctx, common.GetTenantFromContext(ctx), input.ID, input.Content, input.DueDate, input.Dismissed, nil)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		graphql.AddErrorf(ctx, "Failed to update reminder")

--- a/packages/server/customer-os-common-module/service/reminder_service.go
+++ b/packages/server/customer-os-common-module/service/reminder_service.go
@@ -19,7 +19,7 @@ import (
 
 type ReminderService interface {
 	CreateReminder(ctx context.Context, tenant, userId, orgId, content string, dueDate time.Time) (string, error)
-	UpdateReminder(ctx context.Context, tenant, id string, content *string, dueDate *time.Time, dismissed *bool) error
+	UpdateReminder(ctx context.Context, tenant, id string, content *string, dueDate *time.Time, dismissed, sent *bool) error
 	GetReminderById(ctx context.Context, id string) (*neo4jentity.ReminderEntity, error)
 	RemindersForOrganization(ctx context.Context, organizationID string, dismissed *bool) ([]*neo4jentity.ReminderEntity, error)
 
@@ -59,7 +59,7 @@ func (s *reminderService) CreateReminder(ctx context.Context, tenant, userId, or
 	return reminderId, nil
 }
 
-func (s *reminderService) UpdateReminder(ctx context.Context, tenant, reminderId string, content *string, dueDate *time.Time, dismissed *bool) error {
+func (s *reminderService) UpdateReminder(ctx context.Context, tenant, reminderId string, content *string, dueDate *time.Time, dismissed, sent *bool) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ReminderService.UpdateReminder")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
@@ -84,6 +84,10 @@ func (s *reminderService) UpdateReminder(ctx context.Context, tenant, reminderId
 	if dismissed != nil {
 		updateData.Dismissed = dismissed
 		updateData.UpdateDismissed = true
+	}
+	if sent != nil {
+		updateData.Sent = sent
+		updateData.UpdateSent = true
 	}
 
 	err := s.services.Neo4jRepositories.ReminderWriteRepository.UpdateReminder(ctx, tenant, reminderId, updateData)

--- a/packages/server/customer-os-neo4j-repository/entity/reminder.go
+++ b/packages/server/customer-os-neo4j-repository/entity/reminder.go
@@ -11,4 +11,5 @@ type ReminderEntity struct {
 	Content        string    `json:"content"`
 	DueDate        time.Time `json:"dueDate"`
 	Dismissed      bool      `json:"dismissed"`
+	Sent           bool      `json:"sent"`
 }

--- a/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
+++ b/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
@@ -582,6 +582,7 @@ func MapDbNodeToReminderEntity(dbNode *dbtype.Node) *entity.ReminderEntity {
 		Content:        utils.GetStringPropOrEmpty(props, "content"),
 		DueDate:        utils.GetTimePropOrEpochStart(props, "dueDate"),
 		Dismissed:      utils.GetBoolPropOrFalse(props, "dismissed"),
+		Sent:           utils.GetBoolPropOrFalse(props, "sent"),
 	}
 	return &reminder
 }

--- a/packages/server/customer-os-neo4j-repository/repository/reminder_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/reminder_read_repository.go
@@ -111,7 +111,7 @@ func (r *reminderReadRepository) GetReadyToSend(ctx context.Context, dueDate tim
 	defer span.Finish()
 	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
 
-	cypher := `MATCH (r:Reminder) WHERE r.dismissed = false AND r.dueDate <= $dueDate RETURN r ORDER BY r.dueDate ASC`
+	cypher := `MATCH (r:Reminder) WHERE r.dismissed = false and r.sent = false AND r.dueDate <= $dueDate RETURN r ORDER BY r.dueDate ASC`
 
 	params := map[string]any{
 		"dueDate": dueDate,

--- a/packages/server/customer-os-neo4j-repository/repository/reminder_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/reminder_write_repository.go
@@ -15,9 +15,11 @@ type ReminderUpdateFields struct {
 	Content         *string
 	DueDate         *time.Time
 	Dismissed       *bool
+	Sent            *bool
 	UpdateContent   bool
 	UpdateDueDate   bool
 	UpdateDismissed bool
+	UpdateSent      bool
 }
 
 type ReminderWriteRepository interface {
@@ -55,7 +57,8 @@ func (r *reminderWriteRepository) CreateReminder(ctx context.Context, tenant, id
 					r.organizationId=$organizationId,	
 					r.content=$content,	
 					r.dueDate=$dueDate,
-					r.dismissed=$dismissed
+					r.dismissed=$dismissed,
+					r.sent=$sent
 					
 				WITH t, r	
 			
@@ -75,6 +78,7 @@ func (r *reminderWriteRepository) CreateReminder(ctx context.Context, tenant, id
 		"createdAt":      createdAt,
 		"dueDate":        dueDate,
 		"dismissed":      false,
+		"sent":           false,
 	}
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
@@ -111,6 +115,10 @@ func (r *reminderWriteRepository) UpdateReminder(ctx context.Context, tenant, id
 	if data.UpdateDismissed {
 		cypher += ", r.dismissed = $dismissed"
 		params["dismissed"] = *data.Dismissed
+	}
+	if data.UpdateSent {
+		cypher += ", r.sent = $sent"
+		params["sent"] = *data.Sent
 	}
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `sent` status to reminders to prevent multiple sends, updating models, services, and repositories accordingly.
> 
>   - **Behavior**:
>     - `SendReminders()` in `organization_service.go` now updates reminders as sent after sending notifications.
>     - `GetReadyToSend()` in `reminder_read_repository.go` now filters out reminders already sent.
>   - **Models**:
>     - Add `Sent` field to `ReminderEntity` in `reminder.go`.
>   - **Services**:
>     - `UpdateReminder()` in `reminder_service.go` now accepts a `sent` parameter to update the sent status.
>     - `ReminderUpdate()` in `reminders.resolvers.go` updated to pass `nil` for `sent`.
>   - **Repositories**:
>     - `UpdateReminder()` in `reminder_write_repository.go` now updates the `sent` status.
>     - `CreateReminder()` in `reminder_write_repository.go` initializes `sent` to `false`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8a1c1237685aa567dfd446de8244d290758dc910. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->