### PR TITLE
refine Content Security Policy to include Google Fonts

### DIFF
--- a/packages/apps/frontera/nginx.conf
+++ b/packages/apps/frontera/nginx.conf
@@ -8,7 +8,7 @@ server {
 
   add_header X-Frame-Options "DENY" always;
   add_header X-Content-Type-Options "nosniff";
-  add_header Content-Security-Policy "default-src 'self' http: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.customeros.ai *.atlas.so unpkg.com *.heapanalytics.com *.clarity.ms *.stripe.com *.stripe.network; style-src 'self' 'unsafe-inline' http: https:; img-src 'self' data: blob: https:; font-src 'self' http: https:; connect-src 'self' *.customeros.ai *.atlas.so *.highlight.io *.heapanalytics.com *.stripe.com *.clarity.ms *.growthbook.io wss://real.customeros.ai wss://app.atlas.so; worker-src 'self' data: blob: http: https:; media-src 'self' data: http: https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self';" always;
+  add_header Content-Security-Policy "default-src 'self' http: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.customeros.ai *.atlas.so unpkg.com *.heapanalytics.com *.clarity.ms *.stripe.com *.stripe.network; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' *.customeros.ai *.atlas.so *.highlight.io *.heapanalytics.com *.stripe.com *.clarity.ms *.growthbook.io wss://real.customeros.ai wss://app.atlas.so https://fonts.gstatic.com; worker-src 'self' data: blob: http: https:; media-src 'self' data: http: https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self';" always;
 
   location ~ /\. {
       deny all;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refines Content Security Policy in `nginx.conf` to include Google Fonts by updating `style-src`, `font-src`, and `connect-src`.
> 
>   - **Content Security Policy Update**:
>     - In `nginx.conf`, updated `style-src` to include `https://fonts.googleapis.com`.
>     - Updated `font-src` to include `https://fonts.gstatic.com`.
>     - Updated `connect-src` to include `https://fonts.gstatic.com`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c26c7fe2ccaed90f4934945ce03ac752789a2f5d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->