### PR TITLE
fix cloudflare page rules

### DIFF
--- a/packages/server/customer-os-common-module/services/cloudflare/service.go
+++ b/packages/server/customer-os-common-module/services/cloudflare/service.go
@@ -594,6 +594,12 @@ func (s *cloudflareService) addMailStackRedirectPageRules(ctx context.Context, z
 	defer span.Finish()
 	span.LogKV("zoneID", zoneID, "domain", domain, "destinationURL", destinationURL)
 
+	// if destinationURL not starting with http or https, add https
+	destinationURL = strings.TrimSpace(destinationURL)
+	if !strings.HasPrefix(destinationURL, "http") {
+		destinationURL = "https://" + destinationURL
+	}
+
 	// Page rule configurations
 	pageRules := []map[string]interface{}{
 		{


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prepend `https://` to `destinationURL` in `addMailStackRedirectPageRules` if it doesn't start with `http` or `https`.
> 
>   - **Behavior**:
>     - In `addMailStackRedirectPageRules` in `service.go`, prepend `https://` to `destinationURL` if it doesn't start with `http` or `https`.
>   - **Misc**:
>     - No other changes or impacts on other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for afd7be0a9cb6c561a10569e0d102db4efdd529d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->