### PR TITLE
fix: preload behavior for orgs and contacts

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/organization/OrganizationNameCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/organization/OrganizationNameCell.tsx
@@ -34,7 +34,7 @@ export const OrganizationNameCell = observer(
       if (!contactStore || !organizationId) return;
 
       if (!store.organizations.value.has(organizationId)) {
-        store.organizations.retrieve([
+        store.organizations.preload([
           contactStore.value.primaryOrganizationId!,
         ]);
       }

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/PeoplePanel/PeoplePanel.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/PeoplePanel/PeoplePanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
@@ -28,9 +28,9 @@ export const PeoplePanel = observer(() => {
   const store = useStore();
   const { open, onOpen, onClose } = useDisclosure();
   const id = useParams()?.id as string;
-  const organization = store.organizations.getById(id);
   const [expandAll, setExpandAll] = useState(false);
-  const contacts = store.organizations.getById(id)?.contacts;
+  const organization = store.organizations.getById(id);
+  const contacts = organization?.contacts;
 
   const searchSortContact = searchSortContactUseCase;
 
@@ -50,6 +50,12 @@ export const PeoplePanel = observer(() => {
           .includes(search.toLowerCase())
       );
     }).length === 0 && search;
+
+  useEffect(() => {
+    if (organization?.value.contacts.length) {
+      store.contacts.preload(organization?.value.contacts);
+    }
+  }, []);
 
   if (!contacts) return null;
 

--- a/packages/apps/frontera/src/store/Contacts/Contact.dto.ts
+++ b/packages/apps/frontera/src/store/Contacts/Contact.dto.ts
@@ -113,8 +113,6 @@ export class Contact extends Entity<ContactDatum> {
 
   @computed
   get jobRoles() {
-    this.store.root.jobRoles.retrieveJobRoles(this.value.jobRoleIds);
-
     return this.value.jobRoleIds.reduce((acc, id) => {
       const record = this.store.root.jobRoles.getById(id);
 

--- a/packages/apps/frontera/src/store/Contacts/Contacts.store.ts
+++ b/packages/apps/frontera/src/store/Contacts/Contacts.store.ts
@@ -153,8 +153,7 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
     }
   }
 
-  @action
-  async retrieve(ids: string[]) {
+  async preload(ids: string[]) {
     ids.forEach((id) => {
       if (this.value.has(id)) {
         return;
@@ -163,10 +162,21 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
       this.value.set(id, new Contact(this, Contact.default({ id })));
     });
 
+    this.retrieve(ids);
+  }
+
+  @action
+  async retrieve(ids: string[]) {
     try {
       const { ui_contacts } = await this.service.getContactsByIds({
         ids,
       });
+
+      const jobRoleIds = ui_contacts?.reduce(
+        (acc, curr) =>
+          curr?.jobRoleIds?.length ? (acc = [...acc, ...curr.jobRoleIds]) : acc,
+        [] as string[],
+      );
 
       runInAction(() => {
         ui_contacts.forEach((raw) => {
@@ -187,6 +197,7 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
         this.size = this.value.size;
         this.version++;
       });
+      await this.root.jobRoles.retrieveJobRoles(jobRoleIds);
     } catch (err) {
       runInAction(() => {
         ids.forEach((id) => {

--- a/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
+++ b/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
@@ -192,14 +192,18 @@ export class OrganizationsStore extends Store<OrganizationDatum, Organization> {
     }
   }
 
-  @action
-  async retrieve(ids: string[]) {
+  async preload(ids: string[]) {
     ids.forEach((id) => {
       if (this.value.has(id)) return;
 
       this.value.set(id, new Organization(this, Organization.default({ id })));
     });
 
+    this.retrieve(ids);
+  }
+
+  @action
+  async retrieve(ids: string[]) {
     try {
       const { ui_organizations } = await this.service.getOrganizationsByIds({
         ids,


### PR DESCRIPTION
What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix preload behavior for organizations and contacts by introducing `preload` method in stores and updating components to use it.
> 
>   - **Behavior**:
>     - Replace `retrieve` with `preload` in `OrganizationNameCell` and `PeoplePanel` to ensure data is preloaded before access.
>     - `preload` method added to `ContactsStore` and `OrganizationsStore` to initialize data before retrieval.
>   - **Stores**:
>     - `retrieve` in `ContactsStore` and `OrganizationsStore` now calls `preload` to set up data.
>     - Removed `retrieveJobRoles` call from `jobRoles` in `Contact.dto.ts`.
>   - **Misc**:
>     - Added `useEffect` in `PeoplePanel` to preload contacts when organization contacts are available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 0c2c260119b605604f2c5657b6f07da7484f0c2b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->