### PR TITLE
Long LinkedIn URLs make the contact preview jump

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/ContactPreviewCard/ContactPreviewCard.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/ContactPreviewCard/ContactPreviewCard.tsx
@@ -29,7 +29,6 @@ export const ContactPreviewCard = observer(() => {
   const [searchParams] = useSearchParams();
   const [isOpen, setIsOpen] = useState(false);
   const [isEditName, setIsEditName] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
   const contactId = store.ui.focusRow;
   const preset = searchParams?.get('preset');
   const tableViewDef = store.tableViewDefs.getById(preset ?? '1');
@@ -215,25 +214,21 @@ export const ContactPreviewCard = observer(() => {
                 <LinkedInSolid02 className='mt-[1px] text-gray-500 ' />
                 LinkedIn
               </div>
-              <div
-                onMouseEnter={() => setIsHovered(true)}
-                onMouseLeave={() => setIsHovered(false)}
-                className='flex items-center gap-1 w-full'
-              >
+              <div className='flex items-center gap-1 w-full group'>
                 <Link to={href || ''} target='_blank'>
                   <span className='text-sm'>
                     {fromatedUrl || 'LinkedIn profile link'}
                   </span>
                 </Link>
-                {fromatedUrl && isHovered && (
+                {fromatedUrl && (
                   <Link to={href || ''} target='_blank'>
                     <IconButton
                       size='xxs'
                       variant='ghost'
                       colorScheme='gray'
                       aria-label='social link'
-                      className='hover:bg-gray-200 '
                       icon={<LinkExternal02 className='text-gray-500' />}
+                      className='hover:bg-gray-200 opacity-0 group-hover:opacity-100'
                     />
                   </Link>
                 )}

--- a/packages/apps/frontera/src/routes/finder/src/components/ContactPreviewCard/ContactPreviewCard.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/ContactPreviewCard/ContactPreviewCard.tsx
@@ -214,11 +214,11 @@ export const ContactPreviewCard = observer(() => {
                 <LinkedInSolid02 className='mt-[1px] text-gray-500 ' />
                 LinkedIn
               </div>
-              <div className='flex items-center gap-1 w-full group'>
+              <div className='flex items-center gap-1 group  '>
                 <Link to={href || ''} target='_blank'>
-                  <span className='text-sm'>
+                  <p className='text-sm truncate w-[180px]'>
                     {fromatedUrl || 'LinkedIn profile link'}
-                  </span>
+                  </p>
                 </Link>
                 {fromatedUrl && (
                   <Link to={href || ''} target='_blank'>


### PR DESCRIPTION
## Proposed changes



## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves LinkedIn URL handling in `ContactPreviewCard.tsx` by removing hover state and adding group hover effect for better UI.
> 
>   - **Behavior**:
>     - Removed `isHovered` state and related `onMouseEnter` and `onMouseLeave` events in `ContactPreviewCard.tsx`.
>     - Added `group-hover` effect to `IconButton` for LinkedIn URL, making it visible only on hover.
>   - **UI**:
>     - Changed LinkedIn URL display to use `p` tag with `truncate` class for better text overflow handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3679ecc7a1f39b2ce09f29670774cd43f72b9a0a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->