### PR TITLE
Fix panic on update service line item

### DIFF
--- a/packages/server/customer-os-api/service/service_line_item_service.go
+++ b/packages/server/customer-os-api/service/service_line_item_service.go
@@ -430,6 +430,7 @@ func (s *serviceLineItemService) Update(ctx context.Context, serviceLineItemDeta
 			TaxRate:    utils.Float64Ptr(serviceLineItemDetails.SliVatRate),
 			Comments:   utils.StringPtr(serviceLineItemDetails.SliComments),
 			BilledType: utils.ToPtr(serviceLineItemDetails.SliBilledType),
+			ParentId:   utils.StringPtr(baseServiceLineItemEntity.ParentID),
 		}
 
 		// if start date is changed, validate that change is allowed

--- a/packages/server/customer-os-common-module/service/service_line_item_service.go
+++ b/packages/server/customer-os-common-module/service/service_line_item_service.go
@@ -157,7 +157,7 @@ func (s *serviceLineItemService) Save(ctx context.Context, txWithPostCommit *uti
 		dataFields.TaxRate = utils.Float64Ptr(utils.TruncateFloat64(utils.IfNotNilFloat64(dataFields.TaxRate), 2))
 
 		// validate data
-		if sliEntity.Canceled { // TODO add check for deleted SLI
+		if sliEntity.Canceled {
 			err = errors.New("service line item is canceled")
 			tracing.TraceErr(span, err)
 			return "", err
@@ -190,7 +190,7 @@ func (s *serviceLineItemService) Save(ctx context.Context, txWithPostCommit *uti
 			}
 		}
 
-		err := s.services.Neo4jRepositories.ServiceLineItemWriteRepository.AdjustEndDates(ctx, txWithPostCommit.Tx, tenant, *dataFields.ParentId)
+		err := s.services.Neo4jRepositories.ServiceLineItemWriteRepository.AdjustEndDates(ctx, txWithPostCommit.Tx, tenant, utils.IfNotNilString(dataFields.ParentId))
 		if err != nil {
 			tracing.TraceErr(span, err)
 			s.log.Errorf("Error while adjusting end dates for service line item %s: %s", sliId, err.Error())


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix panic in `Update()` by setting `ParentId` in `service_line_item_service.go`.
> 
>   - **Behavior**:
>     - Fix panic in `Update()` in `service_line_item_service.go` by setting `ParentId` using `utils.StringPtr(baseServiceLineItemEntity.ParentID)`.
>   - **Functions**:
>     - Modify `Save()` in `service_line_item_service.go` to use `utils.IfNotNilString(dataFields.ParentId)` for `AdjustEndDates()`.
>   - **Misc**:
>     - Remove outdated comment in `Save()` in `service_line_item_service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 40efbdb92b4655436273c9f1f8afe3b968d49a05. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->