### PR TITLE
fix nil pointers

### DIFF
--- a/packages/server/customer-os-common-module/services/agent/visitor_id_agent.go
+++ b/packages/server/customer-os-common-module/services/agent/visitor_id_agent.go
@@ -133,11 +133,13 @@ func (a *AgentVisitorIDService) executeOrgCreationCapability(ctx context.Context
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 
+	source := "WebVisitor ID Agent"
 	executionContainer := dto.CapabilityExecutionContainer{
 		AgentID:          agentID,
 		AgentExecutionID: executionID,
 		Capability:       enum.CapabilityCreateOrganization,
 		InputData: data_fields.OrganizationFields{
+			Source:  &source,
 			Domains: []string{domain},
 		},
 	}

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
@@ -64,6 +64,13 @@ func (c *agentCapabilityService) executeWebSessionAnalysis(ctx context.Context, 
 	defer span.Finish()
 	tracing.TagComponentService(span)
 
+	// validation
+	if data.SessionID == "" || data.Domain == "" {
+		err := errors.New("Missing required input data")
+		tracing.TraceErr(span, err)
+		return AnalyzeWebSessionResult{}, err
+	}
+
 	// get unique pageviews
 	pageViews, err := c.getUniquePageViews(ctx, data.SessionID)
 	if err != nil {
@@ -152,10 +159,10 @@ func (c *agentCapabilityService) getUniquePageViews(ctx context.Context, session
 		Tenant:    common.GetTenantFromContext(ctx),
 	}, nil)
 	if err != nil {
-		return nil, err
+		return []string{}, err
 	}
 	if session == nil {
-		return nil, nil
+		return []string{}, nil
 	}
 
 	// Use map to track unique pages
@@ -189,6 +196,12 @@ func (c *agentCapabilityService) calculateSessionDuration(ctx context.Context, s
 		return "", err
 	}
 	if session == nil {
+		return "", nil
+	}
+
+	if session.EndTime == nil || session.EndTime.IsZero() {
+		err := errors.New("Session EndTime not set")
+		tracing.TraceErr(span, err)
 		return "", err
 	}
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_create_organization.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_create_organization.go
@@ -2,6 +2,7 @@ package agent_capability
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/opentracing/opentracing-go"
@@ -19,6 +20,12 @@ func (c *agentCapabilityService) handleOrganizationCreationExecution(ctx context
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentCapabilityService.handleOrganizationCreationExecution")
 	defer span.Finish()
 	tracing.TagComponentService(span)
+
+	if executionContainer == nil {
+		err := errors.New("executionContainer cannot be nil")
+		tracing.TraceErr(span, err)
+		return err
+	}
 
 	input, ok := executionContainer.InputData.(data_fields.OrganizationFields)
 	if !ok {

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
@@ -2,6 +2,7 @@ package agent_capability
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/customeros/mailsherpa/domaincheck"
@@ -54,6 +55,17 @@ func (c *agentCapabilityService) executeIdentifyWebsiteVisitor(ctx context.Conte
 
 	results := IdentifyWebsiteVisitorResult{}
 
+	if data.IPAddress == "" {
+		err := errors.New("IP address cannot be empty")
+		tracing.TraceErr(span, err)
+		return results, err
+	}
+	if data.SessionID == "" {
+		err := errors.New("SessionID cannot be empty")
+		tracing.TraceErr(span, err)
+		return results, err
+	}
+
 	domain, linkedInSlug, err := c.identifyIP(ctx, data.IPAddress)
 	if err != nil {
 		tracing.TraceErr(span, err)
@@ -90,6 +102,10 @@ func (c *agentCapabilityService) identifyIP(ctx context.Context, ipAddress strin
 	}
 
 	_, primaryDomain := domaincheck.PrimaryDomainCheck(snitcherData.Company.Domain)
+
+	if snitcherData.Company.Profiles != nil && snitcherData.Company.Profiles.LinkedIn != nil {
+		linkedinSlug = snitcherData.Company.Profiles.LinkedIn.Handle
+	}
 
 	return primaryDomain, snitcherData.Company.Profiles.LinkedIn.Handle, nil
 }

--- a/packages/server/events-subscribers/listeners/agent_engine.go
+++ b/packages/server/events-subscribers/listeners/agent_engine.go
@@ -15,7 +15,6 @@ import (
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/customeros/mailsherpa/mailvalidate"
 	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"golang.org/x/net/context"
 
@@ -38,38 +37,30 @@ func OnWebhookEventCreated(ctx context.Context, dependencies *model.DependencyCo
 	tracing.SetDefaultListenerSpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", input)
 
-	eventName, webhookEvent, err := getWebhookEvent(input)
+	_, webhookEvent, err := getWebhookEvent(input)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err
 	}
 
-	if webhookEvent == nil {
-		err := errors.New("webhookEvent is nil")
-		tracing.TraceErr(span, err)
-		return err
-	}
-
-	if webhookEvent.Data == nil {
-		err := errors.New("webhookEvent.Data is nil")
-		tracing.TraceErr(span, err)
-		return err
+	if webhookEvent == nil || webhookEvent.Data == nil || webhookEvent.DataType == "" {
+		return fmt.Errorf("invalid webhook event: missing required fields")
 	}
 
 	// determine event handler //
 	switch webhookEvent.DataType {
 
-	case data_fields.MeetingSummaryEvent{}.Type():
-		eventData, ok := webhookEvent.Data.(*data_fields.MeetingSummaryEvent)
-		if !ok {
-			return fmt.Errorf("failed to cast to MeetingSummaryEvent, got type: %T", webhookEvent.Data)
-		}
-
-		err = handleMeetingSummaryEvent(ctx, dependencies.CommonServices, eventName, eventData)
-		if err != nil {
-			tracing.TraceErr(span, err)
-			return err
-		}
+	// case data_fields.MeetingSummaryEvent{}.Type():
+	// 	eventData, ok := webhookEvent.Data.(*data_fields.MeetingSummaryEvent)
+	// 	if !ok {
+	// 		return fmt.Errorf("failed to cast to MeetingSummaryEvent, got type: %T", webhookEvent.Data)
+	// 	}
+	//
+	// 	err = handleMeetingSummaryEvent(ctx, dependencies.CommonServices, eventName, eventData)
+	// 	if err != nil {
+	// 		tracing.TraceErr(span, err)
+	// 		return err
+	// 	}
 
 	case data_fields.WebsiteVisitEvent{}.Type():
 		eventData, ok := webhookEvent.Data.(*data_fields.WebsiteVisitEvent)
@@ -77,10 +68,14 @@ func OnWebhookEventCreated(ctx context.Context, dependencies *model.DependencyCo
 			return fmt.Errorf("failed to cast to WebsiteVisitEvent, got type: %T", webhookEvent.Data)
 		}
 
-		websiteVisitEvent := website_visit_event.NewWebsiteVisitEventHandler(
+		websiteVisitEvent, err := website_visit_event.NewWebsiteVisitEventHandler(
 			dependencies,
 			eventData,
 		)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
 
 		return websiteVisitEvent.Handle(ctx)
 
@@ -90,7 +85,6 @@ func OnWebhookEventCreated(ctx context.Context, dependencies *model.DependencyCo
 		return err
 	}
 
-	return nil
 }
 
 func handleMeetingSummaryEvent(ctx context.Context, s *service.CommonServices, sourceEvent commonenum.FlowListenerEvent, eventData *data_fields.MeetingSummaryEvent) error {
@@ -306,41 +300,55 @@ func handleMarkdownEventPublishing(ctx context.Context, s *service.CommonService
 }
 
 func getWebhookEvent(input any) (commonenum.FlowListenerEvent, *dto.WebhookEvent, error) {
+	// Cast input to Event
 	message, ok := input.(*dto.Event)
 	if !ok {
-		return commonenum.NotSet, nil, fmt.Errorf("failed to cast to Event")
-	}
-	// check message data type before conversion
-	if message.Event.Data == nil {
-		err := errors.New("message data is nil")
-		return commonenum.NotSet, nil, err
+		return commonenum.NotSet, nil, fmt.Errorf("expected *dto.Event, got %T", input)
 	}
 
+	// Validate message
+	if message == nil || message.Event.Data == nil {
+		return commonenum.NotSet, nil, fmt.Errorf("message or message.Event.Data is nil")
+	}
+
+	// Cast Event.Data to WebhookEvent
 	webhookEvent, ok := message.Event.Data.(*dto.WebhookEvent)
 	if !ok {
-		err := errors.New("event is not a webhook event")
-		return commonenum.NotSet, nil, err
+		return commonenum.NotSet, nil, fmt.Errorf("expected *dto.WebhookEvent, got %T", message.Event.Data)
 	}
 
-	webhookData, ok := webhookEvent.Data.(map[string]interface{})
-	if !ok {
-		err := errors.New("event data is not a map")
-		return commonenum.NotSet, nil, err
+	// Validate webhook event
+	if webhookEvent.DataType == "" {
+		return commonenum.NotSet, nil, fmt.Errorf("webhook event data type is empty")
 	}
 
+	// Get the expected type for this event
 	eventDataType, ok := eventDataTypes[webhookEvent.DataType]
 	if !ok {
-		err := fmt.Errorf("event data type %s is not supported", webhookEvent.DataType)
-		return commonenum.NotSet, nil, err
+		return commonenum.NotSet, nil, fmt.Errorf("unsupported event data type: %s", webhookEvent.DataType)
 	}
 
+	// Cast webhook data to map
+	webhookData, ok := webhookEvent.Data.(map[string]interface{})
+	if !ok {
+		return commonenum.NotSet, nil, fmt.Errorf("expected map[string]interface{}, got %T", webhookEvent.Data)
+	}
+
+	// Create new instance of the target type
 	webhookDataPtr := reflect.New(eventDataType).Interface()
-	err := utils.Decode(webhookData, webhookDataPtr)
-	if err != nil {
-		return commonenum.NotSet, nil, err
+
+	// Decode the map into the target type
+	if err := utils.Decode(webhookData, webhookDataPtr); err != nil {
+		return commonenum.NotSet, nil, fmt.Errorf("failed to decode webhook data: %w", err)
 	}
 
+	// Set the decoded data
 	webhookEvent.Data = webhookDataPtr
+
+	// Validate name before returning
+	if webhookEvent.Name == commonenum.NotSet {
+		return commonenum.NotSet, nil, fmt.Errorf("webhook event name is not set")
+	}
 
 	return webhookEvent.Name, webhookEvent, nil
 }

--- a/packages/server/events-subscribers/listeners/website_visit_event/handler.go
+++ b/packages/server/events-subscribers/listeners/website_visit_event/handler.go
@@ -20,11 +20,21 @@ type WebsiteVisitEventHandler struct {
 	event        *data_fields.WebsiteVisitEvent
 }
 
-func NewWebsiteVisitEventHandler(dependencies *model.DependencyContainer, event *data_fields.WebsiteVisitEvent) *WebsiteVisitEventHandler {
+func NewWebsiteVisitEventHandler(dependencies *model.DependencyContainer, event *data_fields.WebsiteVisitEvent) (*WebsiteVisitEventHandler, error) {
+	if event == nil {
+		err := errors.New("Event cannot be nil")
+		return nil, err
+	}
+
+	if event.Tenant == "" {
+		err := errors.New("Tenant cannot be empty")
+		return nil, err
+	}
+
 	return &WebsiteVisitEventHandler{
 		dependencies: dependencies,
 		event:        event,
-	}
+	}, nil
 }
 
 // Add all subscribed Agents here
@@ -44,7 +54,7 @@ func (h *WebsiteVisitEventHandler) Handle(ctx context.Context) error {
 	})
 
 	activeAgents := h.lookupActiveAgents(ctx)
-	if activeAgents == nil {
+	if activeAgents == nil || len(activeAgents) == 0 {
 		return nil
 	}
 
@@ -64,6 +74,18 @@ func (h *WebsiteVisitEventHandler) route(ctx context.Context, agent postgres_ent
 	span, ctx := tracing.StartTracerSpan(ctx, "WebsiteVisitEventHandler.execute")
 	defer span.Finish()
 	tracing.SetDefaultListenerSpanTags(ctx, span)
+
+	if agent.Type == "" {
+		err := errors.New("agent.Type is empty")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	if agent.ID == "" {
+		err := errors.New("agent.ID is empty")
+		tracing.TraceErr(span, err)
+		return err
+	}
 
 	// run agent
 	agentType, err := enum.GetAgentType(agent.Type)


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix nil pointer issues and add validation checks across various services and capabilities.
> 
>   - **Validation and Error Handling**:
>     - Add validation for `SessionID` and `Domain` in `executeWebSessionAnalysis()` in `capability_analyze_web_session.go`.
>     - Add validation for `executionContainer` in `handleOrganizationCreationExecution()` in `capability_create_organization.go`.
>     - Add validation for `IPAddress` and `SessionID` in `executeIdentifyWebsiteVisitor()` in `capability_identify_web_visitor.go`.
>     - Add validation for `event` and `Tenant` in `NewWebsiteVisitEventHandler()` in `handler.go`.
>     - Add validation for `agent.Type` and `agent.ID` in `route()` in `handler.go`.
>   - **Behavior Changes**:
>     - Return empty slices instead of nil in `getUniquePageViews()` in `capability_analyze_web_session.go`.
>     - Return empty string instead of nil in `calculateSessionDuration()` in `capability_analyze_web_session.go`.
>     - Handle missing `webhookEvent` fields in `OnWebhookEventCreated()` in `agent_engine.go`.
>   - **Miscellaneous**:
>     - Remove unused import `github.com/pkg/errors` in `agent_engine.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for ce7111475385ff5df4bedcd2e1bfb6fd2e958e91. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->