### PR TITLE
change:  contact table use for edit cmdK

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/contactFlow/ContactFlowCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/contactFlow/ContactFlowCell.tsx
@@ -3,8 +3,6 @@ import { useRef, ReactElement } from 'react';
 import { observer } from 'mobx-react-lite';
 
 import { cn } from '@ui/utils/cn';
-import { Edit03 } from '@ui/media/icons/Edit03';
-import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
 import { Trophy01 } from '@ui/media/icons/Trophy01';
 import { Rocket02 } from '@ui/media/icons/Rocket02';
@@ -45,22 +43,12 @@ export const ContactFlowCell = observer(
     if (!contactFlows?.length) {
       return (
         <div
-          onDoubleClick={open}
+          onClick={open}
           className={cn(
-            'flex w-full gap-1 items-center [&_.edit-button]:hover:opacity-100',
+            'flex w-full gap-1 items-center [&_.edit-button]:hover:opacity-100 cursor-pointer',
           )}
         >
           <div className='text-gray-400'>None</div>
-          <IconButton
-            size='xxs'
-            onClick={open}
-            variant='ghost'
-            id='edit-button'
-            aria-label='edit owner'
-            className='edit-button opacity-0'
-            dataTest={`contact-flow-edit-${contactId}`}
-            icon={<Edit03 className='text-gray-500 size-3' />}
-          />
         </div>
       );
     }
@@ -95,9 +83,9 @@ export const ContactFlowCell = observer(
         }
       >
         <div
-          onDoubleClick={open}
+          onClick={open}
           className={cn(
-            'cursor-default overflow-hidden overflow-ellipsis flex gap-1  [&_.edit-button]:hover:opacity-100',
+            'overflow-hidden overflow-ellipsis flex gap-1 [&_.edit-button]:hover:opacity-100 cursor-pointer',
           )}
         >
           <div ref={itemRef} className='flex overflow-hidden'>
@@ -114,15 +102,6 @@ export const ContactFlowCell = observer(
               </div>
             )}
           </div>
-          <IconButton
-            size='xxs'
-            onClick={open}
-            variant='ghost'
-            id='edit-button'
-            aria-label='edit owner'
-            className='edit-button opacity-0'
-            icon={<Edit03 className='text-gray-500 size-3' />}
-          />
         </div>
       </TableCellTooltip>
     );

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/contactName/ContactNameCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/contactName/ContactNameCell.tsx
@@ -1,12 +1,9 @@
-import { useRef, useState, useEffect, KeyboardEvent } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 import { observer } from 'mobx-react-lite';
 
 import { cn } from '@ui/utils/cn';
