### PR TITLE
COS-6453: Invoice preview should show country name not A3

### DIFF
--- a/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/BillingPanel/BillingPanelInvoice.tsx
+++ b/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/BillingPanel/BillingPanelInvoice.tsx
@@ -57,7 +57,7 @@ export const BillingPanelInvoice = observer(
           locality: 'San Francisco',
           region: 'CA',
           zip: '89302',
-          country: 'United States of America',
+          country: 'United States',
           email: 'invoices@acme.com',
           name: 'Acme Corp.',
         },

--- a/packages/apps/frontera/src/routes/src/components/Invoice/components/InvoicePartySection.tsx
+++ b/packages/apps/frontera/src/routes/src/components/Invoice/components/InvoicePartySection.tsx
@@ -1,7 +1,5 @@
 import { FC } from 'react';
 
-import countries from '@assets/countries/countries.json';
-
 import { cn } from '@ui/utils/cn';
 import { Button } from '@ui/form/Button/Button';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
@@ -35,7 +33,7 @@ export const InvoicePartySection: FC<InvoiceHeaderProps> = ({
   title,
   onClick,
 }) => {
-  const isUSA = country === 'United States of America';
+  const isUSA = country.trim() === 'United States';
   const borderRightPosition = title === 'From' ? 'border-r-0' : 'border-r';
   const filterDynamicClass = isBlurred ? 'blur-[2px]' : 'filter-none';
   const oppacity = isFocused
@@ -106,11 +104,7 @@ export const InvoicePartySection: FC<InvoiceHeaderProps> = ({
               </span>
             )}
 
-            <span className='text-sm leading-4 text-gray-500'>
-              {countries
-                .find((c) => c.name === country)
-                ?.alpha3.toLocaleUpperCase()}
-            </span>
+            <span className='text-sm leading-4 text-gray-500'>{country}</span>
             {email && (
               <span className='text-sm leading-4 text-gray-500 break-words'>
                 {email}

--- a/packages/apps/frontera/src/routes/src/util/countryOptions.ts
+++ b/packages/apps/frontera/src/routes/src/util/countryOptions.ts
@@ -239,7 +239,7 @@ export const countryOptions: SelectOption[] = [
     label: 'United Kingdom',
     value: 'GB',
   },
-  { label: 'United States of America', value: 'US' },
+  { label: 'United States', value: 'US' },
   { label: 'United States Minor Outlying Islands', value: 'UM' },
   { label: 'Uruguay', value: 'UY' },
   { label: 'Uzbekistan', value: 'UZ' },


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update country name from 'United States of America' to 'United States' in invoice components and utility files.
> 
>   - **Behavior**:
>     - Update country name from 'United States of America' to 'United States' in `BillingPanelInvoice.tsx` and `InvoicePartySection.tsx`.
>     - Remove usage of `countries.json` for country code lookup in `InvoicePartySection.tsx`.
>   - **Data**:
>     - Change country label from 'United States of America' to 'United States' in `countryOptions.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f5d6a52321678c9dd3008a6eb364b7da013189c8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->