### PR TITLE
fix capability order

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
@@ -36,6 +36,9 @@ func (c *AnalyzeWebSessionCapability) ValidateInput(data AnalyzeWebSessionInput)
 	if data.Domain == "" {
 		return coserrors.ErrCapabilityDomainMissing
 	}
+	if data.OrganizationID == "" {
+		return errors.New("missing required input data: OrganizationID")
+	}
 	return nil
 }
 

--- a/packages/server/customer-os-postgres-repository/repository/agent_registry_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agent_registry_repository.go
@@ -193,11 +193,11 @@ func registerVisitorIdpostgres_entityAgent() postgres_entity.AgentRegistry {
 					Active: true,
 				},
 				{
-					Type:   enum.CapabilityAnalyzeWebSessionIntent,
+					Type:   enum.CapabilityCreateOrganization,
 					Active: true,
 				},
 				{
-					Type:   enum.CapabilityCreateOrganization,
+					Type:   enum.CapabilityAnalyzeWebSessionIntent,
 					Active: true,
 				},
 				{


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `OrganizationID` validation in `ValidateInput` and fix capability order in `registerVisitorIdpostgres_entityAgent`.
> 
>   - **Validation**:
>     - Add check for `OrganizationID` in `ValidateInput` in `capability_analyze_web_session.go`.
>   - **Capability Order**:
>     - Swap `CapabilityAnalyzeWebSessionIntent` and `CapabilityCreateOrganization` in `registerVisitorIdpostgres_entityAgent` in `agent_registry_repository.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 57513fe93100d9c0c528a486e88e2f6990f0ca25. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->