-import { Input } from '@ui/form/Input';
-import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
-import { Edit03 } from '@ui/media/icons/Edit03.tsx';
 import { useOutsideClick } from '@ui/utils/hooks/useOutsideClick.ts';
 
 interface ContactNameCellProps {
@@ -18,7 +15,6 @@ export const ContactNameCell = observer(
   ({ contactId, canNavigate }: ContactNameCellProps) => {
     const contactNameInputRef = useRef<HTMLInputElement | null>(null);
     const store = useStore();
-    const [isHovered, setIsHovered] = useState(false);
 
     const contactStore = store.contacts.value.get(contactId);
     const contactName = contactStore?.name;
@@ -45,24 +41,10 @@ export const ContactNameCell = observer(
       store.ui.setIsEditingTableCell(isEdit);
     }, [isEdit]);
 
-    const handleEscape = (e: KeyboardEvent<HTMLDivElement>) => {
-      if (e.key === 'Escape' || e.key === 'Enter') {
-        contactNameInputRef?.current?.blur();
-        setIsEdit(false);
-      }
-      e.stopPropagation();
-    };
-
     if (!contactStore) return;
 
     return (
-      <div
-        ref={ref}
-        className='flex'
-        onDoubleClick={() => setIsEdit(true)}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
+      <div ref={ref} className='flex'>
         {!isEdit && !contactName && (
           <p className='text-gray-400'>
             {isEnriching ? 'Enriching...' : 'Unknown'}
@@ -74,7 +56,7 @@ export const ContactNameCell = observer(
             data-test={`contact-name-in-contacts-table`}
             className={cn(
               'overflow-ellipsis overflow-hidden font-medium no-underline hover:no-underline cursor-pointer',
-              !canNavigate && 'cursor-default',
+              canNavigate && 'cursor-default',
             )}
             onClick={() => {
               if (
@@ -90,35 +72,6 @@ export const ContactNameCell = observer(
           >
             {contactName}
           </p>
-        )}
-        {isEdit && (
-          <Input
-            size='xs'
-            placeholder='Name'
-            variant='unstyled'
-            onKeyDown={handleEscape}
-            ref={contactNameInputRef}
-            value={contactStore?.name ?? ''}
-            onFocus={(e) => e.target.select()}
-            className={'font-medium placeholder-font-normal'}
-            onBlur={() => {
-              contactStore.commit();
-            }}
-            onChange={(e) => {
-              contactStore.value.name = e.target.value;
-            }}
-          />
-        )}
-
-        {isHovered && !isEdit && (
-          <IconButton
-            size='xxs'
-            variant='ghost'
-            aria-label='edit'
-            className='ml-3 rounded-[5px]'
-            onClick={() => setIsEdit(!isEdit)}
-            icon={<Edit03 className='text-gray-500' />}
-          />
         )}
       </div>
     );

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/contactName/ContactNameCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/contactName/ContactNameCell.tsx
@@ -1,62 +1,40 @@
-import { useRef, useState, useEffect } from 'react';
+import { useRef } from 'react';
 
 import { observer } from 'mobx-react-lite';
 
 import { cn } from '@ui/utils/cn';
 import { useStore } from '@shared/hooks/useStore';
-import { useOutsideClick } from '@ui/utils/hooks/useOutsideClick.ts';
 
 interface ContactNameCellProps {
   contactId: string;
-  canNavigate?: boolean;
 }
 
 export const ContactNameCell = observer(
-  ({ contactId, canNavigate }: ContactNameCellProps) => {
-    const contactNameInputRef = useRef<HTMLInputElement | null>(null);
+  ({ contactId }: ContactNameCellProps) => {
     const store = useStore();
 
     const contactStore = store.contacts.value.get(contactId);
     const contactName = contactStore?.name;
 
-    const [isEdit, setIsEdit] = useState(false);
     const ref = useRef(null);
 
     const isEnriching = contactStore?.isEnriching;
-
-    useOutsideClick({
-      ref: ref,
-      handler: () => {
-        setIsEdit(false);
-      },
-    });
-
-    useEffect(() => {
-      if (isEdit) {
-        contactNameInputRef.current?.focus();
-      }
-    }, [isEdit]);
-
-    useEffect(() => {
-      store.ui.setIsEditingTableCell(isEdit);
-    }, [isEdit]);
 
     if (!contactStore) return;
 
     return (
       <div ref={ref} className='flex'>
-        {!isEdit && !contactName && (
+        {!contactName && (
           <p className='text-gray-400'>
             {isEnriching ? 'Enriching...' : 'Unknown'}
           </p>
         )}
-        {!isEdit && contactName && (
+        {contactName && (
           <p
             role='button'
             data-test={`contact-name-in-contacts-table`}
             className={cn(
-              'overflow-ellipsis overflow-hidden font-medium no-underline hover:no-underline cursor-pointer',
-              canNavigate && 'cursor-default',
+              'overflow-ellipsis overflow-hidden font-medium no-underline hover:no-underline',
             )}
             onClick={() => {
               if (

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/organization/OrganizationNameCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/organization/OrganizationNameCell.tsx
@@ -1,19 +1,12 @@
+import { useRef } from 'react';
 import { Link } from 'react-router-dom';
-import { useRef, useState } from 'react';
 
 import { observer } from 'mobx-react-lite';
 import { useLocalStorage } from 'usehooks-ts';
 
-import { cn } from '@ui/utils/cn';
-import { Combobox } from '@ui/form/Combobox';
-import { Edit03 } from '@ui/media/icons/Edit03';
 import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from '@ui/overlay/Popover/Popover';
+import { LinkExternal02 } from '@ui/media/icons/LinkExternal02';
 
 interface OrganizationNameCellProps {
   org: string;
@@ -23,8 +16,6 @@ interface OrganizationNameCellProps {
 export const OrganizationNameCell = observer(
   ({ org, contactId, orgId }: OrganizationNameCellProps) => {
     const store = useStore();
-    const [isOpen, setIsOpen] = useState(false);
-    const [isHoverd, setIsHoverd] = useState(false);
 
     const [tabs] = useLocalStorage<{
       [key: string]: string;
@@ -37,13 +28,6 @@ export const OrganizationNameCell = observer(
 
     const isEnriching = contactStore?.isEnriching;
 
-    const organizations = store.organizations.toArray();
-
-    const options = organizations.map((org) => ({
-      label: org.value.name,
-      value: org.value.id,
-    }));
-
     if (!org?.length && isEnriching) {
       return (
         <p className='text-gray-400'>
@@ -53,62 +37,34 @@ export const OrganizationNameCell = observer(
     }
 
     return (
-      <div
-        className='flex items-center'
-        onMouseEnter={() => setIsHoverd(true)}
-        onMouseLeave={() => setIsHoverd(false)}
-      >
+      <div className='flex items-center gap-2 group'>
         <span className='inline truncate'>
           {org.length ? (
-            <Link
-              to={href}
-              ref={linkRef}
-              className='inline text-gray-700 no-underline hover:no-underline font-normal'
+            <span
+              className='inline text-gray-700 no-underline hover:no-underline font-normal cursor-pointer'
+              onClick={() => {
+                store.ui.commandMenu.setType('EditLatestOrgActive');
+                store.ui.commandMenu.setOpen(true);
+              }}
             >
               {contactStore?.value.primaryOrganizationName}
-            </Link>
+            </span>
           ) : (
             <span className='text-gray-400'>None</span>
           )}
         </span>
-        <Popover open={isOpen} onOpenChange={(value) => setIsOpen(value)}>
-          <PopoverTrigger asChild>
+
+        {contactStore?.value.primaryOrganizationName && (
+          <Link to={href} ref={linkRef}>
             <IconButton
               size='xxs'
               variant='ghost'
-              icon={<Edit03 />}
-              aria-label='edit-organization'
-              onClick={() => setIsOpen(true)}
-              className={cn('opacity-0 ml-2', isHoverd && 'opacity-100')}
+              icon={<LinkExternal02 />}
+              className='opacity-0 group-hover:opacity-100'
+              aria-label={`navigate-to-${contactStore?.value.primaryOrganizationName}`}
             />
-          </PopoverTrigger>
-          <PopoverContent align='end' side='bottom' className='w-[200px]'>
-            <Combobox
-              options={options}
-              onChange={(value) => {
-                contactStore?.draft();
-
-                if (contactStore) {
-                  contactStore.value.primaryOrganizationId = value.value;
-                }
-
-                contactStore?.commit();
-
-                if (contactStore) {
-                  contactStore?.draft();
-                  contactStore.value.primaryOrganizationName = value.label;
-                  contactStore?.commit({ syncOnly: true });
-                }
-                const orgStore = store.organizations.getById(value.value);
-
-                orgStore?.draft();
-                orgStore?.value.contacts.push(contactId);
-                orgStore?.commit({ syncOnly: true });
-                setIsOpen(false);
-              }}
-            />
-          </PopoverContent>
-        </Popover>
+          </Link>
+        )}
       </div>
     );
   },

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/socials/ContactLinkedInCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/socials/ContactLinkedInCell.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { observer } from 'mobx-react-lite';
 
 import { useStore } from '@shared/hooks/useStore';
@@ -13,14 +11,9 @@ interface SocialsCellProps {
 export const ContactLinkedInCell = observer(
   ({ contactId }: SocialsCellProps) => {
     const store = useStore();
-    const [isHovered, setIsHovered] = useState(false);
-    const [isEdit, setIsEdit] = useState(false);
     const contact = store.contacts.value.get(contactId);
-    const [metaKey, setMetaKey] = useState(false);
 
     if (!contact) return null;
-
-    const toggleEditMode = () => setIsEdit(!isEdit);
 
     const linkedIn = contact?.value.linkedInUrl;
 
@@ -41,14 +34,7 @@ export const ContactLinkedInCell = observer(
     return (
       <LinkedInDisplay
         type={'in'}
-        isEdit={isEdit}
-        metaKey={metaKey}
         link={linkedIn || ''}
-        isHovered={isHovered}
-        setIsEdit={setIsEdit}
-        setMetaKey={setMetaKey}
-        setIsHovered={setIsHovered}
-        toggleEditMode={toggleEditMode}
         alias={contact.value.linkedInAlias || ''}
       />
     );

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/tags/ContactTagsCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/tags/ContactTagsCell.tsx
@@ -1,9 +1,5 @@
-import { useState } from 'react';
-
 import { observer } from 'mobx-react-lite';
 
-import { Edit01 } from '@ui/media/icons/Edit01';
-import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
 import { Tag } from '@shared/types/__generated__/graphql.types';
 
@@ -15,35 +11,19 @@ interface ContactCardProps {
 
 export const ContactsTagsCell = observer(({ id }: ContactCardProps) => {
   const store = useStore();
-  const [isHovered, setIsHovered] = useState(false);
   const contactStore = store.contacts.value.get(id);
 
   const tags = (contactStore?.value?.tags ?? []).filter((d) => !!d?.name);
 
   return (
     <div
-      className='flex items-center '
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-      onDoubleClick={() => {
+      className='flex items-center cursor-pointer'
+      onClick={() => {
         store.ui.commandMenu.setType('EditPersonaTag');
         store.ui.commandMenu.setOpen(true);
       }}
     >
       <TagsCell tags={(tags ?? []) as Tag[]} />
-      {isHovered && (
-        <IconButton
-          size='xxs'
-          variant='ghost'
-          className='ml-3'
-          aria-label='Edit tags'
-          icon={<Edit01 className='text-gray-500' />}
-          onClick={() => {
-            store.ui.commandMenu.setType('EditPersonaTag');
-            store.ui.commandMenu.setOpen(true);
-          }}
-        />
-      )}
     </div>
   );
 });

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/columns.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/columns.tsx
@@ -65,12 +65,7 @@ const columns: Record<string, Column> = {
     enableColumnFilter: false,
     enableSorting: true,
     cell: (props) => {
-      return (
-        <ContactNameCell
-          contactId={props.row.id}
-          canNavigate={props.getValue()?.hasActiveOrganization}
-        />
-      );
+      return <ContactNameCell contactId={props.row.id} />;
     },
     header: (props) => (
       <THead<HTMLInputElement>

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/shared/Filters/abstract/LinkedIn/LinkedInDisplay.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/shared/Filters/abstract/LinkedIn/LinkedInDisplay.tsx
@@ -1,63 +1,19 @@
-import { useRef, useEffect, KeyboardEvent } from 'react';
-
-import { Input } from '@ui/form/Input';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip.tsx';
 import { IconButton } from '@ui/form/IconButton/IconButton';
 import { LinkExternal02 } from '@ui/media/icons/LinkExternal02';
-import { useOutsideClick } from '@ui/utils/hooks/useOutsideClick.ts';
 import { getExternalUrl, getFormattedLink } from '@utils/getExternalLink';
 
 interface LinkedInDisplayProps {
   link: string;
   type: string;
   alias?: string;
-  isEdit: boolean;
-  metaKey: boolean;
-  isHovered: boolean;
-  toggleEditMode: () => void;
-  setIsEdit: (value: boolean) => void;
-  setMetaKey: (value: boolean) => void;
-  setIsHovered: (value: boolean) => void;
 }
 
 export const LinkedInDisplay = ({
-  isHovered,
   alias,
-  isEdit,
-  setIsHovered,
-  setIsEdit,
-  metaKey,
   link,
-  setMetaKey,
-  toggleEditMode,
   type,
 }: LinkedInDisplayProps) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useOutsideClick({
-    ref: inputRef,
-    handler: () => {
-      setIsEdit(false);
-    },
-  });
-
-  const handleKeyEvents = (e: KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      inputRef.current?.blur();
-      setIsEdit(false);
-    }
-
-    if (e.key === 'Escape') {
-      setIsEdit(false);
-    }
-  };
-
-  useEffect(() => {
-    if (isEdit) {
-      inputRef?.current?.focus();
-    }
-  }, [isEdit]);
-
   const formattedLink = getFormattedLink(link).replace(
     /^linkedin\.com\/(?:in\/|company\/)?/,
     '/',
@@ -71,49 +27,19 @@ export const LinkedInDisplay = ({
     : '';
 
   return (
-    <div
-      className='flex items-center'
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      {isEdit ? (
-        <Input
-          size='xs'
-          ref={inputRef}
-          variant='unstyled'
-          value={link || ''}
-          onKeyDown={handleKeyEvents}
-          onBlur={() => setIsEdit(false)}
-          onFocus={(e) => {
-            e.target.focus();
-            setTimeout(() => e.target.select(), 0);
-          }}
-        />
-      ) : (
-        <Tooltip label={url ?? ''}>
-          <p
-            onDoubleClick={toggleEditMode}
-            onClick={() => metaKey && toggleEditMode()}
-            onKeyUp={() => metaKey && setMetaKey(false)}
-            onKeyDown={(e) => e.metaKey && setMetaKey(true)}
-            className='text-gray-700 cursor-default truncate'
-          >
-            {displayLink}
-          </p>
-        </Tooltip>
-      )}
-      {isHovered && !isEdit && (
-        <>
-          <IconButton
-            size='xxs'
-            variant='ghost'
-            aria-label='contact website'
-            className='ml-1 rounded-[5px]'
-            icon={<LinkExternal02 className='text-gray-500' />}
-            onClick={() => window.open(url, '_blank', 'noopener')}
-          />
-        </>
-      )}
+    <div className='flex items-center group'>
+      <Tooltip label={url ?? ''}>
+        <p className='text-gray-700 cursor-default truncate'>{displayLink}</p>
+      </Tooltip>
+
+      <IconButton
+        size='xxs'
+        variant='ghost'
+        aria-label='contact website'
+        icon={<LinkExternal02 className='text-gray-500' />}
+        onClick={() => window.open(url, '_blank', 'noopener')}
+        className='ml-1 rounded-[5px] opacity-0 group-hover:opacity-100'
+      />
     </div>
   );
 };

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
@@ -22,6 +22,7 @@ import {
 
 import { AddEmail } from './commands/contacts/AddEmail';
 import { AddLinkedinUrl } from './commands/contacts/AddLinkedin';
+import { EditLatestOrgActive } from './commands/contacts/EditLatestOrgActive';
 import {
   FlowHub,
   EditName,
@@ -110,6 +111,7 @@ const Commands: Record<CommandMenuType, ReactElement> = {
   ConfirmSingleFlowEdit: <ConfirmSingleFlowEdit />,
   AddContactsBulk: <AddContactsBulk />,
   AddEmail: <AddEmail />,
+  EditLatestOrgActive: <EditLatestOrgActive />,
 
   // Opportunity
   OpportunityHub: <OpportunityHub />,

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/ContactCommands.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/ContactCommands.tsx
@@ -13,6 +13,7 @@ import { Archive } from '@ui/media/icons/Archive';
 import { User03 } from '@ui/media/icons/User03.tsx';
 import { EyeOff } from '@ui/media/icons/EyeOff.tsx';
 import { Shuffle01 } from '@ui/media/icons/Shuffle01.tsx';
+import { Building07 } from '@ui/media/icons/Building07.tsx';
 import { Certificate02 } from '@ui/media/icons/Certificate02';
 import { ArrowBlockUp } from '@ui/media/icons/ArrowBlockUp.tsx';
 import { LinkedinOutline } from '@ui/media/icons/LinkedinOutline.tsx';
@@ -181,6 +182,16 @@ export const ContactCommands = observer(() => {
         >
           Edit name
         </CommandItem>
+
+        <CommandItem
+          leftAccessory={<Building07 />}
+          keywords={contactKeywords.change_latest_org}
+          onSelect={() => {
+            store.ui.commandMenu.setType('EditLatestOrgActive');
+          }}
+        >
+          Edit organization
+        </CommandItem>
         {/* <CommandItem
           leftAccessory={<Phone />}
           keywords={contactKeywords.edit_phone_number}
@@ -299,5 +310,13 @@ const contactKeywords = {
     'profile',
   ],
   move_to_flow: ['move', 'to', 'flow'],
+  change_latest_org: [
+    'edit',
+    'organization',
+    'change',
+    'update',
+    'latest',
+    'active',
+  ],
   remove_from_flow: ['remove', 'flow', 'delete'],
 };

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/EditLatestOrgActive.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/EditLatestOrgActive.tsx
@@ -1,0 +1,75 @@
+import { observer } from 'mobx-react-lite';
+import { OrganizationDatum } from '@store/Organizations/Organization.dto';
+import { AddSearchOrganizationsUsecase } from '@domain/usecases/command-menu/add-search-organizations.usecase';
+
+import { useStore } from '@shared/hooks/useStore';
+import { Command, CommandItem, CommandInput } from '@ui/overlay/CommandMenu';
+const usecase = new AddSearchOrganizationsUsecase();
+
+export const EditLatestOrgActive = observer(() => {
+  const store = useStore();
+  const context = store.ui.commandMenu.context;
+  const contact = store.contacts.value.get(context.ids?.[0] as string);
+
+  const label = `Contact - ${contact?.name}`;
+
+  const handleClose = () => {
+    store.ui.commandMenu.setOpen(false);
+    store.ui.commandMenu.setType('ContactCommands');
+  };
+
+  const organizations = usecase.mixedOptions;
+  const contactStore = store.contacts.value.get(context.ids?.[0] as string);
+
+  if (!contactStore) return null;
+
+  const handleChangeOrganzation = (value: OrganizationDatum) => {
+    contactStore?.draft();
+
+    if (contactStore) {
+      contactStore.value.primaryOrganizationId = value.id;
+    }
+
+    contactStore?.commit();
+
+    if (contactStore) {
+      contactStore?.draft();
+      contactStore.value.primaryOrganizationName = value.name;
+      contactStore?.commit({ syncOnly: true });
+    }
+    const orgStore = store.organizations.getById(value.id);
+
+    orgStore?.draft();
+    orgStore?.value.contacts.push(contact?.id || '');
+    orgStore?.commit({ syncOnly: true });
+
+    handleClose();
+  };
+
+  return (
+    <Command shouldFilter={false}>
+      <CommandInput
+        label={label}
+        value={usecase.searchTerm}
+        placeholder='Edit organization'
+        onValueChange={usecase.setSearchTerm}
+        onKeyDownCapture={(e) => {
+          if (e.key === ' ') {
+            e.stopPropagation();
+          }
+        }}
+      />
+      <Command.List>
+        {organizations.map((option) => (
+          <CommandItem
+            onSelect={() =>
+              handleChangeOrganzation(option as unknown as OrganizationDatum)
+            }
+          >
+            {option.name}
+          </CommandItem>
+        ))}
+      </Command.List>
+    </Command>
+  );
+});

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/EditLatestOrgActive.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/EditLatestOrgActive.tsx
@@ -23,7 +23,7 @@ export const EditLatestOrgActive = observer(() => {
 
   if (!contactStore) return null;
 
-  const handleChangeOrganzation = (value: OrganizationDatum) => {
+  const handleChangeOrganization = (value: OrganizationDatum) => {
     contactStore?.draft();
 
     if (contactStore) {
@@ -63,7 +63,7 @@ export const EditLatestOrgActive = observer(() => {
         {organizations.map((option) => (
           <CommandItem
             onSelect={() =>
-              handleChangeOrganzation(option as unknown as OrganizationDatum)
+              handleChangeOrganization(option as unknown as OrganizationDatum)
             }
           >
             {option.name}

--- a/packages/apps/frontera/src/store/UI/CommandMenu.store.ts
+++ b/packages/apps/frontera/src/store/UI/CommandMenu.store.ts
@@ -58,7 +58,8 @@ export type CommandMenuType =
   | 'FlowValidationMessage'
   | 'ConfirmEmailContentChanges'
   | 'AddContactsBulk'
-  | 'ContactBulkCommands';
+  | 'ContactBulkCommands'
+  | 'EditLatestOrgActive';
 
 export type Context = {
   ids: Array<string>;


### PR DESCRIPTION
## Proposed changes



## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `EditLatestOrgActive` command to edit contact's latest organization and update related UI components for single-click interaction.
> 
>   - **New Feature**:
>     - Add `EditLatestOrgActive` command to edit the latest organization for a contact in `CommandMenu`.
>     - Implement `EditLatestOrgActive` component in `commands/contacts/EditLatestOrgActive.tsx`.
>   - **UI Changes**:
>     - Update `ContactFlowCell`, `ContactNameCell`, `OrganizationNameCell`, `ContactLinkedInCell`, and `ContactsTagsCell` to use `onClick` instead of `onDoubleClick` for opening command menu.
>     - Remove edit buttons and hover states from these components.
>   - **Command Menu**:
>     - Add `EditLatestOrgActive` to `CommandMenu.store.ts` and `CommandMenu.tsx`.
>     - Update `ContactCommands.tsx` to include new command for editing organization.
>   - **Misc**:
>     - Simplify `LinkedInDisplay` in `LinkedInDisplay.tsx` by removing edit mode and hover states.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 5bfba5a3731374d8c6198b66b75477777f427262. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->