### PR TITLE
fix: display connected to in contactPreviewCard

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/ContactPreviewCard/ContactPreviewCard.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/ContactPreviewCard/ContactPreviewCard.tsx
@@ -97,6 +97,12 @@ export const ContactPreviewCard = observer(() => {
     },
   );
 
+  const usersStore = store.users
+    .toArray()
+    .filter((user) => contact.value.connectedUsers?.includes(user.id));
+
+  const users = usersStore.map((user) => user.value.name);
+
   return (
     <>
       {store.ui.contactPreviewCardOpen && (
@@ -265,16 +271,24 @@ export const ContactPreviewCard = observer(() => {
                 <LinkedInSolid02 className='mt-[1px] text-gray-500' />
                 Connected to
               </div>
-              <span
-                className={cn(
-                  'overflow-hidden text-ellipsis whitespace-nowrap cursor-not-allowed text-sm',
-                  contact?.value?.connectedUsers?.[0]
-                    ? 'text-gray-700'
-                    : 'text-gray-400',
-                )}
-              >
-                {contact?.value?.connectedUsers?.[0] || 'No one yet'}
-              </span>
+
+              {users.length > 0 ? (
+                <span
+                  className={cn(
+                    'overflow-hidden text-ellipsis whitespace-nowrap cursor-not-allowed text-sm text-gray-700',
+                  )}
+                >
+                  {users.join(', ')}
+                </span>
+              ) : (
+                <span
+                  className={cn(
+                    'overflow-hidden text-ellipsis whitespace-nowrap cursor-not-allowed text-sm text-gray-400',
+                  )}
+                >
+                  {'No one yet'}
+                </span>
+              )}
             </div>
             {contact?.value?.enrichedAt && (
               <div className='text-xs text-gray-500'>


### PR DESCRIPTION
## Proposed changes


## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `ContactPreviewCard.tsx` to display all connected users or 'No one yet'.
> 
>   - **Behavior**:
>     - Fixes bug in `ContactPreviewCard.tsx` to display all connected users instead of just the first one.
>     - Displays 'No one yet' if no users are connected.
>   - **Logic**:
>     - Filters `store.users` to find connected users and maps them to their names.
>     - Joins user names with a comma for display.
>   - **UI**:
>     - Updates UI to handle multiple connected users in the 'Connected to' section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d0652d1803451beb6284d327a888b5636dfc4bf4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->