### PR TITLE
agent execution validation

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/web_session_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/web_session_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
@@ -10,6 +11,7 @@ import (
 	commonservice "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/multierr"
 
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/config"
@@ -82,7 +84,7 @@ func (s *webSessionService) ProcessWebSessions() {
 }
 
 func (s *webSessionService) findTimedOutPageExitEvents(ctx context.Context) ([]postgres_entity.WebSession, error) {
-	span, ctx := tracing.StartTracerSpan(ctx, "WebSessionService.findTimedOutPageExitEvents")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionService.findTimedOutPageExitEvents")
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
 
@@ -95,7 +97,7 @@ func (s *webSessionService) findTimedOutPageExitEvents(ctx context.Context) ([]p
 }
 
 func (s *webSessionService) findTimedOutPageViewEvents(ctx context.Context) ([]postgres_entity.WebSession, error) {
-	span, ctx := tracing.StartTracerSpan(ctx, "WebSessionService.findTimedOutPageViewEvents")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionService.findTimedOutPageViewEvents")
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
 
@@ -108,23 +110,19 @@ func (s *webSessionService) findTimedOutPageViewEvents(ctx context.Context) ([]p
 }
 
 func (s *webSessionService) closeSessions(ctx context.Context, sessions []postgres_entity.WebSession) error {
-	span, ctx := tracing.StartTracerSpan(ctx, "WebSessionService.closeSessions")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionService.closeSessions")
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
 
+	if sessions == nil || len(sessions) == 0 {
+		err := errors.New("There are no sessions to process")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
 	var errs error
 	for _, session := range sessions {
-		event := s.createCloseSessionWebhookEvent(ctx, session)
-
-		err := s.commonServices.Events.Publisher.PublishWebhookEvent(ctx, event)
-		if err != nil {
-			tracing.TraceErr(span, err)
-			errs = multierr.Append(errs, err)
-		}
-
-		// update websession record
-		endTime := s.calculateSessionEnd(ctx, session)
-		_, err = s.commonServices.PostgresRepositories.WebSessionRepository.UpdateSessionEnd(ctx, session.ID, endTime)
+		err := s.processClosedSession(ctx, session)
 		if err != nil {
 			tracing.TraceErr(span, err)
 			errs = multierr.Append(errs, err)
@@ -134,18 +132,63 @@ func (s *webSessionService) closeSessions(ctx context.Context, sessions []postgr
 	return errs
 }
 
+func (s *webSessionService) processClosedSession(ctx context.Context, session postgres_entity.WebSession) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionService.processClosedSession")
+	defer span.Finish()
+	tracing.TagComponentCronJob(span)
+
+	if session.ID == "" {
+		err := errors.New("SessionID cannot be empty")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	// close websession record
+	endTime := s.calculateSessionEnd(ctx, session)
+	closedSession, err := s.commonServices.PostgresRepositories.WebSessionRepository.UpdateSessionEnd(ctx, session.ID, endTime)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+	if closedSession == nil {
+		err := errors.New("closedSession is nil")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	event, err := s.createCloseSessionWebhookEvent(ctx, *closedSession)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	err = s.commonServices.Events.Publisher.PublishWebhookEvent(ctx, event)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	return nil
+}
+
 func (s *webSessionService) calculateSessionEnd(ctx context.Context, session postgres_entity.WebSession) time.Time {
-	span, ctx := tracing.StartTracerSpan(ctx, "WebSessionService.calculateSessionEnd")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionService.calculateSessionEnd")
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
 
 	return session.LastActivity.Add(time.Minute)
 }
 
-func (s *webSessionService) createCloseSessionWebhookEvent(ctx context.Context, session postgres_entity.WebSession) dto.WebhookEvent {
-	span, ctx := tracing.StartTracerSpan(ctx, "WebSessionService.createCloseSessionWebhookEvent")
+func (s *webSessionService) createCloseSessionWebhookEvent(ctx context.Context, session postgres_entity.WebSession) (dto.WebhookEvent, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionService.createCloseSessionWebhookEvent")
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
+
+	if session.ID == "" || session.Tenant == "" || session.IP == "" || session.VisitorID == "" {
+		err := errors.New("cannot build web visit event")
+		tracing.TraceErr(span, err)
+		return dto.WebhookEvent{}, err
+	}
 
 	eventData := data_fields.WebsiteVisitEvent{
 		SessionID: session.ID,
@@ -161,5 +204,5 @@ func (s *webSessionService) createCloseSessionWebhookEvent(ctx context.Context, 
 		Data:             &eventData,
 	}
 
-	return event
+	return event, nil
 }

--- a/packages/server/customer-os-api/rest/public/reveal_website_events.go
+++ b/packages/server/customer-os-api/rest/public/reveal_website_events.go
@@ -157,15 +157,15 @@ func (h *WebsiteTrackerEventsHandler) assignEventToSession(ctx context.Context, 
 	}
 
 	trackerData.SessionID = session.ID
-	return h.updateSessionLastActivityTimestamp(ctx, trackerData.SessionID)
+	return h.updateSessionLastActivity(ctx, trackerData.SessionID, trackerData.EventType)
 }
 
-func (h *WebsiteTrackerEventsHandler) updateSessionLastActivityTimestamp(ctx context.Context, sessionID string) error {
+func (h *WebsiteTrackerEventsHandler) updateSessionLastActivity(ctx context.Context, sessionID, eventType string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "WebsiteTrackerEventsHandler.updateSessionLastActivityTimestamp")
 	defer span.Finish()
 	tracing.TagComponentRest(span)
 
-	_, err := h.services.Repositories.PostgresRepositories.WebSessionRepository.UpdateLastActivity(ctx, sessionID)
+	_, err := h.services.Repositories.PostgresRepositories.WebSessionRepository.UpdateLastActivity(ctx, sessionID, eventType)
 	if err != nil {
 		err = errors.New("unable to update web session")
 		tracing.TraceErr(span, err)

--- a/packages/server/customer-os-common-module/services/agent/visitor_id_agent.go
+++ b/packages/server/customer-os-common-module/services/agent/visitor_id_agent.go
@@ -15,6 +15,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/agent_capability"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 )
 
 type AgentVisitorIDService struct {
@@ -46,6 +47,12 @@ func (a *AgentVisitorIDService) Run(ctx context.Context, agentID string, event *
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 
+	err := a.validateWebsiteVisitEvent(event)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
 	// create execution record
 	executionID, err := a.createAgentExecutionRecord(ctx, agentID, event.Type())
 	if err != nil {
@@ -59,10 +66,29 @@ func (a *AgentVisitorIDService) Run(ctx context.Context, agentID string, event *
 	visitorIDResults, err := a.executeVisitorIDCapability(ctx, agentID, executionID, event)
 	if err != nil {
 		tracing.TraceErr(span, err)
+		errMessage := "unable to lookup visitor ID"
+		_, err := a.postgresRepositories.AgentExecutionRepository.Update(
+			ctx, executionID, nil, &errMessage, false)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
 		return err
 	}
+
 	// no result, return early
 	if visitorIDResults.Domain == "" {
+		_, err := a.postgresRepositories.AgentExecutionRepository.Update(
+			ctx,
+			executionID,
+			nil, // completedAt
+			nil, // errorMessage
+			false,
+		)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
 		return nil
 	}
 
@@ -70,6 +96,13 @@ func (a *AgentVisitorIDService) Run(ctx context.Context, agentID string, event *
 	orgCreationResults, err := a.executeOrgCreationCapability(ctx, agentID, executionID, visitorIDResults.Domain)
 	if err != nil {
 		tracing.TraceErr(span, err)
+		errMessage := "unable to create new organization"
+		_, err := a.postgresRepositories.AgentExecutionRepository.Update(
+			ctx, executionID, nil, &errMessage, false)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
 		return err
 	}
 
@@ -84,10 +117,52 @@ func (a *AgentVisitorIDService) Run(ctx context.Context, agentID string, event *
 	)
 	if err != nil {
 		tracing.TraceErr(span, err)
+		errMessage := "unable to analyze web session"
+		_, err := a.postgresRepositories.AgentExecutionRepository.Update(
+			ctx, executionID, nil, &errMessage, false)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
 		return err
 	}
 
 	// execute send notification capability
+
+	// update agentExecutionRecord
+	_, err = a.postgresRepositories.AgentExecutionRepository.Update(
+		ctx,
+		executionID,
+		utils.NowPtr(),
+		nil,
+		true,
+	)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	return nil
+}
+
+func (a *AgentVisitorIDService) validateWebsiteVisitEvent(event *data_fields.WebsiteVisitEvent) error {
+	if event == nil {
+		return fmt.Errorf("event cannot be nil")
+	}
+
+	if event.SessionID == "" {
+		return fmt.Errorf("sessionId cannot be empty")
+	}
+	if event.Tenant == "" {
+		return fmt.Errorf("tenant cannot be empty")
+	}
+	if event.IPAddress == "" {
+		return fmt.Errorf("ipAddress cannot be empty")
+	}
+	if event.VisitorID == "" {
+		return fmt.Errorf("visitorId cannot be empty")
+	}
+
 	return nil
 }
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
@@ -77,12 +77,11 @@ func (c *agentCapabilityService) executeIdentifyWebsiteVisitor(ctx context.Conte
 	results.LinkedInSlug = linkedInSlug
 
 	if domain != "" {
-		return results, nil
-	}
-	_, err = c.postgresRepositories.WebSessionRepository.UpdateSessionWithDomain(ctx, data.SessionID, domain)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return results, err
+		_, err = c.postgresRepositories.WebSessionRepository.UpdateSessionWithDomain(ctx, data.SessionID, domain)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return results, err
+		}
 	}
 
 	return results, nil

--- a/packages/server/customer-os-common-module/services/workflow/service.go
+++ b/packages/server/customer-os-common-module/services/workflow/service.go
@@ -328,5 +328,5 @@ func (w *workflowService) SaveFlowAgentExecutionRecord(ctx context.Context, flow
 		return w.postgres.AgentExecutionRepository.Create(ctx, flowAgentExecutionRecord)
 	}
 
-	return w.postgres.AgentExecutionRepository.Update(ctx, flowAgentExecutionRecord)
+	return &postgres_entity.AgentExecution{}, nil
 }

--- a/packages/server/customer-os-postgres-repository/entity/agent_execution.go
+++ b/packages/server/customer-os-postgres-repository/entity/agent_execution.go
@@ -9,7 +9,7 @@ type AgentExecution struct {
 	AgentID      *string    `gorm:"column:agent_id;type:varchar(50);not null" json:"agent_id" binding:"required"`
 	TriggerEvent string     `gorm:"column:trigger_event;type:varchar(50)" json:"triggerEvent"`
 	FlowID       *string    `gorm:"column:flow_id;type:varchar(255);" json:"flowId"`
-	Status       string     `gorm:"column:status;type:varchar(255);not null;default:'pending'" json:"status"`
+	Status       string     `gorm:"column:status;type:varchar(255);not null;default:'PENDING'" json:"status"`
 	CreatedAt    time.Time  `gorm:"column:created_at;autoCreateTime" json:"createdAt"`
 	StartedAt    *time.Time `gorm:"column:started_at" json:"startedAt"`
 	UpdatedAt    *time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updatedAt"`

--- a/packages/server/customer-os-postgres-repository/repository/agent_execution_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agent_execution_repository.go
@@ -3,7 +3,9 @@ package postgres_repository
 import (
 	"context"
 	"errors"
+	"time"
 
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
@@ -15,7 +17,7 @@ import (
 type AgentExecutionRepository interface {
 	Create(ctx context.Context, executionRecord postgres_entity.AgentExecution) (*postgres_entity.AgentExecution, error)
 	Find(ctx context.Context, executionRecord postgres_entity.AgentExecution) (*postgres_entity.AgentExecution, error)
-	Update(ctx context.Context, executionRecord postgres_entity.AgentExecution) (*postgres_entity.AgentExecution, error)
+	Update(ctx context.Context, executionID string, completedAt *time.Time, errorMessage *string, goalAchieved bool) (*postgres_entity.AgentExecution, error)
 }
 
 type flowAgentExecutionRepository struct {
@@ -66,24 +68,35 @@ func (f *flowAgentExecutionRepository) Find(ctx context.Context, executionRecord
 	return &flowAgentExecution, nil
 }
 
-func (f *flowAgentExecutionRepository) Update(ctx context.Context, executionRecord postgres_entity.AgentExecution) (*postgres_entity.AgentExecution, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.Update")
+func (f *flowAgentExecutionRepository) Update(ctx context.Context, executionID string, completedAt *time.Time, errorMessage *string, goalAchieved bool) (*postgres_entity.AgentExecution, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.UpdateToCompleted")
 	defer span.Finish()
 	tracing.TagComponentPostgresRepository(span)
 
-	if executionRecord.ID == "" {
+	if executionID == "" {
 		err := errors.New("ID is missing")
 		tracing.TraceErr(span, err)
 		return nil, err
 	}
 
+	status := enum.AgentExecutionSuccess.String()
+	if errorMessage != nil {
+		status = enum.AgentExecutionFail.String()
+	}
+
 	var updatedRecord postgres_entity.AgentExecution
 	err := f.gormDb.
 		Model(&postgres_entity.AgentExecution{}).
-		Where("id = ?", executionRecord.ID).
-		Updates(executionRecord).
-		First(&updatedRecord, "id = ?", executionRecord.ID).
+		Where("id = ?", executionID).
+		Updates(map[string]interface{}{
+			"status":        status,
+			"completed_at":  completedAt,
+			"error_message": errorMessage,
+			"goalAchieved":  goalAchieved,
+		}).
+		First(&updatedRecord, "id = ?", executionID).
 		Error
+
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return nil, err

--- a/packages/server/customer-os-postgres-repository/repository/websession_events_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/websession_events_repository.go
@@ -18,7 +18,7 @@ type WebSessionRepository interface {
 	FindAllSessions(ctx context.Context, webWebSessionData postgres_entity.WebSession, sessionTimeoutInMins *int) ([]postgres_entity.WebSession, error)
 	FindSession(ctx context.Context, webSessionData postgres_entity.WebSession, lookbackPeriodInMins *int) (*postgres_entity.WebSession, error)
 	FindLastNotification(ctx context.Context, tenant, domain string) (*postgres_entity.WebSession, error)
-	UpdateLastActivity(ctx context.Context, sessionID string) (*postgres_entity.WebSession, error)
+	UpdateLastActivity(ctx context.Context, sessionID, eventType string) (*postgres_entity.WebSession, error)
 	UpdateSessionEnd(ctx context.Context, sessionID string, endTime time.Time) (*postgres_entity.WebSession, error)
 	UpdateSessionWithDomain(ctx context.Context, sessionID, domain string) (*postgres_entity.WebSession, error)
 }
@@ -119,7 +119,7 @@ func (r *webSessionEventsRepository) FindLastNotification(ctx context.Context, t
 	return &result, nil
 }
 
-func (r *webSessionEventsRepository) UpdateLastActivity(ctx context.Context, sessionID string) (*postgres_entity.WebSession, error) {
+func (r *webSessionEventsRepository) UpdateLastActivity(ctx context.Context, sessionID, eventType string) (*postgres_entity.WebSession, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.UpdateLastActivity")
 	defer span.Finish()
 	tracing.TagComponentPostgresRepository(span)
@@ -129,7 +129,8 @@ func (r *webSessionEventsRepository) UpdateLastActivity(ctx context.Context, ses
 		Model(&postgres_entity.WebSession{}).
 		Where("id = ?", sessionID).
 		Updates(map[string]interface{}{
-			"last_activity": utils.Now(),
+			"last_activity":   utils.Now(),
+			"last_event_type": eventType,
 		}).
 		First(&updatedSession, "id = ?", sessionID).
 		Error

--- a/packages/server/events-subscribers/listeners/website_visit_event/handler.go
+++ b/packages/server/events-subscribers/listeners/website_visit_event/handler.go
@@ -36,6 +36,11 @@ func NewWebsiteVisitEventHandler(dependencies *model.DependencyContainer, event 
 		return nil, err
 	}
 
+	if event.IPAddress == "" {
+		err := errors.New("IP address cannot be empty")
+		return nil, err
+	}
+
 	return &WebsiteVisitEventHandler{
 		dependencies: dependencies,
 		event:        event,


### PR DESCRIPTION
## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance agent execution and web session event handling with improved validation, error handling, and tracing updates.
> 
>   - **Behavior**:
>     - Add validation for `WebsiteVisitEvent` in `visitor_id_agent.go` and `handler.go` to ensure non-empty fields.
>     - Modify `closeSessions()` in `web_session_service.go` to handle empty session lists.
>     - Update `Run()` in `visitor_id_agent.go` to handle errors and update execution records accordingly.
>   - **Tracing**:
>     - Replace `tracing.StartTracerSpan` with `opentracing.StartSpanFromContext` in `web_session_service.go` and `reveal_website_events.go`.
>   - **Repositories**:
>     - Update `Update()` in `agent_execution_repository.go` to handle execution status and error messages.
>     - Modify `UpdateLastActivity()` in `websession_events_repository.go` to include `eventType`.
>   - **Misc**:
>     - Change default `Status` in `agent_execution.go` to uppercase 'PENDING'.
>     - Refactor `createCloseSessionWebhookEvent()` in `web_session_service.go` to return an error if session fields are empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 129f0d562cfcd178c6875a87a062ca2aa02764dc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->