### PR TITLE
COS-6279: Use tags for status cell in contracts table. Fix padding in tag variants, so they match design scheme correctly

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contracts/Cells/status/StatusCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contracts/Cells/status/StatusCell.tsx
@@ -1,4 +1,5 @@
 import { ContractStatus } from '@graphql/types';
+import { Tag, TagLabel } from '@ui/presentation/Tag';
 
 interface StatusCellProps {
   className?: string;
@@ -8,19 +9,39 @@ interface StatusCellProps {
 export function renderStatusNode(type: ContractStatus | null | undefined) {
   switch (type) {
     case ContractStatus.Draft:
-      return <>Draft</>;
+      return (
+        <Tag variant='subtle' colorScheme='grayModern'>
+          <TagLabel>Draft</TagLabel>
+        </Tag>
+      );
 
     case ContractStatus.Live:
-      return <>Live</>;
+      return (
+        <Tag variant='subtle' colorScheme='success'>
+          <TagLabel>Live</TagLabel>
+        </Tag>
+      );
 
     case ContractStatus.Ended:
-      return <>Ended</>;
+      return (
+        <Tag variant='subtle' colorScheme='grayModern'>
+          <TagLabel>Ended</TagLabel>
+        </Tag>
+      );
 
     case ContractStatus.OutOfContract:
-      return <>Out of contract</>;
+      return (
+        <Tag variant='subtle' colorScheme='warning'>
+          <TagLabel>Out of contract</TagLabel>
+        </Tag>
+      );
 
     case ContractStatus.Scheduled:
-      return <>Scheduled</>;
+      return (
+        <Tag variant='subtle' colorScheme='primary'>
+          <TagLabel>Scheduled</TagLabel>
+        </Tag>
+      );
 
     default:
       return '';

--- a/packages/apps/frontera/src/ui/presentation/Tag/Tag.variants.ts
+++ b/packages/apps/frontera/src/ui/presentation/Tag/Tag.variants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const tagSubtleVariant = cva(
-  ['w-fit', 'flex', 'items-center', 'rounded-[6px]', 'leading-none'],
+  ['w-fit', 'flex', 'items-center', 'rounded-[4px]', 'leading-none'],
   {
     variants: {
       colorScheme: {
@@ -34,7 +34,7 @@ export const tagSubtleVariant = cva(
 );
 
 export const tagSolidVariant = cva(
-  ['w-fit', 'flex', 'items-center', 'rounded-[6px]', 'leading-none'],
+  ['w-fit', 'flex', 'items-center', 'rounded-[4px]', 'leading-none'],
   {
     variants: {
       colorScheme: {
@@ -67,7 +67,7 @@ export const tagSolidVariant = cva(
 );
 
 export const tagOutlineVariant = cva(
-  ['w-fit', 'flex', 'items-center', 'rounded-[6px]', 'leading-none'],
+  ['w-fit', 'flex', 'items-center', 'rounded-[4px]', 'leading-none'],
   {
     variants: {
       colorScheme: {
@@ -222,8 +222,8 @@ export const tagOutlineVariant = cva(
 export const tagSizeVariant = cva('', {
   variants: {
     size: {
-      sm: 'px-2 text-xs',
-      md: 'px-2 text-sm',
+      sm: 'px-1 text-xs',
+      md: 'px-1 text-sm',
       lg: 'px-3 text-base',
     },
   },

--- a/packages/apps/frontera/src/ui/presentation/Tag/codegen-variants.ts
+++ b/packages/apps/frontera/src/ui/presentation/Tag/codegen-variants.ts
@@ -41,8 +41,8 @@ const variantsClasses: Record<string, (color: string) => string> = {
 };
 
 const sizeClasses: Record<string, string> = {
-  sm: 'px-2 text-xs',
-  md: 'px-2 text-sm',
+  sm: 'px-1 text-xs',
+  md: 'px-1 text-sm',
   lg: 'px-3 text-base',
 };
 
@@ -50,7 +50,7 @@ const tagCommonClasses = `[
   'w-fit',
   'flex',
   'items-center',
-  'rounded-[6px]',
+  'rounded-[4px]',
   'leading-none',
 ]`;
 


### PR DESCRIPTION
… t
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated `StatusCell` to use tags for contract statuses and adjusted tag variant padding and border-radius.
> 
>   - **UI Components**:
>     - `StatusCell.tsx`: Updated `renderStatusNode()` to use `Tag` and `TagLabel` for displaying contract statuses with specific color schemes.
>   - **Styles**:
>     - `Tag.variants.ts`: Adjusted padding and border-radius for `tagSubtleVariant`, `tagSolidVariant`, and `tagOutlineVariant` to `rounded-[4px]` and `px-1` for `sm` and `md` sizes.
>     - `codegen-variants.ts`: Updated size classes to `px-1` for `sm` and `md` sizes and border-radius to `rounded-[4px]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 185176e897d43e827b0dc17de1a77738f7a94bb3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->