### PR TITLE
fix: orgCreate via url not send anymore name prop

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/command-menu/add-search-organizations.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/command-menu/add-search-organizations.usecase.ts
@@ -325,7 +325,7 @@ export class AddSearchOrganizationsUsecase {
 
       await this.root.organizations.create({
         ...this.getViewDefDefaults(),
-        name: isUrl ? 'Unnamed' : this.searchTerm || 'Unnamed',
+        name: isUrl ? undefined : this.searchTerm || 'Unnamed',
         website: !isUrl ? undefined : this.searchTerm || '',
       });
     }


### PR DESCRIPTION
## Proposed changes



## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe below)

## Additional context


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `addNewOrganization` in `AddSearchOrganizationsUsecase` to set `name` to `undefined` for URL inputs.
> 
>   - **Behavior**:
>     - In `addNewOrganization` method of `AddSearchOrganizationsUsecase`, set `name` to `undefined` if `searchTerm` is a URL.
>     - Previously, `name` was set to 'Unnamed' for URLs, which is now corrected to `undefined`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 87cadcf43dc3d1b4576533c6a96592e84a3c5d7e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->