### PR TITLE
COS-6240: Show modal when user tries to update sender that has scheduled emails

### DIFF
--- a/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/Workspace/Mailboxes/components/MailboxTable/cells/UserCell.tsx
+++ b/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/Workspace/Mailboxes/components/MailboxTable/cells/UserCell.tsx
@@ -23,6 +23,28 @@ export const UserCell = observer(({ id }: UserCellProps) => {
   const user = mailbox?.user;
   const { open, onToggle } = useDisclosure();
 
+  if (mailbox?.value?.scheduledEmails > 0) {
+    return (
+      <p
+        tabIndex={0}
+        role={'button'}
+        className={cn('hover:text-gray-500', !user && 'text-gray-400')}
+        onClick={() => {
+          store.ui.commandMenu.setType('ActiveFlowUpdateInfo');
+          store.ui.commandMenu.setContext({
+            ...store.ui.commandMenu.context,
+            meta: {
+              type: 'senders',
+            },
+          });
+          store.ui.commandMenu.setOpen(true);
+        }}
+      >
+        {user?.name || 'Not set yet'}
+      </p>
+    );
+  }
+
   return (
     <Popover open={open} onOpenChange={onToggle}>
       <PopoverTrigger>


### PR DESCRIPTION
…
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Show modal in `UserCell` when updating sender with scheduled emails by opening `commandMenu`.
> 
>   - **Behavior**:
>     - In `UserCell`, if `mailbox.value.scheduledEmails > 0`, a modal is shown by setting `commandMenu` type to `ActiveFlowUpdateInfo` and opening it.
>     - The modal is triggered when the user clicks on the sender's name.
>   - **UI Components**:
>     - Adds conditional rendering in `UserCell` to handle scheduled emails scenario.
>     - Uses `store.ui.commandMenu` to manage modal state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 51a78621c60b47c3d8d0771634156cedc79bc243. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->