### PR TITLE
COS-6640: Close create new option dropdown upon select + type fix

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/email-composer/email-sender-select.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/email-composer/email-sender-select.usecase.ts
@@ -20,7 +20,8 @@ type EmailOption = {
 export class EmailSenderSelectUsecase {
   @observable public accessor searchTerm = '';
   @observable private accessor newEmailOptions = new Set();
-  @observable public accessor selectedEmail: EmailOption[] = [];
+  @observable public accessor selectedEmail: EmailOption | undefined =
+    undefined;
   @observable public accessor emailOptions: {
     label: string;
     value: string;
@@ -147,9 +148,9 @@ export class EmailSenderSelectUsecase {
   }
 
   @action
-  public select(value: SelectOption[]) {
+  public select(value: SelectOption) {
     if (!value) {
-      this.selectedEmail = [];
+      this.selectedEmail = undefined;
     }
     this.selectedEmail = value;
   }

--- a/packages/apps/frontera/src/domain/usecases/email-composer/send-timeline-email.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/email-composer/send-timeline-email.usecase.ts
@@ -86,8 +86,8 @@ export class TimelineEmailUsecase {
       if (emailContent) {
         await this.root.mail.send(
           {
-            fromProvider: this.fromSelector.selectedEmail?.[0]?.provider ?? '',
-            from: this.fromSelector.selectedEmail?.[0].value,
+            fromProvider: this.fromSelector.selectedEmail?.provider ?? '',
+            from: this.fromSelector.selectedEmail?.value ?? '',
             to: this.toSelector.selectedEmails?.map(({ value }) => value),
             cc: this.ccSelector.selectedEmails?.map(({ value }) => value),
             bcc: this.bccSelector.selectedEmails?.map(({ value }) => value),

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/email/EmailPreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/email/EmailPreviewModal.tsx
@@ -82,7 +82,7 @@ export const EmailPreviewModal = ({
       emailUseCase.updateSubject(`Re: ${subject}`);
 
       if (from?.[0].value) {
-        emailUseCase.fromSelector.select(from as SelectOption[]);
+        emailUseCase.fromSelector.select(from[0] as SelectOption);
       }
       emailUseCase.toSelector.select(
         getEmailParticipantsNameAndEmailSelection(to) || [],

--- a/packages/apps/frontera/src/routes/src/components/EmailMultiCreatableSelect/EmailFormMultiCreatableSelect.tsx
+++ b/packages/apps/frontera/src/routes/src/components/EmailMultiCreatableSelect/EmailFormMultiCreatableSelect.tsx
@@ -175,21 +175,10 @@ export const EmailFormMultiCreatableSelect = observer(
         noOptionsMessage={({ inputValue }) => (
           <div
             className='text-gray-700 px-3 py-1 mt-0.5 rounded-md bg-grayModern-100 gap-1 flex items-center'
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                emailParticipantUseCase.select({
-                  label: '',
-                  value: inputValue,
-                });
-              }
-            }}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              emailParticipantUseCase.select({
-                label: inputValue,
-                value: inputValue,
-              });
+              emailParticipantUseCase.addOption();
             }}
           >
             <Plus />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update email selection logic to handle single options and close dropdown upon selection, with type adjustments for consistency.
> 
>   - **Behavior**:
>     - Update `select()` in `email-sender-select.usecase.ts` to handle `SelectOption` instead of `SelectOption[]`.
>     - Modify `EmailPreviewModal.tsx` to pass single `SelectOption` to `select()`.
>     - Ensure dropdown closes upon selection in `EmailFormMultiCreatableSelect.tsx`.
>   - **Type Adjustments**:
>     - Change `selectedEmail` type in `email-sender-select.usecase.ts` from `EmailOption[]` to `EmailOption | undefined`.
>     - Update `send-timeline-email.usecase.ts` to use `selectedEmail?.provider` and `selectedEmail?.value` directly.
>   - **Misc**:
>     - Remove unnecessary `onKeyDown` logic in `EmailFormMultiCreatableSelect.tsx` for `Enter` key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7826a4cd2d0314cfec495752fd3a4ae4b2e728f2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->