### PR TITLE
COS-6491: Invalidate data after successful organization merge

### DIFF
--- a/packages/apps/frontera/src/domain/services/organization/organizations.service.ts
+++ b/packages/apps/frontera/src/domain/services/organization/organizations.service.ts
@@ -1,3 +1,4 @@
+import { runInAction } from 'mobx';
 import { RootStore } from '@store/root';
 import { OrganizationsService } from '@store/Organizations/__service__/Organizations.service';
 
@@ -55,6 +56,28 @@ export class OrganizationService {
       await this.root.organizations.retrieve(results);
     } catch (_err) {
       throw new Error('Failed to search for tenant');
+    }
+  }
+
+  public async merge(primaryId: string, secondaryIds: string[]) {
+    try {
+      const { organization_Merge } = await this.service.mergeOrganizations({
+        primaryOrganizationId: primaryId,
+        mergedOrganizationIds: secondaryIds,
+      });
+
+      runInAction(() => {
+        if (organization_Merge.id) {
+          this.root.organizations.mergeOrganizations(primaryId, secondaryIds);
+
+          this.root.ui.toastSuccess(
+            `Merged organizations`,
+            `merge-${primaryId}`,
+          );
+        }
+      });
+    } catch (err) {
+      throw new Error('Failed to merge organizations');
     }
   }
 }

--- a/packages/apps/frontera/src/domain/usecases/command-menu/merge-organizations.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/command-menu/merge-organizations.usecase.ts
@@ -1,12 +1,13 @@
 import { RootStore } from '@store/root.ts';
 import { action, observable, runInAction } from 'mobx';
-import { OrganizationsService } from '@store/Organizations/__service__/Organizations.service.ts';
+import { OrganizationService } from '@domain/services';
 
 export class MergeOrganizationsCase {
   @observable accessor primaryId: string = '';
   @observable accessor secondaryId: string = '';
   @observable accessor error: string = '';
-  private service = OrganizationsService.getInstance();
+  private service = new OrganizationService();
+
   private root = RootStore.getInstance();
 
   constructor() {
@@ -22,25 +23,7 @@ export class MergeOrganizationsCase {
   @action
   async merge() {
     try {
-      const { organization_Merge } = await this.service.mergeOrganizations({
-        primaryOrganizationId: this.primaryId,
-        mergedOrganizationIds: [this.secondaryId],
-      });
-
-      runInAction(() => {
-        this.root.organizations.sync({
-          action: 'DELETE',
-          ids: [this.secondaryId],
-        });
-        this.root.organizations.sync({
-          action: 'INVALIDATE',
-          ids: [this.primaryId],
-        });
-
-        if (organization_Merge.id) {
-          this.root.ui.toastSuccess(`Merged organizations`, this.primaryId);
-        }
-      });
+      await this.service.merge(this.primaryId, [this.secondaryId]);
     } catch (err) {
       runInAction(() => {
         this.error = (err as Error).message;

--- a/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
+++ b/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
@@ -516,6 +516,24 @@ export class OrganizationsStore extends Store<OrganizationDatum, Organization> {
     }
   }
 
+  mergeOrganizations = (primaryId: string, secondaryIds: string[]) => {
+    secondaryIds.forEach((id) => {
+      this.root.organizations.value.delete(id);
+    });
+
+    this.root.organizations.sync({
+      action: 'DELETE',
+      ids: secondaryIds,
+    });
+
+    this.root.organizations.sync({
+      action: 'INVALIDATE',
+      ids: [primaryId],
+    });
+
+    this.root.ui.toastSuccess(`Merged organizations`, `merge-${primaryId}`);
+  };
+
   updateTags = (ids: string[], tags: TagDatum[]) => {
     const tagIdsToUpdate = new Set(tags.map((tag) => tag.metadata.id));
 


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds centralized organization merging logic with improved error handling and UI feedback.
> 
>   - **Behavior**:
>     - Adds `merge()` method in `OrganizationService` to handle organization merging and UI feedback.
>     - Updates `merge()` in `MergeOrganizationsCase` to use `OrganizationService.merge()`.
>     - Adds `mergeOrganizations()` in `OrganizationsStore` to delete secondary organizations and invalidate primary.
>   - **Error Handling**:
>     - Improved error handling in `merge()` in `MergeOrganizationsCase` with error messages and UI feedback.
>   - **UI Feedback**:
>     - Displays success toast in `mergeOrganizations()` in `OrganizationsStore` after merging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a6e0d4bbc2d0aadd02e89674397db842370bed29. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->