### PR TITLE
COS-5798: When opening an email in timeline user should be able to respond if they have a MailStack address, not just a Gmail/Outlook account linked.

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/email/compose-email/ParticipantsSelectGroup.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/email/compose-email/ParticipantsSelectGroup.tsx
@@ -1,18 +1,20 @@
 import { useField } from 'react-inverted-form';
 import { useSearchParams } from 'react-router-dom';
-import React, { useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
+
+import { observer } from 'mobx-react-lite';
 
 import { cn } from '@ui/utils/cn';
 import { InputProps } from '@ui/form/Input';
 import { Button } from '@ui/form/Button/Button';
 import { useStore } from '@shared/hooks/useStore';
+import { useChannel } from '@shared/hooks/useChannel';
 import { FormSelect } from '@ui/form/Select/FormSelect';
 import { getContainerClassNames } from '@ui/form/Select';
-import { getGraphQLClient } from '@shared/util/getGraphQLClient';
 import { useOutsideClick } from '@ui/utils/hooks/useOutsideClick';
-import { useGlobalCacheQuery } from '@shared/graphql/global_Cache.generated';
-import { EmailSubjectInput } from '@organization/components/Timeline/PastZone/events/email/compose-email/EmailSubjectInput';
-import { EmailParticipantSelect } from '@organization/components/Timeline/PastZone/events/email/compose-email/EmailParticipantSelect';
+
+import { EmailSubjectInput } from './EmailSubjectInput';
+import { EmailParticipantSelect } from './EmailParticipantSelect';
 
 import postStamp from '/backgrounds/organization/post-stamp.webp';
 
@@ -27,226 +29,218 @@ interface ParticipantSelectGroupGroupProps extends InputProps {
 }
 
 // TODO drop this type of query
-export const ParticipantsSelectGroup = ({
-  attendees = [],
-  cc = [],
-  bcc = [],
-  modal,
-  formId,
-}: ParticipantSelectGroupGroupProps) => {
-  const store = useStore();
-  const [searchParams] = useSearchParams();
-  const params = new URLSearchParams(searchParams?.toString() ?? '');
-  const id = params.get('events') ?? undefined;
-
-  const client = getGraphQLClient();
-  const { data: globalCacheData } = useGlobalCacheQuery(client);
-
-  const { getInputProps: fromGetInputProps } = useField('from', formId);
-  const { getInputProps: fromProviderGetInputProps } = useField(
-    'fromProvider',
+export const ParticipantsSelectGroup = observer(
+  ({
+    attendees = [],
+    cc = [],
+    bcc = [],
+    modal,
     formId,
-  );
-  const { onChange: fromOnChange, value: fromValue } = fromGetInputProps();
-  const { onChange: fromProviderOnChange } = fromProviderGetInputProps();
+  }: ParticipantSelectGroupGroupProps) => {
+    const store = useStore();
+    const [searchParams] = useSearchParams();
+    const params = new URLSearchParams(searchParams?.toString() ?? '');
+    const id = params.get('events') ?? undefined;
+    const { currentUserId } = useChannel(
+      `finder:${store.session.value.tenant}`,
+    );
+    const globalCacheData = store.globalCache.value;
+    const mailboxes = store.mailboxes.toArray();
 
-  const [showCC, setShowCC] = useState(false);
-  const [showBCC, setShowBCC] = useState(false);
-  const [isFocused, setIsFocused] = useState(false);
-  const [focusedItemIndex, setFocusedItemIndex] = useState<false | number>(
-    false,
-  );
-  const ref = React.useRef(null);
+    const userMailboxes = mailboxes.filter(
+      (v) => v.value.userId === currentUserId,
+    );
 
-  useOutsideClick({
-    ref: ref,
-    handler: () => {
-      setIsFocused(false);
-      setFocusedItemIndex(false);
-      setShowCC(false);
-      setShowBCC(false);
-    },
-  });
+    const { getInputProps: fromGetInputProps } = useField('from', formId);
+    const { getInputProps: fromProviderGetInputProps } = useField(
+      'fromProvider',
+      formId,
+    );
+    const { onChange: fromOnChange, value: fromValue } = fromGetInputProps();
+    const { onChange: fromProviderOnChange } = fromProviderGetInputProps();
 
-  const handleFocus = (index: number) => {
-    setIsFocused(true);
-    setFocusedItemIndex(index);
-  };
+    const [showCC, setShowCC] = useState(false);
+    const [showBCC, setShowBCC] = useState(false);
+    const [isFocused, setIsFocused] = useState(false);
+    const [focusedItemIndex, setFocusedItemIndex] = useState<false | number>(
+      false,
+    );
+    const ref = React.useRef(null);
 
-  useEffect(() => {
-    if (showCC && !isFocused) {
-      handleFocus(1);
-    }
-  }, [showCC]);
+    useOutsideClick({
+      ref: ref,
+      handler: () => {
+        setIsFocused(false);
+        setFocusedItemIndex(false);
+        setShowCC(false);
+        setShowBCC(false);
+      },
+    });
 
-  useEffect(() => {
-    if (showBCC && !isFocused) {
-      handleFocus(2);
-    }
-  }, [showBCC]);
+    const handleFocus = (index: number) => {
+      setIsFocused(true);
+      setFocusedItemIndex(index);
+    };
 
-  const [fromOptions, setFromOptions] = useState(
-    [] as Array<{
-      label: string;
-      value: string;
-      active: boolean;
-      provider: string;
-    }>,
-  );
+    useEffect(() => {
+      if (showCC && !isFocused) {
+        handleFocus(1);
+      }
+    }, [showCC]);
 
-  useEffect(() => {
-    if (globalCacheData) {
-      const options = [] as Array<{
-        label: string;
-        value: string;
-        active: boolean;
-        provider: string;
-      }>;
+    useEffect(() => {
+      if (showBCC && !isFocused) {
+        handleFocus(2);
+      }
+    }, [showBCC]);
 
-      globalCacheData?.global_Cache?.activeEmailTokens
-        .filter((a) => (id && attendees.indexOf(a.email) > -1) || !id)
-        .forEach((v) => {
-          options.push({
-            label: v.email,
-            value: v.email,
-            provider: v.provider,
-            active: true,
-          });
-        });
+    const fromOptions = useMemo(() => {
+      const activeEmailOptions = globalCacheData?.activeEmailTokens
+        .filter((a) => (id && attendees.includes(a.email)) || !id)
+        .map((v) => ({
+          label: v.email,
+          value: v.email,
+          provider: v.provider,
+          active: true,
+        }));
 
-      globalCacheData?.global_Cache?.inactiveEmailTokens
-        .filter((a) => (id && attendees.indexOf(a.email) > -1) || !id)
-        .forEach((v) => {
-          options.push({
-            label: v.email,
-            value: v.email,
-            provider: v.provider,
-            active: false,
-          });
-        });
+      const inactiveEmailOptions = globalCacheData?.inactiveEmailTokens
+        .filter((a) => (id && attendees.includes(a.email)) || !id)
+        .map((v) => ({
+          label: v.email,
+          value: v.email,
+          provider: v.provider,
+          active: false,
+        }));
 
-      globalCacheData?.global_Cache?.mailboxes
-        .filter((v) => attendees.indexOf(v) > -1)
-        .forEach((v) => {
-          options.push({
-            label: v,
-            value: v,
-            provider: 'mailbox',
-            active: true,
-          });
-        });
+      const mailboxOptions = globalCacheData?.mailboxes
+        .filter((v) => attendees.includes(v))
+        .map((v) => ({
+          label: v,
+          value: v,
+          provider: 'mailbox',
+          active: true,
+        }));
 
-      setFromOptions(options);
-    }
-  }, [
-    globalCacheData?.global_Cache?.activeEmailTokens,
-    globalCacheData?.global_Cache?.inactiveEmailTokens,
-    globalCacheData?.global_Cache?.mailboxes,
-    id,
-    attendees,
-  ]);
+      const userMailboxOptions = userMailboxes.map((v) => ({
+        label: v.value.mailbox,
+        value: v.value.mailbox,
+        provider: 'mailbox',
+        active: true,
+      }));
 
-  useEffect(() => {
-    if (!fromValue && fromOptions && fromOptions.length > 0) {
-      const activeOption = fromOptions.filter(
-        (v) => v.value === store.session.value.profile.email && v.active,
-      );
+      return [
+        ...(activeEmailOptions || []),
+        ...(inactiveEmailOptions || []),
+        ...(mailboxOptions || []),
+        ...(userMailboxOptions || []),
+      ];
+    }, [globalCacheData, id, attendees, userMailboxes]);
 
-      if (activeOption && activeOption.length > 0) {
-        fromOnChange(activeOption[0]);
-        fromProviderOnChange(activeOption[0].provider);
-      } else {
-        const firstActive = fromOptions.filter((v) => v.active);
+    useEffect(() => {
+      if (!fromValue && fromOptions && fromOptions.length > 0) {
+        const activeOption = fromOptions.filter(
+          (v) => v.value === store.session.value.profile.email && v.active,
+        );
 
-        if (firstActive && firstActive.length > 0) {
-          fromOnChange(firstActive[0]);
-          fromProviderOnChange(firstActive[0].provider);
+        if (activeOption && activeOption.length > 0) {
+          fromOnChange(activeOption[0]);
+          fromProviderOnChange(activeOption[0].provider);
+        } else {
+          const firstActive = fromOptions.filter((v) => v.active);
+
+          if (firstActive && firstActive.length > 0) {
+            fromOnChange(firstActive[0]);
+            fromProviderOnChange(firstActive[0].provider);
+          }
         }
       }
-    }
-  }, [fromValue, fromOptions]);
+    }, [fromValue, fromOptions]);
 
-  return (
-    <div
-      ref={ref}
-      className='flex justify-between mt-3'
-      onMouseDown={(e) => {
-        e.stopPropagation();
-      }}
-    >
-      <div className='w-[100%]'>
-        <div className='flex items-baseline mb-[-1px] mt-0 flex-1 overflow-visible'>
-          <span className='text-gray-700 font-semibold mr-1'>From:</span>
-          <FormSelect
-            size='sm'
-            name='from'
+    return (
+      <div
+        ref={ref}
+        className='flex justify-between mt-3'
+        onMouseDown={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <div className='w-[100%]'>
+          <div className='flex items-baseline mb-[-1px] mt-0 flex-1 overflow-visible'>
+            <span className='text-gray-700 font-semibold mr-1'>From:</span>
+            <FormSelect
+              size='sm'
+              name='from'
+              formId={formId}
+              options={fromOptions}
+              isOptionDisabled={(option) => !option.active}
+              classNames={{
+                container: () =>
+                  getContainerClassNames(undefined, 'flushed', { size: 'sm' }),
+              }}
+              getOptionLabel={(props) => {
+                const { value } = props;
+
+                const activeOption = (fromOptions ?? []).find(
+                  (v) => v.value === value,
+                );
+
+                return (
+                  <div
+                    className={
+                      'flex items-center gap-2 justify-between w-100 ' +
+                      (activeOption?.active === false ? 'opacity-50' : '')
+                    }
+                  >
+                    <div className={'flex'}>
+                      <span>{activeOption?.label}</span>
+                    </div>
+                    <div className={'flex'}>
+                      {activeOption?.active === false && (
+                        <span className='text-red-500'>Expired</span>
+                      )}
+                    </div>
+                  </div>
+                ) as unknown as string;
+              }}
+            />
+          </div>
+
+          <EmailParticipantSelect
+            fieldName='to'
+            entryType='To'
             formId={formId}
-            options={fromOptions}
-            isOptionDisabled={(option) => !option.active}
-            classNames={{
-              container: () =>
-                getContainerClassNames(undefined, 'flushed', { size: 'sm' }),
-            }}
-            getOptionLabel={(props) => {
-              const { value } = props;
-
-              const activeOption = (fromOptions ?? []).find(
-                (v) => v.value === value,
-              );
-
-              return (
-                <div
-                  className={
-                    'flex items-center gap-2 justify-between w-100 ' +
-                    (activeOption?.active === false ? 'opacity-50' : '')
-                  }
-                >
-                  <div className={'flex'}>
-                    <span>{activeOption?.label}</span>
-                  </div>
-                  <div className={'flex'}>
-                    {activeOption?.active === false && (
-                      <span className='text-red-500'>Expired</span>
-                    )}
-                  </div>
-                </div>
-              ) as unknown as string;
-            }}
+            autofocus={focusedItemIndex === 0}
           />
-        </div>
+          {isFocused && (
+            <>
+              {(showCC || !!cc.length) && (
+                <EmailParticipantSelect
+                  fieldName='cc'
+                  entryType='CC'
+                  formId={formId}
+                  autofocus={focusedItemIndex === 1}
+                />
+              )}
+              {(showBCC || !!bcc.length) && (
+                <EmailParticipantSelect
+                  formId={formId}
+                  fieldName='bcc'
+                  entryType='BCC'
+                  autofocus={focusedItemIndex === 2}
+                />
+              )}
+            </>
+          )}
 
-        <EmailParticipantSelect
-          fieldName='to'
-          entryType='To'
-          formId={formId}
-          autofocus={focusedItemIndex === 0}
-        />
-        {isFocused && (
-          <>
-            {(showCC || !!cc.length) && (
-              <EmailParticipantSelect
-                fieldName='cc'
-                entryType='CC'
-                formId={formId}
-                autofocus={focusedItemIndex === 1}
-              />
-            )}
-            {(showBCC || !!bcc.length) && (
-              <EmailParticipantSelect
-                formId={formId}
-                fieldName='bcc'
-                entryType='BCC'
-                autofocus={focusedItemIndex === 2}
-              />
-            )}
-          </>
-        )}
-
-        {!isFocused && (
-          <div
-            className={cn(isFocused ? 'flex-1' : 'unset', 'flex mt-1 flex-col')}
-          >
-            {/* <div
+          {!isFocused && (
+            <div
+              className={cn(
+                isFocused ? 'flex-1' : 'unset',
+                'flex mt-1 flex-col',
+              )}
+            >
+              {/* <div
               className={cn(
                 !cc.length && !bcc.length ? 'flex-1' : 'unset',
                 'flex',
@@ -271,74 +265,75 @@ export const ParticipantsSelectGroup = ({
               </span>
             </div> */}
 
-            {!!cc.length && (
-              <div
-                role='button'
-                onClick={() => handleFocus(1)}
-                onFocusCapture={() => handleFocus(1)}
-                aria-label='Click to input participant data'
-                className={cn(!bcc.length ? 'flex-1' : 'unset', 'flex')}
-              >
-                <span className='text-gray-700 font-semibold mr-1'>CC:</span>
-                <p className='text-gray-500 line-clamp-1'>
-                  {[...cc].map((email) => email.value).join(', ')}
-                </p>
-              </div>
-            )}
-            {!!bcc.length && (
-              <div
-                role='button'
-                className='flex'
-                onClick={() => handleFocus(2)}
-                onFocusCapture={() => handleFocus(2)}
-                aria-label='Click to input participant data'
-              >
-                <span className='text-gray-700 font-semibold mr-1'>BCC:</span>
-                <p className='text-gray-500 line-clamp-1'>
-                  {[...bcc].map((email) => email.value).join(', ')}
-                </p>
-              </div>
-            )}
+              {!!cc.length && (
+                <div
+                  role='button'
+                  onClick={() => handleFocus(1)}
+                  onFocusCapture={() => handleFocus(1)}
+                  aria-label='Click to input participant data'
+                  className={cn(!bcc.length ? 'flex-1' : 'unset', 'flex')}
+                >
+                  <span className='text-gray-700 font-semibold mr-1'>CC:</span>
+                  <p className='text-gray-500 line-clamp-1'>
+                    {[...cc].map((email) => email.value).join(', ')}
+                  </p>
+                </div>
+              )}
+              {!!bcc.length && (
+                <div
+                  role='button'
+                  className='flex'
+                  onClick={() => handleFocus(2)}
+                  onFocusCapture={() => handleFocus(2)}
+                  aria-label='Click to input participant data'
+                >
+                  <span className='text-gray-700 font-semibold mr-1'>BCC:</span>
+                  <p className='text-gray-500 line-clamp-1'>
+                    {[...bcc].map((email) => email.value).join(', ')}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+          <EmailSubjectInput formId={formId} fieldName='subject' />
+        </div>
+        <div className='flex max-w-[64px] mr-4 items-start'>
+          {!showCC && (
+            <Button
+              size='sm'
+              variant='ghost'
+              className='text-gray-400 font-semibold px-1'
+              onClick={() => {
+                setShowCC(true);
+                setFocusedItemIndex(1);
+              }}
+            >
+              CC
+            </Button>
+          )}
+
+          {!showBCC && (
+            <Button
+              size='sm'
+              variant='ghost'
+              color='gray.400'
+              className='text-gray-400 font-semibold px-1'
+              onClick={() => {
+                setShowBCC(true);
+                setFocusedItemIndex(2);
+              }}
+            >
+              BCC
+            </Button>
+          )}
+        </div>
+
+        {!modal && (
+          <div>
+            <img width={54} alt='Email' height={70} src={postStamp} />
           </div>
         )}
-        <EmailSubjectInput formId={formId} fieldName='subject' />
       </div>
-      <div className='flex max-w-[64px] mr-4 items-start'>
-        {!showCC && (
-          <Button
-            size='sm'
-            variant='ghost'
-            className='text-gray-400 font-semibold px-1'
-            onClick={() => {
-              setShowCC(true);
-              setFocusedItemIndex(1);
-            }}
-          >
-            CC
-          </Button>
-        )}
-
-        {!showBCC && (
-          <Button
-            size='sm'
-            variant='ghost'
-            color='gray.400'
-            className='text-gray-400 font-semibold px-1'
-            onClick={() => {
-              setShowBCC(true);
-              setFocusedItemIndex(2);
-            }}
-          >
-            BCC
-          </Button>
-        )}
-      </div>
-
-      {!modal && (
-        <div>
-          <img width={54} alt='Email' height={70} src={postStamp} />
-        </div>
-      )}
-    </div>
-  );
-};
+    );
+  },
+);

--- a/packages/apps/frontera/src/routes/src/components/UserHexagon/UserHexagon.tsx
+++ b/packages/apps/frontera/src/routes/src/components/UserHexagon/UserHexagon.tsx
@@ -93,7 +93,7 @@ const ClippedImage = ({
         <div
           role='img'
           aria-label={name}
-          className={`w-[24px] h-[26px] bg-cover bg-center`}
+          className={`w-[24px] h-[26px] bg-cover bg-center -mr-[0.5px]`}
           style={{
             backgroundImage: `url(${url})`,
             backgroundSize: 'contain',


### PR DESCRIPTION
…

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhanced email composition to support MailStack addresses and adjusted UI in `UserHexagon`.
> 
>   - **Email Composition**:
>     - `ParticipantsSelectGroup.tsx`: Enhanced to support MailStack addresses in 'From' options by including user mailboxes.
>     - Utilizes `useMemo` to compute `fromOptions` including active/inactive email tokens and mailboxes.
>     - Uses `useChannel` to get `currentUserId` for filtering user mailboxes.
>   - **UI Adjustments**:
>     - `UserHexagon.tsx`: Adjusted `ClippedImage` class to include `-mr-[0.5px]` for better alignment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c507e2d8dfbb40b29d70852fd7169c51ab3b5178. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->