### PR TITLE
Fix postmark server creation

### DIFF
--- a/packages/server/customer-os-api/config/config.go
+++ b/packages/server/customer-os-api/config/config.go
@@ -36,6 +36,7 @@ type CommonConfig struct {
 	Stripe           commonconf.StripeConfig
 	BetterContact    commonconf.BetterContactConfig
 	Scrapin          commonconf.ScrapinConfig
+	Postmark         commonconf.PostmarkConfig
 }
 
 type AppConfig struct {
@@ -114,6 +115,8 @@ func InitConfig() (*Config, error) {
 			IpDataConfig:        cmnCfg.IpData,
 			StripeConfig:        cmnCfg.Stripe,
 			BetterContactConfig: cmnCfg.BetterContact,
+			PostmarkConfig:      cmnCfg.Postmark,
+			ScrapinConfig:       cmnCfg.Scrapin,
 		},
 		Internal: commonconf.InternalServicesConfig{
 			MailSherpaApiConfig: cmnCfg.Mailsherpa,

--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -395,6 +395,7 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 				}
 			}
 
+			// TODO temp code, on each login try to prepare default tenant setup.
 			if !isPersonalEmail {
 				err = services.CommonServices.RegistrationService.PrepareDefaultTenantSetup(ctx, signInRequest.LoggedInEmail)
 				if err != nil {

--- a/packages/server/customer-os-common-module/services/events/subscriber.go
+++ b/packages/server/customer-os-common-module/services/events/subscriber.go
@@ -88,6 +88,77 @@ func (r *RabbitMQSubscriber) RegisterHandler(eventType interface{}, handler inte
 	}
 }
 
+// ListenQueue starts listening to a standard queue
+func (r *RabbitMQSubscriber) ListenQueue(queueName string) error {
+	return r.listenQueueWithExclusive(queueName, false)
+}
+
+// ListenQueueExclusive starts listening to an exclusive queue
+func (r *RabbitMQSubscriber) ListenQueueExclusive(queueName string) error {
+	return r.listenQueueWithExclusive(queueName, true)
+}
+
+// listenQueueWithExclusive is the internal method to listen to a queue with optional exclusivity
+func (r *RabbitMQSubscriber) listenQueueWithExclusive(queueName string, exclusive bool) error {
+	go func() {
+		for {
+			// Open a new channel for each queue
+			channel, err := r.connection.Channel()
+			if err != nil {
+				r.logger.Errorf("Failed to open channel for queue %s: %v. Retrying...", queueName, err)
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			defer channel.Close()
+
+			// Consume messages
+			msgs, err := channel.Consume(
+				queueName, // queue
+				"",        // consumer tag
+				false,     // auto-ack
+				exclusive, // exclusive
+				false,     // no-local
+				false,     // no-wait
+				nil,       // args
+			)
+			if err != nil {
+				if exclusive && strings.Contains(err.Error(), "ACCESS_REFUSED") && strings.Contains(err.Error(), "exclusive") {
+					r.logger.Warnf("Exclusive consumer conflict for queue %s. Only one instance can consume exclusively.", queueName)
+					time.Sleep(10 * time.Second)
+					continue
+				}
+				r.logger.Errorf("Failed to register consumer on queue %s: %v. Retrying...", queueName, err)
+				time.Sleep(5 * time.Second)
+				continue
+			}
+
+			r.logger.Infof("Listening for messages on queue %s", queueName)
+
+			for d := range msgs {
+				r.handleMessage(d)
+			}
+
+			r.logger.Warn("Connection lost for queue %s. Reconnecting...", queueName)
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	return nil
+}
+
+func (r *RabbitMQSubscriber) handleMessage(d amqp091.Delivery) {
+	// This will catch panics and send to Jaeger
+	defer tracing.RecoverAndLogToJaeger(r.logger)
+
+	err := r.processMessage(d)
+	if err != nil {
+		r.logger.Errorf("Failed to process message: %v", err)
+		r.retryAckNack(d, false)
+	} else {
+		r.retryAckNack(d, true)
+	}
+}
+
 // processMessage handles the processing of a single message
 func (r *RabbitMQSubscriber) processMessage(d amqp091.Delivery) error {
 	ctx := context.Background()
@@ -144,70 +215,6 @@ func (r *RabbitMQSubscriber) processMessage(d amqp091.Delivery) error {
 
 	// Call the handler
 	return handlerReg.Handler.HandlerFunc(ctx, &event)
-}
-
-// ListenQueue starts listening to a standard queue
-func (r *RabbitMQSubscriber) ListenQueue(queueName string) error {
-	return r.listenQueueWithExclusive(queueName, false)
-}
-
-// ListenQueueExclusive starts listening to an exclusive queue
-func (r *RabbitMQSubscriber) ListenQueueExclusive(queueName string) error {
-	return r.listenQueueWithExclusive(queueName, true)
-}
-
-// listenQueueWithExclusive is the internal method to listen to a queue with optional exclusivity
-func (r *RabbitMQSubscriber) listenQueueWithExclusive(queueName string, exclusive bool) error {
-	go func() {
-		for {
-			// Open a new channel for each queue
-			channel, err := r.connection.Channel()
-			if err != nil {
-				r.logger.Errorf("Failed to open channel for queue %s: %v. Retrying...", queueName, err)
-				time.Sleep(5 * time.Second)
-				continue
-			}
-			defer channel.Close()
-
-			// Consume messages
-			msgs, err := channel.Consume(
-				queueName, // queue
-				"",        // consumer tag
-				false,     // auto-ack
-				exclusive, // exclusive
-				false,     // no-local
-				false,     // no-wait
-				nil,       // args
-			)
-			if err != nil {
-				if exclusive && strings.Contains(err.Error(), "ACCESS_REFUSED") && strings.Contains(err.Error(), "exclusive") {
-					r.logger.Warnf("Exclusive consumer conflict for queue %s. Only one instance can consume exclusively.", queueName)
-					time.Sleep(10 * time.Second)
-					continue
-				}
-				r.logger.Errorf("Failed to register consumer on queue %s: %v. Retrying...", queueName, err)
-				time.Sleep(5 * time.Second)
-				continue
-			}
-
-			r.logger.Infof("Listening for messages on queue %s", queueName)
-
-			for d := range msgs {
-				err := r.processMessage(d)
-				if err != nil {
-					r.logger.Errorf("Failed to process message: %v", err)
-					r.retryAckNack(d, false)
-				} else {
-					r.retryAckNack(d, true)
-				}
-			}
-
-			r.logger.Warn("Connection lost for queue %s. Reconnecting...", queueName)
-			time.Sleep(5 * time.Second)
-		}
-	}()
-
-	return nil
 }
 
 // retryAckNack attempts to acknowledge or negative acknowledge a message with retries

--- a/packages/server/customer-os-common-module/services/registration/service.go
+++ b/packages/server/customer-os-common-module/services/registration/service.go
@@ -77,7 +77,7 @@ func (s *registrationService) IsInitialized() bool {
 }
 
 func (s *registrationService) PrepareDefaultTenantSetup(ctx context.Context, loggedInUserEmail string) error {
-	span, ctx := s.initializeTracing(ctx, "RegistrationService.PrepareDefaultTenantSetup", map[string]interface{}{
+	span, ctx := s.initializeTracing(ctx, "PrepareDefaultTenantSetup", map[string]interface{}{
 		"loggedInUserEmail": loggedInUserEmail,
 	})
 	defer span.Finish()
@@ -449,7 +449,6 @@ func (s *registrationService) CreatePostmarkServer(ctx context.Context) error {
 }
 
 // Helper functions
-
 func (s *registrationService) initializeTracing(ctx context.Context, operation string, logFields map[string]interface{}) (opentracing.Span, context.Context) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, fmt.Sprintf("RegistrationService.%s", operation))
 	tracing.SetDefaultServiceSpanTags(ctx, span)

--- a/packages/server/events-subscribers/events_subscribers_main.go
+++ b/packages/server/events-subscribers/events_subscribers_main.go
@@ -42,7 +42,6 @@ func main() {
 	if tracingCloser != nil {
 		defer tracingCloser.Close()
 	}
-	defer tracing.RecoverAndLogToJaeger(appLogger)
 
 	postgresDb, err := commonConfig.InitPostgres(&commonConfig.CommonConfig{
 		Infrastructure: commonConfig.InfrastructureConfig{


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Postmark configuration and improve RabbitMQ subscriber functionality with refactoring and error handling enhancements.
> 
>   - **Configuration**:
>     - Add `PostmarkConfig` to `CommonConfig` in `config.go`.
>     - Update `InitConfig()` in `config.go` to include `PostmarkConfig`.
>   - **RabbitMQ Subscriber**:
>     - Refactor `ListenQueue` and `ListenQueueExclusive` in `subscriber.go` to improve error handling and logging.
>     - Add `handleMessage()` in `subscriber.go` to process messages with error handling.
>   - **Registration Service**:
>     - Update `PrepareDefaultTenantSetup()` in `service.go` to call `CreatePostmarkServer()`.
>     - Refactor `initializeTracing()` in `service.go` to improve tracing setup.
>   - **Misc**:
>     - Add temporary code in `registration.go` to prepare default tenant setup on each login.
>     - Remove redundant tracing defer in `events_subscribers_main.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c8d2d4e3236283aaafd313d3e0b5c4f8e6cac4a5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->