### PR TITLE
COS-6450: Make search on org table clickable, clicking it will open cmdk

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Search/Search.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Search/Search.tsx
@@ -10,7 +10,7 @@ import { CreateSequenceButton } from '@finder/components/Search/CreateSequenceBu
 import { TableViewsToggleNavigation } from '@finder/components/TableViewsToggleNavigation';
 import { SearchBarFilterData } from '@finder/components/SearchBarFilterData/SearchBarFilterData';
 
-import { cn } from '@ui/utils/cn.ts';
+import { cn } from '@ui/utils/cn';
 import { Input } from '@ui/form/Input/Input';
 import { useStore } from '@shared/hooks/useStore';
 import { Button } from '@ui/form/Button/Button.tsx';
@@ -197,6 +197,7 @@ export const Search = observer(() => {
           defaultValue={searchParams.get('search') ?? ''}
           className={cn({
             'cursor-default': tableType === TableViewType.Contacts,
+            'cursor-pointer': tableType === TableViewType.Organizations,
           })}
           readOnly={
             tableType === TableViewType.Organizations ||
@@ -205,6 +206,11 @@ export const Search = observer(() => {
           onBlur={() => {
             store.ui.setIsSearching(null);
             wrapperRef.current?.removeAttribute('data-focused');
+          }}
+          onClick={() => {
+            if (tableType === TableViewType.Organizations) {
+              store.ui.commandMenu.toggle('AddNewOrganization');
+            }
           }}
           onFocus={() => {
             if (tableType === TableViewType.Organizations) return;


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Make search bar in organization table clickable to open command menu in `Search.tsx`.
> 
>   - **Behavior**:
>     - In `Search.tsx`, clicking the search bar when `tableType` is `TableViewType.Organizations` now toggles the `AddNewOrganization` command menu.
>     - Adds `cursor-pointer` class to the search bar for `TableViewType.Organizations` to indicate clickability.
>   - **Misc**:
>     - Fix import path for `cn` utility in `Search.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for dd2051ab67fedd15ef2288b56e40e3ab352b5dbe. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->