### PR TITLE
Load personal email providers into cache

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/customer_os_data_upkeeper_main.go
+++ b/packages/runner/customer-os-data-upkeeper/customer_os_data_upkeeper_main.go
@@ -78,7 +78,7 @@ func main() {
 		Cfg:                           cfg,
 		Log:                           appLogger,
 		Repositories:                  repositories,
-		CommonServices:                commonService.InitCommonServices(appLogger, repositories.Neo4jRepositories, repositories.PostgresRepositories, cfg.Common, epClient),
+		CommonServices:                commonService.InitCommonServices(appLogger, repositories.Neo4jRepositories, repositories.PostgresRepositories, cfg.Common, epClient, &commonService.InitOptions{LoadPersonalEmailProviders: true}),
 		EventProcessingServicesClient: epClient,
 		EventBufferStoreService:       eventBufferStoreService,
 	}

--- a/packages/runner/sync-gmail-raw/service/services.go
+++ b/packages/runner/sync-gmail-raw/service/services.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/customeros/customeros/packages/runner/sync-gmail-raw/config"
 	"github.com/customeros/customeros/packages/runner/sync-gmail-raw/logger"
 	"github.com/customeros/customeros/packages/runner/sync-gmail-raw/repository"
@@ -10,6 +9,7 @@ import (
 	commonService "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
 	neo4jrepository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
 	postgresRepository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
 type Services struct {
@@ -37,6 +37,7 @@ func InitServices(driver *neo4j.DriverWithContext, postgresDB *commonConfig.Post
 		postgresRepositories,
 		&cfg.CommonConfig,
 		grpc_client.InitClients(nil),
+		&commonService.InitOptions{},
 	)
 
 	services.EmailService = NewEmailService(cfg, services.Repositories, services)

--- a/packages/runner/sync-gmail/caches/caches.go
+++ b/packages/runner/sync-gmail/caches/caches.go
@@ -11,12 +11,9 @@ import (
 const (
 	KB       = 1024
 	cache5MB = 5 * 1024 * KB
-	cache1MB = 1 * 1024 * KB
 )
 const (
 	expire9999Days = 9999 * 24 * 60 * 60
-	expire30Days   = 30 * 24 * 60 * 60
-	expire1Day     = 24 * 60 * 60
 )
 const delimiter = "--"
 

--- a/packages/runner/sync-gmail/service/services.go
+++ b/packages/runner/sync-gmail/service/services.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/customeros/customeros/packages/runner/sync-gmail/caches"
 	"github.com/customeros/customeros/packages/runner/sync-gmail/config"
 	"github.com/customeros/customeros/packages/runner/sync-gmail/repository"
@@ -11,6 +10,7 @@ import (
 	commonService "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
 	neo4jrepository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
 	postgresRepository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
 type Services struct {
@@ -47,6 +47,7 @@ func InitServices(cfg *config.Config, driver *neo4j.DriverWithContext, postgresD
 		postgresRepositories,
 		&cfg.CommonConfig,
 		grpc_client.InitClients(nil),
+		&commonService.InitOptions{LoadPersonalEmailProviders: true},
 	)
 	return services
 }

--- a/packages/server/customer-os-api/services/init.go
+++ b/packages/server/customer-os-api/services/init.go
@@ -95,6 +95,7 @@ func InitServices(log logger.Logger, driver *neo4j.DriverWithContext, postgresDB
 		repositories.PostgresRepositories,
 		&cfg.Common,
 		grpcClients,
+		&commonService.InitOptions{LoadPersonalEmailProviders: true},
 	)
 
 	services := Services{

--- a/packages/server/customer-os-common-module/services/init.go
+++ b/packages/server/customer-os-common-module/services/init.go
@@ -127,12 +127,17 @@ type CommonServices struct {
 	WorkspaceService           interfaces.WorkspaceService
 }
 
+type InitOptions struct {
+	LoadPersonalEmailProviders bool
+}
+
 func InitCommonServices(
 	log logger.Logger,
 	neo4jRepositories *neo4j_repository.Repositories,
 	postgresRepositories *postgres_repository.Repositories,
 	cfg *config.CommonConfig,
 	grpcClients *grpc_client.Clients,
+	options *InitOptions,
 ) *CommonServices {
 	var err error
 
@@ -279,6 +284,22 @@ func InitCommonServices(
 
 	// Check that all services are initialized
 	CheckIsInitialized(&common)
+
+	// Process options
+	if options != nil {
+		if options.LoadPersonalEmailProviders {
+			//init app cache
+			personalEmailProviderEntities, err := postgresRepositories.PersonalEmailProviderRepository.GetPersonalEmailProviders()
+			if err != nil {
+				log.Fatalf("Error getting personal email providers: %s", err.Error())
+			}
+			personalEmailProviders := make([]string, 0)
+			for _, personalEmailProvider := range personalEmailProviderEntities {
+				personalEmailProviders = append(personalEmailProviders, personalEmailProvider.ProviderDomain)
+			}
+			common.Cache.SetPersonalEmailProviders(personalEmailProviders)
+		}
+	}
 
 	return &common
 }

--- a/packages/server/customer-os-platform-admin-api/service/init.go
+++ b/packages/server/customer-os-platform-admin-api/service/init.go
@@ -36,6 +36,7 @@ func InitServices(
 		postgresRepositories,
 		cfg.Common,
 		grpcClients,
+		&commonService.InitOptions{},
 	)
 
 	return &services

--- a/packages/server/customer-os-webhooks/server/server.go
+++ b/packages/server/customer-os-webhooks/server/server.go
@@ -8,15 +8,15 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gin-contrib/cors"
-	ginzap "github.com/gin-contrib/zap"
-	"github.com/gin-gonic/gin"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/clients/grpc_client"
 	commonConfig "github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	commonservice "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/validator"
+	"github.com/gin-contrib/cors"
+	ginzap "github.com/gin-contrib/zap"
+	"github.com/gin-gonic/gin"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -90,6 +90,7 @@ func (server *server) Run(parentCtx context.Context) error {
 		repos.PostgresRepositories,
 		&server.cfg.Common,
 		grpcContainer,
+		&commonservice.InitOptions{LoadPersonalEmailProviders: true},
 	)
 
 	// Setting up Gin

--- a/packages/server/events-processing-platform-subscribers/service/init.go
+++ b/packages/server/events-processing-platform-subscribers/service/init.go
@@ -37,6 +37,7 @@ func InitServices(
 		postgresRepositories,
 		&config,
 		grpcClients,
+		&commonServices.InitOptions{LoadPersonalEmailProviders: true},
 	)
 
 	return &services

--- a/packages/server/events-processing-platform-subscribers/test/utils.go
+++ b/packages/server/events-processing-platform-subscribers/test/utils.go
@@ -70,6 +70,7 @@ func SetupTestDatabase() (TestDatabase, func()) {
 		postgresRepositories,
 		cfg,
 		testDBs.GrpcClients,
+		&commonServices.InitOptions{},
 	)
 
 	testDBs.Services = &service.Services{

--- a/packages/server/events-subscribers/events_subscribers_main.go
+++ b/packages/server/events-subscribers/events_subscribers_main.go
@@ -82,6 +82,7 @@ func main() {
 		postgresRepositories,
 		cfg.Common,
 		eventsProcessingGrpcClient,
+		&commonService.InitOptions{},
 	)
 
 	// Create dependencies for event handlers


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add functionality to load personal email providers into cache across multiple service initializations.
> 
>   - **Behavior**:
>     - Add `LoadPersonalEmailProviders` option to `InitCommonServices` in `init.go`.
>     - Load personal email providers into cache if `LoadPersonalEmailProviders` is true.
>   - **Service Initialization**:
>     - Update `InitServices` in `customer_os_data_upkeeper_main.go`, `services.go` (sync-gmail-raw, sync-gmail), `init.go` (customer-os-api, customer-os-platform-admin-api, events-processing-platform-subscribers), `server.go` (customer-os-webhooks), and `events_subscribers_main.go` to pass `InitOptions` with `LoadPersonalEmailProviders` set to true.
>   - **Cache**:
>     - Add `SetPersonalEmailProviders` and `GetPersonalEmailProviders` methods to `Cache` in `caches.go` to manage personal email providers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f98c2f8f914a615c349a4893a8f0f300340d9207. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->