### PR TITLE
Tenants created twice when logging in with magic link

### DIFF
--- a/packages/server/customer-os-neo4j-repository/entity/player.go
+++ b/packages/server/customer-os-neo4j-repository/entity/player.go
@@ -5,12 +5,6 @@ import (
 	"time"
 )
 
-type PlayerRelation string
-
-const (
-	IDENTIFIES PlayerRelation = "IDENTIFIES"
-)
-
 type PlayerEntity struct {
 	Id            string
 	IdentityId    string

--- a/packages/server/customer-os-neo4j-repository/repository/player_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/player_read_repository.go
@@ -88,7 +88,7 @@ func (r *playerReadRepository) GetPlayersByAuthId(ctx context.Context, authId st
 		}
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error getting player by identityId: %w", err)
+		return nil, fmt.Errorf("error getting player by authId: %w", err)
 	}
 
 	return result.([]*dbtype.Node), nil

--- a/packages/server/customer-os-neo4j-repository/repository/player_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/player_read_repository.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/common"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/tracing"
-	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 
@@ -16,9 +14,8 @@ import (
 
 type PlayerReadRepository interface {
 	GetPlayerByAuthIdProvider(ctx context.Context, authId string, provider string) (*dbtype.Node, error)
+	GetPlayersByAuthId(ctx context.Context, authId string) ([]*dbtype.Node, error)
 	GetUsersForPlayer(ctx context.Context, ids []string) ([]*utils.DbNodeWithRelationIdAndTenant, error)
-	GetPlayerByIdentityId(ctx context.Context, identityId string) (*dbtype.Node, error)
-	GetPlayerForUser(ctx context.Context, userId string, relation entity.PlayerRelation) (*dbtype.Node, error)
 }
 
 type playerReadRepository struct {
@@ -70,6 +67,33 @@ func (r *playerReadRepository) GetPlayerByAuthIdProvider(ctx context.Context, au
 	return dbRecord.(*dbtype.Node), err
 }
 
+func (r *playerReadRepository) GetPlayersByAuthId(ctx context.Context, authId string) ([]*dbtype.Node, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "PlayerReadRepository.GetPlayersByAuthId")
+	defer span.Finish()
+	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+
+	session := utils.NewNeo4jReadSession(ctx, *r.driver)
+	defer session.Close(ctx)
+
+	query := `MATCH (p:Player {authId:$authId}) RETURN p`
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if queryResult, err := tx.Run(ctx, fmt.Sprintf(query),
+			map[string]any{
+				"authId": authId,
+			}); err != nil {
+			return nil, err
+		} else {
+			return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
+		}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error getting player by identityId: %w", err)
+	}
+
+	return result.([]*dbtype.Node), nil
+}
+
 func (r *playerReadRepository) GetUsersForPlayer(ctx context.Context, ids []string) ([]*utils.DbNodeWithRelationIdAndTenant, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "PlayerReadRepository.GetUsersForPlayer")
 	defer span.Finish()
@@ -78,7 +102,7 @@ func (r *playerReadRepository) GetUsersForPlayer(ctx context.Context, ids []stri
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
 
-	query := fmt.Sprintf(`MATCH (p:Player)-[rel:%s]->(u:User)-[:USER_BELONGS_TO_TENANT]->(t:Tenant) WHERE p.id IN $ids RETURN u, rel, p.id, t.name`, entity.IDENTIFIES)
+	query := fmt.Sprintf(`MATCH (p:Player)-[rel:IDENTIFIES]->(u:User)-[:USER_BELONGS_TO_TENANT]->(t:Tenant) WHERE p.id IN $ids RETURN u, rel, p.id, t.name`)
 
 	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		if queryResult, err := tx.Run(ctx, fmt.Sprintf(query),
@@ -103,63 +127,4 @@ func (r *playerReadRepository) GetUsersForPlayer(ctx context.Context, ids []stri
 	span.LogFields(log.Int("result.found", len(data)))
 
 	return data, nil
-}
-
-func (r *playerReadRepository) GetPlayerForUser(ctx context.Context, userId string, relation entity.PlayerRelation) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PlayerReadRepository.GetPlayerForUser")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-
-	tenant := common.GetTenantFromContext(ctx)
-
-	session := utils.NewNeo4jReadSession(ctx, *r.driver)
-	defer session.Close(ctx)
-
-	query := `MATCH (p:Player)-[:%s]->(u:User {id:$userId})-[:USER_BELONGS_TO_TENANT]->(t:Tenant {name:$tenant}) RETURN p`
-
-	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
-		if queryResult, err := tx.Run(ctx, fmt.Sprintf(query, relation),
-			map[string]any{
-				"userId": userId,
-				"tenant": tenant,
-			}); err != nil {
-			return nil, err
-		} else {
-			return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
-		}
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error getting player for user: %w", err)
-	}
-
-	return result.(*dbtype.Node), nil
-
-}
-
-func (r *playerReadRepository) GetPlayerByIdentityId(ctx context.Context, identityId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PlayerReadRepository.GetPlayerByIdentityId")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-
-	session := utils.NewNeo4jReadSession(ctx, *r.driver)
-	defer session.Close(ctx)
-
-	query := `MATCH (p:Player {identityId:$identityId}) RETURN p`
-
-	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
-		if queryResult, err := tx.Run(ctx, fmt.Sprintf(query),
-			map[string]any{
-				"identityId": identityId,
-			}); err != nil {
-			return nil, err
-		} else {
-			return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
-		}
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error getting player by identityId: %w", err)
-	}
-
-	return result.(*dbtype.Node), nil
-
 }

