### PR TITLE
Change social links on About panel to only be icons

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
@@ -155,7 +155,14 @@ export const AboutPanel = observer(() => {
               text={organization.value.description}
             />
           )}
-
+          <SocialMediaList
+            dataTest='org-about-social-link'
+            leftElement={<Share07 className='text-gray-500' />}
+            value={organization?.value.socialMedia.map((s) => ({
+              value: s.id,
+              label: s.url,
+            }))}
+          />
           <Tags
             dataTest='org-about-tags'
             inputPlaceholder='Search...'
@@ -300,14 +307,6 @@ export const AboutPanel = observer(() => {
             id={id}
             dataTest='org-about-org-owner'
             owner={organization?.value.owner}
-          />
-          <SocialMediaList
-            dataTest='org-about-social-link'
-            leftElement={<Share07 className='text-gray-500' />}
-            value={organization?.value.socialMedia.map((s) => ({
-              value: s.id,
-              label: s.url,
-            }))}
           />
 
           {showParentRelationshipSelector &&

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialIcons.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialIcons.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@ui/utils/cn';
 import { X } from '@ui/media/logos/X';
 import { Slack } from '@ui/media/logos/Slack';
 import { Reddit } from '@ui/media/logos/Reddit';
@@ -20,27 +21,44 @@ import { isKnownUrl } from './util';
 
 export const SocialIcon = ({
   children,
+  className,
   url,
-}: React.PropsWithChildren<{ url: string }>) => {
+}: React.PropsWithChildren<{ url: string; className?: string }>) => {
   const knownUrl = isKnownUrl(url);
 
-  if (knownUrl === 'twitter') return <X className='size-4' />;
-  if (knownUrl === 'facebook') return <Facebook className='size-4' />;
-  if (knownUrl === 'linkedin') return <Linkedin className='size-4' />;
-  if (knownUrl === 'github') return <Github className='size-4' />;
-  if (knownUrl === 'instagram') return <Instagram className='size-4' />;
-  if (knownUrl === 'youtube') return <Youtube className='size-4' />;
-  if (knownUrl === 'pinterest') return <Pinterest className='size-4' />;
-  if (knownUrl === 'angellist') return <Angellist className='size-4' />;
-  if (knownUrl === 'notion') return <Notion className='size-4' />;
-  if (knownUrl === 'clubhouse') return <Clubhouse className='size-4' />;
-  if (knownUrl === 'discord') return <Discord className='size-4' />;
-  if (knownUrl === 'slack') return <Slack className='size-4' />;
-  if (knownUrl === 'tiktok') return <Tiktok className='size-4' />;
-  if (knownUrl === 'telegram') return <Telegram className='size-4' />;
-  if (knownUrl === 'snapchat') return <Snapchat className='size-4' />;
-  if (knownUrl === 'reddit') return <Reddit className='size-4' />;
-  if (knownUrl === 'google') return <Google className='size-4' />;
+  if (knownUrl === 'twitter') return <X className={cn('size-4', className)} />;
+  if (knownUrl === 'facebook')
+    return <Facebook className={cn('size-4', className)} />;
+  if (knownUrl === 'linkedin')
+    return <Linkedin className={cn('size-4', className)} />;
+  if (knownUrl === 'github')
+    return <Github className={cn('size-4', className)} />;
+  if (knownUrl === 'instagram')
+    return <Instagram className={cn('size-4', className)} />;
+  if (knownUrl === 'youtube')
+    return <Youtube className={cn('size-4', className)} />;
+  if (knownUrl === 'pinterest')
+    return <Pinterest className={cn('size-4', className)} />;
+  if (knownUrl === 'angellist')
+    return <Angellist className={cn('size-4', className)} />;
+  if (knownUrl === 'notion')
+    return <Notion className={cn('size-4', className)} />;
+  if (knownUrl === 'clubhouse')
+    return <Clubhouse className={cn('size-4', className)} />;
+  if (knownUrl === 'discord')
+    return <Discord className={cn('size-4', className)} />;
+  if (knownUrl === 'slack')
+    return <Slack className={cn('size-4', className)} />;
+  if (knownUrl === 'tiktok')
+    return <Tiktok className={cn('size-4', className)} />;
+  if (knownUrl === 'telegram')
+    return <Telegram className={cn('size-4', className)} />;
+  if (knownUrl === 'snapchat')
+    return <Snapchat className={cn('size-4', className)} />;
+  if (knownUrl === 'reddit')
+    return <Reddit className={cn('size-4', className)} />;
+  if (knownUrl === 'google')
+    return <Google className={cn('size-4', className)} />;
 
   return <>{children}</>;
 };

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaItem.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaItem.tsx
@@ -9,6 +9,7 @@ import { Trash01 } from '@ui/media/icons/Trash01';
 import { Divider } from '@ui/presentation/Divider';
 import { Copy01 } from '@ui/media/icons/Copy01.tsx';
 import { Share03 } from '@ui/media/icons/Share03.tsx';
+import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
 import { formatSocialUrl } from '@ui/form/UrlInput/util';
 import { IconButton } from '@ui/form/IconButton/IconButton';
 import { useDisclosure } from '@ui/utils/hooks/useDisclosure';
@@ -37,7 +38,7 @@ interface SocialMediaItemProps {
 const removeOrgSocialMediaItemUsecase = new RemoveOrgSocialMediaItemUsecase();
 export const SocialMediaItem = observer(
   ({ value, dataTest, leftElement, id }: SocialMediaItemProps) => {
-    const [isHovered, setIsHovered] = useState(false);
+    const [openActionBar, setIsOpenActionBar] = useState(false);
     const [_, copyToClipboard] = useCopyToClipboard();
     const { onClose, onOpen, open } = useDisclosure();
 
@@ -53,17 +54,21 @@ export const SocialMediaItem = observer(
                 data-test={dataTest}
                 className='text-sm truncate cursor-default overflow-hidden overflow-ellipsis mr-3'
               >
-                <Popover open={isHovered} onOpenChange={setIsHovered}>
+                <Popover open={openActionBar} onOpenChange={setIsOpenActionBar}>
                   <PopoverTrigger>
-                    <SocialIcon
-                      url={value}
-                      className={cn(
-                        isHovered &&
-                          'border-[1px] border-gray-700 rounded-full ',
-                      )}
-                    >
-                      {leftElement}
-                    </SocialIcon>
+                    <Tooltip asChild label={formatSocialUrl(value)}>
+                      <div>
+                        <SocialIcon
+                          url={value}
+                          className={cn(
+                            openActionBar &&
+                              'border-[1px] border-gray-700 rounded-full ',
+                          )}
+                        >
+                          {leftElement}
+                        </SocialIcon>
+                      </div>
+                    </Tooltip>
                   </PopoverTrigger>
                   <PopoverContent side='top' className='bg-gray-700'>
                     <div className=' flex items-center text-white'>

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaItem.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaItem.tsx
@@ -4,14 +4,24 @@ import { observer } from 'mobx-react-lite';
 import { RemoveOrgSocialMediaItemUsecase } from '@domain/usecases/organization-about-panel/remove-org-social-media-item.usecase.ts';
 
 import { cn } from '@ui/utils/cn';
-import { XCircle } from '@ui/media/icons/XCircle';
+import { Button } from '@ui/form/Button/Button';
+import { Trash01 } from '@ui/media/icons/Trash01';
+import { Divider } from '@ui/presentation/Divider';
 import { Copy01 } from '@ui/media/icons/Copy01.tsx';
 import { Share03 } from '@ui/media/icons/Share03.tsx';
 import { formatSocialUrl } from '@ui/form/UrlInput/util';
 import { IconButton } from '@ui/form/IconButton/IconButton';
-import { DotsVertical } from '@ui/media/icons/DotsVertical';
+import { useDisclosure } from '@ui/utils/hooks/useDisclosure';
 import { useCopyToClipboard } from '@shared/hooks/useCopyToClipboard';
-import { Menu, MenuItem, MenuList, MenuButton } from '@ui/overlay/Menu/Menu';
+import { Popover, PopoverContent, PopoverTrigger } from '@ui/overlay/Popover';
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogFooter,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  AlertDialogCloseIconButton,
+} from '@ui/overlay/AlertDialog/AlertDialog';
 
 import { SocialIcon } from './SocialIcons';
 
@@ -27,80 +37,112 @@ interface SocialMediaItemProps {
 const removeOrgSocialMediaItemUsecase = new RemoveOrgSocialMediaItemUsecase();
 export const SocialMediaItem = observer(
   ({ value, dataTest, leftElement, id }: SocialMediaItemProps) => {
-    const [isOpen, setIsOpen] = useState(false);
+    const [isHovered, setIsHovered] = useState(false);
     const [_, copyToClipboard] = useCopyToClipboard();
+    const { onClose, onOpen, open } = useDisclosure();
 
     const href = value?.startsWith('http') ? value : `https://${value}`;
-    const formattedUrl = formatSocialUrl(value);
 
     return (
       <>
-        <div className='w-full  group'>
+        <div className='w-full group'>
           <div className='h-full relative w-full flex items-center'>
-            <div className='h-full flex items-center '>
+            <div className='h-full flex items-center'>
               <div
                 tabIndex={0}
-                role={'button'}
                 data-test={dataTest}
-                rel='noopener noreferrer'
-                onClick={() => copyToClipboard(value, 'Link copied')}
-                className='text-sm truncate cursor-default overflow-hidden overflow-ellipsis mr-2'
+                className='text-sm truncate cursor-default overflow-hidden overflow-ellipsis mr-3'
               >
-                <SocialIcon url={value}>{leftElement}</SocialIcon>
-                <span className='ml-3'>{formattedUrl}</span>
-              </div>
-
-              <div className='flex items-center gap-1'>
-                <div>
-                  <IconButton
-                    size='xxs'
-                    variant='ghost'
-                    aria-label={'Open in the new tab'}
-                    icon={<Share03 className={'size-3 m-0'} />}
-                    onClick={() =>
-                      window.open(href, '_blank', 'noopener noreferrer')
-                    }
-                    className={cn('opacity-0 group-hover:opacity-100', {
-                      '!opacity-100': isOpen,
-                    })}
-                  />
-                </div>
-
-                <Menu onOpenChange={(isOpen) => setIsOpen(isOpen)}>
-                  <MenuButton asChild>
-                    <IconButton
-                      size='xxs'
-                      variant='ghost'
-                      aria-label={'Collapse'}
-                      icon={<DotsVertical className={'size-3 m-0'} />}
-                      className={cn('opacity-0 group-hover:opacity-100', {
-                        '!opacity-100': isOpen,
-                      })}
-                    />
-                  </MenuButton>
-
-                  <MenuList className='min-w-[100px]'>
-                    <MenuItem
-                      onClick={() => copyToClipboard(value, 'Link copied')}
+                <Popover open={isHovered} onOpenChange={setIsHovered}>
+                  <PopoverTrigger>
+                    <SocialIcon
+                      url={value}
+                      className={cn(
+                        isHovered &&
+                          'border-[1px] border-gray-700 rounded-full ',
+                      )}
                     >
-                      <Copy01 />
-                      Copy link
-                    </MenuItem>
-                    <MenuItem
-                      onClick={() => {
-                        removeOrgSocialMediaItemUsecase.remove(id);
-                      }}
-                    >
-                      <XCircle />
-                      Remove social link
-                    </MenuItem>
-                  </MenuList>
-                </Menu>
+                      {leftElement}
+                    </SocialIcon>
+                  </PopoverTrigger>
+                  <PopoverContent side='top' className='bg-gray-700'>
+                    <div className=' flex items-center text-white'>
+                      <span className=' mr-2 text-sm truncate w-[150px]'>
+                        {formatSocialUrl(value)}
+                      </span>
+                      <Divider className='bg-gray-500 w-3 rotate-90 h-[1px] border-0' />
+                      <div className='flex gap-2'>
+                        <IconButton
+                          size='xxs'
+                          variant='ghost'
+                          icon={<Share03 />}
+                          colorScheme={'white'}
+                          aria-label={'Open in the new tab'}
+                          onClick={() =>
+                            window.open(href, '_blank', 'noopener noreferrer')
+                          }
+                        />
+                        <IconButton
+                          size='xxs'
+                          variant='ghost'
+                          icon={<Copy01 />}
+                          colorScheme={'white'}
+                          aria-label={'copy-social-link'}
+                          onClick={() => copyToClipboard(value, 'Link copied')}
+                        />
+                        <IconButton
+                          size='xxs'
+                          variant='ghost'
+                          icon={<Trash01 />}
+                          colorScheme={'white'}
+                          onClick={() => onOpen()}
+                          aria-label={'delete-social-link'}
+                        />
+                      </div>
+                    </div>
+                  </PopoverContent>
+                </Popover>
               </div>
             </div>
           </div>
         </div>
+
+        <DeleteModal open={open} socialId={id} onClose={onClose} />
       </>
+    );
+  },
+);
+
+interface DeleteModalProps {
+  open: boolean;
+  socialId: string;
+  onClose: () => void;
+}
+
+export const DeleteModal = observer(
+  ({ socialId, onClose, open }: DeleteModalProps) => {
+    return (
+      <AlertDialog isOpen={open} onClose={onClose}>
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogCloseIconButton />
+            <AlertDialogBody>
+              <span className='font-medium'>Delete this social link?</span>
+            </AlertDialogBody>
+            <AlertDialogFooter>
+              <Button onClick={onClose}>Cancel</Button>
+              <Button
+                colorScheme='primary'
+                onClick={() => {
+                  removeOrgSocialMediaItemUsecase.remove(socialId);
+                }}
+              >
+                Confirm
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
     );
   },
 );

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaList.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaList.tsx
@@ -22,18 +22,20 @@ export const SocialMediaList = observer(
     if (!organization || !organization?.value) return null;
 
     return (
-      <div className='flex flex-col gap-3 '>
-        {value?.map(({ value: v, label: l }) => (
-          <SocialMediaItem
-            id={v}
-            key={v}
-            value={l}
-            dataTest={dataTest}
-            isReadOnly={isReadOnly}
-            leftElement={leftElement}
-          />
-        ))}
-      </div>
+      <>
+        <div className='flex '>
+          {value?.map(({ value: v, label: l }) => (
+            <SocialMediaItem
+              id={v}
+              key={v}
+              value={l}
+              dataTest={dataTest}
+              isReadOnly={isReadOnly}
+              leftElement={leftElement}
+            />
+          ))}
+        </div>
+      </>
     );
   },
 );

--- a/packages/apps/frontera/src/ui/form/Button/Button.variants.ts
+++ b/packages/apps/frontera/src/ui/form/Button/Button.variants.ts
@@ -15,6 +15,7 @@ export const iconVariant = cva('', {
       ghost: [],
     },
     colorScheme: {
+      white: [],
       primary: [],
       gray: [],
       grayBlue: [],
@@ -41,6 +42,12 @@ export const iconVariant = cva('', {
     },
   },
   compoundVariants: [
+    {
+      size: 'xxs',
+      variant: 'solid',
+      colorScheme: 'white',
+      className: ['w-3 h-3', 'text-white'],
+    },
     {
       size: 'xxs',
       variant: 'solid',
@@ -178,6 +185,12 @@ export const iconVariant = cva('', {
       variant: 'solid',
       colorScheme: 'pink',
       className: ['w-3 h-3', 'text-white'],
+    },
+    {
+      size: 'xxs',
+      variant: 'outline',
+      colorScheme: 'white',
+      className: ['w-3 h-3', 'text-white-600'],
     },
     {
       size: 'xxs',
@@ -320,6 +333,12 @@ export const iconVariant = cva('', {
     {
       size: 'xxs',
       variant: 'link',
+      colorScheme: 'white',
+      className: ['w-3 h-3', 'text-white-700'],
+    },
+    {
+      size: 'xxs',
+      variant: 'link',
       colorScheme: 'primary',
       className: ['w-3 h-3', 'text-primary-700'],
     },
@@ -458,6 +477,12 @@ export const iconVariant = cva('', {
     {
       size: 'xxs',
       variant: 'ghost',
+      colorScheme: 'white',
+      className: ['w-3 h-3', 'text-white-700'],
+    },
+    {
+      size: 'xxs',
+      variant: 'ghost',
       colorScheme: 'primary',
       className: ['w-3 h-3', 'text-primary-700'],
     },
@@ -596,6 +621,12 @@ export const iconVariant = cva('', {
     {
       size: 'xs',
       variant: 'solid',
+      colorScheme: 'white',
+      className: ['w-4 h-4', 'text-white'],
+    },
+    {
+      size: 'xs',
+      variant: 'solid',
       colorScheme: 'primary',
       className: ['w-4 h-4', 'text-white'],
     },
@@ -730,6 +761,12 @@ export const iconVariant = cva('', {
       variant: 'solid',
       colorScheme: 'pink',
       className: ['w-4 h-4', 'text-white'],
+    },
+    {
+      size: 'xs',
+      variant: 'outline',
+      colorScheme: 'white',
+      className: ['w-4 h-4', 'text-white-600'],
     },
     {
       size: 'xs',
@@ -872,6 +909,12 @@ export const iconVariant = cva('', {
     {
       size: 'xs',
       variant: 'link',
+      colorScheme: 'white',
+      className: ['w-4 h-4', 'text-white-700'],
+    },
+    {
+      size: 'xs',
+      variant: 'link',
       colorScheme: 'primary',
       className: ['w-4 h-4', 'text-primary-700'],
     },
@@ -1010,6 +1053,12 @@ export const iconVariant = cva('', {
     {
       size: 'xs',
       variant: 'ghost',
+      colorScheme: 'white',
+      className: ['w-4 h-4', 'text-white-700'],
+    },
+    {
+      size: 'xs',
+      variant: 'ghost',
       colorScheme: 'primary',
       className: ['w-4 h-4', 'text-primary-700'],
     },
@@ -1148,6 +1197,12 @@ export const iconVariant = cva('', {
     {
       size: 'sm',
       variant: 'solid',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white'],
+    },
+    {
+      size: 'sm',
+      variant: 'solid',
       colorScheme: 'primary',
       className: ['w-5 h-5', 'text-white'],
     },
@@ -1282,6 +1337,12 @@ export const iconVariant = cva('', {
       variant: 'solid',
       colorScheme: 'pink',
       className: ['w-5 h-5', 'text-white'],
+    },
+    {
+      size: 'sm',
+      variant: 'outline',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white-600'],
     },
     {
       size: 'sm',
@@ -1424,6 +1485,12 @@ export const iconVariant = cva('', {
     {
       size: 'sm',
       variant: 'link',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white-700'],
+    },
+    {
+      size: 'sm',
+      variant: 'link',
       colorScheme: 'primary',
       className: ['w-5 h-5', 'text-primary-700'],
     },
@@ -1562,6 +1629,12 @@ export const iconVariant = cva('', {
     {
       size: 'sm',
       variant: 'ghost',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white-700'],
+    },
+    {
+      size: 'sm',
+      variant: 'ghost',
       colorScheme: 'primary',
       className: ['w-5 h-5', 'text-primary-700'],
     },
@@ -1700,6 +1773,12 @@ export const iconVariant = cva('', {
     {
       size: 'md',
       variant: 'solid',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white'],
+    },
+    {
+      size: 'md',
+      variant: 'solid',
       colorScheme: 'primary',
       className: ['w-5 h-5', 'text-white'],
     },
@@ -1834,6 +1913,12 @@ export const iconVariant = cva('', {
       variant: 'solid',
       colorScheme: 'pink',
       className: ['w-5 h-5', 'text-white'],
+    },
+    {
+      size: 'md',
+      variant: 'outline',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white-600'],
     },
     {
       size: 'md',
@@ -1976,6 +2061,12 @@ export const iconVariant = cva('', {
     {
       size: 'md',
       variant: 'link',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white-700'],
+    },
+    {
+      size: 'md',
+      variant: 'link',
       colorScheme: 'primary',
       className: ['w-5 h-5', 'text-primary-700'],
     },
@@ -2114,6 +2205,12 @@ export const iconVariant = cva('', {
     {
       size: 'md',
       variant: 'ghost',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white-700'],
+    },
+    {
+      size: 'md',
+      variant: 'ghost',
       colorScheme: 'primary',
       className: ['w-5 h-5', 'text-primary-700'],
     },
@@ -2252,6 +2349,12 @@ export const iconVariant = cva('', {
     {
       size: 'lg',
       variant: 'solid',
+      colorScheme: 'white',
+      className: ['w-6 h-6', 'text-white'],
+    },
+    {
+      size: 'lg',
+      variant: 'solid',
       colorScheme: 'primary',
       className: ['w-6 h-6', 'text-white'],
     },
@@ -2386,6 +2489,12 @@ export const iconVariant = cva('', {
       variant: 'solid',
       colorScheme: 'pink',
       className: ['w-6 h-6', 'text-white'],
+    },
+    {
+      size: 'lg',
+      variant: 'outline',
+      colorScheme: 'white',
+      className: ['w-6 h-6', 'text-white-600'],
     },
     {
       size: 'lg',
@@ -2528,6 +2637,12 @@ export const iconVariant = cva('', {
     {
       size: 'lg',
       variant: 'link',
+      colorScheme: 'white',
+      className: ['w-6 h-6', 'text-white-700'],
+    },
+    {
+      size: 'lg',
+      variant: 'link',
       colorScheme: 'primary',
       className: ['w-6 h-6', 'text-primary-700'],
     },
@@ -2662,6 +2777,12 @@ export const iconVariant = cva('', {
       variant: 'link',
       colorScheme: 'pink',
       className: ['w-6 h-6', 'text-pink-700'],
+    },
+    {
+      size: 'lg',
+      variant: 'ghost',
+      colorScheme: 'white',
+      className: ['w-6 h-6', 'text-white-700'],
     },
     {
       size: 'lg',
@@ -2822,6 +2943,13 @@ export const linkButton = cva(
   {
     variants: {
       colorScheme: {
+        white: [
+          'text-white-700',
+          'hover:text-white-700',
+          'focus:text-white-700',
+          'hover:underline',
+          'focus:underline',
+        ],
         primary: [
           'text-primary-700',
           'hover:text-primary-700',
@@ -3009,6 +3137,18 @@ export const solidButton = cva(
   {
     variants: {
       colorScheme: {
+        white: [
+          'text-white',
+          'border',
+          'border-solid',
+          'bg-white-600',
+          'hover:bg-white-700',
+          'focus:bg-white-700',
+          'border-white-600',
+          'hover:border-white-700',
+          'focus:shadow-ringPrimary',
+          'focus-visible:shadow-ringPrimary',
+        ],
         primary: [
           'text-white',
           'border',
@@ -3311,6 +3451,15 @@ export const ghostButton = cva(
   {
     variants: {
       colorScheme: {
+        white: [
+          'bg-transparent',
+          'shadow-none',
+          'text-gray-25',
+          'hover:text-gray-25',
+          'focus:text-gray-25',
+          'hover:bg-gray-600',
+          'focus:bg-gray-600',
+        ],
         primary: [
           'bg-transparent',
           'text-primary-700',
@@ -3544,6 +3693,16 @@ export const outlineButton = cva(
   {
     variants: {
       colorScheme: {
+        white: [
+          'bg-white-50',
+          'text-white-700',
+          'border',
+          'border-solid',
+          'border-white-300',
+          'hover:bg-white-100',
+          'hover:text-white-700',
+          'focus:bg-white-100',
+        ],
         primary: [
           'bg-primary-50',
           'text-primary-700',

--- a/packages/apps/frontera/src/ui/form/Button/codegen-variants.ts
+++ b/packages/apps/frontera/src/ui/form/Button/codegen-variants.ts
@@ -10,7 +10,7 @@ const prettierConfig = JSON.parse(
 const buttonTypes = ['Link', 'Solid', 'Ghost', 'Outline'];
 const sizes = ['xxs', 'xs', 'sm', 'md', 'lg'];
 
-const colors = Object.keys(file.colors).filter((color) => color !== 'white');
+const colors = Object.keys(file.colors);
 const variants = ['solid', 'outline', 'link', 'ghost'];
 
 const solidButton = (color: string) => `
@@ -63,6 +63,16 @@ const ghostButton = (color: string) => `
       'focus:text-${color}-700',
       'hover:bg-${color}-100',
       'focus:bg-${color}-100',
+    ]`
+    : color === 'white'
+    ? `[
+      'bg-transparent',
+      'shadow-none',
+      'text-gray-25',
+      'hover:text-gray-25',
+      'focus:text-gray-25',
+      'hover:bg-gray-600',
+      'focus:bg-gray-600',
     ]`
     : `[
       'bg-transparent',

--- a/packages/apps/frontera/src/ui/form/IconButton/IconButton.variants.ts
+++ b/packages/apps/frontera/src/ui/form/IconButton/IconButton.variants.ts
@@ -14,6 +14,7 @@ export const iconVariant = cva('', {
       ghost: [],
     },
     colorScheme: {
+      white: [],
       primary: [],
       gray: [],
       grayBlue: [],
@@ -40,6 +41,12 @@ export const iconVariant = cva('', {
     },
   },
   compoundVariants: [
+    {
+      size: 'xxs',
+      variant: 'solid',
+      colorScheme: 'white',
+      className: ['w-3 h-3', 'text-white'],
+    },
     {
       size: 'xxs',
       variant: 'solid',
@@ -177,6 +184,12 @@ export const iconVariant = cva('', {
       variant: 'solid',
       colorScheme: 'pink',
       className: ['w-3 h-3', 'text-white'],
+    },
+    {
+      size: 'xxs',
+      variant: 'outline',
+      colorScheme: 'white',
+      className: ['w-3 h-3', 'text-white-600'],
     },
     {
       size: 'xxs',
@@ -319,6 +332,12 @@ export const iconVariant = cva('', {
     {
       size: 'xxs',
       variant: 'ghost',
+      colorScheme: 'white',
+      className: ['w-3 h-3', 'text-white-700'],
+    },
+    {
+      size: 'xxs',
+      variant: 'ghost',
       colorScheme: 'primary',
       className: ['w-3 h-3', 'text-primary-700'],
     },
@@ -457,6 +476,12 @@ export const iconVariant = cva('', {
     {
       size: 'xs',
       variant: 'solid',
+      colorScheme: 'white',
+      className: ['w-4 h-4', 'text-white'],
+    },
+    {
+      size: 'xs',
+      variant: 'solid',
       colorScheme: 'primary',
       className: ['w-4 h-4', 'text-white'],
     },
@@ -591,6 +616,12 @@ export const iconVariant = cva('', {
       variant: 'solid',
       colorScheme: 'pink',
       className: ['w-4 h-4', 'text-white'],
+    },
+    {
+      size: 'xs',
+      variant: 'outline',
+      colorScheme: 'white',
+      className: ['w-4 h-4', 'text-white-600'],
     },
     {
       size: 'xs',
@@ -733,6 +764,12 @@ export const iconVariant = cva('', {
     {
       size: 'xs',
       variant: 'ghost',
+      colorScheme: 'white',
+      className: ['w-4 h-4', 'text-white-700'],
+    },
+    {
+      size: 'xs',
+      variant: 'ghost',
       colorScheme: 'primary',
       className: ['w-4 h-4', 'text-primary-700'],
     },
@@ -871,6 +908,12 @@ export const iconVariant = cva('', {
     {
       size: 'sm',
       variant: 'solid',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white'],
+    },
+    {
+      size: 'sm',
+      variant: 'solid',
       colorScheme: 'primary',
       className: ['w-5 h-5', 'text-white'],
     },
@@ -1005,6 +1048,12 @@ export const iconVariant = cva('', {
       variant: 'solid',
       colorScheme: 'pink',
       className: ['w-5 h-5', 'text-white'],
+    },
+    {
+      size: 'sm',
+      variant: 'outline',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white-600'],
     },
     {
       size: 'sm',
@@ -1147,6 +1196,12 @@ export const iconVariant = cva('', {
     {
       size: 'sm',
       variant: 'ghost',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white-700'],
+    },
+    {
+      size: 'sm',
+      variant: 'ghost',
       colorScheme: 'primary',
       className: ['w-5 h-5', 'text-primary-700'],
     },
@@ -1285,6 +1340,12 @@ export const iconVariant = cva('', {
     {
       size: 'md',
       variant: 'solid',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white'],
+    },
+    {
+      size: 'md',
+      variant: 'solid',
       colorScheme: 'primary',
       className: ['w-5 h-5', 'text-white'],
     },
@@ -1419,6 +1480,12 @@ export const iconVariant = cva('', {
       variant: 'solid',
       colorScheme: 'pink',
       className: ['w-5 h-5', 'text-white'],
+    },
+    {
+      size: 'md',
+      variant: 'outline',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white-600'],
     },
     {
       size: 'md',
@@ -1561,6 +1628,12 @@ export const iconVariant = cva('', {
     {
       size: 'md',
       variant: 'ghost',
+      colorScheme: 'white',
+      className: ['w-5 h-5', 'text-white-700'],
+    },
+    {
+      size: 'md',
+      variant: 'ghost',
       colorScheme: 'primary',
       className: ['w-5 h-5', 'text-primary-700'],
     },
@@ -1699,6 +1772,12 @@ export const iconVariant = cva('', {
     {
       size: 'lg',
       variant: 'solid',
+      colorScheme: 'white',
+      className: ['w-6 h-6', 'text-white'],
+    },
+    {
+      size: 'lg',
+      variant: 'solid',
       colorScheme: 'primary',
       className: ['w-6 h-6', 'text-white'],
     },
@@ -1833,6 +1912,12 @@ export const iconVariant = cva('', {
       variant: 'solid',
       colorScheme: 'pink',
       className: ['w-6 h-6', 'text-white'],
+    },
+    {
+      size: 'lg',
+      variant: 'outline',
+      colorScheme: 'white',
+      className: ['w-6 h-6', 'text-white-600'],
     },
     {
       size: 'lg',
@@ -1971,6 +2056,12 @@ export const iconVariant = cva('', {
       variant: 'outline',
       colorScheme: 'pink',
       className: ['w-6 h-6', 'text-pink-600'],
+    },
+    {
+      size: 'lg',
+      variant: 'ghost',
+      colorScheme: 'white',
+      className: ['w-6 h-6', 'text-white-700'],
     },
     {
       size: 'lg',

--- a/packages/apps/frontera/src/ui/form/IconButton/codegen-variants.ts
+++ b/packages/apps/frontera/src/ui/form/IconButton/codegen-variants.ts
@@ -8,7 +8,7 @@ const prettierConfig = JSON.parse(
 );
 
 const sizes = ['xxs', 'xs', 'sm', 'md', 'lg'];
-const colors = Object.keys(file.colors).filter((color) => color !== 'white');
+const colors = Object.keys(file.colors);
 const variants = ['solid', 'outline', 'ghost'];
 
 const genCompoundVariant = (

--- a/packages/apps/frontera/src/ui/form/UrlInput/util.ts
+++ b/packages/apps/frontera/src/ui/form/UrlInput/util.ts
@@ -25,5 +25,13 @@ export function formatSocialUrl(value = '', orgUrl?: boolean) {
     url = url.replace('linkedin.com/company', '');
   }
 
+  if (url.includes('facebook.com')) {
+    url = url.replace('facebook.com', '');
+  }
+
+  if (url.includes('instagram.com')) {
+    url = url.replace('instagram.com', '');
+  }
+
   return url;
 }

--- a/packages/apps/frontera/src/ui/media/Icon/Icon.variants.ts
+++ b/packages/apps/frontera/src/ui/media/Icon/Icon.variants.ts
@@ -32,9 +32,19 @@ export const featureIconVariant = cva(
         purple: [],
         cyan: [],
         orangeDark: [],
+        white: [],
+        indigo: [],
+        blueLight: [],
+        pink: [],
       },
     },
     compoundVariants: [
+      {
+        colorScheme: 'white',
+        className: [
+          'bg-white-100 ring-white-50 ring-offset-white-100 text-white-600',
+        ],
+      },
       {
         colorScheme: 'primary',
         className: [

--- a/packages/apps/frontera/src/ui/media/Icon/Icon.variants.ts
+++ b/packages/apps/frontera/src/ui/media/Icon/Icon.variants.ts
@@ -96,6 +96,12 @@ export const featureIconVariant = cva(
         ],
       },
       {
+        colorScheme: 'indigo',
+        className: [
+          'bg-indigo-100 ring-indigo-50 ring-offset-indigo-100 text-indigo-600',
+        ],
+      },
+      {
         colorScheme: 'teal',
         className: [
           'bg-teal-100 ring-teal-50 ring-offset-teal-100 text-teal-600',
@@ -111,6 +117,12 @@ export const featureIconVariant = cva(
         colorScheme: 'blue',
         className: [
           'bg-blue-100 ring-blue-50 ring-offset-blue-100 text-blue-600',
+        ],
+      },
+      {
+        colorScheme: 'blueLight',
+        className: [
+          'bg-blueLight-100 ring-blueLight-50 ring-offset-blueLight-100 text-blueLight-600',
         ],
       },
       {
@@ -153,6 +165,12 @@ export const featureIconVariant = cva(
         colorScheme: 'cyan',
         className: [
           'bg-cyan-100 ring-cyan-50 ring-offset-cyan-100 text-cyan-600',
+        ],
+      },
+      {
+        colorScheme: 'pink',
+        className: [
+          'bg-pink-100 ring-pink-50 ring-offset-pink-100 text-pink-600',
         ],
       },
     ],

--- a/packages/apps/frontera/src/ui/media/Icon/codegen-variants.ts
+++ b/packages/apps/frontera/src/ui/media/Icon/codegen-variants.ts
@@ -6,7 +6,7 @@ import * as file from '../../theme/colors';
 const prettierConfig = JSON.parse(
   fs.readFileSync(process.cwd() + '/.prettierrc', 'utf8'),
 );
-const colors = Object.keys(file.colors).filter((color) => color !== 'white');
+const colors = Object.keys(file.colors);
 type compoundVariants = {
   colorScheme: string;
   className: string[];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update About panel to display social media links as icons only, with refactoring and styling enhancements.
> 
>   - **Behavior**:
>     - Update `AboutPanel.tsx` to display social media links as icons only, using `SocialMediaList`.
>     - Remove text labels from social media links in `AboutPanel.tsx`.
>   - **Components**:
>     - Refactor `SocialMediaItem` to use `Popover` for actions like copy, open, and delete.
>     - Add `DeleteModal` in `SocialMediaItem` for confirming link deletion.
>   - **Utilities**:
>     - Update `formatSocialUrl` in `util.ts` to handle Facebook and Instagram URLs.
>   - **Styling**:
>     - Add `white` color scheme to button and icon variants in `Button.variants.ts` and `IconButton.variants.ts`.
>     - Update `featureIconVariant` in `Icon.variants.ts` to include new color schemes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c3fba8d5e5fc8723e85fdd73954274820c2ff5ec. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->