### PR TITLE
Edi/cos 6277 archiving a contact still shows it in the flows contacts

### DIFF
--- a/packages/server/customer-os-common-module/service/contact_service.go
+++ b/packages/server/customer-os-common-module/service/contact_service.go
@@ -245,6 +245,28 @@ func (s *contactService) HideContact(ctx context.Context, txWithPostCommit *util
 			tracing.TraceErr(span, errors.Wrap(err, "unable to refresh contact count by contact id"))
 		}
 
+		flowsWithContact, err := s.services.FlowService.FlowsGetListWithParticipant(ctx, []string{contactId}, model.CONTACT)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return nil, err
+		}
+
+		if flowsWithContact != nil && len(*flowsWithContact) > 0 {
+			for _, v := range *flowsWithContact {
+				flowParticipant, err := s.services.FlowService.FlowParticipantByEntity(ctx, v.Id, contactId, model.CONTACT)
+				if err != nil {
+					tracing.TraceErr(span, err)
+					return nil, err
+				}
+
+				err = s.services.FlowService.FlowParticipantDelete(ctx, flowParticipant.Id)
+				if err != nil {
+					tracing.TraceErr(span, err)
+					return nil, err
+				}
+			}
+		}
+
 		txWithPostCommit.AddPostCommitAction(func(ctx context.Context) error {
 			err = s.services.RabbitMQService.PublishEvent(ctx, contactId, model.CONTACT, dto.HideContact{})
 			if err != nil {

--- a/packages/server/customer-os-common-module/service/flow_service.go
+++ b/packages/server/customer-os-common-module/service/flow_service.go
@@ -1011,18 +1011,18 @@ func (s *flowService) FlowParticipantDelete(ctx context.Context, flowParticipant
 
 	tenant := common.GetTenantFromContext(ctx)
 
-	flowparticipant, err := s.FlowParticipantById(ctx, flowParticipantId)
+	flowParticipant, err := s.FlowParticipantById(ctx, flowParticipantId)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err
 	}
 
-	if flowparticipant == nil {
+	if flowParticipant == nil {
 		tracing.TraceErr(span, errors.New("flow participant not found"))
 		return errors.New("flow participant not found")
 	}
 
-	flow, err := s.FlowGetByParticipantId(ctx, nil, flowparticipant.Id)
+	flow, err := s.FlowGetByParticipantId(ctx, nil, flowParticipant.Id)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err
@@ -1034,7 +1034,7 @@ func (s *flowService) FlowParticipantDelete(ctx context.Context, flowParticipant
 
 	_, err = utils.ExecuteWriteInTransaction(ctx, s.services.Neo4jRepositories.Neo4jDriver, s.services.Neo4jRepositories.Database, nil, func(tx neo4j.ManagedTransaction) (any, error) {
 
-		flowActionExecutions, err := s.services.FlowExecutionService.GetFlowActionExecutionsForParticipant(ctx, &tx, flow.Id, flowparticipant.EntityId, flowparticipant.EntityType)
+		flowActionExecutions, err := s.services.FlowExecutionService.GetFlowActionExecutionsForParticipant(ctx, &tx, flow.Id, flowParticipant.EntityId, flowParticipant.EntityType)
 		if err != nil {
 			return nil, err
 		}
@@ -1052,7 +1052,7 @@ func (s *flowService) FlowParticipantDelete(ctx context.Context, flowParticipant
 			FromEntityId:   flow.Id,
 			FromEntityType: model.FLOW,
 			Relationship:   model.HAS,
-			ToEntityId:     flowparticipant.Id,
+			ToEntityId:     flowParticipant.Id,
 			ToEntityType:   model.FLOW_PARTICIPANT,
 		})
 		if err != nil {
@@ -1060,17 +1060,17 @@ func (s *flowService) FlowParticipantDelete(ctx context.Context, flowParticipant
 		}
 
 		err = s.services.Neo4jRepositories.CommonWriteRepository.Unlink(ctx, &tx, tenant, repository.LinkDetails{
-			FromEntityId:   flowparticipant.Id,
+			FromEntityId:   flowParticipant.Id,
 			FromEntityType: model.FLOW_PARTICIPANT,
 			Relationship:   model.HAS,
-			ToEntityId:     flowparticipant.EntityId,
-			ToEntityType:   flowparticipant.EntityType,
+			ToEntityId:     flowParticipant.EntityId,
+			ToEntityType:   flowParticipant.EntityType,
 		})
 		if err != nil {
 			return nil, err
 		}
 
-		err = s.services.Neo4jRepositories.FlowParticipantWriteRepository.Delete(ctx, &tx, flowparticipant.Id)
+		err = s.services.Neo4jRepositories.FlowParticipantWriteRepository.Delete(ctx, &tx, flowParticipant.Id)
 		if err != nil {
 			return nil, err
 		}
@@ -1082,7 +1082,7 @@ func (s *flowService) FlowParticipantDelete(ctx context.Context, flowParticipant
 		return err
 	}
 
-	s.services.RabbitMQService.PublishEventCompleted(ctx, tenant, flowparticipant.Id, model.FLOW_PARTICIPANT, utils.NewEventCompletedDetails().WithDelete())
+	s.services.RabbitMQService.PublishEventCompleted(ctx, tenant, flowParticipant.Id, model.FLOW_PARTICIPANT, utils.NewEventCompletedDetails().WithDelete())
 
 	return nil
 }

--- a/packages/server/customer-os-neo4j-repository/entity/flow.go
+++ b/packages/server/customer-os-neo4j-repository/entity/flow.go
@@ -131,6 +131,7 @@ const (
 	FlowParticipantStatusInProgress   FlowParticipantStatus = "IN_PROGRESS"
 	FlowParticipantStatusCompleted    FlowParticipantStatus = "COMPLETED"
 	FlowParticipantStatusGoalAchieved FlowParticipantStatus = "GOAL_ACHIEVED"
+	FlowParticipantStatusGoalArchived FlowParticipantStatus = "ARCHIVED"
 	FlowParticipantStatusError        FlowParticipantStatus = "ERROR"
 )
 

--- a/packages/server/customer-os-neo4j-repository/entity/flow.go
+++ b/packages/server/customer-os-neo4j-repository/entity/flow.go
@@ -131,7 +131,6 @@ const (
 	FlowParticipantStatusInProgress   FlowParticipantStatus = "IN_PROGRESS"
 	FlowParticipantStatusCompleted    FlowParticipantStatus = "COMPLETED"
 	FlowParticipantStatusGoalAchieved FlowParticipantStatus = "GOAL_ACHIEVED"
-	FlowParticipantStatusGoalArchived FlowParticipantStatus = "ARCHIVED"
 	FlowParticipantStatusError        FlowParticipantStatus = "ERROR"
 )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes issue where archived contacts still appear in flows by removing them from associated flows in `HideContact` and refactors variable names for consistency.
> 
>   - **Behavior**:
>     - In `contact_service.go`, `HideContact` now removes the contact from associated flows by deleting flow participants.
>   - **Refactoring**:
>     - In `flow_service.go`, rename `flowparticipant` to `flowParticipant` for consistency in `FlowParticipantDelete` and related logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c24bcbdc0f960a9c98c141e49d8552df95df8244. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->