### PR TITLE
COS-6186: Select new node when it is created

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/commands/action/StepsHub.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/commands/action/StepsHub.tsx
@@ -75,11 +75,13 @@ const createNode = (
   type: FlowActionType | 'WAIT',
   position: { x: number; y: number },
   data: Partial<NodeData> & BaseContent,
+  selected: boolean = false,
 ): Node => ({
   id: `${type}-${crypto.randomUUID()}`,
   type: type === 'WAIT' ? 'wait' : 'action',
   position,
   data: { ...data, action: type },
+  selected,
 });
 
 const useFlowNodeManagement = (ui: UIStore) => {
@@ -175,6 +177,12 @@ const useFlowNodeManagement = (ui: UIStore) => {
 
     if (!sourceNode) return;
 
+    // Deselect all existing nodes
+    const deselectedNodes = nodes.map((node) => ({
+      ...node,
+      selected: false,
+    }));
+
     const isFirstEmailNode =
       type === FlowActionType.EMAIL_NEW &&
       !nodes.some((node) => node.data.action === FlowActionType.EMAIL_NEW);
@@ -201,6 +209,7 @@ const useFlowNodeManagement = (ui: UIStore) => {
         y: sourceNode.position.y + 56,
       },
       typeBasedContent,
+      true, // Ensure the new node is selected
     );
 
     if (isEmailNode || isLinkedInNode) {
@@ -218,6 +227,7 @@ const useFlowNodeManagement = (ui: UIStore) => {
           fe_waitDurationUnit: isFirstEmailNode ? 'minutes' : 'days',
           nextStepId: newNode.id,
         },
+        false, // Ensure the wait node is not selected
       );
 
       newNode.data.waitStepId = waitNode.id;
@@ -232,7 +242,7 @@ const useFlowNodeManagement = (ui: UIStore) => {
         (e) => !(e.source === source && e.target === target),
       );
 
-      setNodes([...nodes, waitNode, newNode]);
+      setNodes([...deselectedNodes, waitNode, newNode]);
       setEdges([...updatedEdges, ...newEdges]);
     } else {
       const newEdges = [
@@ -244,7 +254,7 @@ const useFlowNodeManagement = (ui: UIStore) => {
         (e) => !(e.source === source && e.target === target),
       );
 
-      setNodes([...nodes, newNode]);
+      setNodes([...deselectedNodes, newNode]);
       setEdges([...updatedEdges, ...newEdges]);
     }
   };


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Automatically select new nodes and deselect existing ones in `StepsHub.tsx` when a node is created.
> 
>   - **Behavior**:
>     - New nodes are automatically selected when created in `handleAddNode()` in `StepsHub.tsx`.
>     - Existing nodes are deselected before adding a new node in `handleAddNode()`.
>   - **Functions**:
>     - `createNode()` updated to accept a `selected` parameter, defaulting to `false`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 4184806b1c45a6c210384e133562ac54e6159da0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->