--- a/packages/server/customer-os-neo4j-repository/repository/player_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/player_write_repository.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"fmt"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/common"
 	"github.com/openline-ai/openline-customer-os/packages/server/customer-os-common-module/tracing"
@@ -25,10 +24,6 @@ type PlayerFields struct {
 
 type PlayerWriteRepository interface {
 	Merge(ctx context.Context, userId string, data entity.PlayerEntity) error
-
-	SetDefaultUser(ctx context.Context, tenant, userId, playerId string, relation entity.PlayerRelation) error
-	LinkWithUser(ctx context.Context, tenant, userId, playerId string, relation entity.PlayerRelation) error
-	UnlinkUser(ctx context.Context, tenant, userId, playerId string, relation entity.PlayerRelation) error
 }
 
 type playerWriteRepository struct {
@@ -84,88 +79,4 @@ func (r *playerWriteRepository) Merge(c context.Context, userId string, data ent
 		tracing.TraceErr(span, err)
 	}
 	return err
-}
-
-func (r *playerWriteRepository) SetDefaultUser(c context.Context, tenant, userId, playerId string, relation entity.PlayerRelation) error {
-	span, ctx := opentracing.StartSpanFromContext(c, "PlayerWriteRepository.SetDefaultUser")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-
-	cypher := fmt.Sprintf(`
-			MATCH (p:Player {id:$playerId})-[r:%s]->(u:User_%s)
-			SET r.default=
-				CASE u.id
-					WHEN $userId THEN true
-					ELSE false
-				END
-			RETURN DISTINCT(p)`, relation, tenant)
-	params := map[string]any{
-		"playerId": playerId,
-		"userId":   userId,
-	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
-
-	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return err
-	}
-
-	return nil
-}
-
-func (r *playerWriteRepository) LinkWithUser(c context.Context, tenant, userId, playerId string, relation entity.PlayerRelation) error {
-	span, ctx := opentracing.StartSpanFromContext(c, "PlayerWriteRepository.LinkWithUser")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-
-	cypher := fmt.Sprintf(`
-			MATCH (p:Player {id:$playerId}), (u:User {id:$userId})-[:USER_BELONGS_TO_TENANT]->(t:Tenant {name:$tenant})
-			MERGE (p)-[r:%s]->(u)
-			SET r.default= CASE
-				WHEN NOT EXISTS((p)-[:%s {default: true}]->(:User)) THEN true
-				ELSE false
-			END
-			RETURN p`, relation, tenant)
-	params := map[string]any{
-		"playerId": playerId,
-		"userId":   userId,
-		"tenant":   tenant,
-	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
-
-	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return err
-	}
-
-	return nil
-}
-
-func (r *playerWriteRepository) UnlinkUser(c context.Context, tenant, userId, playerId string, relation entity.PlayerRelation) error {
-	span, ctx := opentracing.StartSpanFromContext(c, "PlayerWriteRepository.UnlinkUser")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-
-	cypher := fmt.Sprintf(`
-			MATCH (p:Player {id:$playerId}), (u:User_%s {id:$userId})
-							MATCH (p)-[r:%s]->(u)
-							DELETE r return p`, relation, tenant)
-	params := map[string]any{
-		"playerId": playerId,
-		"userId":   userId,
-	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
-
-	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return err
-	}
-
-	return nil
 }

--- a/packages/server/user-admin-api/routes/registration.go
+++ b/packages/server/user-admin-api/routes/registration.go
@@ -521,16 +521,16 @@ func getTenant(c context.Context, services *service.Services, personalEmailProvi
 	span.LogFields(tracingLog.Bool("isPersonalEmail", isPersonalEmail))
 
 	if isPersonalEmail {
-		playerNode, err := services.CommonServices.Neo4jRepositories.PlayerReadRepository.GetPlayerByAuthIdProvider(ctx, signInRequest.LoggedInEmail, signInRequest.Provider)
+		playerNodes, err := services.CommonServices.Neo4jRepositories.PlayerReadRepository.GetPlayersByAuthId(ctx, signInRequest.LoggedInEmail)
 		if err != nil {
 			tracing.TraceErr(span, err)
 			return nil, false, err
 		}
-		if playerNode != nil {
+
+		if playerNodes != nil && len(playerNodes) > 0 {
 			span.LogFields(tracingLog.Object("playerIdentified", true))
 
-			playerId := neo4jmapper.MapDbNodeToPlayerEntity(playerNode).Id
-
+			playerId := neo4jmapper.MapDbNodeToPlayerEntity(playerNodes[0]).Id
 			usersDb, err := services.CommonServices.Neo4jRepositories.PlayerReadRepository.GetUsersForPlayer(ctx, []string{playerId})
 			if err != nil {
 				tracing.TraceErr(span, err)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes tenant duplication issue by updating player retrieval and tenant identification logic in magic link login.
> 
>   - **Behavior**:
>     - Fixes tenant duplication issue when logging in with a magic link by modifying `getTenant` in `registration.go` to handle multiple players.
>     - Updates `GetPlayersByAuthId` in `player_read_repository.go` to return multiple nodes instead of a single node.
>   - **Repositories**:
>     - Removes `GetPlayerByIdentityId` and `GetPlayerForUser` from `PlayerReadRepository`.
>     - Removes `SetDefaultUser`, `LinkWithUser`, and `UnlinkUser` from `PlayerWriteRepository`.
>   - **Entities**:
>     - Removes `PlayerRelation` type and `IDENTIFIES` constant from `player.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8edbf724692fe5c6b7db378ddb169f5edf873a70. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->