### PR TITLE
opportunity_Save mutation returns unexpected error when updating renewalArr

### DIFF
--- a/packages/server/customer-os-common-module/service/opportunity_service.go
+++ b/packages/server/customer-os-common-module/service/opportunity_service.go
@@ -300,7 +300,7 @@ func (s *opportunityService) Save(ctx context.Context, txWithPostCommit *utils.T
 			}
 		}
 
-		likelihoodChanged = input.RenewalLikelihood != nil && existing.RenewalDetails.RenewalLikelihood.String() != utils.IfNotNilString(input.RenewalLikelihood)
+		likelihoodChanged = input.RenewalLikelihood != nil && existing.RenewalDetails.RenewalLikelihood.String() != utils.IfNotNilString(input.RenewalLikelihood.String())
 		adjustedRateChanged = input.RenewalAdjustedRate != nil && existing.RenewalDetails.RenewalAdjustedRate != utils.IfNotNilInt64(input.RenewalAdjustedRate)
 		amountChanged = input.Amount != nil && existing.Amount != utils.IfNotNilFloat64(input.Amount)
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes comparison logic for `RenewalLikelihood` in `Save()` function of `opportunity_service.go`.
> 
>   - **Bug Fix**:
>     - Fixes comparison logic for `RenewalLikelihood` in `Save()` function of `opportunity_service.go` by using `input.RenewalLikelihood.String()` for correct string comparison.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d448e4b4bd74bb86c39a7dbc3bcfb837575fe938. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->