### PR TITLE
COS-6460: Fix unintended highlighting of all items when expanding sidebar groups

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/components/CollapsibleSection.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/components/CollapsibleSection.tsx
@@ -18,7 +18,7 @@ export const CollapsibleSection = ({
 }: CollapsibleSectionProps) => {
   return (
     <div>
-      <div
+      <button
         onClick={onToggle}
         className='w-full gap-1 flex justify-flex-start pl-3.5 cursor-pointer text-gray-500 hover:text-gray-700 transition-colors'
       >
@@ -29,7 +29,7 @@ export const CollapsibleSection = ({
             'transform -rotate-90': !isOpen,
           })}
         />
-      </div>
+      </button>
       {isOpen && <div className='mt-1'>{children}</div>}
     </div>
   );


### PR DESCRIPTION
…

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `div` with `button` in `CollapsibleSection` to fix unintended highlighting issue.
> 
>   - **Bugfix**:
>     - Replace `div` with `button` in `CollapsibleSection` component in `CollapsibleSection.tsx` to fix unintended highlighting of all items when expanding sidebar groups.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 857f410f83434f8c331ebc1a246a2ee942e0cb32. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->