### PR TITLE
COS-6207: Fixed: navigating to org via url is resulting in not found (randomly)

### DIFF
--- a/packages/apps/frontera/src/routes/organization/page.tsx
+++ b/packages/apps/frontera/src/routes/organization/page.tsx
@@ -29,15 +29,16 @@ export const OrganizationPage = observer(() => {
   }
 
   useEffect(() => {
-    if (
-      !store.organizations.value.has(id) &&
-      !store.organizations.isFullyLoaded
-    ) {
-      setIsLoading(true);
-      store.organizations.invalidate(id);
+    if (store.organizations.value.has(id)) {
+      setIsLoading(false);
     }
-    setIsLoading(false);
-  }, []);
+
+    if (!store.organizations.value.has(id) && store.session.isAuthenticated) {
+      store.organizations.invalidate(id, {
+        onFinally: () => setIsLoading(false),
+      });
+    }
+  }, [store.session.isAuthenticated]);
 
   if (isLoading) {
     return <LoadingScreen hide={false} isLoaded={false} showSplash={true} />;

--- a/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
+++ b/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
@@ -244,7 +244,7 @@ export class OrganizationsStore extends Store<OrganizationDatum, Organization> {
   }
 
   @action
-  public async invalidate(id: string) {
+  public async invalidate(id: string, opts?: { onFinally?: () => void }) {
     try {
       const { organization: raw } = await this.service.getOrganization(id);
 
@@ -255,10 +255,18 @@ export class OrganizationsStore extends Store<OrganizationDatum, Organization> {
 
         if (record) {
           Object.assign(record.value, raw);
+        } else {
+          const record = new Organization(this, raw);
+
+          this.value.set(record.id, record);
         }
       });
     } catch (e) {
       console.error('Failed invalidating organization with ID: ' + id);
+    } finally {
+      runInAction(() => {
+        opts?.onFinally?.();
+      });
     }
   }
 


### PR DESCRIPTION
…
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `OrganizationPage` causing 'not found' errors by improving data fetching and loading state management.
> 
>   - **Behavior**:
>     - Fixes bug in `OrganizationPage` where navigating via URL sometimes results in 'not found'.
>     - Updates `useEffect` to check `store.session.isAuthenticated` before invalidating organization data.
>     - Ensures `setIsLoading(false)` is called after data fetch or if data is already present.
>   - **Functions**:
>     - Modifies `invalidate()` in `OrganizationsStore` to accept `opts` with `onFinally` callback for post-fetch actions.
>     - Calls `onFinally` in `finally` block to ensure `setIsLoading(false)` is executed.
>   - **Misc**:
>     - Adjusts `useEffect` dependencies in `OrganizationPage` to include `store.session.isAuthenticated`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 432082152f407daedc615aa1d29627501dda3a21. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->