### PR TITLE
COS-6278: Invalidate affected contacts after archiving flow

### DIFF
--- a/packages/apps/frontera/src/store/Flows/Flows.store.ts
+++ b/packages/apps/frontera/src/store/Flows/Flows.store.ts
@@ -271,6 +271,21 @@ export class FlowsStore implements GroupStore<Flow> {
             { mutate: false },
           );
 
+          const contactParticipantIds = (flow?.value.participants ?? [])
+            .filter((participant) => participant.entityType === 'CONTACT')
+            .map((participant) => participant.entityId);
+
+          contactParticipantIds.forEach((contactId) => {
+            const contact = this.root.contacts.value.get(contactId);
+
+            contact?.invalidate();
+          });
+
+          this.root.contacts.sync({
+            action: 'INVALIDATE',
+            ids: contactParticipantIds,
+          });
+
           this.sync({
             action: 'DELETE',
             ids: [id],


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `FlowsStore`, the `archive` method now invalidates contacts associated with the archived flow.
> 
>   - **Behavior**:
>     - In `FlowsStore`, `archive` method now invalidates contacts associated with the archived flow.
>     - Identifies contact participants by filtering `participants` with `entityType` as 'CONTACT'.
>     - Calls `invalidate()` on each contact and syncs with action 'INVALIDATE'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 46fc5a405e394a7a004ead2da4d0541f76bcd8e0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->