### PR TITLE
set remaining email as primary on removing email from contact

### DIFF
--- a/packages/server/customer-os-neo4j-repository/repository/email_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/email_write_repository.go
@@ -2,20 +2,18 @@ package repository
 
 import (
 	"fmt"
-	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/data_fields"
-	"strings"
-	"time"
-
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/data_fields"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/tracing"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/constants"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
-
-	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/constants"
-	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
+	"strings"
+	"time"
 )
 
 type EmailDeliverableStatus string
@@ -377,7 +375,20 @@ func (r *emailWriteRepository) UnlinkFromContact(ctx context.Context, tx *neo4j.
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact {id:$contactId})-[rel:HAS]->(e:Email)
 				WHERE e.email = $email OR e.rawEmail = $email
-				DELETE rel`
+				DELETE rel
+				
+				WITH c
+				MATCH (c)-[remainingRel:HAS]->(remainingEmail:Email)
+				
+				WITH c, COLLECT(remainingRel) AS remainingRels
+				WHERE SIZE(remainingRels) > 0
+				
+				WITH c, remainingRels, NONE(rel IN remainingRels WHERE rel.primary = true) AS noPrimary
+				WHERE noPrimary
+
+				FOREACH (rel IN [x IN remainingRels | x][0] |
+    				SET rel.primary = true
+				)`
 	params := map[string]any{
 		"tenant":    tenant,
 		"contactId": contactId,


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `UnlinkFromContact`, set the first remaining email as primary if no primary email exists after removal.
> 
>   - **Behavior**:
>     - In `UnlinkFromContact` in `email_write_repository.go`, when an email is removed, if no other email is primary, the first remaining email is set as primary.
>   - **Imports**:
>     - Reorder imports in `email_write_repository.go` for better organization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 9746ecb1b6a89500e83f22e0fadac815a9272068. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->