### PR TITLE
When a flow is archived, we should remove contacts from it

### DIFF
--- a/packages/server/customer-os-common-module/service/flow_service.go
+++ b/packages/server/customer-os-common-module/service/flow_service.go
@@ -727,6 +727,20 @@ func (s *flowService) FlowArchive(ctx context.Context, id string) (*neo4jentity.
 		return nil, err
 	}
 
+	participantNodes, err := s.services.Neo4jRepositories.FlowParticipantReadRepository.GetList(ctx, []string{flow.Id})
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+
+	for _, v := range participantNodes {
+		err = s.FlowParticipantDelete(ctx, utils.GetStringPropOrEmpty(utils.GetPropsFromNode(*v.Node), "id"))
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return nil, err
+		}
+	}
+
 	return mapper.MapDbNodeToFlowEntity(node), nil
 }
 

--- a/packages/server/events-subscribers/listeners/flow_compute_participants_requirements_listener.go
+++ b/packages/server/events-subscribers/listeners/flow_compute_participants_requirements_listener.go
@@ -48,8 +48,6 @@ func Handle_FlowComputeParticipantsRequirements(ctx context.Context, services *s
 			if err != nil {
 				return nil, err
 			}
-
-			return nil, nil
 		}
 
 		return nil, nil


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `FlowArchive` in `flow_service.go` now removes participants when a flow is archived, and a redundant return statement is removed in `flow_compute_participants_requirements_listener.go`.
> 
>   - **Behavior**:
>     - In `flow_service.go`, `FlowArchive` now removes participants from the flow by calling `FlowParticipantDelete` for each participant.
>   - **Misc**:
>     - Remove unnecessary return statement in `Handle_FlowComputeParticipantsRequirements` in `flow_compute_participants_requirements_listener.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d08cebd815a951654eaf31c2dc7be8803ef4c2b5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->