### PR TITLE
Remove Content-Security-Policy header from nginx configuration

### DIFF
--- a/packages/apps/frontera/nginx.conf
+++ b/packages/apps/frontera/nginx.conf
@@ -6,7 +6,7 @@ server {
   proxy_buffer_size 128k;
   large_client_header_buffers 16 32k;
 
-  add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self';" always;
+  # add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self';" always;
   add_header X-Frame-Options "DENY" always;
   add_header X-Content-Type-Options "nosniff";
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Commented out the Content-Security-Policy header in `nginx.conf`, removing it from the nginx configuration.
> 
>   - **Configuration**:
>     - Commented out `add_header Content-Security-Policy` in `nginx.conf`, effectively removing the Content-Security-Policy header from the nginx configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 71b82171a49ef84f8223d1db3d274f573db75c3f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->