### PR TITLE
fix: org creation on customers and targets views

### DIFF
--- a/packages/apps/frontera/src/routes/src/types/__generated__/graphql.types.ts
+++ b/packages/apps/frontera/src/routes/src/types/__generated__/graphql.types.ts
@@ -1364,6 +1364,7 @@ export type Domain = {
 export type DomainCheckDetails = {
   __typename?: 'DomainCheckDetails';
   accessible: Scalars['Boolean']['output'];
+  allowedForOrganization: Scalars['Boolean']['output'];
   domain: Scalars['String']['output'];
   domainOrganizationId?: Maybe<Scalars['String']['output']>;
   domainOrganizationName?: Maybe<Scalars['String']['output']>;
@@ -3195,6 +3196,7 @@ export type MutationOrganization_SaveArgs = {
 
 export type MutationOrganization_SaveByGlobalOrganizationArgs = {
   globalOrganizationId: Scalars['Int64']['input'];
+  input?: InputMaybe<OrganizationSaveInputFromGlobalOrg>;
 };
 
 export type MutationOrganization_SetOwnerArgs = {
@@ -3582,6 +3584,7 @@ export type Organization = MetadataInterface & {
    */
   id: Scalars['ID']['output'];
   inboundCommsCount: Scalars['Int64']['output'];
+  /** @deprecated No longer supported */
   industry?: Maybe<Scalars['String']['output']>;
   /** @deprecated No longer supported */
   industryGroup?: Maybe<Scalars['String']['output']>;
@@ -3668,6 +3671,7 @@ export type Organization = MetadataInterface & {
   subsidiaryOf: Array<LinkedOrganization>;
   suggestedMergeTo: Array<SuggestedMergeOrganization>;
   tags?: Maybe<Array<Tag>>;
+  /** @deprecated No longer supported */
   targetAudience?: Maybe<Scalars['String']['output']>;
   timelineEvents: Array<TimelineEvent>;
   timelineEventsTotalCount: Scalars['Int64']['output'];
@@ -3676,6 +3680,7 @@ export type Organization = MetadataInterface & {
    * @deprecated Use metadata.lastUpdated
    */
   updatedAt: Scalars['Time']['output'];
+  /** @deprecated No longer supported */
   valueProposition?: Maybe<Scalars['String']['output']>;
   website?: Maybe<Scalars['String']['output']>;
   yearFounded?: Maybe<Scalars['Int64']['output']>;
@@ -3791,6 +3796,11 @@ export type OrganizationSaveInput = {
   yearFounded?: InputMaybe<Scalars['Int64']['input']>;
 };
 
+export type OrganizationSaveInputFromGlobalOrg = {
+  relationship?: InputMaybe<OrganizationRelationship>;
+  stage?: InputMaybe<OrganizationStage>;
+};
+
 export type OrganizationSearchResult = {
   __typename?: 'OrganizationSearchResult';
   ids: Array<Scalars['ID']['output']>;
@@ -3869,6 +3879,7 @@ export type OrganizationUiDetails = {
   subsidiaries: Array<Scalars['String']['output']>;
   tags: Array<Tag>;
   updatedAt: Scalars['Time']['output'];
+  /** @deprecated No longer supported */
   valueProposition?: Maybe<Scalars['String']['output']>;
   website?: Maybe<Scalars['String']['output']>;
   yearFounded?: Maybe<Scalars['Int64']['output']>;

--- a/packages/apps/frontera/src/store/Contacts/Contacts.store.ts
+++ b/packages/apps/frontera/src/store/Contacts/Contacts.store.ts
@@ -467,85 +467,6 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
   }
 
   @action
-  async createWithoutOrg({
-    socialUrl,
-    options,
-  }: {
-    socialUrl: string;
-    options?: {
-      onSuccess?: (serverId: string) => void;
-    };
-  }) {
-    this.isLoading = true;
-
-    const newContact = new Contact(this, Contact.default());
-    const tempId = newContact.id;
-    const socialId = crypto.randomUUID();
-    let serverId: string | undefined = undefined;
-
-    (newContact.value = {
-      id: socialId,
-      firstName: '',
-      lastName: '',
-      name: '',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      flows: [],
-      locations: [],
-      emails: [],
-      connectedUsers: [],
-      tags: [],
-      enrichedEmailEnrichedAt: null,
-      enrichedEmailFound: null,
-      enrichedFailedAt: null,
-      enrichedAt: null,
-      description: '',
-      phones: [],
-      jobRoleIds: [],
-      prefix: '',
-      timezone: '',
-      profilePhotoUrl: '',
-    }),
-      this.value.set(tempId, newContact);
-
-    try {
-      const { contact_Create } = await this.service.createContact({
-        contactInput: {
-          socialUrl,
-        },
-      });
-
-      runInAction(() => {
-        serverId = contact_Create;
-        newContact.id = serverId;
-        this.value.set(serverId, newContact);
-        this.value.delete(tempId);
-
-        this.sync({ action: 'APPEND', ids: [serverId] });
-        this.isLoading = false;
-      });
-
-      this.root.ui.toastSuccess(`Contact created`, 'create-contact-success');
-    } catch (e) {
-      this.root.ui.toastError(
-        `We couldn't create this contact. Please try again.`,
-        'create-contact-error',
-      );
-      runInAction(() => {
-        this.error = (e as Error)?.message;
-      });
-    } finally {
-      serverId && options?.onSuccess?.(serverId);
-
-      setTimeout(() => {
-        if (serverId) {
-          this.value.get(serverId)?.invalidate();
-        }
-      }, 2000);
-    }
-  }
-
-  @action
   async createBulkByEmail({
     emails,
     options,
@@ -586,6 +507,7 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
         this.isBootstrapped = false;
         this.bootstrap();
       }, 300);
+      this.refreshCurrentView();
     }
   }
 
@@ -630,6 +552,7 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
         this.isBootstrapped = false;
         this.bootstrap();
       }, 300);
+      this.refreshCurrentView();
     }
   }
 
@@ -745,4 +668,14 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
       }
     });
   };
