### PR TITLE
Fix tenant hard delete

### DIFF
--- a/packages/server/customer-os-postgres-repository/repository/common_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/common_repository.go
@@ -135,7 +135,7 @@ func (r *commonRepository) PermanentlyDelete(ctx context.Context, tenant string)
 	}
 
 	for _, tableName := range asyncTablesWithTenantColumn {
-		if err := r.postgresDB.AsyncGormDB.Exec("DELETE FROM "+tableName+" WHERE tenant_name = ?", tenant).Error; err != nil {
+		if err := r.postgresDB.AsyncGormDB.Exec("DELETE FROM "+tableName+" WHERE tenant = ?", tenant).Error; err != nil {
 			tracing.TraceErr(span, err)
 			return err
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes SQL query in `PermanentlyDelete` to use `tenant` instead of `tenant_name` for certain tables.
> 
>   - **Behavior**:
>     - Fixes SQL query in `PermanentlyDelete` function in `common_repository.go` to use `tenant` instead of `tenant_name` for tables in `asyncTablesWithTenantColumn`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 4d61a5e8cbccc6c5afdda1244fc10f83718eeef9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->