### PR TITLE
Handle blank linkedins on contact creation

### DIFF
--- a/packages/server/customer-os-api/rest/customerbase/contact.go
+++ b/packages/server/customer-os-api/rest/customerbase/contact.go
@@ -107,30 +107,36 @@ func processContact(c *gin.Context, s *service.Services, record ContactRecord) s
 	span, ctx := tracing.StartTracerSpan(c.Request.Context(), "Customerbase.processContact")
 	defer span.Finish()
 	tracing.TagComponentRest(span)
+	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	span.LogFields(log.String("email", record.Email), log.String("linkedin", record.LinkedInURL))
 
-	if record.LinkedInURL == "" && record.Email == "" {
+	linkedInUrl := strings.TrimSpace(record.LinkedInURL)
+	email := strings.TrimSpace(record.Email)
+
+	if linkedInUrl == "" && strings.TrimSpace(record.Email) == "" {
+		span.LogFields(log.String("result", "No email or LinkedIn URL provided"))
 		return ""
 	}
 
 	createdContactId := ""
 	var err error
-	if record.LinkedInURL != "" {
-		createdContactId, err = s.CommonServices.ContactService.CreateContactByLinkedIn(ctx, nil, record.LinkedInURL)
+	if linkedInUrl != "" {
+		createdContactId, err = s.CommonServices.ContactService.CreateContactByLinkedIn(ctx, nil, linkedInUrl)
 		if err != nil {
 			tracing.TraceErr(span, errors.Wrap(err, "failed to save contact"))
 			return ""
 		}
 	}
 
-	if record.Email != "" {
+	if email != "" {
 		if createdContactId == "" {
-			createdContactId, err = s.CommonServices.ContactService.CreateContactByEmail(ctx, nil, record.Email)
+			createdContactId, err = s.CommonServices.ContactService.CreateContactByEmail(ctx, nil, email)
 			if err != nil {
 				tracing.TraceErr(span, errors.Wrap(err, "failed to save contact"))
 				return ""
 			}
 		} else {
-			associateEmailWithContact(c, s, record.Email, createdContactId)
+			associateEmailWithContact(c, s, email, createdContactId)
 		}
 	}
 	return createdContactId


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Trim whitespace from LinkedIn URLs and emails in `processContact()` to handle blank values during contact creation.
> 
>   - **Behavior**:
>     - Trim whitespace from `LinkedInURL` and `Email` in `processContact()` in `contact.go`.
>     - Log a message if both `LinkedInURL` and `Email` are blank after trimming.
>     - Adjust contact creation logic to use trimmed values.
>   - **Functions**:
>     - Update `processContact()` to handle trimmed `LinkedInURL` and `Email`.
>     - Modify `associateEmailWithContact()` to use trimmed `Email`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 5a3346c514da7ee207732f4485c5d2a349c49f4c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->