### PR TITLE
Stop sending slack notification when inbound emails are not processed

### DIFF
--- a/packages/server/customer-os-webhooks/route/interaction_event.go
+++ b/packages/server/customer-os-webhooks/route/interaction_event.go
@@ -256,23 +256,23 @@ func syncPostmarkInteractionEventHandler(services *service.Services, cfg *config
 					c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
 					return
 				}
-			}
 
-			if cfg.Slack.NotifyPostmarkEmail != "" {
-				slackMessageText := "*From:* " + postmarkEmailWebhookData.FromFull.Email + " - " + postmarkEmailWebhookData.FromFull.Name + "\n"
-				for _, t := range postmarkEmailWebhookData.ToFull {
-					slackMessageText += "*To:* " + t.Email + " - " + t.Name + "\n"
-				}
-				for _, t := range postmarkEmailWebhookData.CcFull {
-					slackMessageText += "*CC:* " + t.Email + " - " + t.Name + "\n"
-				}
-				for _, t := range postmarkEmailWebhookData.BccFull {
-					slackMessageText += "*BCC:* " + t.Email + " - " + t.Name + "\n"
-				}
-				slackMessageText += "*Subject:* " + postmarkEmailWebhookData.Subject + "\n"
-				slackMessageText += "*Body:* " + postmarkEmailWebhookData.HtmlBody
+				if cfg.Slack.NotifyPostmarkEmail != "" {
+					slackMessageText := "*From:* " + postmarkEmailWebhookData.FromFull.Email + " - " + postmarkEmailWebhookData.FromFull.Name + "\n"
+					for _, t := range postmarkEmailWebhookData.ToFull {
+						slackMessageText += "*To:* " + t.Email + " - " + t.Name + "\n"
+					}
+					for _, t := range postmarkEmailWebhookData.CcFull {
+						slackMessageText += "*CC:* " + t.Email + " - " + t.Name + "\n"
+					}
+					for _, t := range postmarkEmailWebhookData.BccFull {
+						slackMessageText += "*BCC:* " + t.Email + " - " + t.Name + "\n"
+					}
+					slackMessageText += "*Subject:* " + postmarkEmailWebhookData.Subject + "\n"
+					slackMessageText += "*Body:* " + postmarkEmailWebhookData.HtmlBody
 
-				utils.SendSlackMessage(ctx, cfg.Slack.NotifyPostmarkEmail, slackMessageText)
+					utils.SendSlackMessage(ctx, cfg.Slack.NotifyPostmarkEmail, slackMessageText)
+				}
 			}
 		}
 		c.JSON(http.StatusOK, gin.H{})


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Slack notifications for unprocessed inbound emails are stopped in `syncPostmarkInteractionEventHandler()` by moving notification logic inside the email processing condition.
> 
>   - **Behavior**:
>     - Slack notifications for unprocessed inbound emails are no longer sent in `syncPostmarkInteractionEventHandler()` in `interaction_event.go`.
>     - Slack notification logic is now inside the `if processEmailCheck.ProcessEmail` block, ensuring notifications are only sent for processed emails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f89b2ae3f7329637ff8750ee3467d8f263bc2f2c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->