### PR TITLE
fix crash in events subscribers

### DIFF
--- a/packages/server/events-subscribers/handlers/handle_listener_meeting_summary_create.go
+++ b/packages/server/events-subscribers/handlers/handle_listener_meeting_summary_create.go
@@ -34,6 +34,10 @@ func HandleMeetingSummaryEvent(ctx context.Context, s *service.Services, sourceE
 		return err
 	}
 
+	if len(*flows) == 0 {
+		return nil
+	}
+
 	var errs error
 	for _, flow := range *flows {
 		// get next action on the flow


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix crash in `HandleMeetingSummaryEvent` by checking for empty `flows`.
> 
>   - **Bugfix**:
>     - In `handle_listener_meeting_summary_create.go`, add a check in `HandleMeetingSummaryEvent` to return early if `flows` is empty, preventing a crash.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b41b0e7bdd648f172bdcf297ec80233a2f33b17c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->