### PR TITLE
COS-6451: Hide LinkedIn step options from Flows

### DIFF
--- a/packages/apps/frontera/src/routes/flow-editor/src/commands/action/StepsHub.tsx
+++ b/packages/apps/frontera/src/routes/flow-editor/src/commands/action/StepsHub.tsx
@@ -14,7 +14,6 @@ import { Hourglass02 } from '@ui/media/icons/Hourglass02';
 import { RefreshCw01 } from '@ui/media/icons/RefreshCw01';
 import { ArrowIfPath } from '@ui/media/icons/ArrowIfPath';
 import { ClipboardCheck } from '@ui/media/icons/ClipboardCheck';
-import { LinkedinOutline } from '@ui/media/icons/LinkedinOutline';
 
 import { keywords } from './keywords';
 import { useUndoRedo } from '../../hooks';
@@ -347,31 +346,32 @@ export const StepsHub = observer(() => {
         Wait
       </FlowCommandItem>
 
-      <FlowCommandItem
-        leftAccessory={<LinkedinOutline />}
-        keywords={keywords.send_connection_request}
-        onSelect={() =>
-          updateSelectedNode(FlowActionType.LINKEDIN_CONNECTION_REQUEST)
-        }
-      >
-        <span
-          className='text-gray-700'
-          data-test='flow-send-linkedin-connection-request'
-        >
-          Send connection request
-        </span>
-      </FlowCommandItem>
+      {/* uncomment when functionality is ready*/}
+      {/*<FlowCommandItem*/}
+      {/*  leftAccessory={<LinkedinOutline />}*/}
+      {/*  keywords={keywords.send_connection_request}*/}
+      {/*  onSelect={() =>*/}
+      {/*    updateSelectedNode(FlowActionType.LINKEDIN_CONNECTION_REQUEST)*/}
+      {/*  }*/}
+      {/*>*/}
+      {/*  <span*/}
+      {/*    className='text-gray-700'*/}
+      {/*    data-test='flow-send-linkedin-connection-request'*/}
+      {/*  >*/}
+      {/*    Send connection request*/}
+      {/*  </span>*/}
+      {/*</FlowCommandItem>*/}
 
-      <FlowCommandItem
-        disabled
-        leftAccessory={<LinkedinOutline />}
-        keywords={keywords.send_linkedin_message}
-      >
-        <span className='text-gray-700' data-test='flow-send-linkedin-message'>
-          Send LinkedIn message
-        </span>
-        <span className='text-gray-500'>(Coming soon)</span>
-      </FlowCommandItem>
+      {/*<FlowCommandItem*/}
+      {/*  disabled*/}
+      {/*  leftAccessory={<LinkedinOutline />}*/}
+      {/*  keywords={keywords.send_linkedin_message}*/}
+      {/*>*/}
+      {/*  <span className='text-gray-700' data-test='flow-send-linkedin-message'>*/}
+      {/*    Send LinkedIn message*/}
+      {/*  </span>*/}
+      {/*  <span className='text-gray-500'>(Coming soon)</span>*/}
+      {/*</FlowCommandItem>*/}
 
       <FlowCommandItem
         disabled


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Commented out LinkedIn-related options in `StepsHub` to hide them from the UI.
> 
>   - **UI Changes**:
>     - Commented out LinkedIn-related `FlowCommandItem` components in `StepsHub` to hide them from the UI.
>     - Affected items include "Send connection request" and "Send LinkedIn message" options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 4e55014cfed660f427a4adbe3f9f4d390d224316. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->