### PR TITLE
Get parents and sub orgs

### DIFF
--- a/packages/server/customer-os-api/graph/resolver/organizationV2.resolvers.go
+++ b/packages/server/customer-os-api/graph/resolver/organizationV2.resolvers.go
@@ -6,6 +6,8 @@ package resolver
 
 import (
 	"context"
+	neo4jentity "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
+	neo4jrepository "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/repository"
 	"sync"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -15,7 +17,7 @@ import (
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/common"
 	commonModel "github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 // UIOrganizations is the resolver for the ui_organizations field.
@@ -29,12 +31,13 @@ func (r *queryResolver) UIOrganizations(ctx context.Context, ids []string) ([]*m
 	mapResponse := map[string]*model.OrganizationUIDetails{}
 	for _, id := range ids {
 		mapResponse[id] = &model.OrganizationUIDetails{
-			ID:          id,
-			Contacts:    make([]string, 0),
-			Contracts:   make([]string, 0),
-			SocialMedia: make([]*model.Social, 0),
-			Tags:        make([]*model.Tag, 0),
-			Locations:   make([]*model.Location, 0),
+			ID:           id,
+			Contacts:     make([]string, 0),
+			Contracts:    make([]string, 0),
+			SocialMedia:  make([]*model.Social, 0),
+			Tags:         make([]*model.Tag, 0),
+			Locations:    make([]*model.Location, 0),
+			Subsidiaries: make([]string, 0),
 		}
 	}
 
@@ -202,12 +205,51 @@ func (r *queryResolver) UIOrganizations(ctx context.Context, ids []string) ([]*m
 		}
 	}(&mapResponse)
 
+	wg.Add(1)
+	go func(resp *map[string]*model.OrganizationUIDetails) {
+		span, ctx := opentracing.StartSpanFromContext(ctx, "QueryResolver.UIOrganizations.GetSubsidiaries")
+		defer span.Finish()
+		defer wg.Done()
+		tracing.SetDefaultResolverSpanTags(ctx, span)
+
+		subsidiaries, err := r.Services.Repositories.Neo4jRepositories.OrganizationReadRepository.GetLinkedSubOrganizations(ctx, tenant, ids, neo4jrepository.Relationship_Subsidiary)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			setError(err)
+			return
+		}
+
+		for _, sub := range subsidiaries {
+			(*resp)[sub.LinkedNodeId].Subsidiaries = append((*resp)[sub.LinkedNodeId].Subsidiaries, utils.GetStringPropOrEmpty(utils.GetPropsFromNode(*sub.Node), "id"))
+		}
+	}(&mapResponse)
+
+	wg.Add(1)
+	go func(resp *map[string]*model.OrganizationUIDetails) {
+		span, ctx := opentracing.StartSpanFromContext(ctx, "QueryResolver.UIOrganizations.GetParents")
+		defer span.Finish()
+		defer wg.Done()
+		tracing.SetDefaultResolverSpanTags(ctx, span)
+
+		parents, err := r.Services.Repositories.Neo4jRepositories.OrganizationReadRepository.GetLinkedParentOrganizations(ctx, tenant, ids, neo4jrepository.Relationship_Subsidiary)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			setError(err)
+			return
+		}
+
+		for _, par := range parents {
+			(*resp)[par.LinkedNodeId].ParentID = utils.StringPtr(utils.GetStringPropOrEmpty(utils.GetPropsFromNode(*par.Node), "id"))
+			(*resp)[par.LinkedNodeId].ParentName = utils.StringPtr(utils.GetStringPropOrEmpty(utils.GetPropsFromNode(*par.Node), string(neo4jentity.OrganizationPropertyName)))
+		}
+	}(&mapResponse)
+
 	wg.Wait()
 
 	if firstErr != nil {
 		tracing.TraceErr(opentracing.SpanFromContext(ctx), firstErr)
-		r.log.Errorf("Failed to get organizations: %v", firstErr)
-		graphql.AddErrorf(ctx, "Failed to get organizations: %v", firstErr)
+		r.log.Errorf("Failed to get organizations: %w", firstErr)
+		graphql.AddErrorf(ctx, "Failed to get organizations: %w", firstErr)
 		return nil, nil
 	}
 

--- a/packages/server/customer-os-api/repository/organization_repository.go
+++ b/packages/server/customer-os-api/repository/organization_repository.go
@@ -17,10 +17,6 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 )
 
