### PR TITLE
add tracing for Cloudflare API error

### DIFF
--- a/packages/server/customer-os-common-module/services/cloudflare/service.go
+++ b/packages/server/customer-os-common-module/services/cloudflare/service.go
@@ -722,7 +722,7 @@ func (s *cloudflareService) addRedirectPageRule(ctx context.Context, zoneID stri
 			errMsg = addPageRuleResponse.Errors[0].Message
 		}
 		err = fmt.Errorf(errMsg)
-		tracing.TraceErr(span, err)
+		tracing.TraceErr(span, err, tracingLog.String("responseBody", string(body)))
 		s.log.Error("Cloudflare API error: ", errMsg)
 		return err
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance error tracing in `addRedirectPageRule()` in `service.go` by logging the response body.
> 
>   - **Tracing Enhancement**:
>     - In `service.go`, `addRedirectPageRule()` now includes `responseBody` in error tracing logs using `tracing.TraceErr()`.
>   - **Logging**:
>     - Logs Cloudflare API error messages with additional context from the response body.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 16089444611f8a2fb1bd661b63e8a05c4d7a8d26. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->