### PR TITLE
COS-6232: Save flow when you go to its contact table

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/Header.tsx
@@ -60,22 +60,31 @@ export const Header = observer(
       }
     }, [store.ui.commandMenu.isOpen, id]);
 
+    // todo remove when we move to save on node by node basis
+    const handleSaveChanges = () => {
+      const nodes = getNodes();
+      const edges = getEdges();
+
+      // this should never happen
+      if (nodes.length === 0 && edges.length === 0) return;
+      onToggleHasChanges(false);
+
+      flow?.updateFlow({
+        nodes: JSON.stringify(nodes),
+        edges: JSON.stringify(edges),
+      });
+    };
+
+    useEffect(() => {
+      if (canSave) {
+        handleSaveChanges();
+      }
+    }, [showFinder]);
     useUnmount(() => {
       if (canSave) {
-        const nodes = getNodes();
-        const edges = getEdges();
-
-        // this should never happen
-        if (nodes.length === 0 && edges.length === 0) return;
-        onToggleHasChanges(false);
-
-        flow?.updateFlow({
-          nodes: JSON.stringify(nodes),
-          edges: JSON.stringify(edges),
-        });
+        handleSaveChanges();
       }
     });
-
     useEffect(() => {
       const handleBeforeUnload = (event: BeforeUnloadEvent) => {
         if (hasChanges) {


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extracts `handleSaveChanges` in `Header.tsx` to save flow changes on `showFinder` change or component unmount, ensuring data is saved if `canSave` is true.
> 
>   - **Behavior**:
>     - Extracts `handleSaveChanges` function in `Header.tsx` to save flow changes when `showFinder` changes or on component unmount.
>     - Ensures flow changes are saved if `canSave` is true, preventing data loss when navigating to the contact table.
>   - **Functions**:
>     - `handleSaveChanges` is called in `useEffect` and `useUnmount` hooks to handle saving logic.
>   - **Misc**:
>     - Adds a comment to remove `handleSaveChanges` when node-by-node saving is implemented.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b0281f96241e7daa00caf8f94852a5fc1563809c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->