### PR TITLE
Fix email bounce identification

### DIFF
--- a/packages/server/customer-os-common-module/service/mail_service_analyzer.go
+++ b/packages/server/customer-os-common-module/service/mail_service_analyzer.go
@@ -171,6 +171,7 @@ func (a *mailService) mailsherpaChecks(from string) (failedCheck bool, reason st
 func (a *mailService) isBounceSubject(subject string) bool {
 	subject = strings.ToLower(subject)
 	keywords := []string{
+		"undelivered mail returned to sender",
 		"delivery status notification",
 		"undeliverable",
 		"undelivered",

--- a/packages/server/customer-os-webhooks/route/interaction_event.go
+++ b/packages/server/customer-os-webhooks/route/interaction_event.go
@@ -511,9 +511,6 @@ func processMailstackReply(ctx context.Context, services *service.Services, tena
 
 		if mailstackEmail != nil && strings.Contains(mailstackEmail.ToString, input.FromFull.Email) && mailstackEmail.ProducerType == commonModel.NodeLabelFlowActionExecution {
 
-			// TODO check that it isn't an automatic reply
-			// header: Subject: Automatic reply: First restaurant killed by DoorDash reviews?
-
 			flowActionExecution, err := services.CommonServices.FlowExecutionService.GetFlowActionExecutionById(ctx, mailstackEmail.ProducerId)
 			if err != nil {
 				tracing.TraceErr(span, err)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance email bounce detection by adding a new keyword and remove a redundant comment in webhook processing.
> 
>   - **Behavior**:
>     - Add "undelivered mail returned to sender" to bounce keywords in `isBounceSubject()` in `mail_service_analyzer.go`.
>   - **Code Cleanup**:
>     - Remove redundant comment in `processMailstackReply()` in `interaction_event.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d447fb6220b9550cf7c2b69bb16a52f9c048caf3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->