+
+  private refreshCurrentView() {
+    const currentPreset = new URLSearchParams(window.location.search).get(
+      'preset',
+    );
+
+    if (currentPreset) {
+      this.search(currentPreset);
+    }
+  }
 }

--- a/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
+++ b/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
@@ -376,6 +376,10 @@ export class OrganizationsStore extends Store<OrganizationDatum, Organization> {
       const { organization_SaveByGlobalOrganization } =
         await this.service.importOrganization({
           globalOrganizationId: globalId,
+          input: {
+            relationship: payload?.relationship,
+            stage: payload?.stage,
+          },
         });
 
       serverId = organization_SaveByGlobalOrganization?.id;

--- a/packages/apps/frontera/src/store/Organizations/__service__/importOrganization.generated.ts
+++ b/packages/apps/frontera/src/store/Organizations/__service__/importOrganization.generated.ts
@@ -2,7 +2,13 @@ import * as Types from '../../../routes/src/types/__generated__/graphql.types';
 
 export type ImportOrganizationMutationVariables = Types.Exact<{
   globalOrganizationId: Types.Scalars['Int64']['input'];
+  input?: Types.InputMaybe<Types.OrganizationSaveInputFromGlobalOrg>;
 }>;
 
-
-export type ImportOrganizationMutation = { __typename?: 'Mutation', organization_SaveByGlobalOrganization: { __typename?: 'OrganizationUiDetails', id: string } };
+export type ImportOrganizationMutation = {
+  __typename?: 'Mutation';
+  organization_SaveByGlobalOrganization: {
+    __typename?: 'OrganizationUiDetails';
+    id: string;
+  };
+};

--- a/packages/apps/frontera/src/store/Organizations/__service__/importOrganization.graphql
+++ b/packages/apps/frontera/src/store/Organizations/__service__/importOrganization.graphql
@@ -1,6 +1,7 @@
-mutation importOrganization($globalOrganizationId: Int64!) {
+mutation importOrganization($globalOrganizationId: Int64!, $input: OrganizationSaveInputFromGlobalOrg) {
   organization_SaveByGlobalOrganization(
     globalOrganizationId: $globalOrganizationId
+    input: $input
   ) {
     id
   }


### PR DESCRIPTION
What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance organization creation and import with `OrganizationSaveInputFromGlobalOrg`, deprecate certain fields, and improve contact management in stores.
> 
>   - **Behavior**:
>     - Added `allowedForOrganization` to `DomainCheckDetails` in `graphql.types.ts`.
>     - Deprecated `industry`, `industryGroup`, `targetAudience`, and `valueProposition` in `Organization` and `OrganizationUiDetails`.
>     - Removed `createWithoutOrg` method from `Contacts.store.ts`.
>     - Added `refreshCurrentView()` call after bulk contact creation in `Contacts.store.ts`.
>   - **GraphQL**:
>     - Added `OrganizationSaveInputFromGlobalOrg` type in `graphql.types.ts`.
>     - Updated `importOrganization` mutation to accept `OrganizationSaveInputFromGlobalOrg` in `importOrganization.graphql` and `importOrganization.generated.ts`.
>   - **Store**:
>     - Updated `import()` method in `Organizations.store.ts` to use `OrganizationSaveInputFromGlobalOrg`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 6e800b5e8665fd7e16bbf3b6fa8676fb4271e329. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->