### PR TITLE
Fix find work email error

### DIFF
--- a/packages/server/customer-os-api/graphql/resolver/contact.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/contact.resolvers.go
@@ -894,9 +894,7 @@ func (r *mutationResolver) ContactFindWorkEmail(ctx context.Context, contactID s
 		return &model.ActionResponse{Accepted: false}, nil
 	}
 	if enrichmentResponse == nil {
-		tracing.TraceErr(span, errors.New("enrichment response is nil"))
-		graphql.AddErrorf(ctx, "Failed to find work email for contact %s", contactID)
-		return &model.ActionResponse{Accepted: false}, nil
+		return &model.ActionResponse{Accepted: true}, nil
 	}
 
 	var emailsToCreateAndLinkWithContact []string

--- a/packages/server/customer-os-api/rest/enrich/enrich_person.go
+++ b/packages/server/customer-os-api/rest/enrich/enrich_person.go
@@ -386,7 +386,7 @@ func (h *EnrichHandler) EnrichPerson() gin.HandlerFunc {
 			companyName,
 			companyDomain,
 			enrichPhoneNumber)
-		if err != nil || findWorkEmailResponse == nil {
+		if err != nil {
 			h.responseHandler.HandleError(c, http.StatusInternalServerError, nil)
 			return
 		}
@@ -397,15 +397,15 @@ func (h *EnrichHandler) EnrichPerson() gin.HandlerFunc {
 			response.Data = *enrichedPersonData
 		}
 
-		betterContactResponseBody := findWorkEmailResponse.Data
-		query := postgresentity.CosApiEnrichPersonTempResult{
-			Tenant:                tenant,
-			BettercontactRecordId: dbID,
-		}
-		if personDbID != nil {
-			query.ScrapinRecordId = *personDbID
-		}
-		if betterContactResponseBody == nil {
+		if findWorkEmailResponse == nil || findWorkEmailResponse.Data == nil {
+			query := postgresentity.CosApiEnrichPersonTempResult{
+				Tenant:                tenant,
+				BettercontactRecordId: dbID,
+			}
+			if personDbID != nil {
+				query.ScrapinRecordId = *personDbID
+			}
+
 			dbRecord, err := h.services.Repositories.PostgresRepositories.CosApiEnrichPersonTempResultRepository.Create(ctx, query)
 			if err != nil {
 				tracing.TraceErr(span, errors.Wrap(err, "failed to create temp result"))
@@ -419,6 +419,8 @@ func (h *EnrichHandler) EnrichPerson() gin.HandlerFunc {
 			}
 			response.ResultURL = h.services.Cfg.Common.Internal.CustomerOsApi.ApiUrl + enrichPersonAcceptedUrl + "/" + dbRecord.ID.String()
 		} else {
+			betterContactResponseBody := findWorkEmailResponse.Data
+
 			response.IsComplete = true
 			emailFound, phoneFound := false, false
 			for _, item := range betterContactResponseBody {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix handling of nil enrichment responses in `ContactFindWorkEmail` and `EnrichPerson` to prevent unnecessary errors.
> 
>   - **Behavior**:
>     - In `ContactFindWorkEmail` in `contact.resolvers.go`, change behavior to return `Accepted: true` when `enrichmentResponse` is nil.
>     - In `EnrichPerson` in `enrich_person.go`, modify condition to handle `findWorkEmailResponse` being nil without error.
>   - **Error Handling**:
>     - Remove error logging and GraphQL error addition when `enrichmentResponse` is nil in `ContactFindWorkEmail`.
>     - Adjust error handling in `EnrichPerson` to not treat nil `findWorkEmailResponse` as an error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 93f16fa0cdd6925b0cd38390518cacc9439ffa2e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->