### PR TITLE
Remove ability to edit existing LinkedIn  from ContactCardPreview

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/ContactPreviewCard/ContactPreviewCard.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/ContactPreviewCard/ContactPreviewCard.tsx
@@ -12,14 +12,12 @@ import { Input } from '@ui/form/Input';
 import { flags } from '@ui/media/flags';
 import { Avatar } from '@ui/media/Avatar';
 import { DateTimeUtils } from '@utils/date';
-import { Spinner } from '@ui/feedback/Spinner';
-import { Star06 } from '@ui/media/icons/Star06';
 import { IconButton } from '@ui/form/IconButton';
 import { getTimezone } from '@utils/getTimezone';
 import { useStore } from '@shared/hooks/useStore';
 import { Tag, TableViewType } from '@graphql/types';
 import { Tags } from '@organization/components/Tabs';
-import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
+import { getFormattedLink } from '@utils/getExternalLink';
 import { LinkExternal02 } from '@ui/media/icons/LinkExternal02';
 import { LinkedInSolid02 } from '@ui/media/icons/LinkedInSolid02';
 
@@ -66,10 +64,12 @@ export const ContactPreviewCard = observer(() => {
       })?.timezone
     : null;
 
-  const fromatedUrl = contact?.value.linkedInUrl?.replace('https://www.', '');
-  const href = fromatedUrl?.startsWith('http')
-    ? fromatedUrl
-    : `https://${fromatedUrl}`;
+  const linkedInProfile = contact?.value.linkedInUrl;
+  const fromatedUrl = getFormattedLink(linkedInProfile || '').replace(
+    /^linkedin\.com\/(?:in\/|company\/)?/,
+    '/',
+  );
+  const href = contact?.value.linkedInUrl;
 
   const formatedFollowersCount = contact?.value?.linkedInFollowerCount
     ?.toLocaleString()
@@ -92,11 +92,6 @@ export const ContactPreviewCard = observer(() => {
     },
   );
 
-  const contactEnriched =
-    contact.value.enrichedAt || contact.value.enrichedFailedAt;
-
-  const requestedEnrichment = contact?.value?.enrichedAt;
-
   return (
     <>
       {store.ui.contactPreviewCardOpen && (
@@ -113,25 +108,6 @@ export const ContactPreviewCard = observer(() => {
               src={src || undefined}
             />
             <div className='flex items-center gap-2'>
-              {contactEnriched && (
-                <Tooltip asChild label='Enrich this contact'>
-                  {requestedEnrichment ? (
-                    <IconButton
-                      size='xs'
-                      variant='ghost'
-                      icon={<Star06 />}
-                      onClick={() => setIsOpen(true)}
-                      aria-label='enrich this contact'
-                    />
-                  ) : (
-                    <Spinner
-                      size='sm'
-                      label='enriching'
-                      className='text-gray-400 fill-gray-700'
-                    />
-                  )}
-                </Tooltip>
-              )}
               <IconButton
                 size='xs'
                 icon={<X />}
@@ -244,16 +220,13 @@ export const ContactPreviewCard = observer(() => {
                 onMouseLeave={() => setIsHovered(false)}
                 className='flex items-center gap-1 w-full'
               >
-                <Input
-                  size='xs'
-                  variant='unstyled'
-                  value={fromatedUrl}
-                  className='text-ellipsis'
-                  onFocus={(e) => e.target.select()}
-                  placeholder='LinkedIn profile link'
-                />
+                <Link to={href || ''} target='_blank'>
+                  <span className='text-sm'>
+                    {fromatedUrl || 'LinkedIn profile link'}
+                  </span>
+                </Link>
                 {fromatedUrl && isHovered && (
-                  <Link to={href} target='_blank'>
+                  <Link to={href || ''} target='_blank'>
                     <IconButton
                       size='xxs'
                       variant='ghost'


### PR DESCRIPTION
## Proposed changes



## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove editable LinkedIn URL input in `ContactPreviewCard`, replacing it with a non-editable clickable link.
> 
>   - **Behavior**:
>     - Removed editable `Input` for LinkedIn URL in `ContactPreviewCard`.
>     - Replaced with non-editable `Link` displaying formatted LinkedIn URL.
>   - **Functions**:
>     - Utilizes `getFormattedLink` to format LinkedIn URLs.
>   - **UI**:
>     - Removed `Tooltip` and `Spinner` related to LinkedIn enrichment.
>     - Simplified LinkedIn display to a clickable link with `LinkExternal02` icon on hover.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 0e9e004abfaea7f4c2dc15ea025e7c34503c4dae. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->