### PR TITLE
COS-6315: FE: strip formatting enforced by pre tags from pasted content

### DIFF
--- a/packages/apps/frontera/src/ui/form/Editor/plugins/PastePlugin.tsx
+++ b/packages/apps/frontera/src/ui/form/Editor/plugins/PastePlugin.tsx
@@ -40,6 +40,20 @@ export function LinkPastePlugin() {
             if (htmlData) {
               const parser = new DOMParser();
               const doc = parser.parseFromString(htmlData, 'text/html');
+
+              // strip all formatting enforced by pre tags
+              doc.querySelectorAll('pre')?.forEach((preEl) => {
+                if (!preEl.querySelector('code')) {
+                  const span = doc.createElement('div');
+
+                  // Move all child nodes into the new div
+                  while (preEl.firstChild) {
+                    span.appendChild(preEl.firstChild);
+                  }
+                  preEl.replaceWith(span);
+                }
+              });
+
               const nodes = $generateNodesFromDOM(editor, doc);
 
               selection.insertNodes(nodes);


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `LinkPastePlugin` to strip formatting from `pre` tags during paste unless they contain `code` tags.
> 
>   - **Behavior**:
>     - In `LinkPastePlugin`, added logic to strip formatting from `pre` tags when pasting, unless they contain `code` tags.
>     - Converts `pre` tags to `div` elements and moves child nodes to preserve content without formatting.
>   - **Functions**:
>     - Modified `handlePaste` function to include new logic for handling `pre` tags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 80004680d21eb688a0a7a73af3cdc54f0c09e819. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->