### PR TITLE
COS-6600 fix(tags): increase popover trigger clickable area

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/Tags/Tags.tsx
+++ b/packages/apps/frontera/src/routes/src/components/Tags/Tags.tsx
@@ -50,7 +50,7 @@ export const Tags = observer(
     return (
       <Popover>
         <Tooltip align='start' label='Organization tags'>
-          <PopoverTrigger className={cn('flex items-center', className)}>
+          <PopoverTrigger className={cn('flex items-center w-full', className)}>
             {leftAccessory}
             <div
               data-test={dataTest}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increased clickable area of `PopoverTrigger` in `Tags.tsx` by adding `w-full` to its className.
> 
>   - **UI Improvement**:
>     - In `Tags.tsx`, increased the clickable area of `PopoverTrigger` by adding `w-full` to its className.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 0c966336aa09898f2805efa80141a627b8e82494. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->