### PR TITLE
COS-6456: fix: handle empty entries case in useColumnSizing hook to prevent TypeError on column resize

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/hooks/useColumnSizing.ts
+++ b/packages/apps/frontera/src/routes/finder/src/hooks/useColumnSizing.ts
@@ -20,7 +20,10 @@ export const useColumnSizing = (
         | ((prev: ColumnSizingState) => ColumnSizingState),
     ) => {
       const update = typeof updater === 'function' ? updater({}) : updater;
-      const [columnId, width] = Object.entries(update)[0];
+      const entries = Object.entries(update);
+
+      if (!entries.length) return;
+      const [columnId, width] = entries[0];
 
       let columnSettings = columnCache.get(columnId);
 


### PR DESCRIPTION
…

## Proposed changes

<!---Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!--->

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes TypeError in `useColumnSizing` by checking for empty entries before destructuring during column resizing.
> 
>   - **Bugfix**:
>     - In `useColumnSizing` hook, added a check for empty `entries` array before destructuring to prevent `TypeError` during column resizing.
>     - Handles cases where `updater` results in no entries, ensuring safe execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for bb9c1f767ba015372d56826959a686d45ffcdce8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->