### PR TITLE
COS-6229:  Display info when email is missing for contact in "Add existing contact modal"

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/addContactsToFlow/AddExistingContactsToFlow.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/flows/addContactsToFlow/AddExistingContactsToFlow.tsx
@@ -118,11 +118,9 @@ export const AddExistingContacts = observer(() => {
                     {contactStore.name?.length ? contactStore.name : 'Unnamed'}
                   </span>
 
-                  {contactStore.primaryEmail && (
-                    <span className='ml-1.5 text-gray-500 line-clamp-1 max-w-[250px]'>
-                      · {contactStore.primaryEmail?.email ?? ''}
-                    </span>
-                  )}
+                  <span className='ml-1.5 text-gray-500 line-clamp-1 max-w-[250px]'>
+                    · {contactStore.primaryEmail?.email ?? 'No email yet'}
+                  </span>
                 </div>
                 {isSelected && <Check />}
               </div>


### PR DESCRIPTION
…

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `AddExistingContactsToFlow.tsx` to display 'No email yet' when a contact's email is missing.
> 
>   - **UI Update**:
>     - In `AddExistingContactsToFlow.tsx`, updated the display logic for contact emails.
>     - Shows 'No email yet' when `contactStore.primaryEmail` is missing instead of hiding the email span.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for ff9038e8b22e64accf3ac057b6559b941f37a20a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->