### PR TITLE
Notify on slack on mailstack reply

### DIFF
--- a/packages/server/customer-os-common-module/service/mail_service_analyzer.go
+++ b/packages/server/customer-os-common-module/service/mail_service_analyzer.go
@@ -171,6 +171,7 @@ func (a *mailService) mailsherpaChecks(from string) (failedCheck bool, reason st
 func (a *mailService) isBounceSubject(subject string) bool {
 	subject = strings.ToLower(subject)
 	keywords := []string{
+		"mail delivery failure",
 		"undelivered mail returned to sender",
 		"delivery status notification",
 		"undeliverable",
@@ -181,7 +182,7 @@ func (a *mailService) isBounceSubject(subject string) bool {
 		"returned to sender",
 	}
 	for _, phrase := range keywords {
-		if strings.Contains(subject, phrase) {
+		if strings.Contains(strings.ToLower(subject), phrase) {
 			return true
 		}
 	}

--- a/packages/server/customer-os-postgres-repository/entity/slack_channel_notification.go
+++ b/packages/server/customer-os-postgres-repository/entity/slack_channel_notification.go
@@ -5,15 +5,22 @@ import (
 	"time"
 )
 
+type SlackChannelNotificationWorkflow string
+
+const (
+	SlackChannelNotificationWorkflowWebsiteVisit   SlackChannelNotificationWorkflow = "REVEAL-AI-WEBSITE-VISIT"
+	SlackChannelNotificationWorkflowMailstackReply SlackChannelNotificationWorkflow = "MAILSTACK-REPLY"
+)
+
 // send notifications to slack channels
 // tenants can configure this for particular workflows
 type SlackChannelNotification struct {
-	ID        uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
-	CreatedAt time.Time `gorm:"column:created_at;type:timestamp;DEFAULT:current_timestamp"`
-	UpdatedAt time.Time `gorm:"column:updated_at;type:timestamp"`
-	Tenant    string    `gorm:"column:tenant;type:varchar(255);NOT NULL"`
-	ChannelId string    `gorm:"column:channel_id;type:varchar(255);NOT NULL"`
-	Workflow  string    `gorm:"column:workflow;type:varchar(255);"`
+	ID        uuid.UUID                        `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
+	CreatedAt time.Time                        `gorm:"column:created_at;type:timestamp;DEFAULT:current_timestamp"`
+	UpdatedAt time.Time                        `gorm:"column:updated_at;type:timestamp"`
+	Tenant    string                           `gorm:"column:tenant;type:varchar(255);NOT NULL"`
+	ChannelId string                           `gorm:"column:channel_id;type:varchar(255);NOT NULL"`
+	Workflow  SlackChannelNotificationWorkflow `gorm:"column:workflow;type:varchar(255);"`
 }
 
 func (SlackChannelNotification) TableName() string {

--- a/packages/server/customer-os-postgres-repository/repository/slack_channel_notification_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/slack_channel_notification_repository.go
@@ -14,32 +14,30 @@ type slackChannelNotificationRepository struct {
 }
 
 type SlackChannelNotificationRepository interface {
-	GetSlackChannels(c context.Context, tenant, workflow string) ([]*entity.SlackChannelNotification, error)
+	GetSlackChannel(c context.Context, tenant string, workflow entity.SlackChannelNotificationWorkflow) (*entity.SlackChannelNotification, error)
 }
 
 func NewSlackChannelNotificationRepository(db *gorm.DB) SlackChannelNotificationRepository {
 	return &slackChannelNotificationRepository{db: db}
 }
 
-func (r *slackChannelNotificationRepository) GetSlackChannels(c context.Context, tenant, workflow string) ([]*entity.SlackChannelNotification, error) {
+func (r *slackChannelNotificationRepository) GetSlackChannel(c context.Context, tenant string, workflow entity.SlackChannelNotificationWorkflow) (*entity.SlackChannelNotification, error) {
 	span, _ := opentracing.StartSpanFromContext(c, "SlackChannelNotificationRepository.GetSlackChannels")
 	defer span.Finish()
 	tracing.TagComponentPostgresRepository(span)
 	tracing.TagTenant(span, tenant)
-	span.LogFields(tracingLog.String("workflow", workflow))
+	span.LogFields(tracingLog.Object("workflow", workflow))
 
-	var entities []*entity.SlackChannelNotification
+	var e *entity.SlackChannelNotification
 	err := r.db.
 		Where("tenant = ?", tenant).
 		Where("workflow = ?", workflow).
-		Find(&entities).Error
+		First(&e).Error
 
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.Int("result.count", len(entities)))
-
-	return entities, nil
+	return e, nil
 }

--- a/packages/server/customer-os-webhooks/route/interaction_event.go
+++ b/packages/server/customer-os-webhooks/route/interaction_event.go
@@ -203,15 +203,6 @@ func syncPostmarkInteractionEventHandler(services *service.Services, cfg *config
 			return
 		}
 
-		// TODO remove this hack
-		err = processEmailForFlows(ctx, services, tenantByName, username, participants, postmarkEmailWebhookData.Subject, postmarkEmailWebhookData)
-		if err != nil {
-			tracing.TraceErr(span, err)
-			log.Errorf("(SyncInteractionEvent) error processing email for flows: %s", err.Error())
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
-			return
-		}
-
 		span.LogFields(tracingLog.Bool("mailbox.found", true))
 		span.LogFields(tracingLog.String("mailbox.username", username))
 
@@ -397,93 +388,6 @@ func mapPostmarkToEmailRawData(tenant string, pmData model.PostmarkEmailWebhookD
 		Reference:         references,
 		Headers:           headers,
 	}, nil
-}
-
-// Deprecated
-
-// if the sender is a user in the system, it means that this is outbound communication
-// we mark the contacts that received this email as COMPLETED in the flows that they are in
-// this is a hack for now as we should identify the flow that the contact is in and mark the contact as COMPLETED only in that specific flow
-func processEmailForFlows(ctx context.Context, services *service.Services, tenant, mailboxUsername string, participantsEmailAddresses []string, emailSubject string, input model.PostmarkEmailWebhookData) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventService.processEmailForFlows")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-
-	mailbox, err := services.CommonServices.PostgresRepositories.TenantSettingsMailboxRepository.GetByMailbox(ctx, mailboxUsername)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return err
-	}
-
-	if mailbox == nil {
-		err := errors.New("mailbox not found")
-		tracing.TraceErr(span, err)
-		return err
-	}
-
-	if mailbox.UserId == "" {
-		err := errors.New("mailbox user id is empty")
-		tracing.TraceErr(span, err)
-		return err
-	}
-
-	senderUser, err := services.CommonServices.Neo4jRepositories.UserReadRepository.GetUserById(ctx, tenant, mailbox.UserId)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return err
-	}
-
-	outbound := false
-	if senderUser != nil {
-		outbound = true
-	}
-
-	if outbound {
-		for _, p := range participantsEmailAddresses {
-			contactsWithEmailNodes, err := services.CommonServices.Neo4jRepositories.ContactReadRepository.GetContactsWithEmail(ctx, tenant, p)
-			if err != nil {
-				tracing.TraceErr(span, err)
-				return err
-			}
-
-			for _, contactNode := range contactsWithEmailNodes {
-				contactEntity := mapper.MapDbNodeToContactEntity(contactNode)
-
-				flowsWithContact, err := services.CommonServices.FlowService.FlowsGetListWithParticipant(ctx, []string{contactEntity.Id}, commonModel.CONTACT)
-				if err != nil {
-					tracing.TraceErr(span, err)
-					return err
-				}
-
-				for _, flow := range *flowsWithContact {
-					flowContact, err := services.CommonServices.FlowService.FlowParticipantByEntity(ctx, flow.Id, contactEntity.Id, commonModel.CONTACT)
-					if err != nil {
-						tracing.TraceErr(span, err)
-						return err
-					}
-
-					if flowContact == nil || flowContact.Status == neo4jentity.FlowParticipantStatusCompleted || flowContact.Status == neo4jentity.FlowParticipantStatusGoalAchieved {
-						continue
-					}
-
-					if emailSubject == "Welcome to Embedd - Product Tips" {
-						flowContact.Status = neo4jentity.FlowParticipantStatusGoalAchieved
-					} else {
-						flowContact.Status = neo4jentity.FlowParticipantStatusCompleted
-					}
-
-					_, err = services.CommonServices.Neo4jRepositories.FlowParticipantWriteRepository.Merge(ctx, nil, flowContact)
-					if err != nil {
-						tracing.TraceErr(span, err)
-						return err
-					}
-				}
-
-			}
-		}
-	}
-
-	return nil
 }
 
 // check if the email is a reply to an email sent by mailstack

--- a/packages/server/events-subscribers/handlers/handle_listener_website_visit.go
+++ b/packages/server/events-subscribers/handlers/handle_listener_website_visit.go
@@ -166,18 +166,16 @@ func buildSlackNotifyEvent(ctx context.Context, s *service.Services, eventData *
 	defer span.Finish()
 	tracing.SetDefaultListenerSpanTags(ctx, span)
 
-	channelIds, err := s.PostgresRepositories.SlackChannelNotificationRepository.GetSlackChannels(ctx, eventData.Tenant, "REVEAL-AI")
+	slackChannel, err := s.PostgresRepositories.SlackChannelNotificationRepository.GetSlackChannel(ctx, eventData.Tenant, entity.SlackChannelNotificationWorkflowWebsiteVisit)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return nil, err
 	}
-	if len(channelIds) == 0 {
+	if slackChannel == nil {
 		err = fmt.Errorf("no slack channels found for tenant %s", eventData.Tenant)
 		tracing.TraceErr(span, err)
 		return nil, err
 	}
-
-	channelId := channelIds[0]
 
 	ratelimit := MinHoursBetweenNotifications
 
@@ -189,7 +187,7 @@ func buildSlackNotifyEvent(ctx context.Context, s *service.Services, eventData *
 
 	event := data_fields.SlackNotifyEventFields{
 		Tenant:        eventData.Tenant,
-		ChannelID:     channelId.ChannelId,
+		ChannelID:     slackChannel.ChannelId,
 		Message:       message,
 		DomainContext: &domainContext,
 	}

--- a/packages/server/events-subscribers/listeners/flow_participant_goal_achieved_listener.go
+++ b/packages/server/events-subscribers/listeners/flow_participant_goal_achieved_listener.go
@@ -7,9 +7,10 @@ import (
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/model"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/service"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/tracing"
+	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/utils"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
+	postgresEntity "github.com/openline-ai/openline-customer-os/packages/server/customer-os-postgres-repository/entity"
 	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 )
 
@@ -35,6 +36,24 @@ func Handle_FlowParticipantGoalAchieved(ctx context.Context, services *service.S
 	}
 
 	flowParticipant, err := services.FlowService.FlowParticipantByEntity(ctx, flow.Id, event.ParticipantId, event.ParticipantType)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	contact, err := services.ContactService.GetContactById(ctx, flowParticipant.EntityId)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	if contact == nil {
+		err = errors.New("contact not found")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	contactEmail, err := services.EmailService.GetPrimaryEmailForEntityId(ctx, model.CONTACT, flowParticipant.EntityId)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err
@@ -81,15 +100,13 @@ func Handle_FlowParticipantGoalAchieved(ctx context.Context, services *service.S
 			return err
 		}
 
-		primaryEmail, err := services.EmailService.GetPrimaryEmailForEntityId(ctx, model.USER, user.Id)
-		if err != nil {
-			tracing.TraceErr(span, err)
-			return err
-		}
-
-		if primaryEmail == nil {
-			span.LogFields(log.String("msg", "primary email not found"))
-			return nil
+		contactName := ""
+		if utils.StringFirstNonEmpty(contact.Name) != "" {
+			contactName = contact.Name
+		} else if utils.StringFirstNonEmpty(contact.FirstName, contact.LastName) != "" {
+			contactName = utils.JoinNonEmpty(" ", contact.FirstName, contact.LastName)
+		} else if contactEmail != nil && utils.StringFirstNonEmpty(contactEmail.RawEmail) != "" {
+			contactName = contactEmail.RawEmail
 		}
 
 		organizationName := ""
@@ -105,25 +122,50 @@ func Handle_FlowParticipantGoalAchieved(ctx context.Context, services *service.S
 			organizationPublicLink = fmt.Sprintf("%s/organization/%s", services.GlobalConfig.NovuConfig.FronteraUrl, contactWithOrganization.Organization.ID)
 		}
 
-		notification := &service.NovuNotification{
-			WorkflowId: service.WorkflowId_FlowParticipantGoalAchievedEmail,
-			TemplateData: map[string]string{
-				"{{orgLink}}": organizationPublicLink,
-				"{{orgName}}": organizationName,
-			},
-			To: &service.NotifiableUser{
-				FirstName:    user.FirstName,
-				LastName:     user.LastName,
-				Email:        primaryEmail.RawEmail,
-				SubscriberID: user.Id,
-			},
-			Subject: fmt.Sprintf("%s has achieved it’s goal!", flow.Name),
-		}
-
-		err = services.NovuService.SendNotification(ctx, notification)
+		//slack notification
+		slackChannel, err := services.PostgresRepositories.SlackChannelNotificationRepository.GetSlackChannel(ctx, message.Event.Tenant, postgresEntity.SlackChannelNotificationWorkflowMailstackReply)
 		if err != nil {
 			tracing.TraceErr(span, err)
 			return err
+		}
+
+		if slackChannel != nil && slackChannel.ChannelId != "" {
+			slackMessageText := contactName + " has replied to the email. " + organizationName + " has achieved it’s goal!"
+
+			err = services.SlackService.Notify(ctx, message.Event.Tenant, slackChannel.ChannelId, &slackMessageText)
+			if err != nil {
+				tracing.TraceErr(span, err)
+				return err
+			}
+		}
+
+		primaryEmail, err := services.EmailService.GetPrimaryEmailForEntityId(ctx, model.USER, user.Id)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
+
+		if primaryEmail != nil {
+			notification := &service.NovuNotification{
+				WorkflowId: service.WorkflowId_FlowParticipantGoalAchievedEmail,
+				TemplateData: map[string]string{
+					"{{orgLink}}": organizationPublicLink,
+					"{{orgName}}": organizationName,
+				},
+				To: &service.NotifiableUser{
+					FirstName:    user.FirstName,
+					LastName:     user.LastName,
+					Email:        primaryEmail.RawEmail,
+					SubscriberID: user.Id,
+				},
+				Subject: fmt.Sprintf("%s has achieved it’s goal!", flow.Name),
+			}
+
+			err = services.NovuService.SendNotification(ctx, notification)
+			if err != nil {
+				tracing.TraceErr(span, err)
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Slack notifications for mailstack replies and refactor related repository and handler code.
> 
>   - **Behavior**:
>     - Add Slack notification for mailstack replies in `flow_participant_goal_achieved_listener.go` and `interaction_event.go`.
>     - Remove deprecated `processEmailForFlows` function in `interaction_event.go`.
>   - **Models**:
>     - Add `SlackChannelNotificationWorkflowMailstackReply` to `SlackChannelNotificationWorkflow` in `slack_channel_notification.go`.
>   - **Repositories**:
>     - Change `GetSlackChannels` to `GetSlackChannel` in `slack_channel_notification_repository.go` to return a single channel.
>   - **Handlers**:
>     - Update `Handle_FlowParticipantGoalAchieved` in `flow_participant_goal_achieved_listener.go` to send Slack notifications.
>     - Modify `buildSlackNotifyEvent` in `handle_listener_website_visit.go` to use the updated repository method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7ed5373b7c357c0807675590bb09669707470606. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->