### PR TITLE
COS-6217: Show email in contact list instead of company

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/addContactsToFlow/AddExistingContactsToFlow.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/addContactsToFlow/AddExistingContactsToFlow.tsx
@@ -14,7 +14,7 @@ import { useModKey } from '@shared/hooks/useModKey';
 import { Command, CommandInput } from '@ui/overlay/CommandMenu';
 
 export const AddExistingContacts = observer(() => {
-  const { contacts, ui, flows, organizations, flowParticipants } = useStore();
+  const { contacts, ui, flows, flowParticipants } = useStore();
   const [search, setSearch] = useState('');
 
   const context = ui.commandMenu.context;
@@ -118,11 +118,9 @@ export const AddExistingContacts = observer(() => {
                     {contactStore.name?.length ? contactStore.name : 'Unnamed'}
                   </span>
 
-                  {contactStore.organizationId && (
+                  {contactStore.primaryEmail && (
                     <span className='ml-1.5 text-gray-500 line-clamp-1 max-w-[250px]'>
-                      ·{' '}
-                      {organizations.value.get(contactStore.organizationId)
-                        ?.value.name ?? ''}
+                      · {contactStore.primaryEmail?.email ?? ''}
                     </span>
                   )}
                 </div>

--- a/packages/apps/frontera/src/store/Contacts/Contact.store.ts
+++ b/packages/apps/frontera/src/store/Contacts/Contact.store.ts
@@ -35,6 +35,7 @@ export class ContactStore extends Syncable<Contact> {
       invalidate: action,
       getChannelName: override,
       isEnriching: computed,
+      primaryEmail: computed,
     });
   }
 
@@ -97,8 +98,11 @@ export class ContactStore extends Syncable<Contact> {
     );
   }
 
-  get emailId() {
-    return this.value.emails?.[0]?.id;
+  get primaryEmail() {
+    return (
+      this.value.emails?.find((email) => email.primary) ||
+      this.value.emails?.[0]
+    );
   }
 
   get connectedUsers() {


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Display primary email instead of company name in contact list by updating `AddExistingContactsToFlow.tsx` and adding `primaryEmail` to `ContactStore`.
> 
>   - **Behavior**:
>     - In `AddExistingContactsToFlow.tsx`, display primary email instead of company name in contact list.
>     - Uses `contactStore.primaryEmail` to fetch and display the email.
>   - **Models**:
>     - Add `primaryEmail` computed property to `ContactStore` in `Contact.store.ts` to retrieve the primary email or fallback to the first email.
>   - **Misc**:
>     - Remove unused `organizations` from `useStore()` in `AddExistingContactsToFlow.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c58f681bf7278636561ed4d148ccf8c18bfeb6e9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->