### PR TITLE
SLI - deprecate description in favor of skuId

### DIFF
--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -1611,6 +1611,7 @@ type ComplexityRoot struct {
 		ServiceEnded   func(childComplexity int) int
 		ServiceStarted func(childComplexity int) int
 		Sku            func(childComplexity int) int
+		SkuID          func(childComplexity int) int
 		Tax            func(childComplexity int) int
 	}
 
@@ -2240,6 +2241,8 @@ type ReminderResolver interface {
 	Owner(ctx context.Context, obj *model.Reminder) (*model.User, error)
 }
 type ServiceLineItemResolver interface {
+	Sku(ctx context.Context, obj *model.ServiceLineItem) (*model.Sku, error)
+
 	CreatedBy(ctx context.Context, obj *model.ServiceLineItem) (*model.User, error)
 	ExternalLinks(ctx context.Context, obj *model.ServiceLineItem) ([]*model.ExternalSystem, error)
 }
@@ -11858,6 +11861,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ServiceLineItem.Sku(childComplexity), true
 
+	case "ServiceLineItem.skuId":
+		if e.complexity.ServiceLineItem.SkuID == nil {
+			break
+		}
+
+		return e.complexity.ServiceLineItem.SkuID(childComplexity), true
+
 	case "ServiceLineItem.tax":
 		if e.complexity.ServiceLineItem.Tax == nil {
 			break
@@ -16594,7 +16604,8 @@ type ServiceLineItem implements MetadataInterface {
     metadata:           Metadata!
     billingCycle:       BilledType!
     comments:           String!
-    sku:                Sku!
+    skuId:              ID  #todo make it mandatory
+    sku:                Sku @goField(forceResolver: true) #todo make it mandatory
     description:        String! @deprecated(reason: "use skuId")
     parentId:           ID!
     price:              Float!
@@ -16610,7 +16621,7 @@ type ServiceLineItem implements MetadataInterface {
 
 input ServiceLineItemInput {
     contractId:         ID!
-    skuId:              ID!
+    skuId:              ID #todo make this mandatory after FE changes
     description:        String @deprecated(reason: "use skuId")
     billingCycle:       BilledType
     price:              Float
@@ -16624,7 +16635,7 @@ input ServiceLineItemInput {
 input ServiceLineItemUpdateInput {
     id:                         ID
     description:                String @deprecated(reason: "use skuId")
-    skuId:                      ID!
+    skuId:                      ID #todo make this mandatory after FE changes
     """
     Deprecated: billing cycle is not updatable.
     """
@@ -16641,7 +16652,7 @@ input ServiceLineItemUpdateInput {
 
 input ServiceLineItemNewVersionInput {
     id:                         ID
-    skuId:                      ID!
+    skuId:                      ID  #todo make this mandatory after FE changes
     description:                String @deprecated(reason: "use skuId")
     price:                      Float
     quantity:                   Int64
@@ -35883,6 +35894,8 @@ func (ec *executionContext) fieldContext_Contract_contractLineItems(_ context.Co
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "skuId":
+				return ec.fieldContext_ServiceLineItem_skuId(ctx, field)
 			case "sku":
 				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
@@ -37766,6 +37779,8 @@ func (ec *executionContext) fieldContext_Contract_serviceLineItems(_ context.Con
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "skuId":
+				return ec.fieldContext_ServiceLineItem_skuId(ctx, field)
 			case "sku":
 				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
@@ -53061,6 +53076,8 @@ func (ec *executionContext) fieldContext_InvoiceLine_contractLineItem(_ context.
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "skuId":
+				return ec.fieldContext_ServiceLineItem_skuId(ctx, field)
 			case "sku":
 				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
@@ -76644,6 +76661,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Create(ctx co
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "skuId":
+				return ec.fieldContext_ServiceLineItem_skuId(ctx, field)
 			case "sku":
 				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
@@ -76765,6 +76784,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_NewVersion(ct
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "skuId":
+				return ec.fieldContext_ServiceLineItem_skuId(ctx, field)
 			case "sku":
 				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
@@ -76886,6 +76907,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Update(ctx co
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "skuId":
+				return ec.fieldContext_ServiceLineItem_skuId(ctx, field)
 			case "sku":
 				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
@@ -97793,6 +97816,8 @@ func (ec *executionContext) fieldContext_Query_serviceLineItem(ctx context.Conte
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "skuId":
+				return ec.fieldContext_ServiceLineItem_skuId(ctx, field)
 			case "sku":
 				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
@@ -100575,6 +100600,47 @@ func (ec *executionContext) fieldContext_ServiceLineItem_comments(_ context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _ServiceLineItem_skuId(ctx context.Context, field graphql.CollectedField, obj *model.ServiceLineItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceLineItem_skuId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SkuID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOID2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceLineItem_skuId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceLineItem",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ServiceLineItem_sku(ctx context.Context, field graphql.CollectedField, obj *model.ServiceLineItem) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ServiceLineItem_sku(ctx, field)
 	if err != nil {
@@ -100589,29 +100655,26 @@ func (ec *executionContext) _ServiceLineItem_sku(ctx context.Context, field grap
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Sku, nil
+		return ec.resolvers.ServiceLineItem().Sku(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*model.Sku)
 	fc.Result = res
-	return ec.marshalNSku2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐSku(ctx, field.Selections, res)
+	return ec.marshalOSku2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐSku(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ServiceLineItem_sku(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ServiceLineItem",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "id":
@@ -115047,7 +115110,7 @@ func (ec *executionContext) unmarshalInputServiceLineItemInput(ctx context.Conte
 			it.ContractID = data
 		case "skuId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skuId"))
-			data, err := ec.unmarshalNID2string(ctx, v)
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -115137,7 +115200,7 @@ func (ec *executionContext) unmarshalInputServiceLineItemNewVersionInput(ctx con
 			it.ID = data
 		case "skuId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skuId"))
-			data, err := ec.unmarshalNID2string(ctx, v)
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -115227,7 +115290,7 @@ func (ec *executionContext) unmarshalInputServiceLineItemUpdateInput(ctx context
 			it.Description = data
 		case "skuId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skuId"))
-			data, err := ec.unmarshalNID2string(ctx, v)
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -130768,11 +130831,41 @@ func (ec *executionContext) _ServiceLineItem(ctx context.Context, sel ast.Select
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "skuId":
+			out.Values[i] = ec._ServiceLineItem_skuId(ctx, field, obj)
 		case "sku":
-			out.Values[i] = ec._ServiceLineItem_sku(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ServiceLineItem_sku(ctx, field, obj)
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "description":
 			out.Values[i] = ec._ServiceLineItem_description(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -139509,6 +139602,13 @@ func (ec *executionContext) unmarshalOServiceLineItemBulkUpdateItem2ᚖgithubᚗ
 	}
 	res, err := ec.unmarshalInputServiceLineItemBulkUpdateItem(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOSku2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐSku(ctx context.Context, sel ast.SelectionSet, v *model.Sku) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Sku(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOSortBy2ᚕᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑcommonᚑmoduleᚋmodelᚐSortByᚄ(ctx context.Context, v any) ([]*model1.SortBy, error) {

--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -1610,6 +1610,7 @@ type ComplexityRoot struct {
 		Quantity       func(childComplexity int) int
 		ServiceEnded   func(childComplexity int) int
 		ServiceStarted func(childComplexity int) int
+		Sku            func(childComplexity int) int
 		Tax            func(childComplexity int) int
 	}
 
@@ -11850,6 +11851,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ServiceLineItem.ServiceStarted(childComplexity), true
 
+	case "ServiceLineItem.sku":
+		if e.complexity.ServiceLineItem.Sku == nil {
+			break
+		}
+
+		return e.complexity.ServiceLineItem.Sku(childComplexity), true
+
 	case "ServiceLineItem.tax":
 		if e.complexity.ServiceLineItem.Tax == nil {
 			break
@@ -16586,7 +16594,8 @@ type ServiceLineItem implements MetadataInterface {
     metadata:           Metadata!
     billingCycle:       BilledType!
     comments:           String!
-    description:        String!
+    sku:                Sku!
+    description:        String! @deprecated(reason: "use skuId")
     parentId:           ID!
     price:              Float!
     quantity:           Int64!
@@ -16601,7 +16610,8 @@ type ServiceLineItem implements MetadataInterface {
 
 input ServiceLineItemInput {
     contractId:         ID!
-    description:        String
+    skuId:              ID!
+    description:        String @deprecated(reason: "use skuId")
     billingCycle:       BilledType
     price:              Float
     quantity:           Int64
@@ -16613,7 +16623,8 @@ input ServiceLineItemInput {
 
 input ServiceLineItemUpdateInput {
     id:                         ID
-    description:                String
+    description:                String @deprecated(reason: "use skuId")
+    skuId:                      ID!
     """
     Deprecated: billing cycle is not updatable.
     """
@@ -16630,7 +16641,8 @@ input ServiceLineItemUpdateInput {
 
 input ServiceLineItemNewVersionInput {
     id:                         ID
-    description:                String
+    skuId:                      ID!
+    description:                String @deprecated(reason: "use skuId")
     price:                      Float
     quantity:                   Int64
     tax:                        TaxInput
@@ -16647,7 +16659,8 @@ input ServiceLineItemBulkUpdateInput {
 
 input ServiceLineItemBulkUpdateItem {
     serviceLineItemId:       ID
-    name:                    String
+    skuId:                   ID
+    name:                    String @deprecated(reason: "use skuId")
     billed:                  BilledType
     price:                   Float
     quantity:                Int64
@@ -35870,6 +35883,8 @@ func (ec *executionContext) fieldContext_Contract_contractLineItems(_ context.Co
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "sku":
+				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
 				return ec.fieldContext_ServiceLineItem_description(ctx, field)
 			case "parentId":
@@ -37751,6 +37766,8 @@ func (ec *executionContext) fieldContext_Contract_serviceLineItems(_ context.Con
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "sku":
+				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
 				return ec.fieldContext_ServiceLineItem_description(ctx, field)
 			case "parentId":
@@ -53044,6 +53061,8 @@ func (ec *executionContext) fieldContext_InvoiceLine_contractLineItem(_ context.
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "sku":
+				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
 				return ec.fieldContext_ServiceLineItem_description(ctx, field)
 			case "parentId":
@@ -76625,6 +76644,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Create(ctx co
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "sku":
+				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
 				return ec.fieldContext_ServiceLineItem_description(ctx, field)
 			case "parentId":
@@ -76744,6 +76765,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_NewVersion(ct
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "sku":
+				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
 				return ec.fieldContext_ServiceLineItem_description(ctx, field)
 			case "parentId":
@@ -76863,6 +76886,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Update(ctx co
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "sku":
+				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
 				return ec.fieldContext_ServiceLineItem_description(ctx, field)
 			case "parentId":
@@ -97768,6 +97793,8 @@ func (ec *executionContext) fieldContext_Query_serviceLineItem(ctx context.Conte
 				return ec.fieldContext_ServiceLineItem_billingCycle(ctx, field)
 			case "comments":
 				return ec.fieldContext_ServiceLineItem_comments(ctx, field)
+			case "sku":
+				return ec.fieldContext_ServiceLineItem_sku(ctx, field)
 			case "description":
 				return ec.fieldContext_ServiceLineItem_description(ctx, field)
 			case "parentId":
@@ -100543,6 +100570,58 @@ func (ec *executionContext) fieldContext_ServiceLineItem_comments(_ context.Cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceLineItem_sku(ctx context.Context, field graphql.CollectedField, obj *model.ServiceLineItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceLineItem_sku(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Sku, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Sku)
+	fc.Result = res
+	return ec.marshalNSku2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐSku(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceLineItem_sku(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceLineItem",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Sku_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Sku_name(ctx, field)
+			case "price":
+				return ec.fieldContext_Sku_price(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Sku", field.Name)
 		},
 	}
 	return fc, nil
@@ -114807,7 +114886,7 @@ func (ec *executionContext) unmarshalInputServiceLineItemBulkUpdateItem(ctx cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"serviceLineItemId", "name", "billed", "price", "quantity", "vatRate", "comments", "isRetroactiveCorrection", "serviceStarted", "closeVersion", "newVersion"}
+	fieldsInOrder := [...]string{"serviceLineItemId", "skuId", "name", "billed", "price", "quantity", "vatRate", "comments", "isRetroactiveCorrection", "serviceStarted", "closeVersion", "newVersion"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -114821,6 +114900,13 @@ func (ec *executionContext) unmarshalInputServiceLineItemBulkUpdateItem(ctx cont
 				return it, err
 			}
 			it.ServiceLineItemID = data
+		case "skuId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skuId"))
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkuID = data
 		case "name":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -114945,7 +115031,7 @@ func (ec *executionContext) unmarshalInputServiceLineItemInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"contractId", "description", "billingCycle", "price", "quantity", "tax", "appSource", "serviceStarted", "serviceEnded"}
+	fieldsInOrder := [...]string{"contractId", "skuId", "description", "billingCycle", "price", "quantity", "tax", "appSource", "serviceStarted", "serviceEnded"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -114959,6 +115045,13 @@ func (ec *executionContext) unmarshalInputServiceLineItemInput(ctx context.Conte
 				return it, err
 			}
 			it.ContractID = data
+		case "skuId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skuId"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkuID = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -115028,7 +115121,7 @@ func (ec *executionContext) unmarshalInputServiceLineItemNewVersionInput(ctx con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "description", "price", "quantity", "tax", "comments", "appSource", "serviceStarted"}
+	fieldsInOrder := [...]string{"id", "skuId", "description", "price", "quantity", "tax", "comments", "appSource", "serviceStarted"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -115042,6 +115135,13 @@ func (ec *executionContext) unmarshalInputServiceLineItemNewVersionInput(ctx con
 				return it, err
 			}
 			it.ID = data
+		case "skuId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skuId"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkuID = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -115104,7 +115204,7 @@ func (ec *executionContext) unmarshalInputServiceLineItemUpdateInput(ctx context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "description", "billingCycle", "price", "quantity", "tax", "comments", "appSource", "isRetroactiveCorrection", "serviceStarted", "serviceEnded"}
+	fieldsInOrder := [...]string{"id", "description", "skuId", "billingCycle", "price", "quantity", "tax", "comments", "appSource", "isRetroactiveCorrection", "serviceStarted", "serviceEnded"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -115125,6 +115225,13 @@ func (ec *executionContext) unmarshalInputServiceLineItemUpdateInput(ctx context
 				return it, err
 			}
 			it.Description = data
+		case "skuId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skuId"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkuID = data
 		case "billingCycle":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("billingCycle"))
 			data, err := ec.unmarshalOBilledType2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐBilledType(ctx, v)
@@ -130658,6 +130765,11 @@ func (ec *executionContext) _ServiceLineItem(ctx context.Context, sel ast.Select
 			}
 		case "comments":
 			out.Values[i] = ec._ServiceLineItem_comments(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "sku":
+			out.Values[i] = ec._ServiceLineItem_sku(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -2527,7 +2527,8 @@ type ServiceLineItem struct {
 	Metadata       *Metadata         `json:"metadata"`
 	BillingCycle   BilledType        `json:"billingCycle"`
 	Comments       string            `json:"comments"`
-	Sku            *Sku              `json:"sku"`
+	SkuID          *string           `json:"skuId,omitempty"`
+	Sku            *Sku              `json:"sku,omitempty"`
 	Description    string            `json:"description"`
 	ParentID       string            `json:"parentId"`
 	Price          float64           `json:"price"`
@@ -2573,7 +2574,7 @@ type ServiceLineItemCloseInput struct {
 
 type ServiceLineItemInput struct {
 	ContractID     string      `json:"contractId"`
-	SkuID          string      `json:"skuId"`
+	SkuID          *string     `json:"skuId,omitempty"`
 	Description    *string     `json:"description,omitempty"`
 	BillingCycle   *BilledType `json:"billingCycle,omitempty"`
 	Price          *float64    `json:"price,omitempty"`
@@ -2586,7 +2587,7 @@ type ServiceLineItemInput struct {
 
 type ServiceLineItemNewVersionInput struct {
 	ID             *string    `json:"id,omitempty"`
-	SkuID          string     `json:"skuId"`
+	SkuID          *string    `json:"skuId,omitempty"`
 	Description    *string    `json:"description,omitempty"`
 	Price          *float64   `json:"price,omitempty"`
 	Quantity       *int64     `json:"quantity,omitempty"`
@@ -2599,7 +2600,7 @@ type ServiceLineItemNewVersionInput struct {
 type ServiceLineItemUpdateInput struct {
 	ID          *string `json:"id,omitempty"`
 	Description *string `json:"description,omitempty"`
-	SkuID       string  `json:"skuId"`
+	SkuID       *string `json:"skuId,omitempty"`
 	// Deprecated: billing cycle is not updatable.
 	BillingCycle            *BilledType `json:"billingCycle,omitempty"`
 	Price                   *float64    `json:"price,omitempty"`

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -2527,6 +2527,7 @@ type ServiceLineItem struct {
 	Metadata       *Metadata         `json:"metadata"`
 	BillingCycle   BilledType        `json:"billingCycle"`
 	Comments       string            `json:"comments"`
+	Sku            *Sku              `json:"sku"`
 	Description    string            `json:"description"`
 	ParentID       string            `json:"parentId"`
 	Price          float64           `json:"price"`
@@ -2551,6 +2552,7 @@ type ServiceLineItemBulkUpdateInput struct {
 
 type ServiceLineItemBulkUpdateItem struct {
 	ServiceLineItemID       *string     `json:"serviceLineItemId,omitempty"`
+	SkuID                   *string     `json:"skuId,omitempty"`
 	Name                    *string     `json:"name,omitempty"`
 	Billed                  *BilledType `json:"billed,omitempty"`
 	Price                   *float64    `json:"price,omitempty"`
@@ -2571,6 +2573,7 @@ type ServiceLineItemCloseInput struct {
 
 type ServiceLineItemInput struct {
 	ContractID     string      `json:"contractId"`
+	SkuID          string      `json:"skuId"`
 	Description    *string     `json:"description,omitempty"`
 	BillingCycle   *BilledType `json:"billingCycle,omitempty"`
 	Price          *float64    `json:"price,omitempty"`
@@ -2583,6 +2586,7 @@ type ServiceLineItemInput struct {
 
 type ServiceLineItemNewVersionInput struct {
 	ID             *string    `json:"id,omitempty"`
+	SkuID          string     `json:"skuId"`
 	Description    *string    `json:"description,omitempty"`
 	Price          *float64   `json:"price,omitempty"`
 	Quantity       *int64     `json:"quantity,omitempty"`
@@ -2595,6 +2599,7 @@ type ServiceLineItemNewVersionInput struct {
 type ServiceLineItemUpdateInput struct {
 	ID          *string `json:"id,omitempty"`
 	Description *string `json:"description,omitempty"`
+	SkuID       string  `json:"skuId"`
 	// Deprecated: billing cycle is not updatable.
 	BillingCycle            *BilledType `json:"billingCycle,omitempty"`
 	Price                   *float64    `json:"price,omitempty"`

--- a/packages/server/customer-os-api/graphql/resolver/service_line_item.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/service_line_item.resolvers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-api/mapper"
 	api_sli "github.com/customeros/customeros/packages/server/customer-os-api/services/service_line_item"
 	"github.com/customeros/customeros/packages/server/customer-os-api/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
@@ -35,6 +36,7 @@ func (r *mutationResolver) ContractLineItemCreate(ctx context.Context, input mod
 		Source:      neo4jentity.DataSourceOpenline,
 		StartedAt:   input.ServiceStarted,
 		EndedAt:     input.ServiceEnded,
+		SkuId:       utils.IfNotNilString(input.SkuID),
 		SliName:     utils.IfNotNilString(input.Description),
 		SliPrice:    utils.IfNotNilFloat64(input.Price),
 		SliQuantity: utils.IfNotNilInt64(input.Quantity),
@@ -79,6 +81,7 @@ func (r *mutationResolver) ContractLineItemNewVersion(ctx context.Context, input
 
 	data := cosapi_interfaces.ServiceLineItemNewVersionData{
 		Id:        utils.IfNotNilString(input.ID),
+		SkuId:     utils.IfNotNilString(input.SkuID),
 		Name:      utils.IfNotNilString(input.Description),
 		Price:     utils.IfNotNilFloat64(input.Price),
 		Quantity:  utils.IfNotNilInt64(input.Quantity),
@@ -119,6 +122,7 @@ func (r *mutationResolver) ContractLineItemUpdate(ctx context.Context, input mod
 	data := cosapi_interfaces.ServiceLineItemUpdateData{
 		Id:                      utils.IfNotNilString(input.ID),
 		IsRetroactiveCorrection: utils.IfNotNilBool(input.IsRetroactiveCorrection),
+		SkuId:                   utils.IfNotNilString(input.SkuID),
 		SliName:                 utils.IfNotNilString(input.Description),
 		SliPrice:                utils.IfNotNilFloat64(input.Price),
 		SliQuantity:             utils.IfNotNilInt64(input.Quantity),
@@ -299,6 +303,29 @@ func (r *queryResolver) ServiceLineItem(ctx context.Context, id string) (*model.
 		return nil, err
 	}
 	return mapper.MapEntityToServiceLineItem(serviceLineItemEntityPtr), nil
+}
+
+// Sku is the resolver for the sku field.
+func (r *serviceLineItemResolver) Sku(ctx context.Context, obj *model.ServiceLineItem) (*model.Sku, error) {
+	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.ServiceLineItem.Sku", graphql.GetOperationContext(ctx))
+	defer span.Finish()
+	tracing.SetDefaultResolverSpanTags(ctx, span)
+
+	tenant := common.GetTenantFromContext(ctx)
+
+	//TODO remove after migration
+	if obj.SkuID == nil || *obj.SkuID == "" {
+		return nil, nil
+	}
+
+	skuEntity, err := r.Services.CommonServices.PostgresRepositories.SkuRepository.Get(ctx, tenant, *obj.SkuID)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		graphql.AddErrorf(ctx, "Failed to get sku by id %s", obj.SkuID)
+		return nil, err
+	}
+
+	return mapper.MapEntityToSku(skuEntity), nil
 }
 
 // CreatedBy is the resolver for the createdBy field.

--- a/packages/server/customer-os-api/graphql/resolver/service_line_item.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/service_line_item.resolvers.go
@@ -321,7 +321,7 @@ func (r *serviceLineItemResolver) Sku(ctx context.Context, obj *model.ServiceLin
 	skuEntity, err := r.Services.CommonServices.PostgresRepositories.SkuRepository.Get(ctx, tenant, *obj.SkuID)
 	if err != nil {
 		tracing.TraceErr(span, err)
-		graphql.AddErrorf(ctx, "Failed to get sku by id %s", obj.SkuID)
+		graphql.AddErrorf(ctx, "Failed to get sku by id %s", *obj.SkuID)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-api/graphql/resolver/service_line_item.resolvers_it_test.go
+++ b/packages/server/customer-os-api/graphql/resolver/service_line_item.resolvers_it_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	neo4jtest "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/test"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"

--- a/packages/server/customer-os-api/graphql/resolver/sku.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/sku.resolvers.go
@@ -7,13 +7,13 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/dto"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
 	"github.com/customeros/customeros/packages/server/customer-os-api/mapper"
 	"github.com/customeros/customeros/packages/server/customer-os-api/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/dto"
 	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"

--- a/packages/server/customer-os-api/graphql/schemas/service_line_item.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/service_line_item.graphqls
@@ -17,7 +17,8 @@ type ServiceLineItem implements MetadataInterface {
     metadata:           Metadata!
     billingCycle:       BilledType!
     comments:           String!
-    sku:                Sku!
+    skuId:              ID  #todo make it mandatory
+    sku:                Sku @goField(forceResolver: true) #todo make it mandatory
     description:        String! @deprecated(reason: "use skuId")
     parentId:           ID!
     price:              Float!
@@ -33,7 +34,7 @@ type ServiceLineItem implements MetadataInterface {
 
 input ServiceLineItemInput {
     contractId:         ID!
-    skuId:              ID!
+    skuId:              ID #todo make this mandatory after FE changes
     description:        String @deprecated(reason: "use skuId")
     billingCycle:       BilledType
     price:              Float
@@ -47,7 +48,7 @@ input ServiceLineItemInput {
 input ServiceLineItemUpdateInput {
     id:                         ID
     description:                String @deprecated(reason: "use skuId")
-    skuId:                      ID!
+    skuId:                      ID #todo make this mandatory after FE changes
     """
     Deprecated: billing cycle is not updatable.
     """
@@ -64,7 +65,7 @@ input ServiceLineItemUpdateInput {
 
 input ServiceLineItemNewVersionInput {
     id:                         ID
-    skuId:                      ID!
+    skuId:                      ID  #todo make this mandatory after FE changes
     description:                String @deprecated(reason: "use skuId")
     price:                      Float
     quantity:                   Int64

--- a/packages/server/customer-os-api/graphql/schemas/service_line_item.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/service_line_item.graphqls
@@ -17,7 +17,8 @@ type ServiceLineItem implements MetadataInterface {
     metadata:           Metadata!
     billingCycle:       BilledType!
     comments:           String!
-    description:        String!
+    sku:                Sku!
+    description:        String! @deprecated(reason: "use skuId")
     parentId:           ID!
     price:              Float!
     quantity:           Int64!
@@ -32,7 +33,8 @@ type ServiceLineItem implements MetadataInterface {
 
 input ServiceLineItemInput {
     contractId:         ID!
-    description:        String
+    skuId:              ID!
+    description:        String @deprecated(reason: "use skuId")
     billingCycle:       BilledType
     price:              Float
     quantity:           Int64
@@ -44,7 +46,8 @@ input ServiceLineItemInput {
 
 input ServiceLineItemUpdateInput {
     id:                         ID
-    description:                String
+    description:                String @deprecated(reason: "use skuId")
+    skuId:                      ID!
     """
     Deprecated: billing cycle is not updatable.
     """
@@ -61,7 +64,8 @@ input ServiceLineItemUpdateInput {
 
 input ServiceLineItemNewVersionInput {
     id:                         ID
-    description:                String
+    skuId:                      ID!
+    description:                String @deprecated(reason: "use skuId")
     price:                      Float
     quantity:                   Int64
     tax:                        TaxInput
@@ -78,7 +82,8 @@ input ServiceLineItemBulkUpdateInput {
 
 input ServiceLineItemBulkUpdateItem {
     serviceLineItemId:       ID
-    name:                    String
+    skuId:                   ID
+    name:                    String @deprecated(reason: "use skuId")
     billed:                  BilledType
     price:                   Float
     quantity:                Int64

--- a/packages/server/customer-os-api/interfaces/service_line_item.go
+++ b/packages/server/customer-os-api/interfaces/service_line_item.go
@@ -18,7 +18,8 @@ type ServiceLineItemService interface {
 
 type ServiceLineItemCreateData struct {
 	ContractId        string                            `json:"contractId"`
-	SliName           string                            `json:"sliName"`
+	SliName           string                            `json:"sliName"` //deprecated
+	SkuId             string                            `json:"skuId"`
 	SliPrice          float64                           `json:"sliPrice"`
 	SliQuantity       int64                             `json:"sliQuantity"`
 	SliBilledType     neo4jenum.BilledType              `json:"sliBilledType"`
@@ -32,7 +33,8 @@ type ServiceLineItemCreateData struct {
 
 type ServiceLineItemNewVersionData struct {
 	Id        string                 `json:"id"`
-	Name      string                 `json:"sliName"`
+	SkuId     string                 `json:"skuId"`
+	Name      string                 `json:"sliName"` //deprecated
 	Price     float64                `json:"sliPrice"`
 	Quantity  int64                  `json:"sliQuantity"`
 	Comments  string                 `json:"sliComments"`
@@ -45,7 +47,8 @@ type ServiceLineItemNewVersionData struct {
 type ServiceLineItemUpdateData struct {
 	Id                      string                 `json:"id"`
 	IsRetroactiveCorrection bool                   `json:"isRetroactiveCorrection"`
-	SliName                 string                 `json:"sliName"`
+	SkuId                   string                 `json:"skuId"`
+	SliName                 string                 `json:"sliName"` //deprecated
 	SliPrice                float64                `json:"sliPrice"`
 	SliQuantity             int64                  `json:"sliQuantity"`
 	SliBilledType           neo4jenum.BilledType   `json:"sliBilledType"`

--- a/packages/server/customer-os-api/mapper/service_line_item_mapper.go
+++ b/packages/server/customer-os-api/mapper/service_line_item_mapper.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
@@ -21,6 +22,7 @@ func MapEntityToServiceLineItem(entity *neo4jentity.ServiceLineItemEntity) *mode
 		},
 		BillingCycle:   MapBilledTypeToModel(entity.Billed),
 		Comments:       entity.Comments,
+		SkuID:          utils.StringPtr(entity.SkuId),
 		Description:    entity.Name,
 		ParentID:       entity.ParentID,
 		Price:          entity.Price,

--- a/packages/server/customer-os-api/services/service_line_item/service_line_item_service.go
+++ b/packages/server/customer-os-api/services/service_line_item/service_line_item_service.go
@@ -62,6 +62,8 @@ func (s *serviceLineItemService) Create(ctx context.Context, serviceLineItemDeta
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "serviceLineItemDetails", serviceLineItemDetails)
 
+	tenant := common.GetTenantFromContext(ctx)
+
 	// check that quantity is not negative
 	if serviceLineItemDetails.SliQuantity < 0 {
 		err := errors.New("quantity must not be negative")
@@ -77,6 +79,7 @@ func (s *serviceLineItemService) Create(ctx context.Context, serviceLineItemDeta
 
 	sliDataFields := data_fields.SLIFields{
 		ContractId: utils.StringPtr(serviceLineItemDetails.ContractId),
+		SkuId:      utils.StringPtr(serviceLineItemDetails.SkuId),
 		Name:       utils.StringPtr(serviceLineItemDetails.SliName),
 		Quantity:   utils.Int64Ptr(serviceLineItemDetails.SliQuantity),
 		Price:      utils.Float64Ptr(serviceLineItemDetails.SliPrice),
@@ -84,6 +87,22 @@ func (s *serviceLineItemService) Create(ctx context.Context, serviceLineItemDeta
 		StartedAt:  serviceLineItemDetails.StartedAt,
 		EndedAt:    serviceLineItemDetails.EndedAt,
 		Source:     utils.StringPtr(serviceLineItemDetails.Source.String()),
+	}
+
+	if serviceLineItemDetails.SkuId != "" && serviceLineItemDetails.SliName == "" {
+		skuEntity, err := s.repositories.PostgresRepositories.SkuRepository.Get(ctx, tenant, serviceLineItemDetails.SkuId)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return "", err
+		}
+
+		if skuEntity == nil {
+			err := fmt.Errorf("sku with id {%s} not found", serviceLineItemDetails.SkuId)
+			tracing.TraceErr(span, err)
+			return "", err
+		}
+
+		sliDataFields.Name = utils.StringPtr(skuEntity.Name)
 	}
 
 	sliDataFields.BilledType = utils.ToPtr(serviceLineItemDetails.SliBilledType)
@@ -219,6 +238,7 @@ func (s *serviceLineItemService) NewVersion(ctx context.Context, data cosapi_int
 	sliDataFields := data_fields.SLIFields{
 		ContractId: utils.StringPtr(contractEntity.Id),
 		ParentId:   utils.StringPtr(baseServiceLineItemEntity.ID),
+		SkuId:      utils.StringPtr(utils.StringFirstNonEmpty(data.SkuId, baseServiceLineItemEntity.SkuId)),
 		Name:       utils.StringPtr(utils.StringFirstNonEmpty(data.Name, baseServiceLineItemEntity.Name)),
 		Quantity:   utils.Int64Ptr(data.Quantity),
 		Price:      utils.Float64Ptr(data.Price),
@@ -270,7 +290,8 @@ func (s *serviceLineItemService) Update(ctx context.Context, serviceLineItemDeta
 	sliIsInvoiced, _ := s.repositories.Neo4jRepositories.ServiceLineItemReadRepository.WasServiceLineItemInvoiced(ctx, common.GetTenantFromContext(ctx), baseServiceLineItemEntity.ID)
 	startedAt := utils.ToDate(utils.IfNotNilTimeWithDefault(serviceLineItemDetails.StartedAt, baseServiceLineItemEntity.StartedAt))
 
-	anyFieldChanged := baseServiceLineItemEntity.Name != serviceLineItemDetails.SliName ||
+	anyFieldChanged := baseServiceLineItemEntity.SkuId != serviceLineItemDetails.SkuId ||
+		baseServiceLineItemEntity.Name != serviceLineItemDetails.SliName ||
 		baseServiceLineItemEntity.Price != serviceLineItemDetails.SliPrice ||
 		baseServiceLineItemEntity.Quantity != serviceLineItemDetails.SliQuantity ||
 		baseServiceLineItemEntity.VatRate != serviceLineItemDetails.SliVatRate ||
@@ -281,6 +302,23 @@ func (s *serviceLineItemService) Update(ctx context.Context, serviceLineItemDeta
 	if !anyFieldChanged && (utils.ToDate(baseServiceLineItemEntity.StartedAt).Equal(startedAt) || sliIsInvoiced) {
 		span.LogFields(log.String("result", "No changes recorded"))
 		return nil
+	}
+
+	//todo remove this when name is removed from SLI
+	if baseServiceLineItemEntity.SkuId != serviceLineItemDetails.SkuId {
+		skuEntity, err := s.repositories.PostgresRepositories.SkuRepository.Get(ctx, common.GetTenantFromContext(ctx), serviceLineItemDetails.SkuId)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
+
+		if skuEntity == nil {
+			err := fmt.Errorf("sku with id {%s} not found", serviceLineItemDetails.SkuId)
+			tracing.TraceErr(span, err)
+			return err
+		}
+
+		serviceLineItemDetails.SliName = skuEntity.Name
 	}
 
 	if baseServiceLineItemEntity.Canceled {
@@ -389,6 +427,7 @@ func (s *serviceLineItemService) Update(ctx context.Context, serviceLineItemDeta
 
 	if isRetroactiveCorrection == true {
 		sliDataFields := data_fields.SLIFields{
+			SkuId:      utils.StringPtr(serviceLineItemDetails.SkuId),
 			Name:       utils.StringPtr(serviceLineItemDetails.SliName),
 			Quantity:   utils.Int64Ptr(serviceLineItemDetails.SliQuantity),
 			Price:      utils.Float64Ptr(serviceLineItemDetails.SliPrice),
@@ -426,6 +465,7 @@ func (s *serviceLineItemService) Update(ctx context.Context, serviceLineItemDeta
 		// Create new SLI version
 		_, err := s.NewVersion(ctx, cosapi_interfaces.ServiceLineItemNewVersionData{
 			Id:        baseServiceLineItemEntity.ParentID,
+			SkuId:     utils.StringFirstNonEmpty(serviceLineItemDetails.SkuId, baseServiceLineItemEntity.SkuId),
 			Name:      utils.StringFirstNonEmpty(serviceLineItemDetails.SliName, baseServiceLineItemEntity.Name),
 			Price:     serviceLineItemDetails.SliPrice,
 			Quantity:  serviceLineItemDetails.SliQuantity,

--- a/packages/server/customer-os-common-module/data_fields/service_line_item_fields.go
+++ b/packages/server/customer-os-common-module/data_fields/service_line_item_fields.go
@@ -12,7 +12,8 @@ type SLIFields struct {
 	BilledType *neo4jenum.BilledType `json:"billedType,omitempty"`
 	Quantity   *int64                `json:"quantity,omitempty"`
 	Price      *float64              `json:"price,omitempty"`
-	Name       *string               `json:"name,omitempty"`
+	SkuId      *string               `json:"skuId,omitempty"`
+	Name       *string               `json:"name,omitempty"` //deprecated
 	ContractId *string               `json:"contractId,omitempty"`
 	StartedAt  *time.Time            `json:"startedAt,omitempty"`
 	EndedAt    *time.Time            `json:"endedAt,omitempty"`

--- a/packages/server/customer-os-neo4j-repository/entity/service_line_item.go
+++ b/packages/server/customer-os-neo4j-repository/entity/service_line_item.go
@@ -15,7 +15,8 @@ const (
 
 type ServiceLineItemEntity struct {
 	ID               string
-	Name             string
+	SkuId            string
+	Name             string //deprecated
 	CreatedAt        time.Time
 	UpdatedAt        time.Time
 	StartedAt        time.Time  // DateTime

--- a/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
+++ b/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
@@ -473,6 +473,7 @@ func MapDbNodeToServiceLineItemEntity(dbNode *dbtype.Node) *neo4j_entity.Service
 	props := utils.GetPropsFromNode(*dbNode)
 	serviceLineItem := neo4j_entity.ServiceLineItemEntity{
 		ID:            utils.GetStringPropOrEmpty(props, "id"),
+		SkuId:         utils.GetStringPropOrEmpty(props, "skuId"),
 		Name:          utils.GetStringPropOrEmpty(props, "name"),
 		CreatedAt:     utils.GetTimePropOrEpochStart(props, "createdAt"),
 		UpdatedAt:     utils.GetTimePropOrEpochStart(props, "updatedAt"),

--- a/packages/server/customer-os-neo4j-repository/repository/service_line_item_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/service_line_item_write_repository.go
@@ -3,10 +3,10 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	"time"
@@ -61,6 +61,7 @@ func (r *serviceLineItemWriteRepository) CreateForContract(ctx context.Context, 
 								sli.endedAt=$endedAt,
 								sli.source=$source,
 								sli.appSource=$appSource,
+								sli.skuId=$skuId,
 								sli.name=$name,
 								sli.price=toFloat($price),
 								sli.quantity=$quantity,
@@ -81,6 +82,7 @@ func (r *serviceLineItemWriteRepository) CreateForContract(ctx context.Context, 
 		"parentId":          utils.IfNotNilString(data.ParentId),
 		"price":             utils.IfNotNilFloat64(data.Price),
 		"quantity":          utils.IfNotNilInt64(data.Quantity),
+		"skuId":             utils.IfNotNilString(data.SkuId),
 		"name":              utils.IfNotNilString(data.Name),
 		"comments":          utils.IfNotNilString(data.Comments),
 		"vatRate":           utils.IfNotNilFloat64(data.TaxRate),
@@ -118,6 +120,10 @@ func (r *serviceLineItemWriteRepository) Update(ctx context.Context, tx *neo4j.M
 							SET sli.updatedAt=datetime()`, tenant)
 	params := map[string]any{
 		"serviceLineItemId": serviceLineItemId,
+	}
+	if data.SkuId != nil {
+		params["skuId"] = *data.SkuId
+		cypher += `, sli.skuId = $skuId`
 	}
 	if data.Name != nil {
 		params["name"] = *data.Name

--- a/packages/server/customer-os-neo4j-repository/test/neo4j_data_helper.go
+++ b/packages/server/customer-os-neo4j-repository/test/neo4j_data_helper.go
@@ -781,6 +781,7 @@ func CreateServiceLineItemForContract(ctx context.Context, driver *neo4j.DriverW
 				MERGE (c)-[:HAS_SERVICE]->(sli:ServiceLineItem {id:$id})
 				SET 
 					sli:ServiceLineItem_%s,
+					sli.skuId=$skuId,
 					sli.name=$name,
 					sli.source=$source,
 					sli.sourceOfTruth=$sourceOfTruth,
@@ -805,6 +806,7 @@ func CreateServiceLineItemForContract(ctx context.Context, driver *neo4j.DriverW
 		"id":               serviceLineItemId,
 		"contractId":       contractId,
 		"tenant":           tenant,
+		"skuId":            serviceLineItem.SkuId,
 		"name":             serviceLineItem.Name,
 		"source":           serviceLineItem.Source,
 		"sourceOfTruth":    serviceLineItem.SourceOfTruth,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Deprecate `description` in favor of `skuId` in `ServiceLineItem`, updating GraphQL schemas, resolvers, models, and database interactions accordingly.
> 
>   - **GraphQL Schema Changes**:
>     - `ServiceLineItem` type in `service_line_item.graphqls`: Add `skuId` and `sku` fields, deprecate `description`.
>     - Update input types (`ServiceLineItemInput`, `ServiceLineItemUpdateInput`, etc.) to include `skuId` and deprecate `description`.
>   - **Resolvers**:
>     - Update `service_line_item.resolvers.go` to handle `skuId` and `sku` in `ServiceLineItem`.
>     - Add `Sku` resolver in `service_line_item.resolvers.go`.
>   - **Models and Interfaces**:
>     - Update `ServiceLineItem` struct in `models_gen.go` to include `skuId` and `sku`.
>     - Modify `ServiceLineItemCreateData`, `ServiceLineItemUpdateData`, and `ServiceLineItemNewVersionData` in `interfaces/service_line_item.go` to include `skuId`.
>   - **Database and Mapping**:
>     - Update `service_line_item_fields.go` and `service_line_item_mapper.go` to map `skuId`.
>     - Modify `service_line_item_write_repository.go` to handle `skuId` in database operations.
>     - Update `node_to_entity_mapper.go` to map `skuId` from database nodes.
>   - **Tests**:
>     - Update integration tests in `service_line_item.resolvers_it_test.go` to reflect changes in `skuId` handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 510884dc901310f807d23467af56af327920e871. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->