### PR TITLE
COS-6564: Fix opportunity sorting by stage

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/opportunities/sortFns.ts
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/opportunities/sortFns.ts
@@ -13,10 +13,9 @@ export const getOpportunitiesSortFn = (columnId: string) =>
       () => (row: OpportunityStore) =>
         row.organization?.value?.name?.trim().toLocaleLowerCase() || null,
     )
-    .with(
-      ColumnViewType.OpportunitiesStage,
-      () => (row: OpportunityStore) => row.value.externalStage || null,
-    )
+    .with(ColumnViewType.OpportunitiesStage, () => (row: OpportunityStore) => {
+      return row?.externalStage?.order || row.value.internalStage || null;
+    })
     .with(ColumnViewType.OpportunitiesOwner, () => (row: OpportunityStore) => {
       return row.owner?.name?.trim().toLowerCase() || null;
     })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes sorting logic for opportunities by stage in `sortFns.ts` using `externalStage.order` or `internalStage`.
> 
>   - **Behavior**:
>     - Fixes sorting logic for `OpportunitiesStage` in `sortFns.ts`.
>     - Uses `row?.externalStage?.order` or `row.value.internalStage` for sorting.
>   - **Misc**:
>     - Removes redundant null check for `externalStage` in `sortFns.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 57da2a817406b6d1fef5332af912c25595cb0705. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->