### PR TITLE
Flows - change name mutation

### DIFF
--- a/packages/server/customer-os-api/graph/generated/generated.go
+++ b/packages/server/customer-os-api/graph/generated/generated.go
@@ -1021,6 +1021,7 @@ type ComplexityRoot struct {
 		ExternalSystemCreate                       func(childComplexity int, input model.ExternalSystemInput) int
 		FlowArchive                                func(childComplexity int, id string) int
 		FlowArchiveBulk                            func(childComplexity int, ids []string) int
+		FlowChangeName                             func(childComplexity int, id string, name string) int
 		FlowDummy1Email                            func(childComplexity int, flowsCount int, contactsCount int, userCount int, mailboxForEachUserCount int) int
 		FlowEmailActionTest                        func(childComplexity int, subject string, bodyTemplate string, sendToEmailAddress string) int
 		FlowMerge                                  func(childComplexity int, input model.FlowMergeInput) int
@@ -1896,6 +1897,7 @@ type MutationResolver interface {
 	EmailReplaceForOrganization(ctx context.Context, organizationID string, previousEmail *string, input model.EmailInput) (*model.Email, error)
 	EmailValidate(ctx context.Context, id string) (*model.ActionResponse, error)
 	ExternalSystemCreate(ctx context.Context, input model.ExternalSystemInput) (string, error)
+	FlowChangeName(ctx context.Context, id string, name string) (*model.Flow, error)
 	FlowMerge(ctx context.Context, input model.FlowMergeInput) (*model.Flow, error)
 	FlowOn(ctx context.Context, id string) (*model.Flow, error)
 	FlowOff(ctx context.Context, id string) (*model.Flow, error)
@@ -7377,6 +7379,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.FlowArchiveBulk(childComplexity, args["ids"].([]string)), true
+
+	case "Mutation.flow_ChangeName":
+		if e.complexity.Mutation.FlowChangeName == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_flow_ChangeName_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.FlowChangeName(childComplexity, args["id"].(string), args["name"].(string)), true
 
 	case "Mutation.flow_Dummy_1Email":
 		if e.complexity.Mutation.FlowDummy1Email == nil {
@@ -14113,6 +14127,7 @@ enum ComparisonOperator {
 }
 
 extend type Mutation {
+    flow_ChangeName(id: ID!, name: String!): Flow! @hasRole(roles: [ADMIN, USER]) @hasTenant
     flow_Merge(input: FlowMergeInput!): Flow! @hasRole(roles: [ADMIN, USER]) @hasTenant
     flow_On(id: ID!): Flow! @hasRole(roles: [ADMIN, USER]) @hasTenant
     flow_Off(id: ID!): Flow! @hasRole(roles: [ADMIN, USER]) @hasTenant
@@ -20336,6 +20351,65 @@ func (ec *executionContext) field_Mutation_flow_Archive_argsID(
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
 	if tmp, ok := rawArgs["id"]; ok {
 		return ec.unmarshalNID2string(ctx, tmp)
+	}
+
+	var zeroVal string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_flow_ChangeName_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	arg0, err := ec.field_Mutation_flow_ChangeName_argsID(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["id"] = arg0
+	arg1, err := ec.field_Mutation_flow_ChangeName_argsName(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["name"] = arg1
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_flow_ChangeName_argsID(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["id"]
+	if !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+	if tmp, ok := rawArgs["id"]; ok {
+		return ec.unmarshalNID2string(ctx, tmp)
+	}
+
+	var zeroVal string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_flow_ChangeName_argsName(
+	ctx context.Context,
+	rawArgs map[string]interface{},
+) (string, error) {
+	// We won't call the directive if the argument is null.
+	// Set call_argument_directives_with_null to true to call directives
+	// even if the argument is null.
+	_, ok := rawArgs["name"]
+	if !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+	if tmp, ok := rawArgs["name"]; ok {
+		return ec.unmarshalNString2string(ctx, tmp)
 	}
 
 	var zeroVal string
@@ -64386,6 +64460,117 @@ func (ec *executionContext) fieldContext_Mutation_externalSystem_Create(ctx cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_externalSystem_Create_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_flow_ChangeName(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_flow_ChangeName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().FlowChangeName(rctx, fc.Args["id"].(string), fc.Args["name"].(string))
+		}
+
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			roles, err := ec.unmarshalNRole2ᚕgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐRoleᚄ(ctx, []interface{}{"ADMIN", "USER"})
+			if err != nil {
+				var zeroVal *model.Flow
+				return zeroVal, err
+			}
+			if ec.directives.HasRole == nil {
+				var zeroVal *model.Flow
+				return zeroVal, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, roles)
+		}
+		directive2 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.HasTenant == nil {
+				var zeroVal *model.Flow
+				return zeroVal, errors.New("directive hasTenant is not implemented")
+			}
+			return ec.directives.HasTenant(ctx, nil, directive1)
+		}
+
+		tmp, err := directive2(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*model.Flow); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/openline-ai/openline-customer-os/packages/server/customer-os-api/graph/model.Flow`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Flow)
+	fc.Result = res
+	return ec.marshalNFlow2ᚖgithubᚗcomᚋopenlineᚑaiᚋopenlineᚑcustomerᚑosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphᚋmodelᚐFlow(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_flow_ChangeName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "metadata":
+				return ec.fieldContext_Flow_metadata(ctx, field)
+			case "name":
+				return ec.fieldContext_Flow_name(ctx, field)
+			case "description":
+				return ec.fieldContext_Flow_description(ctx, field)
+			case "nodes":
+				return ec.fieldContext_Flow_nodes(ctx, field)
+			case "edges":
+				return ec.fieldContext_Flow_edges(ctx, field)
+			case "firstStartedAt":
+				return ec.fieldContext_Flow_firstStartedAt(ctx, field)
+			case "status":
+				return ec.fieldContext_Flow_status(ctx, field)
+			case "participants":
+				return ec.fieldContext_Flow_participants(ctx, field)
+			case "senders":
+				return ec.fieldContext_Flow_senders(ctx, field)
+			case "statistics":
+				return ec.fieldContext_Flow_statistics(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Flow", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_flow_ChangeName_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -122705,6 +122890,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "externalSystem_Create":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_externalSystem_Create(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "flow_ChangeName":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_flow_ChangeName(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/packages/server/customer-os-api/graph/resolver/flow.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/flow.resolvers.go
@@ -7,6 +7,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"github.com/opentracing/opentracing-go/log"
 	"sync"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -152,6 +153,36 @@ func (r *flowSenderResolver) User(ctx context.Context, obj *model.FlowSender) (*
 		return nil, nil
 	}
 	return mapper.MapEntityToUser(entities), nil
+}
+
+// FlowChangeName is the resolver for the flow_ChangeName field.
+func (r *mutationResolver) FlowChangeName(ctx context.Context, id string, name string) (*model.Flow, error) {
+	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "FlowResolver.FlowChangeName", graphql.GetOperationContext(ctx))
+	defer span.Finish()
+	tracing.SetDefaultResolverSpanTags(ctx, span)
+
+	span.LogFields(log.String("flowId", id), log.String("name", name))
+
+	tenant := common.GetTenantFromContext(ctx)
+
+	flow, err := r.Services.CommonServices.FlowService.FlowGetById(ctx, id)
+	if err != nil || flow == nil {
+		tracing.TraceErr(span, err)
+		graphql.AddErrorf(ctx, "")
+		return nil, err
+	}
+
+	err = r.Services.CommonServices.Neo4jRepositories.CommonWriteRepository.UpdateStringProperty(ctx, nil, tenant, commonModel.NodeLabelFlow, id, "name", name)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		graphql.AddErrorf(ctx, "")
+		return nil, err
+	}
+
+	r.Services.CommonServices.RabbitMQService.PublishEventCompleted(ctx, tenant, flow.Id, commonModel.FLOW, utils.NewEventCompletedDetails().WithUpdate())
+
+	flow.Name = name
+	return mapper.MapEntityToFlow(flow), nil
 }
 
 // FlowMerge is the resolver for the flow_Merge field.
@@ -506,7 +537,7 @@ func (r *mutationResolver) FlowDummy1Email(ctx context.Context, flowsCount int, 
 	worker := func(wg *sync.WaitGroup) {
 		defer wg.Done()
 		for flowId := range jobs { // Each worker will process items from jobs channel
-			_, err := r.Services.CommonServices.FlowService.FlowChangeStatus(ctx, flowId, neo4jentity.FlowStatusOn)
+			_, err := r.Services.CommonServices.FlowService.FlowOn(ctx, flowId)
 			if err != nil {
 				errChan <- err // Send error to error channel if occurs
 			}

--- a/packages/server/customer-os-api/graph/schemas/flow.graphqls
+++ b/packages/server/customer-os-api/graph/schemas/flow.graphqls
@@ -8,6 +8,7 @@ extend type Query {
 }
 
 extend type Mutation {
+    flow_ChangeName(id: ID!, name: String!): Flow! @hasRole(roles: [ADMIN, USER]) @hasTenant
     flow_Merge(input: FlowMergeInput!): Flow! @hasRole(roles: [ADMIN, USER]) @hasTenant
     flow_On(id: ID!): Flow! @hasRole(roles: [ADMIN, USER]) @hasTenant
     flow_Off(id: ID!): Flow! @hasRole(roles: [ADMIN, USER]) @hasTenant

--- a/packages/server/customer-os-common-module/service/flow_service.go
+++ b/packages/server/customer-os-common-module/service/flow_service.go
@@ -26,7 +26,6 @@ type FlowService interface {
 	FlowsGetListWithParticipant(ctx context.Context, entityIds []string, entityType model.EntityType) (*neo4jentity.FlowEntities, error)
 	FlowsGetListWithSender(ctx context.Context, senderIds []string) (*neo4jentity.FlowEntities, error)
 	FlowMerge(ctx context.Context, tx *neo4j.ManagedTransaction, entity *neo4jentity.FlowEntity) (*neo4jentity.FlowEntity, error)
-	FlowChangeStatus(ctx context.Context, id string, status neo4jentity.FlowStatus) (*neo4jentity.FlowEntity, error)
 	FlowOn(ctx context.Context, id string) (*neo4jentity.FlowEntity, error)
 	FlowOff(ctx context.Context, id string) (*neo4jentity.FlowEntity, error)
 	FlowArchive(ctx context.Context, id string) (*neo4jentity.FlowEntity, error)
@@ -588,69 +587,6 @@ func (s *flowService) ProcessNode(ctx context.Context, tx *neo4j.ManagedTransact
 	}
 
 	return nil
-}
-
-func (s *flowService) FlowChangeStatus(ctx context.Context, id string, status neo4jentity.FlowStatus) (*neo4jentity.FlowEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowService.FlowChangeStatus")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-
-	tenant := common.GetTenantFromContext(ctx)
-
-	node, err := s.services.Neo4jRepositories.FlowReadRepository.GetById(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-
-	if node == nil {
-		tracing.TraceErr(span, errors.New("flow not found"))
-		return nil, errors.New("flow not found")
-	}
-
-	flow := mapper.MapDbNodeToFlowEntity(node)
-
-	if flow.Status == status {
-		return flow, nil
-	}
-
-	if status == neo4jentity.FlowStatusOn {
-
-		if flow.FirstStartedAt == nil {
-			flow.FirstStartedAt = utils.TimePtr(utils.Now())
-		}
-
-		flow.Status = status
-		_, err = s.services.Neo4jRepositories.FlowWriteRepository.Merge(ctx, nil, flow)
-		if err != nil {
-			tracing.TraceErr(span, err)
-			return nil, err
-		}
-
-		err := s.services.RabbitMQService.PublishEvent(ctx, flow.Id, model.FLOW, dto.FlowOn{})
-		if err != nil {
-			tracing.TraceErr(span, err)
-			return nil, err
-		}
-
-	} else if status == neo4jentity.FlowStatusOff {
-		_, err := s.FlowOff(ctx, flow.Id)
-		if err != nil {
-			tracing.TraceErr(span, err)
-			return nil, err
-		}
-	} else if status == neo4jentity.FlowStatusArchived {
-		_, err := s.FlowArchive(ctx, flow.Id)
-		if err != nil {
-			tracing.TraceErr(span, err)
-			return nil, err
-		}
-	}
-
-	s.services.RabbitMQService.PublishEventCompleted(ctx, tenant, flow.Id, model.FLOW, utils.NewEventCompletedDetails().WithUpdate())
-
-	flow.Status = status
-
-	return flow, nil
 }
 
 func (s *flowService) FlowOn(ctx context.Context, id string) (*neo4jentity.FlowEntity, error) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `FlowChangeName` mutation to update flow names, with role and tenant checks, and removes unused `FlowChangeStatus` function.
> 
>   - **Behavior**:
>     - Adds `FlowChangeName` mutation to change a flow's name in `flow.resolvers.go`.
>     - Updates GraphQL schema in `flow.graphqls` to include `flow_ChangeName` mutation.
>     - Mutation requires `ADMIN` or `USER` role and tenant context.
>   - **Service Layer**:
>     - Implements `FlowChangeName` logic in `flow_service.go` to update flow name in Neo4j.
>     - Removes unused `FlowChangeStatus` function from `flow_service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b62d937b45a5c86f0eacf3f28c45e6ec44fec521. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->