### PR TITLE
COS-6190: Automatically open flow settings panel on flow entry

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/page.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/page.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
+import { ReactFlowProvider } from '@xyflow/react';
 import { FinderTable } from '@finder/components/FinderTable';
-import { useReactFlow, ReactFlowProvider } from '@xyflow/react';
 import { FinderFilters } from '@finder/components/FinderFilters/FinderFilters';
 
 import { cn } from '@ui/utils/cn';
@@ -89,7 +89,6 @@ const FlowContent = observer(
     const store = useStore();
 
     const [searchParams] = useSearchParams();
-    const { getNodes } = useReactFlow();
     const id = useParams().id as string;
     const preset = searchParams.get('preset');
     const showFinder = searchParams.get('show') === 'finder';
@@ -99,12 +98,7 @@ const FlowContent = observer(
     const tableType = tableViewDef?.value?.tableType;
 
     useEffect(() => {
-      const nodes = getNodes();
-
-      // open settings
-      if (nodes.length === 2) {
-        setIsSidePanelOpen(true);
-      }
+      setIsSidePanelOpen(true);
     }, []);
 
     return (


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Automatically opens the side panel on flow entry in `FlowContent` by setting `setIsSidePanelOpen(true)` in `useEffect`.
> 
>   - **Behavior**:
>     - Automatically opens the side panel on flow entry in `FlowContent` component by setting `setIsSidePanelOpen(true)` in `useEffect`.
>     - Removes conditional check for node count in `useEffect`.
>   - **Imports**:
>     - Removes unused `getNodes` import from `useReactFlow`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b5314b52dcff0bcccba211540a69982f90acc977. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->