### PR TITLE
COS-6214: Show extended message for "on_hold" flow participant status

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/flowStatus/FlowStatusCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/flowStatus/FlowStatusCell.tsx
@@ -81,12 +81,15 @@ export const FlowStatusCell = observer(({ contactID }: FlowStatusCellProps) => {
     ))
     .with(FlowParticipantStatus.Scheduled, () => (
       <StatusTag
-        status='Sceduled'
+        status='Scheduled'
         icon={<CalendarCheck01 className='size-3' />}
       />
     ))
     .with(FlowParticipantStatus.Scheduling, () => (
-      <StatusTag status='Sceduling' icon={<RefreshCw02 className='size-3' />} />
+      <StatusTag
+        status='Scheduling'
+        icon={<RefreshCw02 className='size-3' />}
+      />
     ))
     .with(FlowParticipantStatus.GoalAchieved, () => (
       <StatusTag

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/flowStatus/FlowStatusCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/flowStatus/FlowStatusCell.tsx
@@ -1,3 +1,4 @@
+import { ReactElement } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { match } from 'ts-pattern';
@@ -6,6 +7,7 @@ import { observer } from 'mobx-react-lite';
 import { useStore } from '@shared/hooks/useStore';
 import { Rocket02 } from '@ui/media/icons/Rocket02';
 import { Trophy01 } from '@ui/media/icons/Trophy01';
+import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
 import { Hourglass02 } from '@ui/media/icons/Hourglass02';
 import { CheckCircle } from '@ui/media/icons/CheckCircle';
 import { RefreshCw02 } from '@ui/media/icons/RefreshCw02';
@@ -20,6 +22,11 @@ interface FlowStatusCellProps {
   contactID: string;
 }
 
+const requirementsCopy = {
+  [FlowParticipantRequirementsUnmeet.MissingLinkedinUrl]: 'Missing LinkedIn',
+  [FlowParticipantRequirementsUnmeet.MissingPrimaryEmail]: 'Missing email',
+};
+
 export const FlowStatusCell = observer(({ contactID }: FlowStatusCellProps) => {
   const { flows } = useStore();
   const id = useParams()?.id as string;
@@ -27,52 +34,83 @@ export const FlowStatusCell = observer(({ contactID }: FlowStatusCellProps) => {
   const flowStore = flows.value.get(id)?.value;
   const contact = flowStore?.participants.find((c) => c.entityId === contactID);
 
-  const flowStatus = match(contact?.status)
-    .with(FlowParticipantStatus.OnHold, () => [
-      contact?.requirementsUnmeet.includes(
-        FlowParticipantRequirementsUnmeet.MissingPrimaryEmail,
-      )
-        ? 'Missing email'
-        : contact?.requirementsUnmeet.includes(
-            FlowParticipantRequirementsUnmeet.MissingLinkedinUrl,
-          )
-        ? 'Missing LinkedIn'
-        : 'Blocked',
-      <SlashCircle01 className='size-3' />,
-    ])
-    .with(FlowParticipantStatus.Ready, () => [
-      'Ready',
-      <Rocket02 className='size-3' />,
-    ])
-    .with(FlowParticipantStatus.InProgress, () => [
-      'In Progress',
-      <Hourglass02 className='size-3' />,
-    ])
-    .with(FlowParticipantStatus.Completed, () => [
-      'Completed',
-      <CheckCircle className='size-3' />,
-    ])
-    .with(FlowParticipantStatus.Scheduled, () => [
-      'Scheduled',
-      <CalendarCheck01 className='size-3' />,
-    ])
-    .with(FlowParticipantStatus.Scheduling, () => [
-      'Scheduling',
-      <RefreshCw02 className='size-3' />,
-    ])
-    .with(FlowParticipantStatus.GoalAchieved, () => [
-      'Goal achieved',
-      <Trophy01 className='size-3' />,
-    ])
+  return match(contact?.status)
+    .with(FlowParticipantStatus.OnHold, () => {
+      if (!contact?.requirementsUnmeet?.length) {
+        return (
+          <StatusTag
+            status='Blocked'
+            icon={<SlashCircle01 className='size-3' />}
+          />
+        );
+      }
+      const copy =
+        contact?.requirementsUnmeet?.length &&
+        contact?.requirementsUnmeet?.length > 1
+          ? 'Missing Details'
+          : requirementsCopy[contact.requirementsUnmeet[0]];
+
+      return (
+        <Tooltip
+          align='center'
+          label={
+            contact?.requirementsUnmeet?.length > 1 &&
+            contact?.requirementsUnmeet.map((e) => <p>{requirementsCopy[e]}</p>)
+          }
+        >
+          <div>
+            <StatusTag
+              status={copy}
+              icon={<SlashCircle01 className='size-3' />}
+            />
+          </div>
+        </Tooltip>
+      );
+    })
+    .with(FlowParticipantStatus.Ready, () => (
+      <StatusTag status='Ready' icon={<Rocket02 className='size-3' />} />
+    ))
+    .with(FlowParticipantStatus.InProgress, () => (
+      <StatusTag
+        status='In Progress'
+        icon={<Hourglass02 className='size-3' />}
+      />
+    ))
+    .with(FlowParticipantStatus.Completed, () => (
+      <StatusTag status='Completed' icon={<CheckCircle className='size-3' />} />
+    ))
+    .with(FlowParticipantStatus.Scheduled, () => (
+      <StatusTag
+        status='Sceduled'
+        icon={<CalendarCheck01 className='size-3' />}
+      />
+    ))
+    .with(FlowParticipantStatus.Scheduling, () => (
+      <StatusTag status='Sceduling' icon={<RefreshCw02 className='size-3' />} />
+    ))
+    .with(FlowParticipantStatus.GoalAchieved, () => (
+      <StatusTag
+        status='Goal achieved'
+        icon={<Trophy01 className='size-3' />}
+      />
+    ))
     .otherwise(() => [
       <span className='text-grayModern-400'>No status yet</span>,
       null,
     ]);
+});
 
+const StatusTag = ({
+  status,
+  icon,
+}: {
+  status: string;
+  icon?: ReactElement;
+}) => {
   return (
     <div className='flex items-center overflow-x-hidden gap-2 overflow-ellipsis bg-gray-100 rounded-md px-1.5 truncate w-[fit-content]'>
-      {flowStatus?.[1] && <span className='flex'>{flowStatus[1]}</span>}
-      <div className='truncate'>{flowStatus[0]}</div>
+      {icon && <span className='flex'>{icon}</span>}
+      <div className='truncate'>{status}</div>
     </div>
   );
-});
+};

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/flowStatus/FlowStatusCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/flowStatus/FlowStatusCell.tsx
@@ -6,12 +6,15 @@ import { observer } from 'mobx-react-lite';
 import { useStore } from '@shared/hooks/useStore';
 import { Rocket02 } from '@ui/media/icons/Rocket02';
 import { Trophy01 } from '@ui/media/icons/Trophy01';
-import { FlowParticipantStatus } from '@graphql/types';
 import { Hourglass02 } from '@ui/media/icons/Hourglass02';
 import { CheckCircle } from '@ui/media/icons/CheckCircle';
 import { RefreshCw02 } from '@ui/media/icons/RefreshCw02';
 import { SlashCircle01 } from '@ui/media/icons/SlashCircle01';
 import { CalendarCheck01 } from '@ui/media/icons/CalendarCheck01';
+import {
+  FlowParticipantStatus,
+  FlowParticipantRequirementsUnmeet,
+} from '@graphql/types';
 
 interface FlowStatusCellProps {
   contactID: string;
@@ -26,7 +29,15 @@ export const FlowStatusCell = observer(({ contactID }: FlowStatusCellProps) => {
 
   const flowStatus = match(contact?.status)
     .with(FlowParticipantStatus.OnHold, () => [
-      'Blocked',
+      contact?.requirementsUnmeet.includes(
+        FlowParticipantRequirementsUnmeet.MissingPrimaryEmail,
+      )
+        ? 'Missing email'
+        : contact?.requirementsUnmeet.includes(
+            FlowParticipantRequirementsUnmeet.MissingLinkedinUrl,
+          )
+        ? 'Missing LinkedIn'
+        : 'Blocked',
       <SlashCircle01 className='size-3' />,
     ])
     .with(FlowParticipantStatus.Ready, () => [

--- a/packages/apps/frontera/src/routes/src/types/__generated__/graphql.types.ts
+++ b/packages/apps/frontera/src/routes/src/types/__generated__/graphql.types.ts
@@ -1,20 +1,33 @@
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T,
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  Any: { input: any; output: any; }
-  Int64: { input: any; output: any; }
-  Time: { input: any; output: any; }
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  Any: { input: any; output: any };
+  Int64: { input: any; output: any };
+  Time: { input: any; output: any };
 };
 
 export type Action = {
@@ -63,7 +76,7 @@ export enum ActionType {
   ServiceLineItemBilledTypeUsageCreated = 'SERVICE_LINE_ITEM_BILLED_TYPE_USAGE_CREATED',
   ServiceLineItemPriceUpdated = 'SERVICE_LINE_ITEM_PRICE_UPDATED',
   ServiceLineItemQuantityUpdated = 'SERVICE_LINE_ITEM_QUANTITY_UPDATED',
-  ServiceLineItemRemoved = 'SERVICE_LINE_ITEM_REMOVED'
+  ServiceLineItemRemoved = 'SERVICE_LINE_ITEM_REMOVED',
 }
 
 export type AddTagInput = {
@@ -153,7 +166,7 @@ export enum BilledType {
    * Deprecated
    * @deprecated Not supported yet.
    */
-  Usage = 'USAGE'
+  Usage = 'USAGE',
 }
 
 export type BillingDetails = {
@@ -208,17 +221,18 @@ export type BillingDetailsInput = {
   region?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type BillingProfile = Node & SourceFields & {
-  __typename?: 'BillingProfile';
-  appSource: Scalars['String']['output'];
-  createdAt: Scalars['Time']['output'];
-  id: Scalars['ID']['output'];
-  legalName: Scalars['String']['output'];
-  source: DataSource;
-  sourceOfTruth: DataSource;
-  taxId: Scalars['String']['output'];
-  updatedAt: Scalars['Time']['output'];
-};
+export type BillingProfile = Node &
+  SourceFields & {
+    __typename?: 'BillingProfile';
+    appSource: Scalars['String']['output'];
+    createdAt: Scalars['Time']['output'];
+    id: Scalars['ID']['output'];
+    legalName: Scalars['String']['output'];
+    source: DataSource;
+    sourceOfTruth: DataSource;
+    taxId: Scalars['String']['output'];
+    updatedAt: Scalars['Time']['output'];
+  };
 
 export type BillingProfileInput = {
   createdAt?: InputMaybe<Scalars['Time']['input']>;
@@ -267,7 +281,7 @@ export type Calendar = {
 
 export enum CalendarType {
   Calcom = 'CALCOM',
-  Google = 'GOOGLE'
+  Google = 'GOOGLE',
 }
 
 export type ColumnView = {
@@ -386,7 +400,7 @@ export enum ColumnViewType {
   OrganizationsTags = 'ORGANIZATIONS_TAGS',
   OrganizationsUpdatedDate = 'ORGANIZATIONS_UPDATED_DATE',
   OrganizationsWebsite = 'ORGANIZATIONS_WEBSITE',
-  OrganizationsYearFounded = 'ORGANIZATIONS_YEAR_FOUNDED'
+  OrganizationsYearFounded = 'ORGANIZATIONS_YEAR_FOUNDED',
 }
 
 export type Comment = {
@@ -419,91 +433,91 @@ export enum ComparisonOperator {
   Lte = 'LTE',
   NotContains = 'NOT_CONTAINS',
   NotEquals = 'NOT_EQUALS',
-  StartsWith = 'STARTS_WITH'
+  StartsWith = 'STARTS_WITH',
 }
 
 /**
  * A contact represents an individual in customerOS.
  * **A `response` object.**
  */
-export type Contact = MetadataInterface & Node & {
-  __typename?: 'Contact';
-  appSource?: Maybe<Scalars['String']['output']>;
-  /** All users associated on linkedin to this contact */
-  connectedUsers: Array<User>;
-  /**
-   * An ISO8601 timestamp recording when the contact was created in customerOS.
-   * **Required**
-   */
-  createdAt: Scalars['Time']['output'];
-  /**
-   * User defined metadata appended to the contact record in customerOS.
-   * **Required.  If no values it returns an empty array.**
-   */
-  customFields: Array<CustomField>;
-  description?: Maybe<Scalars['String']['output']>;
-  /**
-   * All email addresses associated with a contact in customerOS.
-   * **Required.  If no values it returns an empty array.**
-   */
-  emails: Array<Email>;
-  enrichDetails: EnrichDetails;
-  /** The first name of the contact in customerOS. */
-  firstName?: Maybe<Scalars['String']['output']>;
-  flows: Array<Flow>;
-  hide?: Maybe<Scalars['Boolean']['output']>;
-  /**
-   * Deprecated, use metadata instead
-   * @deprecated Use `metadata.id` instead
-   */
-  id: Scalars['ID']['output'];
-  /**
-   * `organizationName` and `jobTitle` of the contact if it has been associated with an organization.
-   * **Required.  If no values it returns an empty array.**
-   */
-  jobRoles: Array<JobRole>;
-  /**
-   * Deprecated
-   * @deprecated Use `tags` instead
-   */
-  label?: Maybe<Scalars['String']['output']>;
-  /** The last name of the contact in customerOS. */
-  lastName?: Maybe<Scalars['String']['output']>;
-  latestOrganizationWithJobRole?: Maybe<OrganizationWithJobRole>;
-  /**
-   * All locations associated with a contact in customerOS.
-   * **Required.  If no values it returns an empty array.**
-   */
-  locations: Array<Location>;
-  metadata: Metadata;
-  /** The name of the contact in customerOS, alternative for firstName + lastName. */
-  name?: Maybe<Scalars['String']['output']>;
-  organizations: OrganizationPage;
-  /** Contact owner (user) */
-  owner?: Maybe<User>;
-  /**
-   * All phone numbers associated with a contact in customerOS.
-   * **Required.  If no values it returns an empty array.**
-   */
-  phoneNumbers: Array<PhoneNumber>;
-  prefix?: Maybe<Scalars['String']['output']>;
-  primaryEmail?: Maybe<Email>;
-  profilePhotoUrl?: Maybe<Scalars['String']['output']>;
-  socials: Array<Social>;
-  source: DataSource;
-  tags?: Maybe<Array<Tag>>;
-  timelineEvents: Array<TimelineEvent>;
-  timelineEventsTotalCount: Scalars['Int64']['output'];
-  timezone?: Maybe<Scalars['String']['output']>;
-  /**
-   * Deprecated
-   * @deprecated Use `prefix` instead
-   */
-  title?: Maybe<Scalars['String']['output']>;
-  updatedAt: Scalars['Time']['output'];
-  username?: Maybe<Scalars['String']['output']>;
-};
-
+export type Contact = MetadataInterface &
+  Node & {
+    __typename?: 'Contact';
+    appSource?: Maybe<Scalars['String']['output']>;
+    /** All users associated on linkedin to this contact */
+    connectedUsers: Array<User>;
+    /**
+     * An ISO8601 timestamp recording when the contact was created in customerOS.
+     * **Required**
+     */
+    createdAt: Scalars['Time']['output'];
+    /**
+     * User defined metadata appended to the contact record in customerOS.
+     * **Required.  If no values it returns an empty array.**
+     */
+    customFields: Array<CustomField>;
+    description?: Maybe<Scalars['String']['output']>;
+    /**
+     * All email addresses associated with a contact in customerOS.
+     * **Required.  If no values it returns an empty array.**
+     */
+    emails: Array<Email>;
+    enrichDetails: EnrichDetails;
+    /** The first name of the contact in customerOS. */
+    firstName?: Maybe<Scalars['String']['output']>;
+    flows: Array<Flow>;
+    hide?: Maybe<Scalars['Boolean']['output']>;
+    /**
+     * Deprecated, use metadata instead
+     * @deprecated Use `metadata.id` instead
+     */
+    id: Scalars['ID']['output'];
+    /**
+     * `organizationName` and `jobTitle` of the contact if it has been associated with an organization.
+     * **Required.  If no values it returns an empty array.**
+     */
+    jobRoles: Array<JobRole>;
+    /**
+     * Deprecated
+     * @deprecated Use `tags` instead
+     */
+    label?: Maybe<Scalars['String']['output']>;
+    /** The last name of the contact in customerOS. */
+    lastName?: Maybe<Scalars['String']['output']>;
+    latestOrganizationWithJobRole?: Maybe<OrganizationWithJobRole>;
+    /**
+     * All locations associated with a contact in customerOS.
+     * **Required.  If no values it returns an empty array.**
+     */
+    locations: Array<Location>;
+    metadata: Metadata;
+    /** The name of the contact in customerOS, alternative for firstName + lastName. */
+    name?: Maybe<Scalars['String']['output']>;
+    organizations: OrganizationPage;
+    /** Contact owner (user) */
+    owner?: Maybe<User>;
+    /**
+     * All phone numbers associated with a contact in customerOS.
+     * **Required.  If no values it returns an empty array.**
+     */
+    phoneNumbers: Array<PhoneNumber>;
+    prefix?: Maybe<Scalars['String']['output']>;
+    primaryEmail?: Maybe<Email>;
+    profilePhotoUrl?: Maybe<Scalars['String']['output']>;
+    socials: Array<Social>;
+    source: DataSource;
+    tags?: Maybe<Array<Tag>>;
+    timelineEvents: Array<TimelineEvent>;
+    timelineEventsTotalCount: Scalars['Int64']['output'];
+    timezone?: Maybe<Scalars['String']['output']>;
+    /**
+     * Deprecated
+     * @deprecated Use `prefix` instead
+     */
+    title?: Maybe<Scalars['String']['output']>;
+    updatedAt: Scalars['Time']['output'];
+    username?: Maybe<Scalars['String']['output']>;
+  };
 
 /**
  * A contact represents an individual in customerOS.
@@ -515,7 +529,6 @@ export type ContactOrganizationsArgs = {
   where?: InputMaybe<Filter>;
 };
 
-
 /**
  * A contact represents an individual in customerOS.
  * **A `response` object.**
@@ -525,7 +538,6 @@ export type ContactTimelineEventsArgs = {
   size: Scalars['Int']['input'];
   timelineEventTypes?: InputMaybe<Array<TimelineEventType>>;
 };
-
 
 /**
  * A contact represents an individual in customerOS.
@@ -786,7 +798,7 @@ export enum ContractBillingCycle {
   CustomBilling = 'CUSTOM_BILLING',
   MonthlyBilling = 'MONTHLY_BILLING',
   None = 'NONE',
-  QuarterlyBilling = 'QUARTERLY_BILLING'
+  QuarterlyBilling = 'QUARTERLY_BILLING',
 }
 
 export type ContractInput = {
@@ -837,7 +849,7 @@ export enum ContractRenewalCycle {
   AnnualRenewal = 'ANNUAL_RENEWAL',
   MonthlyRenewal = 'MONTHLY_RENEWAL',
   None = 'NONE',
-  QuarterlyRenewal = 'QUARTERLY_RENEWAL'
+  QuarterlyRenewal = 'QUARTERLY_RENEWAL',
 }
 
 export type ContractRenewalInput = {
@@ -851,7 +863,7 @@ export enum ContractStatus {
   Live = 'LIVE',
   OutOfContract = 'OUT_OF_CONTRACT',
   Scheduled = 'SCHEDULED',
-  Undefined = 'UNDEFINED'
+  Undefined = 'UNDEFINED',
 }
 
 export type ContractUpdateInput = {
@@ -942,12 +954,12 @@ export enum Currency {
   Sgd = 'SGD',
   Try = 'TRY',
   Usd = 'USD',
-  Zar = 'ZAR'
+  Zar = 'ZAR',
 }
 
 export enum CustomEntityType {
   Contact = 'Contact',
-  Organization = 'Organization'
+  Organization = 'Organization',
 }
 
 /**
@@ -988,7 +1000,7 @@ export enum CustomFieldDataType {
   Datetime = 'DATETIME',
   Decimal = 'DECIMAL',
   Integer = 'INTEGER',
-  Text = 'TEXT'
+  Text = 'TEXT',
 }
 
 export type CustomFieldEntityType = {
@@ -1047,7 +1059,7 @@ export type CustomFieldTemplateInput = {
 export enum CustomFieldTemplateType {
   FreeText = 'FREE_TEXT',
   Number = 'NUMBER',
-  SingleSelect = 'SINGLE_SELECT'
+  SingleSelect = 'SINGLE_SELECT',
 }
 
 /**
@@ -1153,7 +1165,7 @@ export enum DashboardCustomerMapState {
   Churned = 'CHURNED',
   HighRisk = 'HIGH_RISK',
   MediumRisk = 'MEDIUM_RISK',
-  Ok = 'OK'
+  Ok = 'OK',
 }
 
 export type DashboardGrossRevenueRetention = {
@@ -1282,7 +1294,7 @@ export enum DataSource {
   Unthread = 'UNTHREAD',
   Webscrape = 'WEBSCRAPE',
   ZendeskSell = 'ZENDESK_SELL',
-  ZendeskSupport = 'ZENDESK_SUPPORT'
+  ZendeskSupport = 'ZENDESK_SUPPORT',
 }
 
 export type DeleteResponse = {
@@ -1330,7 +1342,7 @@ export type Email = {
 export enum EmailDeliverable {
   Deliverable = 'DELIVERABLE',
   Undeliverable = 'UNDELIVERABLE',
-  Unknown = 'UNKNOWN'
+  Unknown = 'UNKNOWN',
 }
 
 /**
@@ -1360,7 +1372,7 @@ export enum EmailLabel {
   Main = 'MAIN',
   Other = 'OTHER',
   Personal = 'PERSONAL',
-  Work = 'WORK'
+  Work = 'WORK',
 }
 
 export type EmailParticipant = {
@@ -1426,7 +1438,7 @@ export type EmailVariableEntity = {
 };
 
 export enum EmailVariableEntityType {
-  Contact = 'CONTACT'
+  Contact = 'CONTACT',
 }
 
 export enum EmailVariableName {
@@ -1436,7 +1448,7 @@ export enum EmailVariableName {
   ContactLastName = 'CONTACT_LAST_NAME',
   OrganizationName = 'ORGANIZATION_NAME',
   SenderFirstName = 'SENDER_FIRST_NAME',
-  SenderLastName = 'SENDER_LAST_NAME'
+  SenderLastName = 'SENDER_LAST_NAME',
 }
 
 export type EnrichDetails = {
@@ -1458,7 +1470,7 @@ export enum EntityType {
   Issue = 'ISSUE',
   LogEntry = 'LOG_ENTRY',
   Opportunity = 'OPPORTUNITY',
-  Organization = 'ORGANIZATION'
+  Organization = 'ORGANIZATION',
 }
 
 export type ExternalSystem = {
@@ -1508,7 +1520,7 @@ export enum ExternalSystemType {
   Unthread = 'UNTHREAD',
   Weconnect = 'WECONNECT',
   ZendeskSell = 'ZENDESK_SELL',
-  ZendeskSupport = 'ZENDESK_SUPPORT'
+  ZendeskSupport = 'ZENDESK_SUPPORT',
 }
 
 export type Filter = {
@@ -1562,7 +1574,7 @@ export enum FlowActionExecutionStatus {
   Scheduled = 'SCHEDULED',
   Skipped = 'SKIPPED',
   Success = 'SUCCESS',
-  TechError = 'TECH_ERROR'
+  TechError = 'TECH_ERROR',
 }
 
 export type FlowActionInputData = {
@@ -1595,14 +1607,14 @@ export enum FlowActionStatus {
   Active = 'ACTIVE',
   Archived = 'ARCHIVED',
   Inactive = 'INACTIVE',
-  Paused = 'PAUSED'
+  Paused = 'PAUSED',
 }
 
 export enum FlowActionType {
   EmailNew = 'EMAIL_NEW',
   EmailReply = 'EMAIL_REPLY',
   LinkedinConnectionRequest = 'LINKEDIN_CONNECTION_REQUEST',
-  LinkedinMessage = 'LINKEDIN_MESSAGE'
+  LinkedinMessage = 'LINKEDIN_MESSAGE',
 }
 
 export type FlowContact = MetadataInterface & {
@@ -1615,7 +1627,7 @@ export type FlowContact = MetadataInterface & {
 };
 
 export enum FlowEntityType {
-  Contact = 'CONTACT'
+  Contact = 'CONTACT',
 }
 
 export type FlowMergeInput = {
@@ -1631,8 +1643,14 @@ export type FlowParticipant = MetadataInterface & {
   entityType: Scalars['String']['output'];
   executions: Array<FlowActionExecution>;
   metadata: Metadata;
+  requirementsUnmeet: Array<FlowParticipantRequirementsUnmeet>;
   status: FlowParticipantStatus;
 };
+
+export enum FlowParticipantRequirementsUnmeet {
+  MissingLinkedinUrl = 'MISSING_LINKEDIN_URL',
+  MissingPrimaryEmail = 'MISSING_PRIMARY_EMAIL',
+}
 
 export enum FlowParticipantStatus {
   Completed = 'COMPLETED',
@@ -1642,7 +1660,7 @@ export enum FlowParticipantStatus {
   OnHold = 'ON_HOLD',
   Ready = 'READY',
   Scheduled = 'SCHEDULED',
-  Scheduling = 'SCHEDULING'
+  Scheduling = 'SCHEDULING',
 }
 
 export type FlowSender = MetadataInterface & {
@@ -1671,7 +1689,7 @@ export type FlowStatistics = {
 export enum FlowStatus {
   Archived = 'ARCHIVED',
   Off = 'OFF',
-  On = 'ON'
+  On = 'ON',
 }
 
 export enum FundingRound {
@@ -1686,7 +1704,7 @@ export enum FundingRound {
   SeriesC = 'SERIES_C',
   SeriesD = 'SERIES_D',
   SeriesE = 'SERIES_E',
-  SeriesF = 'SERIES_F'
+  SeriesF = 'SERIES_F',
 }
 
 export type GCliAttributeKeyValuePair = {
@@ -1699,7 +1717,7 @@ export type GCliAttributeKeyValuePair = {
 export enum GCliCacheItemType {
   Contact = 'CONTACT',
   Organization = 'ORGANIZATION',
-  State = 'STATE'
+  State = 'STATE',
 }
 
 export type GCliItem = {
@@ -1715,7 +1733,7 @@ export enum GCliSearchResultType {
   Email = 'EMAIL',
   Organization = 'ORGANIZATION',
   OrganizationRelationship = 'ORGANIZATION_RELATIONSHIP',
-  State = 'STATE'
+  State = 'STATE',
 }
 
 export type GetPaymentIntent = {
@@ -1746,6 +1764,7 @@ export type GlobalCacheEmailToken = {
 
 export type GlobalOrganization = {
   __typename?: 'GlobalOrganization';
+  domains: Array<Scalars['String']['output']>;
   iconUrl: Scalars['String']['output'];
   id: Scalars['Int64']['output'];
   logoUrl: Scalars['String']['output'];
@@ -1780,7 +1799,13 @@ export type InteractionEvent = Node & {
   sourceOfTruth: DataSource;
 };
 
-export type InteractionEventParticipant = ContactParticipant | EmailParticipant | JobRoleParticipant | OrganizationParticipant | PhoneNumberParticipant | UserParticipant;
+export type InteractionEventParticipant =
+  | ContactParticipant
+  | EmailParticipant
+  | JobRoleParticipant
+  | OrganizationParticipant
+  | PhoneNumberParticipant
+  | UserParticipant;
 
 export type InteractionSession = Node & {
   __typename?: 'InteractionSession';
@@ -1800,19 +1825,23 @@ export type InteractionSession = Node & {
   updatedAt: Scalars['Time']['output'];
 };
 
-export type InteractionSessionParticipant = ContactParticipant | EmailParticipant | PhoneNumberParticipant | UserParticipant;
+export type InteractionSessionParticipant =
+  | ContactParticipant
+  | EmailParticipant
+  | PhoneNumberParticipant
+  | UserParticipant;
 
 export enum InternalStage {
   ClosedLost = 'CLOSED_LOST',
   ClosedWon = 'CLOSED_WON',
-  Open = 'OPEN'
+  Open = 'OPEN',
 }
 
 export enum InternalType {
   CrossSell = 'CROSS_SELL',
   Nbo = 'NBO',
   Renewal = 'RENEWAL',
-  Upsell = 'UPSELL'
+  Upsell = 'UPSELL',
 }
 
 export type Invoice = MetadataInterface & {
@@ -1956,7 +1985,7 @@ export enum InvoiceStatus {
   Overdue = 'OVERDUE',
   Paid = 'PAID',
   Scheduled = 'SCHEDULED',
-  Void = 'VOID'
+  Void = 'VOID',
 }
 
 export type InvoiceUpdateInput = {
@@ -1973,34 +2002,38 @@ export type InvoicesPage = Pages & {
   totalPages: Scalars['Int']['output'];
 };
 
-export type Issue = Node & SourceFields & {
-  __typename?: 'Issue';
-  appSource: Scalars['String']['output'];
-  assignedTo: Array<IssueParticipant>;
-  comments: Array<Comment>;
-  createdAt: Scalars['Time']['output'];
-  description?: Maybe<Scalars['String']['output']>;
-  externalLinks: Array<ExternalSystem>;
-  followedBy: Array<IssueParticipant>;
-  id: Scalars['ID']['output'];
-  interactionEvents: Array<InteractionEvent>;
-  issueStatus: Scalars['String']['output'];
-  priority?: Maybe<Scalars['String']['output']>;
-  reportedBy?: Maybe<IssueParticipant>;
-  source: DataSource;
-  sourceOfTruth: DataSource;
-  /**
-   * Deprecated: Use issueStatus field instead
-   * @deprecated Use issueStatus field instead
-   */
-  status: Scalars['String']['output'];
-  subject?: Maybe<Scalars['String']['output']>;
-  submittedBy?: Maybe<IssueParticipant>;
-  tags?: Maybe<Array<Maybe<Tag>>>;
-  updatedAt: Scalars['Time']['output'];
-};
+export type Issue = Node &
+  SourceFields & {
+    __typename?: 'Issue';
+    appSource: Scalars['String']['output'];
+    assignedTo: Array<IssueParticipant>;
+    comments: Array<Comment>;
+    createdAt: Scalars['Time']['output'];
+    description?: Maybe<Scalars['String']['output']>;
+    externalLinks: Array<ExternalSystem>;
+    followedBy: Array<IssueParticipant>;
+    id: Scalars['ID']['output'];
+    interactionEvents: Array<InteractionEvent>;
+    issueStatus: Scalars['String']['output'];
+    priority?: Maybe<Scalars['String']['output']>;
+    reportedBy?: Maybe<IssueParticipant>;
+    source: DataSource;
+    sourceOfTruth: DataSource;
+    /**
+     * Deprecated: Use issueStatus field instead
+     * @deprecated Use issueStatus field instead
+     */
+    status: Scalars['String']['output'];
+    subject?: Maybe<Scalars['String']['output']>;
+    submittedBy?: Maybe<IssueParticipant>;
+    tags?: Maybe<Array<Maybe<Tag>>>;
+    updatedAt: Scalars['Time']['output'];
+  };
 
-export type IssueParticipant = ContactParticipant | OrganizationParticipant | UserParticipant;
+export type IssueParticipant =
+  | ContactParticipant
+  | OrganizationParticipant
+  | UserParticipant;
 
 export type IssueSummaryByStatus = {
   __typename?: 'IssueSummaryByStatus';
@@ -2091,7 +2124,7 @@ export enum LastTouchpointType {
   LogEntry = 'LOG_ENTRY',
   Meeting = 'MEETING',
   Note = 'NOTE',
-  PageView = 'PAGE_VIEW'
+  PageView = 'PAGE_VIEW',
 }
 
 export type LinkOrganizationsInput = {
@@ -2107,37 +2140,38 @@ export type LinkedOrganization = {
   type?: Maybe<Scalars['String']['output']>;
 };
 
-export type Location = Node & SourceFields & {
-  __typename?: 'Location';
-  address?: Maybe<Scalars['String']['output']>;
-  address2?: Maybe<Scalars['String']['output']>;
-  addressType?: Maybe<Scalars['String']['output']>;
-  appSource: Scalars['String']['output'];
-  commercial?: Maybe<Scalars['Boolean']['output']>;
-  country?: Maybe<Scalars['String']['output']>;
-  countryCodeA2?: Maybe<Scalars['String']['output']>;
-  countryCodeA3?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['Time']['output'];
-  district?: Maybe<Scalars['String']['output']>;
-  houseNumber?: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-  latitude?: Maybe<Scalars['Float']['output']>;
-  locality?: Maybe<Scalars['String']['output']>;
-  longitude?: Maybe<Scalars['Float']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-  plusFour?: Maybe<Scalars['String']['output']>;
-  postalCode?: Maybe<Scalars['String']['output']>;
-  predirection?: Maybe<Scalars['String']['output']>;
-  rawAddress?: Maybe<Scalars['String']['output']>;
-  region?: Maybe<Scalars['String']['output']>;
-  source: DataSource;
-  sourceOfTruth: DataSource;
-  street?: Maybe<Scalars['String']['output']>;
-  timeZone?: Maybe<Scalars['String']['output']>;
-  updatedAt: Scalars['Time']['output'];
-  utcOffset?: Maybe<Scalars['Float']['output']>;
-  zip?: Maybe<Scalars['String']['output']>;
-};
+export type Location = Node &
+  SourceFields & {
+    __typename?: 'Location';
+    address?: Maybe<Scalars['String']['output']>;
+    address2?: Maybe<Scalars['String']['output']>;
+    addressType?: Maybe<Scalars['String']['output']>;
+    appSource: Scalars['String']['output'];
+    commercial?: Maybe<Scalars['Boolean']['output']>;
+    country?: Maybe<Scalars['String']['output']>;
+    countryCodeA2?: Maybe<Scalars['String']['output']>;
+    countryCodeA3?: Maybe<Scalars['String']['output']>;
+    createdAt: Scalars['Time']['output'];
+    district?: Maybe<Scalars['String']['output']>;
+    houseNumber?: Maybe<Scalars['String']['output']>;
+    id: Scalars['ID']['output'];
+    latitude?: Maybe<Scalars['Float']['output']>;
+    locality?: Maybe<Scalars['String']['output']>;
+    longitude?: Maybe<Scalars['Float']['output']>;
+    name?: Maybe<Scalars['String']['output']>;
+    plusFour?: Maybe<Scalars['String']['output']>;
+    postalCode?: Maybe<Scalars['String']['output']>;
+    predirection?: Maybe<Scalars['String']['output']>;
+    rawAddress?: Maybe<Scalars['String']['output']>;
+    region?: Maybe<Scalars['String']['output']>;
+    source: DataSource;
+    sourceOfTruth: DataSource;
+    street?: Maybe<Scalars['String']['output']>;
+    timeZone?: Maybe<Scalars['String']['output']>;
+    updatedAt: Scalars['Time']['output'];
+    utcOffset?: Maybe<Scalars['Float']['output']>;
+    zip?: Maybe<Scalars['String']['output']>;
+  };
 
 export type LocationUpdateInput = {
   address?: InputMaybe<Scalars['String']['input']>;
@@ -2215,7 +2249,7 @@ export type MarkdownEvent = {
 export enum Market {
   B2B = 'B2B',
   B2C = 'B2C',
-  Marketplace = 'MARKETPLACE'
+  Marketplace = 'MARKETPLACE',
 }
 
 export type Meeting = Node & {
@@ -2260,7 +2294,11 @@ export type MeetingInput = {
   status?: InputMaybe<MeetingStatus>;
 };
 
-export type MeetingParticipant = ContactParticipant | EmailParticipant | OrganizationParticipant | UserParticipant;
+export type MeetingParticipant =
+  | ContactParticipant
+  | EmailParticipant
+  | OrganizationParticipant
+  | UserParticipant;
 
 export type MeetingParticipantInput = {
   contactId?: InputMaybe<Scalars['ID']['input']>;
@@ -2271,7 +2309,7 @@ export type MeetingParticipantInput = {
 export enum MeetingStatus {
   Accepted = 'ACCEPTED',
   Canceled = 'CANCELED',
-  Undefined = 'UNDEFINED'
+  Undefined = 'UNDEFINED',
 }
 
 export type MeetingUpdateInput = {
@@ -2311,24 +2349,25 @@ export type MeetingsPage = Pages & {
   totalPages: Scalars['Int']['output'];
 };
 
-export type Metadata = Node & SourceFieldsInterface & {
-  __typename?: 'Metadata';
-  appSource: Scalars['String']['output'];
-  created: Scalars['Time']['output'];
-  id: Scalars['ID']['output'];
-  lastUpdated: Scalars['Time']['output'];
-  source: DataSource;
-  /**
-   * Deprecated
-   * @deprecated Use source
-   */
-  sourceOfTruth: DataSource;
-  /**
-   * Aggregate version from event store db
-   * @deprecated No longer supported
-   */
-  version?: Maybe<Scalars['Int64']['output']>;
-};
+export type Metadata = Node &
+  SourceFieldsInterface & {
+    __typename?: 'Metadata';
+    appSource: Scalars['String']['output'];
+    created: Scalars['Time']['output'];
+    id: Scalars['ID']['output'];
+    lastUpdated: Scalars['Time']['output'];
+    source: DataSource;
+    /**
+     * Deprecated
+     * @deprecated Use source
+     */
+    sourceOfTruth: DataSource;
+    /**
+     * Aggregate version from event store db
+     * @deprecated No longer supported
+     */
+    version?: Maybe<Scalars['Int64']['output']>;
+  };
 
 export type MetadataInterface = {
   metadata: Metadata;
@@ -2405,6 +2444,7 @@ export type Mutation = {
   flowSender_Merge: FlowSender;
   flow_Archive: Result;
   flow_ArchiveBulk: Result;
+  flow_ChangeName: Flow;
   flow_Dummy_1Email: Result;
   flow_Merge: Flow;
   flow_Off: Flow;
@@ -2516,105 +2556,85 @@ export type Mutation = {
   workflow_Update: ActionResponse;
 };
 
-
 export type MutationAddTagArgs = {
   input: AddTagInput;
 };
-
 
 export type MutationAttachment_CreateArgs = {
   input: AttachmentInput;
 };
 
-
 export type MutationBankAccount_CreateArgs = {
   input?: InputMaybe<BankAccountCreateInput>;
 };
-
 
 export type MutationBankAccount_DeleteArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationBankAccount_UpdateArgs = {
   input?: InputMaybe<BankAccountUpdateInput>;
 };
-
 
 export type MutationBillingProfile_CreateArgs = {
   input: BillingProfileInput;
 };
 
-
 export type MutationBillingProfile_LinkEmailArgs = {
   input: BillingProfileLinkEmailInput;
 };
-
 
 export type MutationBillingProfile_LinkLocationArgs = {
   input: BillingProfileLinkLocationInput;
 };
 
-
 export type MutationBillingProfile_UnlinkEmailArgs = {
   input: BillingProfileLinkEmailInput;
 };
-
 
 export type MutationBillingProfile_UnlinkLocationArgs = {
   input: BillingProfileLinkLocationInput;
 };
 
-
 export type MutationBillingProfile_UpdateArgs = {
   input: BillingProfileUpdateInput;
 };
-
 
 export type MutationContact_AddNewLocationArgs = {
   contactId: Scalars['ID']['input'];
 };
 
-
 export type MutationContact_AddOrganizationByIdArgs = {
   input: ContactOrganizationInput;
 };
-
 
 export type MutationContact_AddSocialArgs = {
   contactId: Scalars['ID']['input'];
   input: SocialInput;
 };
 
-
 export type MutationContact_AddTagArgs = {
   input: ContactTagInput;
 };
 
-
 export type MutationContact_CreateArgs = {
   input: ContactInput;
 };
-
 
 export type MutationContact_CreateBulkByEmailArgs = {
   emails: Array<Scalars['String']['input']>;
   flowId?: InputMaybe<Scalars['String']['input']>;
 };
 
-
 export type MutationContact_CreateBulkByLinkedInArgs = {
   flowId?: InputMaybe<Scalars['String']['input']>;
   linkedInUrls: Array<Scalars['String']['input']>;
 };
 
-
 export type MutationContact_CreateForOrganizationArgs = {
   input: ContactInput;
   organizationId: Scalars['ID']['input'];
 };
-
 
 export type MutationContact_FindWorkEmailArgs = {
   contactId: Scalars['ID']['input'];
@@ -2623,193 +2643,158 @@ export type MutationContact_FindWorkEmailArgs = {
   organizationId?: InputMaybe<Scalars['ID']['input']>;
 };
 
-
 export type MutationContact_HardDeleteArgs = {
   contactId: Scalars['ID']['input'];
 };
 
-
 export type MutationContact_HideArgs = {
   contactId: Scalars['ID']['input'];
 };
-
 
 export type MutationContact_MergeArgs = {
   mergedContactIds: Array<Scalars['ID']['input']>;
   primaryContactId: Scalars['ID']['input'];
 };
 
-
 export type MutationContact_RemoveLocationArgs = {
   contactId: Scalars['ID']['input'];
   locationId: Scalars['ID']['input'];
 };
-
 
 export type MutationContact_RemoveSocialArgs = {
   contactId: Scalars['ID']['input'];
   socialId: Scalars['ID']['input'];
 };
 
-
 export type MutationContact_RemoveTagArgs = {
   input: ContactTagInput;
 };
-
 
 export type MutationContact_UpdateArgs = {
   input: ContactUpdateInput;
 };
 
-
 export type MutationContractLineItem_CloseArgs = {
   input: ServiceLineItemCloseInput;
 };
-
 
 export type MutationContractLineItem_CreateArgs = {
   input: ServiceLineItemInput;
 };
 
-
 export type MutationContractLineItem_NewVersionArgs = {
   input: ServiceLineItemNewVersionInput;
 };
-
 
 export type MutationContractLineItem_PauseArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationContractLineItem_ResumeArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationContractLineItem_UpdateArgs = {
   input: ServiceLineItemUpdateInput;
 };
-
 
 export type MutationContract_AddAttachmentArgs = {
   attachmentId: Scalars['ID']['input'];
   contractId: Scalars['ID']['input'];
 };
 
-
 export type MutationContract_CreateArgs = {
   input: ContractInput;
 };
 
-
 export type MutationContract_DeleteArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type MutationContract_RemoveAttachmentArgs = {
   attachmentId: Scalars['ID']['input'];
   contractId: Scalars['ID']['input'];
 };
 
-
 export type MutationContract_RenewArgs = {
   input: ContractRenewalInput;
 };
 
-
 export type MutationContract_UpdateArgs = {
   input: ContractUpdateInput;
 };
-
 
 export type MutationCustomFieldDeleteFromContactByIdArgs = {
   contactId: Scalars['ID']['input'];
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationCustomFieldDeleteFromContactByNameArgs = {
   contactId: Scalars['ID']['input'];
   fieldName: Scalars['String']['input'];
 };
-
 
 export type MutationCustomFieldMergeToContactArgs = {
   contactId: Scalars['ID']['input'];
   input: CustomFieldInput;
 };
 
-
 export type MutationCustomFieldTemplate_DeleteArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationCustomFieldTemplate_SaveArgs = {
   input: CustomFieldTemplateInput;
 };
-
 
 export type MutationCustomFieldUpdateInContactArgs = {
   contactId: Scalars['ID']['input'];
   input: CustomFieldUpdateInput;
 };
 
-
 export type MutationCustomFieldsMergeAndUpdateInContactArgs = {
   contactId: Scalars['ID']['input'];
   customFields?: InputMaybe<Array<CustomFieldInput>>;
 };
 
-
 export type MutationCustomer_Contact_CreateArgs = {
   input: CustomerContactInput;
 };
-
 
 export type MutationCustomer_User_AddJobRoleArgs = {
   id: Scalars['ID']['input'];
   jobRoleInput: JobRoleInput;
 };
 
-
 export type MutationEmailMergeToContactArgs = {
   contactId: Scalars['ID']['input'];
   input: EmailInput;
 };
-
 
 export type MutationEmailMergeToOrganizationArgs = {
   input: EmailInput;
   organizationId: Scalars['ID']['input'];
 };
 
-
 export type MutationEmailMergeToUserArgs = {
   input: EmailInput;
   userId: Scalars['ID']['input'];
 };
-
 
 export type MutationEmailRemoveFromContactArgs = {
   contactId: Scalars['ID']['input'];
   email: Scalars['String']['input'];
 };
 
-
 export type MutationEmailRemoveFromOrganizationArgs = {
   email: Scalars['String']['input'];
   organizationId: Scalars['ID']['input'];
 };
 
-
 export type MutationEmailRemoveFromUserArgs = {
   email: Scalars['String']['input'];
   userId: Scalars['ID']['input'];
 };
-
 
 export type MutationEmailReplaceForContactArgs = {
   contactId: Scalars['ID']['input'];
@@ -2817,13 +2802,11 @@ export type MutationEmailReplaceForContactArgs = {
   previousEmail?: InputMaybe<Scalars['String']['input']>;
 };
 
-
 export type MutationEmailReplaceForOrganizationArgs = {
   input: EmailInput;
   organizationId: Scalars['ID']['input'];
   previousEmail?: InputMaybe<Scalars['String']['input']>;
 };
-
 
 export type MutationEmailReplaceForUserArgs = {
   input: EmailInput;
@@ -2831,22 +2814,18 @@ export type MutationEmailReplaceForUserArgs = {
   userId: Scalars['ID']['input'];
 };
 
-
 export type MutationEmailSetPrimaryForContactArgs = {
   contactId: Scalars['ID']['input'];
   email: Scalars['String']['input'];
 };
 
-
 export type MutationEmail_ValidateArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationExternalSystem_CreateArgs = {
   input: ExternalSystemInput;
 };
-
 
 export type MutationFlowEmailActionTestArgs = {
   bodyTemplate: Scalars['String']['input'];
@@ -2854,13 +2833,11 @@ export type MutationFlowEmailActionTestArgs = {
   subject: Scalars['String']['input'];
 };
 
-
 export type MutationFlowParticipant_AddArgs = {
   entityId: Scalars['ID']['input'];
   entityType: FlowEntityType;
   flowId: Scalars['ID']['input'];
 };
-
 
 export type MutationFlowParticipant_AddBulkArgs = {
   entityIds: Array<Scalars['ID']['input']>;
@@ -2868,37 +2845,35 @@ export type MutationFlowParticipant_AddBulkArgs = {
   flowId: Scalars['ID']['input'];
 };
 
-
 export type MutationFlowParticipant_DeleteArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type MutationFlowParticipant_DeleteBulkArgs = {
   id: Array<Scalars['ID']['input']>;
 };
 
-
 export type MutationFlowSender_DeleteArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type MutationFlowSender_MergeArgs = {
   flowId: Scalars['ID']['input'];
   input: FlowSenderMergeInput;
 };
 
-
 export type MutationFlow_ArchiveArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type MutationFlow_ArchiveBulkArgs = {
   ids?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
 
+export type MutationFlow_ChangeNameArgs = {
+  id: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+};
 
 export type MutationFlow_Dummy_1EmailArgs = {
   contactsCount: Scalars['Int']['input'];
@@ -2907,124 +2882,102 @@ export type MutationFlow_Dummy_1EmailArgs = {
   userCount: Scalars['Int']['input'];
 };
 
-
 export type MutationFlow_MergeArgs = {
   input: FlowMergeInput;
 };
-
 
 export type MutationFlow_OffArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationFlow_OnArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type MutationInteractionEvent_LinkAttachmentArgs = {
   attachmentId: Scalars['ID']['input'];
   eventId: Scalars['ID']['input'];
 };
 
-
 export type MutationInvoice_NextDryRunForContractArgs = {
   contractId: Scalars['ID']['input'];
 };
-
 
 export type MutationInvoice_PayArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationInvoice_SimulateArgs = {
   input: InvoiceSimulateInput;
 };
-
 
 export type MutationInvoice_UpdateArgs = {
   input: InvoiceUpdateInput;
 };
 
-
 export type MutationInvoice_VoidArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type MutationJobRole_CreateArgs = {
   contactId: Scalars['ID']['input'];
   input: JobRoleInput;
 };
 
-
 export type MutationJobRole_DeleteArgs = {
   contactId: Scalars['ID']['input'];
   roleId: Scalars['ID']['input'];
 };
-
 
 export type MutationJobRole_UpdateArgs = {
   contactId: Scalars['ID']['input'];
   input: JobRoleUpdateInput;
 };
 
-
 export type MutationLocation_RemoveFromContactArgs = {
   contactId: Scalars['ID']['input'];
   locationId: Scalars['ID']['input'];
 };
-
 
 export type MutationLocation_RemoveFromOrganizationArgs = {
   locationId: Scalars['ID']['input'];
   organizationId: Scalars['ID']['input'];
 };
 
-
 export type MutationLocation_UpdateArgs = {
   input: LocationUpdateInput;
 };
-
 
 export type MutationLogEntry_AddTagArgs = {
   id: Scalars['ID']['input'];
   input: TagIdOrNameInput;
 };
 
-
 export type MutationLogEntry_CreateForOrganizationArgs = {
   input: LogEntryInput;
   organizationId: Scalars['ID']['input'];
 };
-
 
 export type MutationLogEntry_RemoveTagArgs = {
   id: Scalars['ID']['input'];
   input: TagIdOrNameInput;
 };
 
-
 export type MutationLogEntry_ResetTagsArgs = {
   id: Scalars['ID']['input'];
   input?: InputMaybe<Array<TagIdOrNameInput>>;
 };
-
 
 export type MutationLogEntry_UpdateArgs = {
   id: Scalars['ID']['input'];
   input: LogEntryUpdateInput;
 };
 
-
 export type MutationMailstack_GetPaymentIntentArgs = {
   amount: Scalars['Float']['input'];
   domains: Array<Scalars['String']['input']>;
   usernames: Array<Scalars['String']['input']>;
 };
-
 
 export type MutationMailstack_RegisterBuyDomainsWithMailboxesArgs = {
   amount: Scalars['Float']['input'];
@@ -3035,387 +2988,316 @@ export type MutationMailstack_RegisterBuyDomainsWithMailboxesArgs = {
   usernames: Array<Scalars['String']['input']>;
 };
 
-
 export type MutationMailstack_SetUserArgs = {
   mailbox: Scalars['String']['input'];
   userId: Scalars['ID']['input'];
 };
 
-
 export type MutationMeeting_AddNewLocationArgs = {
   meetingId: Scalars['ID']['input'];
 };
-
 
 export type MutationMeeting_AddNoteArgs = {
   meetingId: Scalars['ID']['input'];
   note?: InputMaybe<NoteInput>;
 };
 
-
 export type MutationMeeting_CreateArgs = {
   meeting: MeetingInput;
 };
-
 
 export type MutationMeeting_LinkAttachmentArgs = {
   attachmentId: Scalars['ID']['input'];
   meetingId: Scalars['ID']['input'];
 };
 
-
 export type MutationMeeting_LinkAttendedByArgs = {
   meetingId: Scalars['ID']['input'];
   participant: MeetingParticipantInput;
 };
-
 
 export type MutationMeeting_LinkRecordingArgs = {
   attachmentId: Scalars['ID']['input'];
   meetingId: Scalars['ID']['input'];
 };
 
-
 export type MutationMeeting_UnlinkAttachmentArgs = {
   attachmentId: Scalars['ID']['input'];
   meetingId: Scalars['ID']['input'];
 };
-
 
 export type MutationMeeting_UnlinkAttendedByArgs = {
   meetingId: Scalars['ID']['input'];
   participant: MeetingParticipantInput;
 };
 
-
 export type MutationMeeting_UnlinkRecordingArgs = {
   attachmentId: Scalars['ID']['input'];
   meetingId: Scalars['ID']['input'];
 };
-
 
 export type MutationMeeting_UpdateArgs = {
   meeting: MeetingUpdateInput;
   meetingId: Scalars['ID']['input'];
 };
 
-
 export type MutationNote_DeleteArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type MutationNote_LinkAttachmentArgs = {
   attachmentId: Scalars['ID']['input'];
   noteId: Scalars['ID']['input'];
 };
 
-
 export type MutationNote_UnlinkAttachmentArgs = {
   attachmentId: Scalars['ID']['input'];
   noteId: Scalars['ID']['input'];
 };
 
-
 export type MutationNote_UpdateArgs = {
   input: NoteUpdateInput;
 };
-
 
 export type MutationOpportunityRenewalUpdateArgs = {
   input: OpportunityRenewalUpdateInput;
   ownerUserId?: InputMaybe<Scalars['ID']['input']>;
 };
 
-
 export type MutationOpportunityRenewal_UpdateAllForOrganizationArgs = {
   input: OpportunityRenewalUpdateAllForOrganizationInput;
 };
-
 
 export type MutationOpportunity_ArchiveArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationOpportunity_SaveArgs = {
   input: OpportunitySaveInput;
 };
-
 
 export type MutationOrganization_AddSocialArgs = {
   input: SocialInput;
   organizationId: Scalars['ID']['input'];
 };
 
-
 export type MutationOrganization_AddSubsidiaryArgs = {
   input: LinkOrganizationsInput;
 };
-
 
 export type MutationOrganization_AddTagArgs = {
   input: OrganizationTagInput;
 };
 
-
 export type MutationOrganization_HideArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationOrganization_HideAllArgs = {
   ids: Array<Scalars['ID']['input']>;
 };
-
 
 export type MutationOrganization_MergeArgs = {
   mergedOrganizationIds: Array<Scalars['ID']['input']>;
   primaryOrganizationId: Scalars['ID']['input'];
 };
 
-
 export type MutationOrganization_RemoveSocialArgs = {
   organizationId: Scalars['ID']['input'];
   socialId: Scalars['ID']['input'];
 };
-
 
 export type MutationOrganization_RemoveSubsidiaryArgs = {
   organizationId: Scalars['ID']['input'];
   subsidiaryId: Scalars['ID']['input'];
 };
 
-
 export type MutationOrganization_RemoveTagArgs = {
   input: OrganizationTagInput;
 };
-
 
 export type MutationOrganization_SaveArgs = {
   input: OrganizationSaveInput;
 };
 
-
 export type MutationOrganization_SaveByGlobalOrganizationArgs = {
   globalOrganizationId: Scalars['Int64']['input'];
 };
-
 
 export type MutationOrganization_SetOwnerArgs = {
   organizationId: Scalars['ID']['input'];
   userId: Scalars['ID']['input'];
 };
 
-
 export type MutationOrganization_ShowArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type MutationOrganization_ShowAllArgs = {
   ids: Array<Scalars['ID']['input']>;
 };
 
-
 export type MutationOrganization_UnlinkAllDomainsArgs = {
   organizationId: Scalars['ID']['input'];
 };
-
 
 export type MutationOrganization_UnsetOwnerArgs = {
   organizationId: Scalars['ID']['input'];
 };
 
-
 export type MutationOrganization_UpdateArgs = {
   input: OrganizationUpdateInput;
 };
 
-
 export type MutationOrganization_UpdateOnboardingStatusArgs = {
   input: OnboardingStatusInput;
 };
-
 
 export type MutationPhoneNumberMergeToContactArgs = {
   contactId: Scalars['ID']['input'];
   input: PhoneNumberInput;
 };
 
-
 export type MutationPhoneNumberMergeToOrganizationArgs = {
   input: PhoneNumberInput;
   organizationId: Scalars['ID']['input'];
 };
-
 
 export type MutationPhoneNumberMergeToUserArgs = {
   input: PhoneNumberInput;
   userId: Scalars['ID']['input'];
 };
 
-
 export type MutationPhoneNumberRemoveFromContactByE164Args = {
   contactId: Scalars['ID']['input'];
   e164: Scalars['String']['input'];
 };
-
 
 export type MutationPhoneNumberRemoveFromContactByIdArgs = {
   contactId: Scalars['ID']['input'];
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationPhoneNumberRemoveFromOrganizationByE164Args = {
   e164: Scalars['String']['input'];
   organizationId: Scalars['ID']['input'];
 };
-
 
 export type MutationPhoneNumberRemoveFromOrganizationByIdArgs = {
   id: Scalars['ID']['input'];
   organizationId: Scalars['ID']['input'];
 };
 
-
 export type MutationPhoneNumberRemoveFromUserByE164Args = {
   e164: Scalars['String']['input'];
   userId: Scalars['ID']['input'];
 };
-
 
 export type MutationPhoneNumberRemoveFromUserByIdArgs = {
   id: Scalars['ID']['input'];
   userId: Scalars['ID']['input'];
 };
 
-
 export type MutationPhoneNumberUpdateInContactArgs = {
   contactId: Scalars['ID']['input'];
   input: PhoneNumberRelationUpdateInput;
 };
-
 
 export type MutationPhoneNumberUpdateInOrganizationArgs = {
   input: PhoneNumberRelationUpdateInput;
   organizationId: Scalars['ID']['input'];
 };
 
-
 export type MutationPhoneNumberUpdateInUserArgs = {
   input: PhoneNumberRelationUpdateInput;
   userId: Scalars['ID']['input'];
 };
 
-
 export type MutationPhoneNumber_UpdateArgs = {
   input: PhoneNumberUpdateInput;
 };
-
 
 export type MutationReminder_CreateArgs = {
   input: ReminderInput;
 };
 
-
 export type MutationReminder_UpdateArgs = {
   input: ReminderUpdateInput;
 };
-
 
 export type MutationRemoveTagArgs = {
   input: RemoveTagInput;
 };
 
-
 export type MutationServiceLineItem_BulkUpdateArgs = {
   input: ServiceLineItemBulkUpdateInput;
 };
-
 
 export type MutationServiceLineItem_DeleteArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationSocial_RemoveArgs = {
   socialId: Scalars['ID']['input'];
 };
-
 
 export type MutationSocial_UpdateArgs = {
   input: SocialUpdateInput;
 };
 
-
 export type MutationTableViewDef_ArchiveArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type MutationTableViewDef_CreateArgs = {
   input: TableViewDefCreateInput;
 };
 
-
 export type MutationTableViewDef_UpdateArgs = {
   input: TableViewDefUpdateInput;
 };
-
 
 export type MutationTableViewDef_UpdateSharedArgs = {
   input: TableViewDefUpdateInput;
 };
 
-
 export type MutationTag_CreateArgs = {
   input: TagInput;
 };
-
 
 export type MutationTag_DeleteArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationTag_UpdateArgs = {
   input: TagUpdateInput;
 };
-
 
 export type MutationTenant_AddBillingProfileArgs = {
   input: TenantBillingProfileInput;
 };
 
-
 export type MutationTenant_UpdateBillingProfileArgs = {
   input: TenantBillingProfileUpdateInput;
 };
-
 
 export type MutationTenant_UpdateSettingsArgs = {
   input?: InputMaybe<TenantSettingsInput>;
 };
 
-
 export type MutationTenant_UpdateSettingsOpportunityStageArgs = {
   input: TenantSettingsOpportunityStageConfigurationInput;
 };
-
 
 export type MutationTenant_HardDeleteArgs = {
   confirmTenant: Scalars['String']['input'];
   tenant: Scalars['String']['input'];
 };
 
-
 export type MutationUser_AddRoleArgs = {
   id: Scalars['ID']['input'];
   role: Role;
 };
-
 
 export type MutationUser_AddRoleInTenantArgs = {
   id: Scalars['ID']['input'];
@@ -3423,28 +3305,23 @@ export type MutationUser_AddRoleInTenantArgs = {
   tenant: Scalars['String']['input'];
 };
 
-
 export type MutationUser_CreateArgs = {
   input: UserInput;
 };
 
-
 export type MutationUser_DeleteArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type MutationUser_DeleteInTenantArgs = {
   id: Scalars['ID']['input'];
   tenant: Scalars['String']['input'];
 };
 
-
 export type MutationUser_RemoveRoleArgs = {
   id: Scalars['ID']['input'];
   role: Role;
 };
-
 
 export type MutationUser_RemoveRoleInTenantArgs = {
   id: Scalars['ID']['input'];
@@ -3452,21 +3329,17 @@ export type MutationUser_RemoveRoleInTenantArgs = {
   tenant: Scalars['String']['input'];
 };
 
-
 export type MutationUser_UpdateArgs = {
   input: UserUpdateInput;
 };
-
 
 export type MutationUser_UpdateOnboardingDetailsArgs = {
   input: UserOnboardingDetailsInput;
 };
 
-
 export type MutationWorkflow_CreateArgs = {
   input: WorkflowCreateInput;
 };
-
 
 export type MutationWorkflow_UpdateArgs = {
   input: WorkflowUpdateInput;
@@ -3523,7 +3396,7 @@ export enum OnboardingStatus {
   NotStarted = 'NOT_STARTED',
   OnTrack = 'ON_TRACK',
   Stuck = 'STUCK',
-  Successful = 'SUCCESSFUL'
+  Successful = 'SUCCESSFUL',
 }
 
 export type OnboardingStatusInput = {
@@ -3600,7 +3473,7 @@ export enum OpportunityRenewalLikelihood {
   HighRenewal = 'HIGH_RENEWAL',
   LowRenewal = 'LOW_RENEWAL',
   MediumRenewal = 'MEDIUM_RENEWAL',
-  ZeroRenewal = 'ZERO_RENEWAL'
+  ZeroRenewal = 'ZERO_RENEWAL',
 }
 
 export type OpportunityRenewalUpdateAllForOrganizationInput = {
@@ -3800,20 +3673,17 @@ export type Organization = MetadataInterface & {
   yearFounded?: Maybe<Scalars['Int64']['output']>;
 };
 
-
 export type OrganizationContactsArgs = {
   pagination?: InputMaybe<Pagination>;
   sort?: InputMaybe<Array<SortBy>>;
   where?: InputMaybe<Filter>;
 };
 
-
 export type OrganizationTimelineEventsArgs = {
   from?: InputMaybe<Scalars['Time']['input']>;
   size: Scalars['Int']['input'];
   timelineEventTypes?: InputMaybe<Array<TimelineEventType>>;
 };
-
 
 export type OrganizationTimelineEventsTotalCountArgs = {
   timelineEventTypes?: InputMaybe<Array<TimelineEventType>>;
@@ -3879,7 +3749,7 @@ export enum OrganizationRelationship {
   Customer = 'CUSTOMER',
   FormerCustomer = 'FORMER_CUSTOMER',
   NotAFit = 'NOT_A_FIT',
-  Prospect = 'PROSPECT'
+  Prospect = 'PROSPECT',
 }
 
 export type OrganizationSaveInput = {
@@ -3931,7 +3801,7 @@ export enum OrganizationStage {
   RecurringValue = 'RECURRING_VALUE',
   Target = 'TARGET',
   Trial = 'TRIAL',
-  Unqualified = 'UNQUALIFIED'
+  Unqualified = 'UNQUALIFIED',
 }
 
 export type OrganizationTagInput = {
@@ -3948,10 +3818,12 @@ export type OrganizationUiDetails = {
   createdAt: Scalars['Time']['output'];
   customerOsId: Scalars['String']['output'];
   description?: Maybe<Scalars['String']['output']>;
+  domains: Array<Scalars['String']['output']>;
   employees?: Maybe<Scalars['Int64']['output']>;
   enrichedAt?: Maybe<Scalars['Time']['output']>;
   enrichedFailedAt?: Maybe<Scalars['Time']['output']>;
   enrichedRequestedAt?: Maybe<Scalars['Time']['output']>;
+  hide: Scalars['Boolean']['output'];
   iconUrl?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   industry?: Maybe<Scalars['String']['output']>;
@@ -4037,21 +3909,22 @@ export type OrganizationWithJobRole = {
   organization: Organization;
 };
 
-export type PageView = Node & SourceFields & {
-  __typename?: 'PageView';
-  appSource: Scalars['String']['output'];
-  application: Scalars['String']['output'];
-  endedAt: Scalars['Time']['output'];
-  engagedTime: Scalars['Int64']['output'];
-  id: Scalars['ID']['output'];
-  orderInSession: Scalars['Int64']['output'];
-  pageTitle: Scalars['String']['output'];
-  pageUrl: Scalars['String']['output'];
-  sessionId: Scalars['ID']['output'];
-  source: DataSource;
-  sourceOfTruth: DataSource;
-  startedAt: Scalars['Time']['output'];
-};
+export type PageView = Node &
+  SourceFields & {
+    __typename?: 'PageView';
+    appSource: Scalars['String']['output'];
+    application: Scalars['String']['output'];
+    endedAt: Scalars['Time']['output'];
+    engagedTime: Scalars['Int64']['output'];
+    id: Scalars['ID']['output'];
+    orderInSession: Scalars['Int64']['output'];
+    pageTitle: Scalars['String']['output'];
+    pageUrl: Scalars['String']['output'];
+    sessionId: Scalars['ID']['output'];
+    source: DataSource;
+    sourceOfTruth: DataSource;
+    startedAt: Scalars['Time']['output'];
+  };
 
 /**
  * Describes the number of pages and total elements included in a query response.
@@ -4098,7 +3971,7 @@ export enum PersonTitle {
   /** For married women. */
   Mrs = 'MRS',
   /** For women, regardless of marital status, or when marital status is unknown. */
-  Ms = 'MS'
+  Ms = 'MS',
 }
 
 /**
@@ -4162,7 +4035,7 @@ export enum PhoneNumberLabel {
   Main = 'MAIN',
   Mobile = 'MOBILE',
   Other = 'OTHER',
-  Work = 'WORK'
+  Work = 'WORK',
 }
 
 export type PhoneNumberParticipant = {
@@ -4270,7 +4143,7 @@ export type Query = {
   organization_ByCustomId?: Maybe<Organization>;
   organization_ByCustomerOsId?: Maybe<Organization>;
   organization_ByLinkedIn?: Maybe<Organization>;
-  organization_CheckWebsite: WebsiteDetails;
+  organization_CheckWebsite: WebsiteCheckDetails;
   organization_DistinctOwners: Array<User>;
   organization_ExistsByLinkedIn: Scalars['Boolean']['output'];
   organizations: OrganizationPage;
@@ -4298,36 +4171,29 @@ export type Query = {
   workflows: Array<Workflow>;
 };
 
-
 export type QueryAttachmentArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type QueryContactArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type QueryContact_ByEmailArgs = {
   email: Scalars['String']['input'];
 };
-
 
 export type QueryContact_ByLinkedInArgs = {
   linkedInUrl: Scalars['String']['input'];
 };
 
-
 export type QueryContact_ByPhoneArgs = {
   e164: Scalars['String']['input'];
 };
 
-
 export type QueryContact_ExistsByLinkedInArgs = {
   linkedInUrl: Scalars['String']['input'];
 };
-
 
 export type QueryContactsArgs = {
   pagination?: InputMaybe<Pagination>;
@@ -4335,16 +4201,13 @@ export type QueryContactsArgs = {
   where?: InputMaybe<Filter>;
 };
 
-
 export type QueryContractArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type QueryContractsArgs = {
   pagination?: InputMaybe<Pagination>;
 };
-
 
 export type QueryDashboardView_OrganizationsArgs = {
   pagination: Pagination;
@@ -4352,58 +4215,47 @@ export type QueryDashboardView_OrganizationsArgs = {
   where?: InputMaybe<Filter>;
 };
 
-
 export type QueryDashboardView_RenewalsArgs = {
   pagination: Pagination;
   sort?: InputMaybe<SortBy>;
   where?: InputMaybe<Filter>;
 };
 
-
 export type QueryDashboard_ArrBreakdownArgs = {
   period?: InputMaybe<DashboardPeriodInput>;
 };
-
 
 export type QueryDashboard_GrossRevenueRetentionArgs = {
   period?: InputMaybe<DashboardPeriodInput>;
 };
 
-
 export type QueryDashboard_MrrPerCustomerArgs = {
   period?: InputMaybe<DashboardPeriodInput>;
 };
-
 
 export type QueryDashboard_NewCustomersArgs = {
   period?: InputMaybe<DashboardPeriodInput>;
 };
 
-
 export type QueryDashboard_OnboardingCompletionArgs = {
   period?: InputMaybe<DashboardPeriodInput>;
 };
-
 
 export type QueryDashboard_RetentionRateArgs = {
   period?: InputMaybe<DashboardPeriodInput>;
 };
 
-
 export type QueryDashboard_RevenueAtRiskArgs = {
   period?: InputMaybe<DashboardPeriodInput>;
 };
-
 
 export type QueryDashboard_TimeToOnboardArgs = {
   period?: InputMaybe<DashboardPeriodInput>;
 };
 
-
 export type QueryEmailArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type QueryExternalMeetingsArgs = {
   externalId?: InputMaybe<Scalars['ID']['input']>;
@@ -4413,43 +4265,35 @@ export type QueryExternalMeetingsArgs = {
   where?: InputMaybe<Filter>;
 };
 
-
 export type QueryFlowArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type QueryFlowParticipantArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type QueryGcli_SearchArgs = {
   keyword: Scalars['String']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
 };
 
-
 export type QueryGlobalOrganizations_SearchArgs = {
   limit: Scalars['Int']['input'];
   searchTerm: Scalars['String']['input'];
 };
 
-
 export type QueryInteractionEventArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type QueryInvoiceArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type QueryInvoice_ByNumberArgs = {
   number: Scalars['String']['input'];
 };
-
 
 export type QueryInvoicesArgs = {
   organizationId?: InputMaybe<Scalars['ID']['input']>;
@@ -4458,71 +4302,57 @@ export type QueryInvoicesArgs = {
   where?: InputMaybe<Filter>;
 };
 
-
 export type QueryIssueArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type QueryLogEntryArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type QueryMailstack_CheckUnavailableDomainsArgs = {
   domains: Array<Scalars['String']['input']>;
 };
-
 
 export type QueryMailstack_DomainPurchaseSuggestionsArgs = {
   domain: Scalars['String']['input'];
 };
 
-
 export type QueryMeetingArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type QueryOpportunities_LinkedToOrganizationsArgs = {
   pagination?: InputMaybe<Pagination>;
 };
 
-
 export type QueryOpportunityArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type QueryOrganizationArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type QueryOrganization_ByCustomIdArgs = {
   customId: Scalars['String']['input'];
 };
-
 
 export type QueryOrganization_ByCustomerOsIdArgs = {
   customerOsId: Scalars['String']['input'];
 };
 
-
 export type QueryOrganization_ByLinkedInArgs = {
   linkedInUrl: Scalars['String']['input'];
 };
-
 
 export type QueryOrganization_CheckWebsiteArgs = {
   website: Scalars['String']['input'];
 };
 
-
 export type QueryOrganization_ExistsByLinkedInArgs = {
   linkedInUrl: Scalars['String']['input'];
 };
-
 
 export type QueryOrganizationsArgs = {
   pagination?: InputMaybe<Pagination>;
@@ -4530,57 +4360,46 @@ export type QueryOrganizationsArgs = {
   where?: InputMaybe<Filter>;
 };
 
-
 export type QueryOrganizations_HiddenAfterArgs = {
   date: Scalars['Time']['input'];
 };
-
 
 export type QueryPhoneNumberArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type QueryReminderArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type QueryRemindersForOrganizationArgs = {
   dismissed?: InputMaybe<Scalars['Boolean']['input']>;
   organizationId: Scalars['ID']['input'];
 };
 
-
 export type QueryServiceLineItemArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type QuerySlack_ChannelsArgs = {
   pagination?: InputMaybe<Pagination>;
 };
 
-
 export type QueryTags_ByEntityTypeArgs = {
   entityType: EntityType;
 };
-
 
 export type QueryTenantBillingProfileArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type QueryTimelineEventsArgs = {
   ids: Array<Scalars['ID']['input']>;
 };
 
-
 export type QueryUi_OrganizationsArgs = {
   ids?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
-
 
 export type QueryUi_Organizations_SearchArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -4588,23 +4407,19 @@ export type QueryUi_Organizations_SearchArgs = {
   where?: InputMaybe<Filter>;
 };
 
-
 export type QueryUserArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type QueryUser_ByEmailArgs = {
   email: Scalars['String']['input'];
 };
-
 
 export type QueryUsersArgs = {
   pagination?: InputMaybe<Pagination>;
   sort?: InputMaybe<Array<SortBy>>;
   where?: InputMaybe<Filter>;
 };
-
 
 export type QueryWorkflow_ByTypeArgs = {
   workflowType: WorkflowType;
@@ -4679,7 +4494,7 @@ export enum Role {
   Admin = 'ADMIN',
   Owner = 'OWNER',
   PlatformOwner = 'PLATFORM_OWNER',
-  User = 'USER'
+  User = 'USER',
 }
 
 export type ServiceLineItem = MetadataInterface & {
@@ -4780,20 +4595,21 @@ export type SlackChannelPage = Pages & {
   totalPages: Scalars['Int']['output'];
 };
 
-export type Social = Node & SourceFields & {
-  __typename?: 'Social';
-  alias: Scalars['String']['output'];
-  appSource: Scalars['String']['output'];
-  createdAt: Scalars['Time']['output'];
-  externalId: Scalars['String']['output'];
-  followersCount: Scalars['Int64']['output'];
-  id: Scalars['ID']['output'];
-  metadata: Metadata;
-  source: DataSource;
-  sourceOfTruth: DataSource;
-  updatedAt: Scalars['Time']['output'];
-  url: Scalars['String']['output'];
-};
+export type Social = Node &
+  SourceFields & {
+    __typename?: 'Social';
+    alias: Scalars['String']['output'];
+    appSource: Scalars['String']['output'];
+    createdAt: Scalars['Time']['output'];
+    externalId: Scalars['String']['output'];
+    followersCount: Scalars['Int64']['output'];
+    id: Scalars['ID']['output'];
+    metadata: Metadata;
+    source: DataSource;
+    sourceOfTruth: DataSource;
+    updatedAt: Scalars['Time']['output'];
+    url: Scalars['String']['output'];
+  };
 
 export type SocialInput = {
   appSource?: InputMaybe<Scalars['String']['input']>;
@@ -4813,7 +4629,7 @@ export type SortBy = {
 
 export enum SortingDirection {
   Asc = 'ASC',
-  Desc = 'DESC'
+  Desc = 'DESC',
 }
 
 export type SourceFields = {
@@ -4857,7 +4673,7 @@ export enum TableIdType {
   Organizations = 'ORGANIZATIONS',
   PastInvoices = 'PAST_INVOICES',
   Targets = 'TARGETS',
-  UpcomingInvoices = 'UPCOMING_INVOICES'
+  UpcomingInvoices = 'UPCOMING_INVOICES',
 }
 
 export type TableViewDef = Node & {
@@ -4909,7 +4725,7 @@ export enum TableViewType {
   Flow = 'FLOW',
   Invoices = 'INVOICES',
   Opportunities = 'OPPORTUNITIES',
-  Organizations = 'ORGANIZATIONS'
+  Organizations = 'ORGANIZATIONS',
 }
 
 export type Tag = {
@@ -4965,65 +4781,66 @@ export type TenantBillableInfo = {
   whitelistedOrganizations: Scalars['Int64']['output'];
 };
 
-export type TenantBillingProfile = Node & SourceFields & {
-  __typename?: 'TenantBillingProfile';
-  addressLine1: Scalars['String']['output'];
-  addressLine2: Scalars['String']['output'];
-  addressLine3: Scalars['String']['output'];
-  appSource: Scalars['String']['output'];
-  canPayWithBankTransfer: Scalars['Boolean']['output'];
-  /**
-   * Deprecated
-   * @deprecated Not used
-   */
-  canPayWithCard?: Maybe<Scalars['Boolean']['output']>;
-  /**
-   * Deprecated
-   * @deprecated Not used
-   */
-  canPayWithDirectDebitACH?: Maybe<Scalars['Boolean']['output']>;
-  /**
-   * Deprecated
-   * @deprecated Not used
-   */
-  canPayWithDirectDebitBacs?: Maybe<Scalars['Boolean']['output']>;
-  /**
-   * Deprecated
-   * @deprecated Not used
-   */
-  canPayWithDirectDebitSEPA?: Maybe<Scalars['Boolean']['output']>;
-  canPayWithPigeon: Scalars['Boolean']['output'];
-  check: Scalars['Boolean']['output'];
-  country: Scalars['String']['output'];
-  createdAt: Scalars['Time']['output'];
-  /**
-   * Deprecated
-   * @deprecated Not used
-   */
-  domesticPaymentsBankInfo?: Maybe<Scalars['String']['output']>;
-  /**
-   * Deprecated
-   * @deprecated Use sendInvoicesFrom
-   */
-  email: Scalars['String']['output'];
-  id: Scalars['ID']['output'];
-  /**
-   * Deprecated
-   * @deprecated Not used
-   */
-  internationalPaymentsBankInfo?: Maybe<Scalars['String']['output']>;
-  legalName: Scalars['String']['output'];
-  locality: Scalars['String']['output'];
-  phone: Scalars['String']['output'];
-  region: Scalars['String']['output'];
-  sendInvoicesBcc: Scalars['String']['output'];
-  sendInvoicesFrom: Scalars['String']['output'];
-  source: DataSource;
-  sourceOfTruth: DataSource;
-  updatedAt: Scalars['Time']['output'];
-  vatNumber: Scalars['String']['output'];
-  zip: Scalars['String']['output'];
-};
+export type TenantBillingProfile = Node &
+  SourceFields & {
+    __typename?: 'TenantBillingProfile';
+    addressLine1: Scalars['String']['output'];
+    addressLine2: Scalars['String']['output'];
+    addressLine3: Scalars['String']['output'];
+    appSource: Scalars['String']['output'];
+    canPayWithBankTransfer: Scalars['Boolean']['output'];
+    /**
+     * Deprecated
+     * @deprecated Not used
+     */
+    canPayWithCard?: Maybe<Scalars['Boolean']['output']>;
+    /**
+     * Deprecated
+     * @deprecated Not used
+     */
+    canPayWithDirectDebitACH?: Maybe<Scalars['Boolean']['output']>;
+    /**
+     * Deprecated
+     * @deprecated Not used
+     */
+    canPayWithDirectDebitBacs?: Maybe<Scalars['Boolean']['output']>;
+    /**
+     * Deprecated
+     * @deprecated Not used
+     */
+    canPayWithDirectDebitSEPA?: Maybe<Scalars['Boolean']['output']>;
+    canPayWithPigeon: Scalars['Boolean']['output'];
+    check: Scalars['Boolean']['output'];
+    country: Scalars['String']['output'];
+    createdAt: Scalars['Time']['output'];
+    /**
+     * Deprecated
+     * @deprecated Not used
+     */
+    domesticPaymentsBankInfo?: Maybe<Scalars['String']['output']>;
+    /**
+     * Deprecated
+     * @deprecated Use sendInvoicesFrom
+     */
+    email: Scalars['String']['output'];
+    id: Scalars['ID']['output'];
+    /**
+     * Deprecated
+     * @deprecated Not used
+     */
+    internationalPaymentsBankInfo?: Maybe<Scalars['String']['output']>;
+    legalName: Scalars['String']['output'];
+    locality: Scalars['String']['output'];
+    phone: Scalars['String']['output'];
+    region: Scalars['String']['output'];
+    sendInvoicesBcc: Scalars['String']['output'];
+    sendInvoicesFrom: Scalars['String']['output'];
+    source: DataSource;
+    sourceOfTruth: DataSource;
+    updatedAt: Scalars['Time']['output'];
+    vatNumber: Scalars['String']['output'];
+    zip: Scalars['String']['output'];
+  };
 
 export type TenantBillingProfileInput = {
   addressLine1?: InputMaybe<Scalars['String']['input']>;
@@ -5152,7 +4969,16 @@ export type TimeRange = {
   to: Scalars['Time']['input'];
 };
 
-export type TimelineEvent = Action | InteractionEvent | InteractionSession | Issue | LogEntry | MarkdownEvent | Meeting | Note | PageView;
+export type TimelineEvent =
+  | Action
+  | InteractionEvent
+  | InteractionSession
+  | Issue
+  | LogEntry
+  | MarkdownEvent
+  | Meeting
+  | Note
+  | PageView;
 
 export enum TimelineEventType {
   Action = 'ACTION',
@@ -5165,7 +4991,7 @@ export enum TimelineEventType {
   Meeting = 'MEETING',
   Note = 'NOTE',
   Order = 'ORDER',
-  PageView = 'PAGE_VIEW'
+  PageView = 'PAGE_VIEW',
 }
 
 /**
@@ -5317,11 +5143,13 @@ export type UserUpdateInput = {
   timezone?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type WebsiteDetails = {
-  __typename?: 'WebsiteDetails';
+export type WebsiteCheckDetails = {
+  __typename?: 'WebsiteCheckDetails';
+  accepted: Scalars['Boolean']['output'];
   domain: Scalars['String']['output'];
+  globalOrganization?: Maybe<GlobalOrganization>;
   primary: Scalars['Boolean']['output'];
-  website: Scalars['String']['output'];
+  primaryDomain: Scalars['String']['output'];
 };
 
 export type Workflow = Node & {
@@ -5344,7 +5172,7 @@ export type WorkflowCreateInput = {
 
 export enum WorkflowType {
   IdealContactPersona = 'IDEAL_CONTACT_PERSONA',
-  IdealCustomerProfile = 'IDEAL_CUSTOMER_PROFILE'
+  IdealCustomerProfile = 'IDEAL_CUSTOMER_PROFILE',
 }
 
 export type WorkflowUpdateInput = {

--- a/packages/apps/frontera/src/store/FlowParticipants/FlowParticipant.store.ts
+++ b/packages/apps/frontera/src/store/FlowParticipants/FlowParticipant.store.ts
@@ -141,4 +141,5 @@ const getDefaultValue = (): FlowParticipant => ({
     sourceOfTruth: DataSource.Openline,
   },
   status: FlowParticipantStatus.Scheduled,
+  requirementsUnmeet: [],
 });

--- a/packages/apps/frontera/src/store/Flows/Flow.store.ts
+++ b/packages/apps/frontera/src/store/Flows/Flow.store.ts
@@ -245,6 +245,7 @@ export class FlowStore implements Store<Flow> {
         );
 
         const newFlowContactValue = {
+          ...newFLowContact.value,
           metadata: {
             ...newFLowContact.value.metadata,
             id: flowParticipant_Add.metadata.id,

--- a/packages/apps/frontera/src/store/Flows/__service__/getFlow.generated.ts
+++ b/packages/apps/frontera/src/store/Flows/__service__/getFlow.generated.ts
@@ -38,6 +38,7 @@ export type GetFlowQuery = {
       status: Types.FlowParticipantStatus;
       entityId: string;
       entityType: string;
+      requirementsUnmeet: Array<Types.FlowParticipantRequirementsUnmeet>;
       executions: Array<{
         __typename?: 'FlowActionExecution';
         status: Types.FlowActionExecutionStatus;

--- a/packages/apps/frontera/src/store/Flows/__service__/getFlow.graphql
+++ b/packages/apps/frontera/src/store/Flows/__service__/getFlow.graphql
@@ -35,6 +35,7 @@ query getFlow($id: ID!) {
       status
       entityId
       entityType
+      requirementsUnmeet
       executions {
         metadata {
           id

--- a/packages/apps/frontera/src/store/Flows/__service__/getFlows.generated.ts
+++ b/packages/apps/frontera/src/store/Flows/__service__/getFlows.generated.ts
@@ -36,6 +36,7 @@ export type GetFlowsQuery = {
       status: Types.FlowParticipantStatus;
       entityId: string;
       entityType: string;
+      requirementsUnmeet: Array<Types.FlowParticipantRequirementsUnmeet>;
       executions: Array<{
         __typename?: 'FlowActionExecution';
         status: Types.FlowActionExecutionStatus;

--- a/packages/apps/frontera/src/store/Flows/__service__/getFlows.graphql
+++ b/packages/apps/frontera/src/store/Flows/__service__/getFlows.graphql
@@ -35,6 +35,7 @@ query getFlows {
       status
       entityId
       entityType
+      requirementsUnmeet
       executions {
         metadata {
           id


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance `FlowStatusCell` to display specific messages for 'on_hold' status based on unmet requirements, with GraphQL and store updates.
> 
>   - **Behavior**:
>     - `FlowStatusCell.tsx` now shows specific messages for 'on_hold' status based on `requirementsUnmeet` (e.g., 'Missing email', 'Missing LinkedIn').
>     - Default message 'Blocked' if no specific unmet requirement is found.
>   - **GraphQL**:
>     - Added `requirementsUnmeet` to `FlowParticipant` in `graphql.types.ts`.
>     - Updated `getFlow.graphql` and `getFlows.graphql` to query `requirementsUnmeet`.
>   - **Stores**:
>     - Updated `FlowParticipant.store.ts` and `Flow.store.ts` to handle `requirementsUnmeet` in flow participants.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 482f1adbdb990c092eceecee2ec4fb6d9cbefa5a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->