### PR TITLE
COS-6201: Regression fix: user should not be able to edit live flow

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/FlowBuilder.tsx
@@ -445,7 +445,10 @@ export const FlowBuilder = observer(
               return;
             }
 
-            if (node.type === 'trigger') {
+            if (
+              node.type === 'trigger' &&
+              flow.value.status === FlowStatus.Off
+            ) {
               event.stopPropagation();
               ui.flowCommandMenu.setOpen(true);
               ui.flowCommandMenu.setType('TriggersHub');

--- a/packages/apps/frontera/src/routes/flow-editor/src/edges/BasicEdge.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/edges/BasicEdge.tsx
@@ -12,6 +12,7 @@ import {
 
 import { cn } from '@ui/utils/cn';
 import { Plus } from '@ui/media/icons/Plus';
+import { FlowStatus } from '@graphql/types';
 import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
 
@@ -33,7 +34,8 @@ export const BasicEdge: FC<
 
   const { ui, flows } = useStore();
   const flowId = useParams()?.id as string;
-  const flowWasStarted = flows.value.get(flowId)?.value?.firstStartedAt;
+  const flow = flows.value.get(flowId)?.value;
+  const flowWasStarted = flow?.status === FlowStatus.On || flow?.firstStartedAt;
 
   const toggleOpen: MouseEventHandler<HTMLButtonElement> = (e) => {
     // do not open when  flow actions panel is open

--- a/packages/apps/frontera/src/routes/flow-editor/src/nodes/TriggerNode.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/nodes/TriggerNode.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 import { NodeProps, ViewportPortal } from '@xyflow/react';
 
+import { FlowStatus } from '@graphql/types';
 import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
 import { UserPlus01 } from '@ui/media/icons/UserPlus01';
@@ -17,7 +18,8 @@ export const TriggerNode = (
 ) => {
   const { ui, flows } = useStore();
   const flowId = useParams()?.id as string;
-  const flowWasStarted = flows.value.get(flowId)?.value?.firstStartedAt;
+  const flow = flows.value.get(flowId)?.value;
+  const flowWasStarted = flow?.status === FlowStatus.On || flow?.firstStartedAt;
 
   return (
     <>

--- a/packages/apps/frontera/src/routes/flow-editor/src/nodes/WaitNode.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/nodes/WaitNode.tsx
@@ -1,9 +1,11 @@
+import { useParams } from 'react-router-dom';
 import { useRef, useState, useEffect } from 'react';
 
 import { MaskElement } from 'imask';
 import { observer } from 'mobx-react-lite';
 import { NodeProps, useNodesData, useReactFlow } from '@xyflow/react';
 
+import { FlowStatus } from '@graphql/types';
 import { Button } from '@ui/form/Button/Button';
 import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
@@ -33,9 +35,10 @@ export const WaitNode = observer(
     data,
   }: NodeProps & { data: Record<string, string | number | boolean> }) => {
     const { setNodes, getNode, deleteElements } = useReactFlow();
-    const { ui } = useStore();
+    const { ui, flows } = useStore();
     const nodeData = useNodesData(id);
     const inputRef = useRef<MaskElement>();
+    const flowId = useParams()?.id as string;
 
     const [unit, setUnit] = useState<DurationUnit>(
       (data.fe_waitDurationUnit as DurationUnit) || 'days',
@@ -47,6 +50,9 @@ export const WaitNode = observer(
 
     const isEditing = nodeData?.data?.isEditing;
     const selected = getNode(id)?.selected;
+    const flow = flows.value.get(flowId)?.value;
+    const flowWasStarted =
+      flow?.status === FlowStatus.On || flow?.firstStartedAt;
 
     const convertDuration = (
       value: number,
@@ -194,7 +200,7 @@ export const WaitNode = observer(
             )}
           </div>
 
-          {!ui.flowActionSidePanel.isOpen && (
+          {!ui.flowActionSidePanel.isOpen && !flowWasStarted && (
             <IconButton
               size='xxs'
               variant='ghost'

--- a/packages/apps/frontera/src/routes/flow-editor/src/nodes/actions/EmailActionNode.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/nodes/actions/EmailActionNode.tsx
@@ -1,3 +1,4 @@
+import { useParams } from 'react-router-dom';
 import { useMemo, ReactElement, MouseEventHandler } from 'react';
 
 import { htmlToText } from 'html-to-text';
@@ -6,6 +7,7 @@ import { FlowActionType } from '@store/Flows/types';
 import { NodeProps, useReactFlow } from '@xyflow/react';
 
 import { cn } from '@ui/utils/cn';
+import { FlowStatus } from '@graphql/types';
 import { Mail01 } from '@ui/media/icons/Mail01';
 import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
@@ -35,7 +37,12 @@ export const EmailActionNode = observer(
     };
   }) => {
     const color = colorMap?.[data.action];
-    const { ui } = useStore();
+    const { ui, flows } = useStore();
+    const flowId = useParams()?.id as string;
+    const flow = flows.value.get(flowId)?.value;
+    const flowWasStarted =
+      flow?.status === FlowStatus.On || flow?.firstStartedAt;
+
     const { deleteElements } = useReactFlow();
 
     const parsedTemplate = useMemo(
@@ -76,7 +83,7 @@ export const EmailActionNode = observer(
             </span>
           </div>
 
-          {!ui.flowActionSidePanel.isOpen && (
+          {!ui.flowActionSidePanel.isOpen && !flowWasStarted && (
             <IconButton
               size='xxs'
               variant='ghost'

--- a/packages/apps/frontera/src/routes/flow-editor/src/nodes/actions/SendConnectionRequestActionNode.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/nodes/actions/SendConnectionRequestActionNode.tsx
@@ -1,9 +1,11 @@
 import { MouseEventHandler } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
 import { useReactFlow } from '@xyflow/react';
 
 import { cn } from '@ui/utils/cn';
+import { FlowStatus } from '@graphql/types';
 import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
 import { Trash01 } from '@ui/media/icons/Trash01';
@@ -11,7 +13,12 @@ import { LinkedinOutline } from '@ui/media/icons/LinkedinOutline';
 
 export const SendConnectionRequestActionNode = observer(
   ({ id }: { id: string }) => {
-    const { ui } = useStore();
+    const { ui, flows } = useStore();
+    const flowId = useParams()?.id as string;
+    const flow = flows.value.get(flowId)?.value;
+    const flowWasStarted =
+      flow?.status === FlowStatus.On || flow?.firstStartedAt;
+
     const { deleteElements } = useReactFlow();
 
     const handleDelete: MouseEventHandler = (e) => {
@@ -34,7 +41,7 @@ export const SendConnectionRequestActionNode = observer(
 
             <span className='truncate'>Send connection request</span>
           </div>
-          {!ui.flowActionSidePanel.isOpen && (
+          {!ui.flowActionSidePanel.isOpen && !flowWasStarted && (
             <IconButton
               size='xxs'
               variant='ghost'


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent editing of live flows by checking flow status across multiple components.
> 
>   - **Behavior**:
>     - Prevent editing of live flows by checking `flow.status` in `FlowBuilder.tsx`, `BasicEdge.tsx`, `TriggerNode.tsx`, `WaitNode.tsx`, `EmailActionNode.tsx`, and `SendConnectionRequestActionNode.tsx`.
>     - Disable UI elements like `IconButton` for editing or deleting when `flow.status` is `On` or `firstStartedAt` is set.
>   - **Imports**:
>     - Add `FlowStatus` import from `@graphql/types` in `BasicEdge.tsx`, `TriggerNode.tsx`, `WaitNode.tsx`, `EmailActionNode.tsx`, and `SendConnectionRequestActionNode.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c0734d39d5f04905a72b81f4632cf861e7c42c06. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->