### PR TITLE
COS-6629: Fix false positive usecases error

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/edit-contact-tags-select/edit-contact-tag.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/edit-contact-tags-select/edit-contact-tag.usecase.ts
@@ -39,9 +39,7 @@ export class EditContactTagUsecase {
     const contact = this.root.contacts.getById(this.contactId);
 
     if (!contact) {
-      console.error(
-        'Invalid usage of EditContactTagUsecase or contact does not exist in the store',
-      );
+      return;
     }
 
     return contact;

--- a/packages/apps/frontera/src/domain/usecases/organization-about-panel/edit-organization-tag.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/organization-about-panel/edit-organization-tag.usecase.ts
@@ -4,7 +4,6 @@ import { TagService, OrganizationService } from '@domain/services';
 
 import { EntityType } from '@graphql/types';
 import { SelectOption } from '@ui/utils/types.ts';
-import { getOrganizationUUID } from '@utils/getOrganizationUUID.ts';
 
 export class EditOrganizationTagUsecase {
   @observable public accessor searchTerm = '';
@@ -15,8 +14,10 @@ export class EditOrganizationTagUsecase {
   private root = RootStore.getInstance();
   private tagService = new TagService();
   private organizationService = new OrganizationService();
+  private organizationId: string;
 
-  constructor() {
+  constructor(organizationId: string) {
+    this.organizationId = organizationId;
     this.select = this.select.bind(this);
     this.create = this.create.bind(this);
     this.setSearchTerm = this.setSearchTerm.bind(this);
@@ -34,15 +35,9 @@ export class EditOrganizationTagUsecase {
 
   @computed
   get organization() {
-    const uuid = getOrganizationUUID(window.location.pathname);
+    if (!this.organizationId) return;
 
-    if (!uuid) {
-      console.error('Invalid usage of EditOrganizationTagUsecase');
-
-      return;
-    }
-
-    return this.root.organizations.getById(uuid);
+    return this.root.organizations.getById(this.organizationId);
   }
 
   @computed

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
@@ -1,9 +1,10 @@
+import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { match } from 'ts-pattern';
 import { observer } from 'mobx-react-lite';
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
-import { EditOrganizationTagUsecase } from '@domain/usecases/organization-about-panel/edit-organization-tag.usecase.ts';
+import { EditContactTagUsecase } from '@domain/usecases/edit-contact-tags-select/edit-contact-tag.usecase.ts';
 
 import { cn } from '@ui/utils/cn';
 import { flags } from '@ui/media/flags';
@@ -47,7 +48,6 @@ const iconMap = {
   unknown: <AlignHorizontalCentre02 className='text-gray-500' />,
 };
 
-const tagsUsecase = new EditOrganizationTagUsecase();
 export const AboutPanel = observer(() => {
   const store = useStore();
   const id = useParams()?.id as string;
@@ -74,6 +74,11 @@ export const AboutPanel = observer(() => {
 
   const applicableStageOptions = getStageOptions(
     organization.value?.relationship,
+  );
+
+  const tagsUsecase = useMemo(
+    () => new EditContactTagUsecase(String(id)),
+    [id],
   );
 
   const handleCreateOption = (value: string) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix false positive errors by removing unnecessary error logging and updating constructors in tag use cases.
> 
>   - **Behavior**:
>     - Remove error logging for missing contact in `EditContactTagUsecase` and missing organization in `EditOrganizationTagUsecase`.
>     - Modify constructors in `EditContactTagUsecase` and `EditOrganizationTagUsecase` to accept `contactId` and `organizationId` directly.
>   - **Components**:
>     - Update `AboutPanel.tsx` to use `EditContactTagUsecase` with `useMemo` for tag management, replacing `EditOrganizationTagUsecase`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7625577fd34e3b154a9422de230c27a27126b085. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->