### PR TITLE
COS-6512: Remove contact creation keyboard shortcuts from OrganizationActions

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Actions/OrganizationActions.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Actions/OrganizationActions.tsx
@@ -37,7 +37,7 @@ export const OrganizationTableActions = observer(
   }: TableActionsProps) => {
     const store = useStore();
 
-    const [targetId, setTargetId] = useState<string | null>(null);
+    const [_targetId, setTargetId] = useState<string | null>(null);
 
     const selectCount = selection?.length;
 
@@ -54,12 +54,6 @@ export const OrganizationTableActions = observer(
       store.ui.commandMenu.setCallback(() => {
         clearSelection();
       });
-    };
-
-    const onCreateContact = () => {
-      if (!focusedId) return;
-      store.ui.commandMenu.setType('AddContactsBulk');
-      store.ui.commandMenu.setOpen(true);
     };
 
     const onOpenCommandK = () => {
@@ -161,13 +155,6 @@ export const OrganizationTableActions = observer(
         u: moveToAllOrgs,
         t: moveToTarget,
         o: moveToOpportunities,
-        c: (e) => {
-          e.stopPropagation();
-          e.preventDefault();
-
-          if (selectCount > 1) return;
-          onCreateContact();
-        },
         Escape: clearSelection,
       },
       { when: enableKeyboardShortcuts },
@@ -206,24 +193,6 @@ export const OrganizationTableActions = observer(
         handleOpen('DeleteConfirmationModal');
       },
       { when: enableKeyboardShortcuts },
-    );
-
-    useModKey(
-      'v',
-      () => {
-        if (focusedId) {
-          if (!targetId) {
-            setTargetId(focusedId);
-          }
-          onCreateContact();
-        }
-      },
-      {
-        when:
-          enableKeyboardShortcuts &&
-          selectCount <= 1 &&
-          typeof focusedId === 'string',
-      },
     );
 
     return (


### PR DESCRIPTION
…

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove contact creation keyboard shortcuts from `OrganizationActions.tsx`.
> 
>   - **Behavior**:
>     - Removed `onCreateContact` function from `OrganizationActions.tsx`.
>     - Removed keyboard shortcut 'c' for contact creation.
>     - Removed `useModKey` binding for 'v' related to contact creation.
>   - **State Management**:
>     - Changed `targetId` to `_targetId` to indicate unused state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 6de7738c730cf28e003a0cdebd3c8383f08d898e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->