### PR TITLE
Fix workspace domains getter

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_send_web_visitor_notification_slack.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_send_web_visitor_notification_slack.go
@@ -42,7 +42,7 @@ type SendWebVisitorSlackNotificationConfig struct {
 	CooldownHours SlackCooldownHoursConfig `json:"cooldownHours"`
 }
 type SlackCooldownHoursConfig struct {
-	Value int    `json:"value"`
+	Value int64  `json:"value"`
 	Error string `json:"error"`
 }
 
@@ -166,11 +166,11 @@ func (c *SendWebVisitorSlackNotificationCapability) Execute(ctx context.Context,
 	return result, nil
 }
 
-func (c *SendWebVisitorSlackNotificationCapability) skipNotification(ctx context.Context, domain string, cooldownInHrs int) (bool, error) {
+func (c *SendWebVisitorSlackNotificationCapability) skipNotification(ctx context.Context, domain string, cooldownInHrs int64) (bool, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SendWebVisitorSlackNotificationCapability.skipNotification")
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 	defer span.Finish()
-	span.LogFields(log.String("domain", domain), log.Int("cooldownInHrs", cooldownInHrs))
+	span.LogFields(log.String("domain", domain), log.Int64("cooldownInHrs", cooldownInHrs))
 
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {

--- a/packages/server/customer-os-common-module/services/workspace/service.go
+++ b/packages/server/customer-os-common-module/services/workspace/service.go
@@ -74,7 +74,7 @@ func (s *workspaceService) GetWorkspaceDomainsForTenant(ctx context.Context) ([]
 		return []string{}, err
 	}
 
-	domains := []string{}
+	var domains []string
 	for _, dbNode := range dbNodes {
 		workspaceEntity := neo4jmapper.MapDbNodeToWorkspaceEntity(dbNode)
 		domains = append(domains, workspaceEntity.Name)

--- a/packages/server/customer-os-common-module/utils/core_utils_test.go
+++ b/packages/server/customer-os-common-module/utils/core_utils_test.go
@@ -56,14 +56,6 @@ func TestIntPtr(t *testing.T) {
 	require.Equal(t, num, *ptr)
 }
 
-func TestRemoveDuplicates(t *testing.T) {
-	input := []string{"a", "b", "a", "c", "b"}
-	expected := []string{"a", "b", "c"}
-
-	result := RemoveDuplicates(input)
-	require.Equal(t, expected, result)
-}
-
 func TestReverseMap(t *testing.T) {
 	input := map[int]string{
 		1: "a",

--- a/packages/server/customer-os-common-module/utils/list_utils_test.go
+++ b/packages/server/customer-os-common-module/utils/list_utils_test.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveDuplicates(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "Empty slice",
+			input:    []string{},
+			expected: nil,
+		},
+		{
+			name:     "No duplicates",
+			input:    []string{"apple", "banana", "orange"},
+			expected: []string{"apple", "banana", "orange"},
+		},
+		{
+			name:     "All duplicates",
+			input:    []string{"apple", "apple", "apple"},
+			expected: []string{"apple"},
+		},
+		{
+			name:     "Some duplicates",
+			input:    []string{"apple", "banana", "apple", "orange", "banana"},
+			expected: []string{"apple", "banana", "orange"},
+		},
+		{
+			name:     "Mixed case duplicates",
+			input:    []string{"Apple", "apple", "Banana", "BANANA", "banana"},
+			expected: []string{"Apple", "apple", "Banana", "BANANA", "banana"},
+		},
+		{
+			name:     "Duplicates not contiguous",
+			input:    []string{"a", "b", "c", "a", "d", "b", "e"},
+			expected: []string{"a", "b", "c", "d", "e"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RemoveDuplicates(tc.input)
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("RemoveDuplicates(%v) = %v; want %v", tc.input, got, tc.expected)
+			}
+		})
+	}
+}

--- a/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
+++ b/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
@@ -63,7 +63,7 @@ func MapDbNodeToWorkspaceEntity(dbNode *dbtype.Node) *neo4j_entity.WorkspaceEnti
 	props := utils.GetPropsFromNode(*dbNode)
 	workspace := neo4j_entity.WorkspaceEntity{
 		Id:            utils.GetStringPropOrEmpty(props, "id"),
-		Name:          utils.GetStringPropOrEmpty(props, "domain"),
+		Name:          utils.GetStringPropOrEmpty(props, "name"),
 		Provider:      utils.GetStringPropOrEmpty(props, "provider"),
 		CreatedAt:     utils.GetTimePropOrEpochStart(props, "createdAt"),
 		UpdatedAt:     utils.GetTimePropOrEpochStart(props, "updatedAt"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix workspace domains getter and update related functionality for correct data handling.
> 
>   - **Behavior**:
>     - Change `cooldownInHrs` type from `int` to `int64` in `capability_send_web_visitor_notification_slack.go`.
>     - Fix `GetWorkspaceDomainsForTenant` in `service.go` by initializing `domains` with `var` instead of `[]string{}`.
>   - **Tests**:
>     - Move `TestRemoveDuplicates` from `core_utils_test.go` to `list_utils_test.go` with additional test cases.
>   - **Mapper**:
>     - Change property name from `domain` to `name` in `MapDbNodeToWorkspaceEntity` in `node_to_entity_mapper.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 5735b66a7802c975e6409defedc0202fa9674737. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->