### PR TITLE
COS-2831: Strip rich text formatting from timeline events title

### DIFF
--- a/packages/apps/frontera/package-lock.json
+++ b/packages/apps/frontera/package-lock.json
@@ -72,6 +72,7 @@
         "linkifyjs": "^4.1.3",
         "localforage": "^1.10.0",
         "lodash": "^4.17.21",
+        "markdown-to-txt": "^2.0.1",
         "mobx": "^6.12.3",
         "mobx-react-lite": "^4.0.7",
         "papaparse": "^5.4.1",
@@ -14577,6 +14578,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "node_modules/lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -14636,6 +14642,11 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
+    },
+    "node_modules/lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha512-DhhGRshNS1aX6s5YdBE3njCCouPgnG29ebyHvImlZzXZf2SHgt+J08DHgytTPnpywNbO1Y8mNUFyQuIDBq2JZg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -14803,6 +14814,27 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/markdown-to-txt": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-to-txt/-/markdown-to-txt-2.0.1.tgz",
+      "integrity": "sha512-Hsj7KTN8k1gutlLum3vosHwVZGnv8/cbYKWVkUyo/D1rzOYddbDesILebRfOsaVfjIBJank/AVOySBlHAYqfZw==",
+      "dependencies": {
+        "lodash.escape": "^4.0.1",
+        "lodash.unescape": "^4.0.1",
+        "marked": "^4.0.14"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/match-sorter": {

--- a/packages/apps/frontera/package.json
+++ b/packages/apps/frontera/package.json
@@ -84,6 +84,7 @@
     "linkifyjs": "^4.1.3",
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",
+    "markdown-to-txt": "^2.0.1",
     "mobx": "^6.12.3",
     "mobx-react-lite": "^4.0.7",
     "papaparse": "^5.4.1",

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/issue/IssuePreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/issue/IssuePreviewModal.tsx
@@ -93,7 +93,6 @@ export const IssuePreviewModal: FC = () => {
   return (
     <>
       <TimelineEventPreviewHeader
-        parse='slack'
         onClose={closeModal}
         copyLabel='Copy link'
         name={issue.subject ?? ''}

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/issue/IssueStub.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/issue/IssueStub.tsx
@@ -1,5 +1,7 @@
 import { FC } from 'react';
 
+import markdownToTxt from 'markdown-to-txt';
+
 import { Tag, TagLabel } from '@ui/presentation/Tag/Tag';
 import { IssueBgPattern } from '@ui/media/logos/IssueBgPattern';
 import { IssueWithAliases } from '@organization/components/Timeline/types';
@@ -17,6 +19,8 @@ function getStatusColor(status: string) {
 export const IssueStub: FC<{ data: IssueWithAliases }> = ({ data }) => {
   const { openModal } = useTimelineEventPreviewMethodsContext();
   const statusColorScheme = getStatusColor(data.issueStatus);
+
+  const subject = data?.subject ? markdownToTxt(data.subject) : '[No subject]';
 
   return (
     <div className='flex cursor-pointer !imortant hover:transition-all hover:filter hover:drop-shadow-[0_2px_2px_rgba(16,24,40,0.09)] w-[510px] h-[110px] relative hover:duration-200 hover:ease-oute'>
@@ -36,9 +40,7 @@ export const IssueStub: FC<{ data: IssueWithAliases }> = ({ data }) => {
         }}
       >
         <div className='shadow-xs pr-2 p-3 flex-col flex-1 flex'>
-          <div className='font-semibold p-0 line-clamp-1'>
-            {data?.subject ?? '[No subject]'}
-          </div>
+          <div className='font-semibold p-0 line-clamp-1'>{subject}</div>
           <div className='p-0 max-w-[calc(476px-77px)]'>
             {data?.description ? (
               <MarkdownContentRenderer

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/shared/TimelineEventPreview/header/TimelineEventPreviewHeader.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/shared/TimelineEventPreview/header/TimelineEventPreviewHeader.tsx
@@ -1,4 +1,4 @@
-import { escapeForSlackWithMarkdown } from 'slack-to-html';
+import markdownToTxt from 'markdown-to-txt';
 
 import { DateTimeUtils } from '@utils/date';
 import { XClose } from '@ui/media/icons/XClose';
@@ -10,7 +10,6 @@ import { useCopyToClipboard } from '@shared/hooks/useCopyToClipboard';
 interface TimelineEventPreviewHeaderProps {
   name: string;
   date?: string;
-  parse?: 'slack';
   copyLabel: string;
   onClose: () => void;
   children?: React.ReactNode;
@@ -22,12 +21,9 @@ export const TimelineEventPreviewHeader = ({
   onClose,
   copyLabel,
   children,
-  parse,
 }: TimelineEventPreviewHeaderProps) => {
   const [_, copy] = useCopyToClipboard();
-
-  const parsedName =
-    parse === 'slack' ? escapeForSlackWithMarkdown(name) : name;
+  const parsedName = markdownToTxt(name);
 
   return (
     <div
@@ -36,13 +32,8 @@ export const TimelineEventPreviewHeader = ({
     >
       <div>
         <div className='flex justify-between '>
-          <span
-            className='text-lg font-semibold text-gray-700'
-            dangerouslySetInnerHTML={
-              parse === 'slack' ? { __html: parsedName } : undefined
-            }
-          >
-            {parse !== 'slack' ? name : null}
+          <span className='text-lg font-semibold text-gray-700'>
+            {parsedName}
           </span>
 
           <div className='flex justify-end items-baseline'>


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Strip rich text formatting from timeline event titles using `markdown-to-txt` in `IssueStub` and `TimelineEventPreviewHeader`.
> 
>   - **Behavior**:
>     - Strip rich text formatting from timeline event titles using `markdown-to-txt` in `IssueStub` and `TimelineEventPreviewHeader`.
>     - Remove `parse` prop from `TimelineEventPreviewHeader`.
>   - **Dependencies**:
>     - Add `markdown-to-txt` to `package.json` dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for ad0bd4f26404d262134c117312b94ee35ed067a2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->