### PR TITLE
Create COS income account into QB if missing for SKUs

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/quickbooks.go
+++ b/packages/server/customer-os-common-module/interfaces/quickbooks.go
@@ -46,6 +46,13 @@ type QuickbooksGetProductResponse struct {
 	} `json:"Item"`
 }
 
+type QuickbooksSaveAccountResponse struct {
+	QuickbooksCheckFaultResponse
+	Account *struct {
+		Id string `json:"Id"`
+	} `json:"Account"`
+}
+
 type QuickbooksSaveProductResponse struct {
 	QuickbooksCheckFaultResponse
 	Product *struct {

--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -139,13 +139,43 @@ func (s *quickbooksService) SaveProduct(ctx context.Context, id, productName str
 		return nil, nil
 	}
 
+	if quickbooksSettingsEntity.SalesAccountId == "" {
+
+		salesAccountUrl := fmt.Sprintf("https://sandbox-quickbooks.api.intuit.com/v3/company/%s/account", quickbooksSettingsEntity.RealmId)
+		salesAccountRequest := map[string]interface{}{
+			"Name":        "CustomerOS Sales",
+			"AccountType": "Income",
+		}
+
+		qbAccountResponse, err := s.performRequest(ctx, quickbooksSettingsEntity, salesAccountUrl, "POST", salesAccountRequest)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return nil, err
+		}
+
+		var qbAccount interfaces.QuickbooksSaveAccountResponse
+		err = json.Unmarshal(qbAccountResponse, &qbAccount)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return nil, err
+		}
+
+		quickbooksSettingsEntity.SalesAccountId = qbAccount.Account.Id
+		_, err = s.postgres.QuickbooksSettingsRepository.Save(ctx, *quickbooksSettingsEntity)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return nil, err
+		}
+
+	}
+
 	// load product from QB to get the SyncToken
 
 	request := map[string]interface{}{
 		"Name": productName,
 		"Type": "Service",
 		"IncomeAccountRef": map[string]interface{}{
-			"value": "1", // TODO HOW DO WE GET THIS ID??
+			"value": quickbooksSettingsEntity.SalesAccountId,
 		},
 		"Active": !archived,
 	}

--- a/packages/server/customer-os-postgres-repository/entity/quickbooks_settings.go
+++ b/packages/server/customer-os-postgres-repository/entity/quickbooks_settings.go
@@ -18,6 +18,8 @@ type QuickbooksSettingsEntity struct {
 	RefreshTokenExpiresIn int       `gorm:"column:refresh_token_expires_in;"`
 	RefreshTokenExpiresAt time.Time `gorm:"column:refresh_token_expires_at;type:timestamp"`
 	RefreshTokenExpired   bool      `gorm:"column:refresh_token_expired;"`
+
+	SalesAccountId string `gorm:"column:sales_account_id;"`
 }
 
 func (QuickbooksSettingsEntity) TableName() string {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add functionality to create a QuickBooks income account if missing when saving a product, updating `SaveProduct` and `QuickbooksSettingsEntity`.
> 
>   - **Behavior**:
>     - In `SaveProduct` in `quickbooks.go`, create a QuickBooks income account if `SalesAccountId` is missing.
>     - Use the new account ID for `IncomeAccountRef` when saving products.
>   - **Models**:
>     - Add `SalesAccountId` to `QuickbooksSettingsEntity` in `quickbooks_settings.go`.
>   - **Interfaces**:
>     - Add `QuickbooksSaveAccountResponse` to `quickbooks.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 6a41f9a82b117d7b8face05f56596cd14e34e031. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->