### PR TITLE
COS-6585: Truncate org description on table to 8 lines

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/avatar/AvatarCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/avatar/AvatarCell.tsx
@@ -73,7 +73,7 @@ export const AvatarCell = memo(
               />
             )}
             <p className='text-md font-semibold'>{fullName}</p>
-            <p className='text-xs'>{description}</p>
+            <p className='text-xs line-clamp-[8]'>{description}</p>
           </PopoverContent>
         </Popover>
       </div>

--- a/packages/apps/frontera/tailwind.config.ts
+++ b/packages/apps/frontera/tailwind.config.ts
@@ -34,6 +34,7 @@ export default {
     extend: {
       lineClamp: {
         5: '5',
+        8: '8',
       },
       keyframes: {
         pulseOpacity: {


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Truncates organization description to 8 lines in `AvatarCell` and updates Tailwind config to support this.
> 
>   - **Behavior**:
>     - Truncates organization description to 8 lines in `AvatarCell` component using `line-clamp-[8]`.
>   - **Configuration**:
>     - Adds `8` to `lineClamp` in `tailwind.config.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c3ab483242b6976a080fe2619235c98ab5b95627. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->