### PR TITLE
COS-6511: Make primary domains clickable links in DomainsCell.tsx

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/domains/DomainsCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/domains/DomainsCell.tsx
@@ -16,7 +16,18 @@ export const DomainsCell = observer(({ organizationId }: DomainCellProps) => {
     <div className='flex items-center cursor-pointer'>
       <p className='text-gray-700  truncate'>
         {domains?.length ? (
-          <span className='truncate'>{domains.join(', ')}</span>
+          <span className='truncate'>
+            {domains.map((domain) => (
+              <a
+                target='_blank'
+                rel='noopener noreferrer'
+                href={`https://${domain}`}
+                className='hover:underline'
+              >
+                {domain}
+              </a>
+            ))}
+          </span>
         ) : organization?.isEnriching ? (
           <span
             className='text-gray-400'

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/domains/DomainsCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/domains/DomainsCell.tsx
@@ -23,6 +23,7 @@ export const DomainsCell = observer(({ organizationId }: DomainCellProps) => {
                 rel='noopener noreferrer'
                 href={`https://${domain}`}
                 className='hover:underline'
+                key={`primary-domain-${domain}`}
               >
                 {domain}
               </a>


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Primary domains in `DomainsCell.tsx` are now clickable links that open in a new tab.
> 
>   - **Behavior**:
>     - Primary domains in `DomainsCell.tsx` are now clickable links.
>     - Each domain is wrapped in an `<a>` tag with `target='_blank'` and `rel='noopener noreferrer'`.
>     - Links open in a new tab and have a hover underline effect.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3af03de2b10e6ddcdea0544d4bc58dd0927074a5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->