### PR TITLE
COS-6348: Fix first org not displaying until page refresh

### DIFF
--- a/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
+++ b/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
@@ -309,6 +309,7 @@ export class OrganizationsStore extends Store<OrganizationDatum, Organization> {
         this.value.delete(tempId);
 
         this.version++;
+        this.totalElements++;
 
         tempId = record.id;
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `OrganizationsStore` to increment `totalElements` in `create()` method, ensuring first organization displays without refresh.
> 
>   - **Bugfix**:
>     - Increment `totalElements` in `create()` method of `OrganizationsStore` to ensure the first organization displays without page refresh.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b72ab0231abfc09f2bf1e162626307923eb62e91. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->