### PR TITLE
fix: autoFocus input from cmdK after opening the rename view

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/components/EditableSidenavItem.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/components/EditableSidenavItem.tsx
@@ -89,13 +89,16 @@ export const EditableSideNavItem = observer(
                 onClick={(e) => {
                   e.stopPropagation();
                   e.preventDefault();
+
                   store.ui.commandMenu.setContext({
                     ids: [id],
                     entity: 'TableViewDef',
                   });
                   store.ui.commandMenu.setType('RenameTableViewDef');
                   store.ui.commandMenu.setOpen(true);
-                  setIsEditing(false);
+                  setTimeout(() => {
+                    setIsEditing(false);
+                  }, 1);
                 }}
               >
                 <TextInput className='text-gray-500' />


### PR DESCRIPTION
## Proposed changes



## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a 1ms delay to `setIsEditing(false)` in `EditableSidenavItem.tsx` to ensure input focus after opening the rename view.
> 
>   - **Behavior**:
>     - Adds a `setTimeout` with a 1ms delay to `setIsEditing(false)` in `EditableSidenavItem.tsx` to ensure input focus after opening the rename view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 00f635602b799babe8e705e43aa3b16596930309. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->