### PR TITLE
Search/sort by organization primary domains

### DIFF
--- a/packages/server/customer-os-api/graph/resolver/organizationV2.resolvers_it_test.go
+++ b/packages/server/customer-os-api/graph/resolver/organizationV2.resolvers_it_test.go
@@ -63,6 +63,41 @@ func TestQueryResolver_UIOrganizationsSearch_FilterByWebsite(t *testing.T) {
 	assertSearch(t, searchBy, searchTerm, commonModel.ComparisonOperatorNotContains, 5, 2)
 }
 
+func TestQueryResolver_UIOrganizationsSearch_FilterByPrimaryDomain(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "org1"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "org2"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "org3"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "org4"})
+
+	neo4jtest.LinkDomainToOrganization(ctx, driver, "org1", neo4jentity.DomainEntity{Domain: "domain1", IsPrimary: utils.BoolPtr(true)})
+	neo4jtest.LinkDomainToOrganization(ctx, driver, "org1", neo4jentity.DomainEntity{Domain: "domain1secondary1"})
+	neo4jtest.LinkDomainToOrganization(ctx, driver, "org1", neo4jentity.DomainEntity{Domain: "domain1secondary2"})
+	neo4jtest.LinkDomainToOrganization(ctx, driver, "org2", neo4jentity.DomainEntity{Domain: "domain2", IsPrimary: utils.BoolPtr(true)})
+	neo4jtest.LinkDomainToOrganization(ctx, driver, "org3", neo4jentity.DomainEntity{Domain: "domain3", IsPrimary: utils.BoolPtr(true)})
+
+	require.Equal(t, 4, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+	require.Equal(t, 5, neo4jtest.GetCountOfNodes(ctx, driver, "Domain"))
+	require.Equal(t, 5, neo4jtest.GetCountOfRelationships(ctx, driver, "HAS_DOMAIN"))
+
+	searchBy := model.ColumnViewTypeOrganizationsPrimaryDomains
+
+	assertSearch(t, searchBy, "", commonModel.ComparisonOperatorIsEmpty, 4, 1)
+	assertSearch(t, searchBy, "", commonModel.ComparisonOperatorIsNotEmpty, 4, 3)
+	assertSearch(t, searchBy, "domain", commonModel.ComparisonOperatorContains, 4, 3)
+	assertSearch(t, searchBy, "domain1", commonModel.ComparisonOperatorContains, 4, 1)
+	assertSearch(t, searchBy, "domain2", commonModel.ComparisonOperatorContains, 4, 1)
+	assertSearch(t, searchBy, "domain3", commonModel.ComparisonOperatorContains, 4, 1)
+	assertSearch(t, searchBy, "domain4", commonModel.ComparisonOperatorContains, 4, 0)
+	assertSearch(t, searchBy, "domain", commonModel.ComparisonOperatorNotContains, 4, 0)
+	assertSearch(t, searchBy, "domain1", commonModel.ComparisonOperatorNotContains, 4, 2)
+	assertSearch(t, searchBy, "domain4", commonModel.ComparisonOperatorNotContains, 4, 3)
+}
+
 func TestQueryResolver_UIOrganizationsSearch_FilterByRelationship(t *testing.T) {
 	ctx := context.Background()
 	defer tearDownTestCase(ctx)(t)
@@ -833,6 +868,34 @@ func TestQueryResolver_UIOrganizationsSearch_SortByWebsite(t *testing.T) {
 
 	verifySortOrder(t, model.ColumnViewTypeOrganizationsWebsite, commonModel.SortingDirectionAsc, expectedAsc)
 	verifySortOrder(t, model.ColumnViewTypeOrganizationsWebsite, commonModel.SortingDirectionDesc, expectedDesc)
+}
+
+func TestQueryResolver_UIOrganizationsSearch_SortByPrimaryDomain(t *testing.T) {
+	ctx := context.Background()
+	defer tearDownTestCase(ctx)(t)
+
+	neo4jtest.CreateTenant(ctx, driver, tenantName)
+
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "org1"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "org2"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "org3"})
+	neo4jtest.CreateOrganization(ctx, driver, tenantName, neo4jentity.OrganizationEntity{ID: "org4"})
+
+	neo4jtest.LinkDomainToOrganization(ctx, driver, "org1", neo4jentity.DomainEntity{Domain: "domain1", IsPrimary: utils.BoolPtr(true)})
+	neo4jtest.LinkDomainToOrganization(ctx, driver, "org1", neo4jentity.DomainEntity{Domain: "domain1secondary1"})
+	neo4jtest.LinkDomainToOrganization(ctx, driver, "org1", neo4jentity.DomainEntity{Domain: "domain1secondary2"})
+	neo4jtest.LinkDomainToOrganization(ctx, driver, "org2", neo4jentity.DomainEntity{Domain: "domain2", IsPrimary: utils.BoolPtr(true)})
+	neo4jtest.LinkDomainToOrganization(ctx, driver, "org3", neo4jentity.DomainEntity{Domain: "domain3", IsPrimary: utils.BoolPtr(true)})
+
+	require.Equal(t, 4, neo4jtest.GetCountOfNodes(ctx, driver, "Organization"))
+	require.Equal(t, 5, neo4jtest.GetCountOfNodes(ctx, driver, "Domain"))
+	require.Equal(t, 5, neo4jtest.GetCountOfRelationships(ctx, driver, "HAS_DOMAIN"))
+
+	expectedAsc := []string{"org1", "org2", "org3", "org4"}
+	expectedDesc := []string{"org3", "org2", "org1", "org4"}
+
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsPrimaryDomains, commonModel.SortingDirectionAsc, expectedAsc)
+	verifySortOrder(t, model.ColumnViewTypeOrganizationsPrimaryDomains, commonModel.SortingDirectionDesc, expectedDesc)
 }
 
 func TestQueryResolver_UIOrganizationsSearch_SortByRelationship(t *testing.T) {

--- a/packages/server/customer-os-api/repository/dashboardV2_repository.go
+++ b/packages/server/customer-os-api/repository/dashboardV2_repository.go
@@ -44,6 +44,7 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 	tagFilterCypher, tagFilterParams := "", make(map[string]interface{})
 	locationFilterCypher, locationFilterParams := "", make(map[string]interface{})
 	userFilterCypher, userFilterParams := "", make(map[string]interface{})
+	domainFilterCypher, domainFilterParams := "", make(map[string]interface{})
 	parentOrganizationFilterCypher, parentOrganizationFilterParams := "", make(map[string]interface{})
 
 	//ORGANIZATION, EMAIL, COUNTRY, REGION, LOCALITY
@@ -84,12 +85,20 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 		userFilter.LogicalOperator = utils.AND
 		userFilter.Filters = make([]*utils.CypherFilter, 0)
 
+		domainFilter := new(utils.CypherFilter)
+		domainFilter.Negate = false
+		domainFilter.LogicalOperator = utils.AND
+		domainFilter.Filters = make([]*utils.CypherFilter, 0)
+
 		for _, filter := range where.And {
 			if filter.Filter.Property == model.ColumnViewTypeOrganizationsName.String() {
 				organizationFilter.Filters = append(organizationFilter.Filters, utils.CreateStringCypherFilter("name", filter.Filter.Value.Str, filter.Filter.Operation))
 			}
 			if filter.Filter.Property == model.ColumnViewTypeOrganizationsWebsite.String() {
 				organizationFilter.Filters = append(organizationFilter.Filters, utils.CreateStringCypherFilter("website", filter.Filter.Value.Str, filter.Filter.Operation))
+			}
+			if filter.Filter.Property == model.ColumnViewTypeOrganizationsPrimaryDomains.String() {
+				domainFilter.Filters = append(domainFilter.Filters, utils.CreateStringCypherFilter(string(neo4jentity.DomainPropertyDomain), filter.Filter.Value.Str, filter.Filter.Operation))
 			}
 			if filter.Filter.Property == model.ColumnViewTypeOrganizationsRelationship.String() {
 				createInOrEmptyStringFilter(filter, organizationFilter, "relationship")
@@ -207,6 +216,9 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 		if len(userFilter.Filters) > 0 {
 			userFilterCypher, userFilterParams = userFilter.BuildCypherFilterFragmentWithParamName("u", "u_param_")
 		}
+		if len(domainFilter.Filters) > 0 {
+			domainFilterCypher, domainFilterParams = domainFilter.BuildCypherFilterFragmentWithParamName("d", "d_param_")
+		}
 		if len(parentOrganizationFilter.Filters) > 0 {
 			parentOrganizationFilterCypher, parentOrganizationFilterParams = parentOrganizationFilter.BuildCypherFilterFragmentWithParamName("po", "po_param_")
 		}
@@ -224,12 +236,16 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 	utils.MergeMapToMap(tagFilterParams, params)
 	utils.MergeMapToMap(locationFilterParams, params)
 	utils.MergeMapToMap(userFilterParams, params)
+	utils.MergeMapToMap(domainFilterParams, params)
 	utils.MergeMapToMap(parentOrganizationFilterParams, params)
 
 	//region count selectQuery
 	countQuery := ""
 	{
 		countQuery += fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization_%s) `, tenant)
+		if domainFilterCypher != "" {
+			countQuery += ` OPTIONAL MATCH (o)-[:HAS_DOMAIN]->(d:Domain{primary: true}) WITH *`
+		}
 		if userFilterCypher != "" {
 			countQuery += ` OPTIONAL MATCH (o)<-[:OWNS]-(u:User) WITH *`
 		}
@@ -248,13 +264,16 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 
 		countQuery += ` WHERE (o.hide = false OR o.hide IS NULL) `
 
-		if organizationFilterCypher != "" || socialFilterCypher != "" || tagFilterCypher != "" || locationFilterCypher != "" || parentOrganizationFilterCypher != "" || userFilterCypher != "" {
+		if organizationFilterCypher != "" || domainFilterCypher != "" || socialFilterCypher != "" || tagFilterCypher != "" || locationFilterCypher != "" || parentOrganizationFilterCypher != "" || userFilterCypher != "" {
 			countQuery += " AND "
 		}
 
 		countQueryParts := []string{}
 		if organizationFilterCypher != "" {
 			countQueryParts = append(countQueryParts, organizationFilterCypher)
+		}
+		if domainFilterCypher != "" {
+			countQueryParts = append(countQueryParts, domainFilterCypher)
 		}
 		if userFilterCypher != "" {
 			countQueryParts = append(countQueryParts, userFilterCypher)
@@ -283,6 +302,9 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 		if userFilterCypher != "" || (sort != nil && (sort.By == model.ColumnViewTypeOrganizationsOwner.String())) {
 			selectQuery += fmt.Sprintf(` OPTIONAL MATCH (o)<-[:OWNS]-(u:User) WITH *`)
 		}
+		if domainFilterCypher != "" || (sort != nil && (sort.By == model.ColumnViewTypeOrganizationsPrimaryDomains.String())) {
+			selectQuery += fmt.Sprintf(` OPTIONAL MATCH (o)-[:HAS_DOMAIN]->(d:Domain{primary: true}) WITH *`)
+		}
 		if socialFilterCypher != "" {
 			selectQuery += fmt.Sprintf(` OPTIONAL MATCH (o)-[:HAS]->(s:Social_%s) WITH *`, tenant)
 		}
@@ -297,13 +319,16 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 		}
 		selectQuery += ` WHERE (o.hide = false OR o.hide IS NULL) `
 
-		if organizationFilterCypher != "" || socialFilterCypher != "" || tagFilterCypher != "" || parentOrganizationFilterCypher != "" || locationFilterCypher != "" || userFilterCypher != "" {
+		if organizationFilterCypher != "" || domainFilterCypher != "" || socialFilterCypher != "" || tagFilterCypher != "" || parentOrganizationFilterCypher != "" || locationFilterCypher != "" || userFilterCypher != "" {
 			selectQuery += " AND "
 		}
 
 		queryParts := []string{}
 		if organizationFilterCypher != "" {
 			queryParts = append(queryParts, organizationFilterCypher)
+		}
+		if domainFilterCypher != "" {
+			queryParts = append(queryParts, domainFilterCypher)
 		}
 		if userFilterCypher != "" {
 			queryParts = append(queryParts, userFilterCypher)
@@ -340,6 +365,13 @@ func (r *dashboardV2Repository) GetDashboardViewOrganizationDataV2(ctx context.C
 			aliases += "CASE WHEN o.website <> \"\" and not o.website is null THEN toLower(o.website) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
 		} else {
 			aliases += "CASE WHEN o.website <> \"\" and not o.website is null THEN toLower(o.website) ELSE '' END as SORT_BY "
+		}
+	}
+	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsPrimaryDomains.String() {
+		if sort.Direction == commonmodel.SortingDirectionAsc {
+			aliases += "CASE WHEN d.domain <> \"\" and not d.domain is null THEN toLower(d.domain) ELSE 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' END as SORT_BY "
+		} else {
+			aliases += "CASE WHEN d.domain <> \"\" and not d.domain is null THEN toLower(d.domain) ELSE '' END as SORT_BY "
 		}
 	}
 	if sort != nil && sort.By == model.ColumnViewTypeOrganizationsRelationship.String() {

--- a/packages/server/customer-os-neo4j-repository/test/neo4j_data_helper.go
+++ b/packages/server/customer-os-neo4j-repository/test/neo4j_data_helper.go
@@ -1220,10 +1220,12 @@ func UserOwnsOrganization(ctx context.Context, driver *neo4j.DriverWithContext, 
 	})
 }
 
-func LinkDomainToOrganization(ctx context.Context, driver *neo4j.DriverWithContext, organizationId, domain string) {
+func LinkDomainToOrganization(ctx context.Context, driver *neo4j.DriverWithContext, organizationId string, domain entity.DomainEntity) {
 	query := ` MERGE (d:Domain {domain:$domain})
 			ON CREATE SET
 				d.id=randomUUID(),
+				d.primary=$primary,
+				d.primaryDomain=$primaryDomain,
 				d.source="test",
 				d.appSource="test",
 				d.createdAt=$now,
@@ -1233,7 +1235,9 @@ func LinkDomainToOrganization(ctx context.Context, driver *neo4j.DriverWithConte
 			MERGE (o)-[:HAS_DOMAIN]->(d)`
 	ExecuteWriteQuery(ctx, driver, query, map[string]any{
 		"organizationId": organizationId,
-		"domain":         domain,
+		"domain":         domain.Domain,
+		"primary":        domain.IsPrimary,
+		"primaryDomain":  domain.PrimaryDomain,
 		"now":            utils.Now(),
 	})
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add filtering and sorting by primary domain for organizations, with new test cases and data handling updates.
> 
>   - **Behavior**:
>     - Add filtering and sorting by primary domain in `GetDashboardViewOrganizationDataV2()` in `dashboardV2_repository.go`.
>     - New test cases `TestQueryResolver_UIOrganizationsSearch_FilterByPrimaryDomain` and `TestQueryResolver_UIOrganizationsSearch_SortByPrimaryDomain` in `organizationV2.resolvers_it_test.go`.
>   - **Data Handling**:
>     - Update `LinkDomainToOrganization()` to set `primary` and `primaryDomain` attributes in `neo4j_data_helper.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for e864aa0d5533dbb39cb3e2fe57ab33ef17840ee7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->