### PR TITLE
Fix return path check

### DIFF
--- a/packages/server/customer-os-common-module/service/mail_service_analyzer.go
+++ b/packages/server/customer-os-common-module/service/mail_service_analyzer.go
@@ -152,7 +152,7 @@ func (a *mailService) isBulkMail(headers EmailHeaders, from string, replyTo []Em
 		return true, "BULK | PRECEDENCE: BULK"
 	case (headers.ReturnPathExists && headers.ReturnPath == ""):
 		return true, "BULK | EMPTY RETURN-PATH"
-	case (headers.ReturnPathExists && headers.ReturnPath != from):
+	case headers.ReturnPathExists && strings.Index(headers.ReturnPath, from) == -1:
 		return true, "BULK | RETURN-PATH != FROM"
 	case (headers.Sender != "" && headers.Sender != from):
 		return true, "BULK | SENDER != FROM"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `isBulkMail()` condition in `mail_service_analyzer.go` to check if `from` is not a substring of `ReturnPath`.
> 
>   - **Behavior**:
>     - Fixes condition in `isBulkMail()` in `mail_service_analyzer.go` to check if `from` is not a substring of `ReturnPath` instead of checking for inequality.
>     - Ensures more accurate detection of bulk mail by verifying `ReturnPath` relation to `from` address.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 90a8dc36c55ad19478692ffdbc62b5d63e42a601. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->