### PR TITLE
COS-6384: Align icons always on top of the timeline event modal

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Search/Search.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Search/Search.tsx
@@ -10,6 +10,7 @@ import { CreateSequenceButton } from '@finder/components/Search/CreateSequenceBu
 import { TableViewsToggleNavigation } from '@finder/components/TableViewsToggleNavigation';
 import { SearchBarFilterData } from '@finder/components/SearchBarFilterData/SearchBarFilterData';
 
+import { cn } from '@ui/utils/cn';
 import { Input } from '@ui/form/Input/Input';
 import { useStore } from '@shared/hooks/useStore';
 import { Button } from '@ui/form/Button/Button.tsx';
@@ -111,7 +112,7 @@ export const Search = observer(() => {
 
   const placeholder = match(tableType)
     .with(TableViewType.Flow, () => 'by flow name...')
-    .with(TableViewType.Contacts, () => 'by name, organization or email...')
+    .with(TableViewType.Contacts, () => '')
     .with(TableViewType.Contracts, () => 'by contract name...')
     .with(TableViewType.Organizations, () => '/ to search')
     .with(TableViewType.Invoices, () => 'by contract name...')
@@ -194,11 +195,23 @@ export const Search = observer(() => {
           onChange={handleChange}
           placeholder={placeholder}
           defaultValue={searchParams.get('search') ?? ''}
-          readOnly={tableType === TableViewType.Organizations}
+          readOnly={
+            tableType === TableViewType.Organizations ||
+            tableType === TableViewType.Contacts
+          }
           onBlur={() => {
             store.ui.setIsSearching(null);
             wrapperRef.current?.removeAttribute('data-focused');
           }}
+          onClick={() => {
+            if (tableType === TableViewType.Organizations) {
+              store.ui.commandMenu.toggle('AddNewOrganization');
+            }
+          }}
+          className={cn({
+            'cursor-default': tableType === TableViewType.Contacts,
+            'cursor-pointer': tableType === TableViewType.Organizations,
+          })}
           onFocus={() => {
             if (tableType === TableViewType.Organizations) return;
             store.ui.setIsSearching('organizations');

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/intercom/IntercomThreadPreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/intercom/IntercomThreadPreviewModal.tsx
@@ -86,7 +86,7 @@ export const IntercomThreadPreviewModal = () => {
               {title}
             </h2>
           </div>
-          <div className='flex justify-end items-center flex-row'>
+          <div className='flex justify-end items-baseline flex-row'>
             <Tooltip
               side='bottom'
               asChild={false}

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/invoice/InvoicePreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/invoice/InvoicePreviewModal.tsx
@@ -37,7 +37,7 @@ export const InvoicePreviewModal = observer(() => {
             number={invoice?.value?.invoiceNumber}
           />
 
-          <div className='flex justify-end items-center'>
+          <div className='flex justify-end items-baseline'>
             <Tooltip side='bottom' asChild={false} label='Copy invoice link'>
               <IconButton
                 size='xs'

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/logEntry/LogEntryPreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/logEntry/LogEntryPreviewModal.tsx
@@ -90,7 +90,7 @@ export const LogEntryPreviewModal = ({
           <div className='flex items-center'>
             <h2 className='text-lg font-semibold'>Log entry</h2>
           </div>
-          <div className='flex justify-end items-center'>
+          <div className='flex justify-end items-baseline'>
             <Tooltip side='bottom' asChild={false} label='Copy link'>
               <div>
                 <IconButton

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/markdownEvent/MarkdownEventPreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/markdownEvent/MarkdownEventPreviewModal.tsx
@@ -29,7 +29,7 @@ export const MarkdownEventPreviewModal = () => {
               </div>
             </h2>
           </div>
-          <div className='flex justify-end items-center'>
+          <div className='flex justify-end items-baseline'>
             <Tooltip side='bottom' label='Copy link to this thread'>
               <div>
                 <IconButton

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/slack/SlackThreadPreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/slack/SlackThreadPreviewModal.tsx
@@ -50,7 +50,7 @@ export const SlackThreadPreviewModal = () => {
               {event?.interactionSession?.name || 'Thread'}
             </h2>
           </div>
-          <div className='flex justify-end items-center'>
+          <div className='flex justify-end items-baseline'>
             <Tooltip side='bottom' label='Copy link to this thread'>
               <div>
                 <IconButton

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/shared/TimelineEventPreview/header/TimelineEventPreviewHeader.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/shared/TimelineEventPreview/header/TimelineEventPreviewHeader.tsx
@@ -45,7 +45,7 @@ export const TimelineEventPreviewHeader = ({
             {parse !== 'slack' ? name : null}
           </span>
 
-          <div className='flex justify-end items-center'>
+          <div className='flex justify-end items-baseline'>
             {children}
             <Tooltip side='bottom' asChild={false} label={copyLabel}>
               <div>
@@ -56,7 +56,7 @@ export const TimelineEventPreviewHeader = ({
                   colorScheme='gray'
                   aria-label={copyLabel}
                   onClick={() => copy(window.location.href)}
-                  icon={<Link01 height='18px' color='gray.500' />}
+                  icon={<Link01 className='text-gray-500' />}
                 />
               </div>
             </Tooltip>
@@ -68,7 +68,7 @@ export const TimelineEventPreviewHeader = ({
                   onClick={onClose}
                   colorScheme='gray'
                   aria-label='Close preview'
-                  icon={<XClose height='24px' color='gray.500' />}
+                  icon={<XClose className='text-gray-500' />}
                 />
               </div>
             </Tooltip>


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Align icons to baseline in timeline event modals and update search input behavior.
> 
>   - **Icon Alignment**:
>     - Change `items-center` to `items-baseline` in `IntercomThreadPreviewModal.tsx`, `InvoicePreviewModal.tsx`, `LogEntryPreviewModal.tsx`, `MarkdownEventPreviewModal.tsx`, `SlackThreadPreviewModal.tsx`, and `TimelineEventPreviewHeader.tsx`.
>   - **Search Component**:
>     - In `Search.tsx`, set placeholder to empty string for `TableViewType.Contacts`.
>     - Make input read-only for `TableViewType.Contacts` and `TableViewType.Organizations`.
>     - Add `onClick` handler to toggle `AddNewOrganization` for `TableViewType.Organizations`.
>     - Update input class to change cursor style based on `tableType`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 4a071f596fbca0b8fdb39e87b8c3e8eb30fc3507. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->