### PR TITLE
update csp headers

### DIFF
--- a/packages/apps/frontera/nginx.conf
+++ b/packages/apps/frontera/nginx.conf
@@ -6,17 +6,6 @@ server {
   proxy_buffer_size 128k;
   large_client_header_buffers 16 32k;
 
-  add_header Content-Security-Policy "
-    default-src 'self'; 
-    script-src 'self' https://unpkg.com https://cdn.heapanalytics.com https://www.clarity.ms https://js.stripe.com https://m.stripe.network; 
-    style-src 'self' https://fonts.googleapis.com; 
-    img-src 'self' https://asset.brandfetch.io https://media.licdn.com;
-    font-src 'self' https://fonts.googleapis.com;
-    connect-src 'self' https://mid.customeros.ai https://heapanalytics.com https://r.stripe.com https://u.clarity.ms https://js.stripe.com https://cdn.growthbook.io https://m.stripe.com;
-    object-src 'none';
-    frame-ancestors 'none';
-    base-uri 'self';
-  " always;
   add_header X-Frame-Options "DENY" always;
   add_header X-Content-Type-Options "nosniff";
 

--- a/packages/apps/frontera/nginx.conf
+++ b/packages/apps/frontera/nginx.conf
@@ -8,6 +8,7 @@ server {
 
   add_header X-Frame-Options "DENY" always;
   add_header X-Content-Type-Options "nosniff";
+  add_header Content-Security-Policy "default-src 'self' http: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.customeros.ai *.atlas.so unpkg.com *.heapanalytics.com *.clarity.ms *.stripe.com *.stripe.network; style-src 'self' 'unsafe-inline' http: https:; img-src 'self' data: blob: *.customeros.ai *.brandfetch.io *.licdn.com heapanalytics.com; font-src 'self' http: https:; connect-src 'self' *.customeros.ai *.atlas.so *.highlight.io *.heapanalytics.com *.stripe.com *.clarity.ms *.growthbook.io wss://real.customeros.ai wss://app.atlas.so; worker-src 'self' data: blob: http: https:; media-src 'self' data: http: https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self';" always;
 
   location ~ /\. {
       deny all;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replaced Content-Security-Policy in `nginx.conf` with a more permissive version allowing broader resource loading.
> 
>   - **Content-Security-Policy Update**:
>     - Replaced existing CSP header in `nginx.conf` with a more permissive policy.
>     - New policy allows `script-src` from `*.customeros.ai`, `*.atlas.so`, `unpkg.com`, `*.heapanalytics.com`, `*.clarity.ms`, `*.stripe.com`, `*.stripe.network` and includes `'unsafe-inline'`, `'unsafe-eval'`.
>     - `style-src` now allows `'unsafe-inline'`, `http:`, `https:`.
>     - `img-src` includes `data:`, `blob:`, `*.customeros.ai`, `*.brandfetch.io`, `*.licdn.com`, `heapanalytics.com`.
>     - `connect-src` expanded to include `*.customeros.ai`, `*.atlas.so`, `*.highlight.io`, `*.heapanalytics.com`, `*.stripe.com`, `*.clarity.ms`, `*.growthbook.io`, `wss://real.customeros.ai`, `wss://app.atlas.so`.
>     - `worker-src` and `media-src` allow `data:`, `blob:`, `http:`, `https:`.
>     - `frame-ancestors` set to `'self'`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 05aed56f3bcbc46085760b4f8baf08226f5e3c23. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->