### PR TITLE
Ignore events not handled

### DIFF
--- a/packages/server/customer-os-common-module/service/rabbitmq_service.go
+++ b/packages/server/customer-os-common-module/service/rabbitmq_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	tracingLog "github.com/opentracing/opentracing-go/log"
 	"log"
 	"reflect"
 	"strings"
@@ -440,7 +441,8 @@ func (r *RabbitMQService) ProcessMessage(d amqp091.Delivery) error {
 	// Invoke the appropriate handler based on the event type
 	eventHandler, found := r.handlerRegistry[event.Event.EventType]
 	if !found {
-		return errors.New("Handler not found for event type: " + event.Event.EventType)
+		span.LogFields(tracingLog.Message("Handler not found for event type"))
+		return nil
 	}
 
 	if data == nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `rabbitmq_service.go`, unhandled event types in `ProcessMessage` now log a message and return `nil` instead of an error.
> 
>   - **Behavior**:
>     - In `ProcessMessage` in `rabbitmq_service.go`, unhandled event types now log a message and return `nil` instead of an error.
>   - **Logging**:
>     - Uses `tracingLog.Message` to log when a handler is not found for an event type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8b6f7cfa21f5ab7de2f2006e06bdb6b93fbd6651. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->