### PR TITLE
set default cooldown hours

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capabilities_config.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capabilities_config.go
@@ -9,7 +9,10 @@ func GetCapabilityConfigStruct(capabilityType enum.AgentCapabilityType) any {
 	case enum.CapabilitySendSlackNotification:
 		return &SendSlackNotificationConfig{}
 	case enum.CapabilitySendWebVisitorSlackNotification:
-		return &SendWebVisitorSlackNotificationConfig{}
+		return &SendWebVisitorSlackNotificationConfig{
+			ChannelID:     "",
+			CooldownHours: 12,
+		}
 	default:
 		return &NoConfig{}
 	}

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_send_web_visitor_notification_slack.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_send_web_visitor_notification_slack.go
@@ -38,7 +38,7 @@ type SendWebVisitorSlackNotificationResult struct {
 
 type SendWebVisitorSlackNotificationConfig struct {
 	ChannelID     string `json:"channelId"`
-	CooldownHours int    `json:"cooldownHours" default:"12"`
+	CooldownHours int    `json:"cooldownHours"`
 }
 
 func NewSendWebVisitorSlackNotificationCapability(postgresRepositories *postgres_repository.Repositories,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set default `CooldownHours` to 12 in `SendWebVisitorSlackNotificationConfig` and remove default tag.
> 
>   - **Behavior**:
>     - Set default `CooldownHours` to 12 in `GetCapabilityConfigStruct()` for `SendWebVisitorSlackNotificationConfig`.
>     - Removed default tag from `CooldownHours` in `SendWebVisitorSlackNotificationConfig` struct.
>   - **Validation**:
>     - `ValidateConfig()` in `capability_send_web_visitor_notification_slack.go` ensures `CooldownHours` is non-negative.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 26cc3dbfdec4db432239085c7e0b324cfc16eccb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->