### PR TITLE
COS-6306: Change mailbox button behaviour in flow sender settings

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/components/settings/FlowSender.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/components/settings/FlowSender.tsx
@@ -19,6 +19,7 @@ import { DotsVertical } from '@ui/media/icons/DotsVertical';
 import { LinkedinBlue } from '@ui/media/logos/LinkedinBlue';
 import { LinkedinOutline } from '@ui/media/icons/LinkedinOutline';
 import { Menu, MenuItem, MenuList, MenuButton } from '@ui/overlay/Menu/Menu';
+import { Popover, PopoverTrigger, PopoverContent } from '@ui/overlay/Popover';
 
 export const FlowSender = observer(
   ({
@@ -92,22 +93,53 @@ export const FlowSender = observer(
             </>
           )}
 
-          {hasEmailNodes && (
+          {hasEmailNodes && !userMailboxes?.length && (
             <div>
-              <Tooltip label='Add mailboxes'>
+              <Tooltip label={'Add mailboxes'}>
                 <Button
                   size='xxs'
                   variant='ghost'
                   className='gap-1'
-                  leftIcon={<Mail01 className='text-inherit ' />}
+                  leftIcon={<Mail01 className='text-inherit' />}
                   onClick={() => {
                     navigate('/settings?tab=mailboxes&view=buy');
                   }}
                 >
-                  {userMailboxes?.length ?? 0}{' '}
-                  {userMailboxes?.length === 1 ? 'mailbox' : 'mailboxes'}
+                  0 mailboxes
                 </Button>
               </Tooltip>
+            </div>
+          )}
+
+          {hasEmailNodes && !!userMailboxes?.length && (
+            <div>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    size='xxs'
+                    variant='ghost'
+                    className='gap-1'
+                    leftIcon={<Mail01 className='text-inherit' />}
+                  >
+                    {userMailboxes.length}{' '}
+                    {userMailboxes.length === 1 ? 'mailbox' : 'mailboxes'}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align='end'
+                  side='bottom'
+                  className={'px-4 py-3'}
+                >
+                  <p className='text-sm font-medium mb-1'>Linked mailboxes</p>
+                  <ul className='list-disc px-4 text-sm'>
+                    {userMailboxes?.map((mailbox) => (
+                      <li className='' key={`mailbox-item-${mailbox}`}>
+                        {mailbox}
+                      </li>
+                    ))}
+                  </ul>
+                </PopoverContent>
+              </Popover>
             </div>
           )}
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `FlowSender.tsx` to display a popover with linked mailboxes when available, otherwise navigate to mailbox settings.
> 
>   - **Behavior**:
>     - In `FlowSender.tsx`, change mailbox button behavior to show a popover with linked mailboxes if `userMailboxes` exist.
>     - If no `userMailboxes`, button navigates to `/settings?tab=mailboxes&view=buy`.
>   - **UI Components**:
>     - Add `Popover`, `PopoverTrigger`, and `PopoverContent` to display linked mailboxes.
>     - Update button label to reflect the number of mailboxes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 763bb5a36c3fba971826cc9411ba665b9fbe097b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->