### PR TITLE
COS-6641: API path fix

### DIFF
--- a/packages/apps/frontera/middleware/index.js
+++ b/packages/apps/frontera/middleware/index.js
@@ -197,10 +197,23 @@ async function createServer() {
   app.use(helmet());
   app.use(jwtMiddleware);
 
-  const customerOsApiProxy = createProxyMiddleware({
+  const customerOsApiGqlProxy = createProxyMiddleware({
     pathFilter: '/customer-os-api',
     pathRewrite: { '^/customer-os-api': '' },
     target: process.env.CUSTOMER_OS_API_PATH + '/query',
+    changeOrigin: true,
+    headers: {
+      'X-Openline-API-KEY': process.env.CUSTOMER_OS_API_KEY,
+    },
+    logger: console,
+    preserveHeaderKeyCase: true,
+    followRedirects: true,
+  });
+
+  const customerOsApiRestProxy = createProxyMiddleware({
+    pathFilter: '/cos',
+    pathRewrite: { '^/cos': '' },
+    target: process.env.CUSTOMER_OS_API_PATH,
     changeOrigin: true,
     headers: {
       'X-Openline-API-KEY': process.env.CUSTOMER_OS_API_KEY,
@@ -249,7 +262,8 @@ async function createServer() {
     followRedirects: true,
   });
 
-  app.use(customerOsApiProxy);
+  app.use(customerOsApiGqlProxy);
+  app.use(customerOsApiRestProxy);
   app.use(settingsApiProxy);
   app.use(userAdminApiProxy);
   app.use(fileStorageApiProxy);

--- a/packages/apps/frontera/src/store/Mail/Mail.store.ts
+++ b/packages/apps/frontera/src/store/Mail/Mail.store.ts
@@ -43,11 +43,15 @@ export class MailStore {
 
     try {
       this.isLoading = true;
-      await this.transport.http.post(`/ua/mail/send`, decoratedPayload, {
-        headers: {
-          'Content-Type': 'application/json',
+      await this.transport.http.post(
+        `/cos/internal/v1/mail/send`,
+        decoratedPayload,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
         },
-      });
+      );
 
       runInAction(() => {
         this.root.ui.toastSuccess(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added REST API proxy and updated mail API path in `index.js` and `Mail.store.ts`.
> 
>   - **Middleware Changes**:
>     - Renamed `customerOsApiProxy` to `customerOsApiGqlProxy` in `index.js`.
>     - Added `customerOsApiRestProxy` for REST API requests in `index.js`.
>     - Updated `app.use()` to include `customerOsApiRestProxy` in `index.js`.
>   - **Mail Store Changes**:
>     - Updated API path in `Mail.store.ts` from `/ua/mail/send` to `/cos/internal/v1/mail/send`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f792f96d5bf378c593cf5d4ccc14d29ae44babf7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->