-const (
-	Relationship_Subsidiary = "SUBSIDIARY_OF"
-)
-
 type OrganizationRepository interface {
 	CountCustomers(ctx context.Context, tenant string) (int64, error)
 	GetPaginatedOrganizations(ctx context.Context, tenant string, skip, limit int, filter *utils.CypherFilter, sorting *utils.CypherSort) (*utils.DbNodesWithTotalCount, error)
@@ -31,8 +27,6 @@ type OrganizationRepository interface {
 	GetAllForEmails(ctx context.Context, tenant string, emailIds []string) ([]*utils.DbNodeAndId, error)
 	GetAllForPhoneNumbers(ctx context.Context, tenant string, phoneNumberIds []string) ([]*utils.DbNodeAndId, error)
 	GetAllForJobRoles(ctx context.Context, tenant string, jobRoleIds []string) ([]*utils.DbNodeAndId, error)
-	GetLinkedSubOrganizations(ctx context.Context, tenant string, parentOrganizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error)
-	GetLinkedParentOrganizations(ctx context.Context, tenant string, organizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error)
 	RemoveOwner(ctx context.Context, tenant, organizationId string) (*dbtype.Node, error)
 	GetSuggestedMergePrimaryOrganizations(ctx context.Context, organizationIds []string) ([]*utils.DbNodeWithRelationAndId, error)
 	GetMinMaxRenewalForecastArr(ctx context.Context) (float64, float64, error)
@@ -631,65 +625,6 @@ func (r *organizationRepository) GetAllForJobRoles(ctx context.Context, tenant s
 		return nil, err
 	}
 	return result.([]*utils.DbNodeAndId), err
-}
-
-func (r *organizationRepository) GetLinkedSubOrganizations(ctx context.Context, tenant string, parentOrganizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationRepository.GetLinkedSubOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-
-	query := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(parent:Organization)<-[rel:%s]-(org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(t)
-								WHERE parent.id IN $parentOrganizationIds
-								RETURN org, rel, parent.id ORDER BY org.name`, relationName)
-	span.LogFields(log.String("query", query))
-
-	session := utils.NewNeo4jReadSession(ctx, *r.driver)
-	defer session.Close(ctx)
-	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
-		if queryResult, err := tx.Run(ctx, query,
-			map[string]any{
-				"tenant":                tenant,
-				"parentOrganizationIds": parentOrganizationIds,
-			}); err != nil {
-			return nil, err
-		} else {
-			return utils.ExtractAllRecordsAsDbNodeWithRelationAndId(ctx, queryResult, err)
-		}
-	})
-	if err != nil {
-		return nil, err
-	}
-	return result.([]*utils.DbNodeWithRelationAndId), err
-}
-
-func (r *organizationRepository) GetLinkedParentOrganizations(ctx context.Context, tenant string, organizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationRepository.GetLinkedParentOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-
-	query := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(sub:Organization)-[rel:%s]->(org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(t)
-			WHERE sub.id IN $organizationIds
-			RETURN org, rel, sub.id ORDER BY org.name`, relationName)
-	span.LogFields(log.String("query", query))
-
-	session := utils.NewNeo4jReadSession(ctx, *r.driver)
-	defer session.Close(ctx)
-
-	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
-		if queryResult, err := tx.Run(ctx, query,
-			map[string]any{
-				"tenant":          tenant,
-				"organizationIds": organizationIds,
-			}); err != nil {
-			return nil, err
-		} else {
-			return utils.ExtractAllRecordsAsDbNodeWithRelationAndId(ctx, queryResult, err)
-		}
-	})
-	if err != nil {
-		return nil, err
-	}
-	return result.([]*utils.DbNodeWithRelationAndId), err
 }
 
 func (r *organizationRepository) RemoveOwner(ctx context.Context, tenant, organizationID string) (*dbtype.Node, error) {

--- a/packages/server/customer-os-api/service/organization_service.go
+++ b/packages/server/customer-os-api/service/organization_service.go
@@ -7,6 +7,7 @@ import (
 	commonmodel "github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model"
 	neo4jentity "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/mapper"
+	neo4jrepository "github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/repository"
 	"reflect"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
@@ -338,7 +339,7 @@ func (s *organizationService) GetSubsidiariesForOrganizations(ctx context.Contex
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 	span.LogFields(log.Object("parentOrganizationIds", parentOrganizationIds))
 
-	dbEntries, err := s.repositories.OrganizationRepository.GetLinkedSubOrganizations(ctx, common.GetTenantFromContext(ctx), parentOrganizationIds, repository.Relationship_Subsidiary)
+	dbEntries, err := s.repositories.Neo4jRepositories.OrganizationReadRepository.GetLinkedSubOrganizations(ctx, common.GetTenantFromContext(ctx), parentOrganizationIds, neo4jrepository.Relationship_Subsidiary)
 	if err != nil {
 		s.log.Errorf("(organizationService.GetSubsidiariesForOrganizations) Error getting linked organizations: {%v}", err.Error())
 		tracing.TraceErr(span, err)
@@ -486,7 +487,7 @@ func (s *organizationService) GetSubsidiariesOfForOrganizations(ctx context.Cont
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 	span.LogFields(log.Object("organizationIds", organizationIds))
 
-	dbEntries, err := s.repositories.OrganizationRepository.GetLinkedParentOrganizations(ctx, common.GetTenantFromContext(ctx), organizationIds, repository.Relationship_Subsidiary)
+	dbEntries, err := s.repositories.Neo4jRepositories.OrganizationReadRepository.GetLinkedParentOrganizations(ctx, common.GetTenantFromContext(ctx), organizationIds, neo4jrepository.Relationship_Subsidiary)
 	if err != nil {
 		s.log.Errorf("(organizationService.GetSubsidiariesOfForOrganizations) Error getting linked parent organizations: {%v}", err.Error())
 		tracing.TraceErr(span, err)

--- a/packages/server/customer-os-neo4j-repository/entity/organization.go
+++ b/packages/server/customer-os-neo4j-repository/entity/organization.go
@@ -12,6 +12,7 @@ const (
 	OrganizationPropertyEmployees                 OrganizationProperty = "employees"
 	OrganizationPropertyUpdatedAt                 OrganizationProperty = "updatedAt"
 	OrganizationPropertyYearFounded               OrganizationProperty = "yearFounded"
+	OrganizationPropertyName                      OrganizationProperty = "name"
 	OrganizationPropertyHide                      OrganizationProperty = "hide"
 	OrganizationPropertyStage                     OrganizationProperty = "stage"
 	OrganizationPropertyIndustry                  OrganizationProperty = "industry"

--- a/packages/server/customer-os-neo4j-repository/repository/organization_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/organization_read_repository.go
@@ -15,6 +15,10 @@ import (
 	"time"
 )
 
+const (
+	Relationship_Subsidiary = "SUBSIDIARY_OF"
+)
+
 type TenantAndOrganizationId struct {
 	Tenant         string
 	OrganizationId string
@@ -61,6 +65,8 @@ type OrganizationReadRepository interface {
 	GetOrganizationsWithEmail(ctx context.Context, tenant, email string) ([]*dbtype.Node, error)
 	GetOrganizationsToCheck(ctx context.Context, minutesSinceLastUpdate, hoursSinceLastCheck, limit int) ([]TenantAndOrganization, error)
 	GetActiveOrganizationIdsByDomain(ctx context.Context, tenant string, domains []string) (map[string]string, error)
+	GetLinkedSubOrganizations(ctx context.Context, tenant string, parentOrganizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error)
+	GetLinkedParentOrganizations(ctx context.Context, tenant string, organizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error)
 }
 
 type organizationReadRepository struct {
@@ -1370,4 +1376,70 @@ func (r *organizationReadRepository) GetActiveOrganizationIdsByDomain(ctx contex
 		output[v.Values[0].(string)] = v.Values[1].(string)
 	}
 	return output, err
+}
+
+func (r *organizationReadRepository) GetLinkedSubOrganizations(ctx context.Context, tenant string, parentOrganizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetLinkedSubOrganizations")
+	defer span.Finish()
+	tracing.TagComponentNeo4jRepository(span)
+	tracing.TagTenant(span, tenant)
+
+	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(parent:Organization)<-[rel:%s]-(org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(t)
+								WHERE parent.id IN $parentOrganizationIds
+								RETURN org, rel, parent.id ORDER BY org.name`, relationName)
+	params := map[string]any{
+		"tenant":                tenant,
+		"parentOrganizationIds": parentOrganizationIds,
+	}
+	span.LogFields(log.String("cypher", cypher))
+	tracing.LogObjectAsJson(span, "params", params)
+
+	session := r.prepareReadSession(ctx)
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
+			return nil, err
+		} else {
+			return utils.ExtractAllRecordsAsDbNodeWithRelationAndId(ctx, queryResult, err)
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]*utils.DbNodeWithRelationAndId), err
+}
+
+func (r *organizationReadRepository) GetLinkedParentOrganizations(ctx context.Context, tenant string, organizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetLinkedParentOrganizations")
+	defer span.Finish()
+	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	tracing.TagComponentNeo4jRepository(span)
+	tracing.TagTenant(span, tenant)
+
+	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(sub:Organization)-[rel:%s]->(org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(t)
+			WHERE sub.id IN $organizationIds
+			RETURN org, rel, sub.id ORDER BY org.name`, relationName)
+	params := map[string]any{
+		"tenant":          tenant,
+		"organizationIds": organizationIds,
+	}
+
+	span.LogFields(log.String("cypher", cypher))
+	tracing.LogObjectAsJson(span, "params", params)
+
+	session := r.prepareReadSession(ctx)
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
+			return nil, err
+		} else {
+			return utils.ExtractAllRecordsAsDbNodeWithRelationAndId(ctx, queryResult, err)
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]*utils.DbNodeWithRelationAndId), err
 }


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds functionality to retrieve parent and subsidiary organizations, refactoring repository methods and updating service and resolver layers.
> 
>   - **Behavior**:
>     - Adds retrieval of parent and subsidiary organizations in `UIOrganizations` resolver in `organizationV2.resolvers.go`.
>     - Updates error handling in `UIOrganizations` to use `%w` for error wrapping.
>   - **Repositories**:
>     - Moves `GetLinkedSubOrganizations` and `GetLinkedParentOrganizations` from `organization_repository.go` to `organization_read_repository.go`.
>     - Adds `Relationship_Subsidiary` constant to `organization_read_repository.go`.
>   - **Service**:
>     - Updates `GetSubsidiariesForOrganizations` and `GetSubsidiariesOfForOrganizations` in `organization_service.go` to use new repository methods.
>   - **Models**:
>     - Adds `OrganizationPropertyName` to `organization.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8affd59fe846bb730a9794315f30969329c25a54. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->