### PR TITLE
fix: LinkedIn field change behaviour from ContactPreviewCard

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/ContactPreviewCard/ContactPreviewCard.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/ContactPreviewCard/ContactPreviewCard.tsx
@@ -20,6 +20,7 @@ import { Tags } from '@organization/components/Tabs';
 import { getFormattedLink } from '@utils/getExternalLink';
 import { LinkExternal02 } from '@ui/media/icons/LinkExternal02';
 import { LinkedInSolid02 } from '@ui/media/icons/LinkedInSolid02';
+import { useCopyToClipboard } from '@shared/hooks/useCopyToClipboard';
 
 import { EmailsSection } from './components';
 import { EnrichContactModal } from './components/EnrichContactModal';
@@ -28,6 +29,8 @@ const jobRoleUseCase = new EditJobRole();
 
 export const ContactPreviewCard = observer(() => {
   const store = useStore();
+  const [_, copyToClipboard] = useCopyToClipboard();
+
   const [searchParams] = useSearchParams();
   const [isOpen, setIsOpen] = useState(false);
   const [isEditName, setIsEditName] = useState(false);
@@ -226,11 +229,20 @@ export const ContactPreviewCard = observer(() => {
                 LinkedIn
               </div>
               <div className='flex items-center gap-1 group  '>
-                <Link to={href || ''} target='_blank'>
-                  <p className='text-sm truncate w-[180px]'>
-                    {fromatedUrl || 'LinkedIn profile link'}
+                {fromatedUrl ? (
+                  <p
+                    className='text-sm truncate w-[180px] cursor-default'
+                    onClick={() => {
+                      copyToClipboard(fromatedUrl, 'LinkedIn profile copied');
+                    }}
+                  >
+                    {fromatedUrl}
                   </p>
-                </Link>
+                ) : (
+                  <p className='text-sm truncate w-[180px] text-gray-400'>
+                    LinkedIn profile link
+                  </p>
+                )}
                 {fromatedUrl && (
                   <Link to={href || ''} target='_blank'>
                     <IconButton


### PR DESCRIPTION
## Proposed changes


## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Changes LinkedIn field in `ContactPreviewCard.tsx` to copy URL to clipboard instead of opening link, using `useCopyToClipboard` hook.
> 
>   - **Behavior**:
>     - Changes LinkedIn field in `ContactPreviewCard.tsx` to copy URL to clipboard instead of opening link.
>     - Adds `useCopyToClipboard` hook to handle clipboard operations.
>   - **UI**:
>     - LinkedIn URL is now displayed as non-clickable text with a copy-to-clipboard action on click.
>     - Retains external link icon button for opening LinkedIn profile in a new tab.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 35ea7bfa6aa4a1a14feffd407b3234a09a6eedf2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->