### PR TITLE
refine Content Security Policy in nginx configuration

### DIFF
--- a/packages/apps/frontera/nginx.conf
+++ b/packages/apps/frontera/nginx.conf
@@ -8,7 +8,7 @@ server {
 
   add_header X-Frame-Options "DENY" always;
   add_header X-Content-Type-Options "nosniff";
-  add_header Content-Security-Policy "default-src 'self' http: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.customeros.ai *.atlas.so unpkg.com *.heapanalytics.com *.clarity.ms *.stripe.com *.stripe.network; style-src 'self' 'unsafe-inline' http: https:; img-src 'self' data: blob: *.customeros.ai *.brandfetch.io *.licdn.com heapanalytics.com; font-src 'self' http: https:; connect-src 'self' *.customeros.ai *.atlas.so *.highlight.io *.heapanalytics.com *.stripe.com *.clarity.ms *.growthbook.io wss://real.customeros.ai wss://app.atlas.so; worker-src 'self' data: blob: http: https:; media-src 'self' data: http: https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self';" always;
+  add_header Content-Security-Policy "default-src 'self' http: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.customeros.ai *.atlas.so unpkg.com *.heapanalytics.com *.clarity.ms *.stripe.com *.stripe.network; style-src 'self' 'unsafe-inline' http: https:; img-src 'self' data: blob: https:; font-src 'self' http: https:; connect-src 'self' *.customeros.ai *.atlas.so *.highlight.io *.heapanalytics.com *.stripe.com *.clarity.ms *.growthbook.io wss://real.customeros.ai wss://app.atlas.so; worker-src 'self' data: blob: http: https:; media-src 'self' data: http: https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self';" always;
 
   location ~ /\. {
       deny all;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refined `img-src` directive in `nginx.conf` to restrict image sources to `https:` protocol only, enhancing security.
> 
>   - **Content Security Policy**:
>     - Refined `img-src` directive in `nginx.conf` to allow only `https:` protocol, removing specific domains like `*.customeros.ai`, `*.brandfetch.io`, `*.licdn.com`, and `heapanalytics.com`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 9426ed0376f13106f00d100f6873efab53d7f685. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->