### PR TITLE
Fix anthropic

### DIFF
--- a/packages/Justfile
+++ b/packages/Justfile
@@ -126,7 +126,7 @@ restart-api:
     echo "CustomerOS API restarted"
 
 start:
-	cd ../deployment && podman-compose up rabbitmq jaeger postgres postgres-sidecar neo4j eventstore customer-os-platform-admin-api -d
+	cd ../deployment && podman-compose up rabbitmq jaeger postgres postgres-sidecar neo4j eventstore -d
 
 start-api:
     cd ./server/customer-os-platform-admin-api && go run . > ../../admin-api.log 2>&1 & echo $$! > admin-api.pid

--- a/packages/server/customer-os-common-module/services/ai/anthropic_client.go
+++ b/packages/server/customer-os-common-module/services/ai/anthropic_client.go
@@ -76,14 +76,13 @@ func (c *AnthropicClient) Invoke(ctx context.Context, systemPrompt *string, cont
 }
 
 func (c *AnthropicClient) buildRequest(systemPrompt *string, content any) AnthropicApiRequest {
-	// Convert the map to proper JSON string if it's a map
+	// If content is a map, convert it to JSON string
 	var processedContent any
 	if contentMap, ok := content.(map[string]any); ok {
 		jsonBytes, err := json.Marshal(contentMap)
 		if err == nil {
 			processedContent = string(jsonBytes)
 		} else {
-			// Fallback to original content if marshaling fails
 			processedContent = content
 		}
 	} else {
@@ -92,7 +91,7 @@ func (c *AnthropicClient) buildRequest(systemPrompt *string, content any) Anthro
 
 	req := AnthropicApiRequest{
 		Model:       c.model,
-		Messages:    []Message{{Role: "user", Content: processedContent}},
+		Messages:    []Message{{Role: "user", Content: []any{processedContent}}},
 		MaxTokens:   MaxTokens,
 		Temperature: DefaultTemperature,
 	}

--- a/packages/server/customer-os-common-module/services/ai/anthropic_client.go
+++ b/packages/server/customer-os-common-module/services/ai/anthropic_client.go
@@ -76,15 +76,29 @@ func (c *AnthropicClient) Invoke(ctx context.Context, systemPrompt *string, cont
 }
 
 func (c *AnthropicClient) buildRequest(systemPrompt *string, content any) AnthropicApiRequest {
+	// Convert the map to proper JSON string if it's a map
+	var processedContent any
+	if contentMap, ok := content.(map[string]any); ok {
+		jsonBytes, err := json.Marshal(contentMap)
+		if err == nil {
+			processedContent = string(jsonBytes)
+		} else {
+			// Fallback to original content if marshaling fails
+			processedContent = content
+		}
+	} else {
+		processedContent = content
+	}
+
 	req := AnthropicApiRequest{
 		Model:       c.model,
-		Messages:    []Message{{Role: "user", Content: content}},
+		Messages:    []Message{{Role: "user", Content: processedContent}},
 		MaxTokens:   MaxTokens,
 		Temperature: DefaultTemperature,
 	}
 
 	if systemPrompt != nil {
-		req.System = *systemPrompt // Set as top-level system parameter
+		req.System = *systemPrompt
 	}
 
 	return req


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removes `customer-os-platform-admin-api` from `Justfile` start command and updates `buildRequest` in `anthropic_client.go` to handle map content as JSON string.
> 
>   - **Behavior**:
>     - `Justfile`: Removes `customer-os-platform-admin-api` from the `start` command.
>     - `anthropic_client.go`: Updates `buildRequest` to convert map content to JSON string before processing.
>   - **Functions**:
>     - `buildRequest` in `anthropic_client.go`: Handles map content by converting it to JSON string.
>   - **Misc**:
>     - Minor change in `Justfile` to adjust service startup configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for e30e4472a3e02aa1d065cd805d79db0b0862176f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->