### PR TITLE
change default sorting for orgs tables

### DIFF
--- a/packages/server/customer-os-api/graph/resolver/view_helper.go
+++ b/packages/server/customer-os-api/graph/resolver/view_helper.go
@@ -172,7 +172,7 @@ func DefaultTableViewDefinitionOrganization(span opentracing.Span) (postgresEnti
 		Icon:           "Building07",
 		Filters:        ``,
 		DefaultFilters: ``,
-		Sorting:        `{"id": "ORGANIZATIONS_LAST_TOUCHPOINT", "desc": true}`,
+		Sorting:        `{"id": "ORGANIZATIONS_UPDATED_DATE", "desc": true}`,
 		IsPreset:       true,
 		IsShared:       false,
 	}, nil
@@ -196,7 +196,7 @@ func DefaultTableViewDefinitionCustomers(span opentracing.Span) (postgresEntity.
 		Icon:           "CheckHeart",
 		Filters:        ``,
 		DefaultFilters: fmt.Sprintf(`{"AND":[{"filter":{"includeEmpty":false,"operation":"EQ","property":"RELATIONSHIP","value":["%s"]}}]}`, neo4jenum.OrganizationRelationshipCustomer.String()),
-		Sorting:        `{"id": "ORGANIZATIONS_LAST_TOUCHPOINT", "desc": true}`,
+		Sorting:        `{"id": "ORGANIZATIONS_UPDATED_DATE", "desc": true}`,
 		IsPreset:       true,
 		IsShared:       false,
 	}, nil
@@ -220,7 +220,7 @@ func DefaultTableViewDefinitionTargets(span opentracing.Span) (postgresEntity.Ta
 		Icon:           "Target05",
 		Filters:        ``,
 		DefaultFilters: fmt.Sprintf(`{"AND":[{"filter":{"includeEmpty":false,"operation":"EQ","property":"STAGE","value":["%s"]}},{"filter":{"includeEmpty":false,"operation":"EQ","property":"RELATIONSHIP","value":["%s"]}}]}`, neo4jenum.Target.String(), neo4jenum.OrganizationRelationshipProspect.String()),
-		Sorting:        `{"id": "ORGANIZATIONS_LAST_TOUCHPOINT", "desc": true}`,
+		Sorting:        `{"id": "ORGANIZATIONS_UPDATED_DATE", "desc": true}`,
 		IsPreset:       true,
 		IsShared:       false,
 	}, nil

--- a/packages/server/enrichment-api/service/scrapin_service.go
+++ b/packages/server/enrichment-api/service/scrapin_service.go
@@ -588,18 +588,13 @@ func (s *scrapinService) ScrapInSearchCompany(ctx context.Context, domain string
 				span.LogFields(log.String("result.inputPrimaryDomain", inputPrimaryDomain), log.String("result.outputPrimaryDomain", outputPrimaryDomain))
 				if inputPrimaryDomain != "" && inputPrimaryDomain == outputPrimaryDomain {
 					return latestEnrichDetailsScrapInRecordWithCompanyFound.ID, data, nil
-				} else {
-					tracing.TraceErr(span, errors.New("Scrapin retuned different company domain, expected: "+inputPrimaryDomain+", got: "+data.Company.WebsiteUrl))
 				}
 			}
 			return 0, nil, nil
 		}
 	}
 
-	if data != nil && data.Company != nil {
-		if data.Company.WebsiteUrl == "" {
-			return recordId, data, nil
-		}
+	if data != nil && data.Company != nil && data.Company.WebsiteUrl != "" {
 		// check primary domain matches
 		inputIsPrimary, inputAltPrimaryDomain := domaincheck.PrimaryDomainCheck(domain)
 		outputIsPrimary, outputAltPrimaryDomain := domaincheck.PrimaryDomainCheck(data.Company.WebsiteUrl)
@@ -615,7 +610,7 @@ func (s *scrapinService) ScrapInSearchCompany(ctx context.Context, domain string
 		if inputPrimaryDomain != "" && inputPrimaryDomain == outputPrimaryDomain {
 			return recordId, data, nil
 		} else {
-			tracing.TraceErr(span, errors.New("Scrapin retuned different company domain, expected: "+inputPrimaryDomain+", got: "+data.Company.WebsiteUrl))
+			tracing.TraceErr(span, errors.New("Scrapin retuned different company domain, expected: "+inputPrimaryDomain+", got: "+outputPrimaryDomain))
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default sorting for organization tables to `ORGANIZATIONS_UPDATED_DATE` and streamline error handling in `scrapin_service.go`.
> 
>   - **Behavior**:
>     - Change default sorting from `ORGANIZATIONS_LAST_TOUCHPOINT` to `ORGANIZATIONS_UPDATED_DATE` in `DefaultTableViewDefinitionOrganization`, `DefaultTableViewDefinitionCustomers`, and `DefaultTableViewDefinitionTargets` in `view_helper.go`.
>   - **Error Handling**:
>     - Remove redundant else statement in `ScrapInSearchCompany` in `scrapin_service.go` to streamline error logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d210f82526f40082f3d771df4e671eadc68448c6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->