### PR TITLE
List slack channels with BOT - API

### DIFF
--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -119,6 +119,11 @@ type ComplexityRoot struct {
 		Visible      func(childComplexity int) int
 	}
 
+	AgentSlackChannel struct {
+		ChannelID func(childComplexity int) int
+		Name      func(childComplexity int) int
+	}
+
 	Attachment struct {
 		AppSource     func(childComplexity int) int
 		BasePath      func(childComplexity int) int
@@ -1548,6 +1553,7 @@ type ComplexityRoot struct {
 		ServiceLineItem                    func(childComplexity int, id string) int
 		Skus                               func(childComplexity int) int
 		SlackChannels                      func(childComplexity int, pagination *model.Pagination) int
+		SlackChannelsWithBot               func(childComplexity int) int
 		TableViewDefs                      func(childComplexity int) int
 		Tags                               func(childComplexity int) int
 		TagsByEntityType                   func(childComplexity int, entityType model.EntityType) int
@@ -2160,6 +2166,7 @@ type PhoneNumberResolver interface {
 type QueryResolver interface {
 	Agents(ctx context.Context) ([]*model.Agent, error)
 	Agent(ctx context.Context, id string) (*model.Agent, error)
+	SlackChannelsWithBot(ctx context.Context) ([]*model.AgentSlackChannel, error)
 	Attachment(ctx context.Context, id string) (*model.Attachment, error)
 	BankAccounts(ctx context.Context) ([]*model.BankAccount, error)
 	GlobalCache(ctx context.Context) (*model.GlobalCache, error)
@@ -2472,6 +2479,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Agent.Visible(childComplexity), true
+
+	case "AgentSlackChannel.channelId":
+		if e.complexity.AgentSlackChannel.ChannelID == nil {
+			break
+		}
+
+		return e.complexity.AgentSlackChannel.ChannelID(childComplexity), true
+
+	case "AgentSlackChannel.name":
+		if e.complexity.AgentSlackChannel.Name == nil {
+			break
+		}
+
+		return e.complexity.AgentSlackChannel.Name(childComplexity), true
 
 	case "Attachment.appSource":
 		if e.complexity.Attachment.AppSource == nil {
@@ -11495,6 +11516,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.SlackChannels(childComplexity, args["pagination"].(*model.Pagination)), true
 
+	case "Query.slackChannelsWithBot":
+		if e.complexity.Query.SlackChannelsWithBot == nil {
+			break
+		}
+
+		return e.complexity.Query.SlackChannelsWithBot(childComplexity), true
+
 	case "Query.tableViewDefs":
 		if e.complexity.Query.TableViewDefs == nil {
 			break
@@ -13120,10 +13148,17 @@ enum ActionType {
 	{Name: "../schemas/agent.graphqls", Input: `extend type Query {
     agents: [Agent!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
     agent(id: ID!): Agent @hasRole(roles: [ADMIN, USER]) @hasTenant
+
+    slackChannelsWithBot: [AgentSlackChannel!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
 }
 
 extend type Mutation {
     agent_Save(input: AgentSaveInput!): Agent!@hasRole(roles: [ADMIN, USER]) @hasTenant
+}
+
+type AgentSlackChannel {
+    channelId: String!
+    name: String!
 }
 
 enum CapabilityType {
@@ -28019,6 +28054,94 @@ func (ec *executionContext) _Agent_icon(ctx context.Context, field graphql.Colle
 func (ec *executionContext) fieldContext_Agent_icon(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Agent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AgentSlackChannel_channelId(ctx context.Context, field graphql.CollectedField, obj *model.AgentSlackChannel) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentSlackChannel_channelId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ChannelID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentSlackChannel_channelId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentSlackChannel",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AgentSlackChannel_name(ctx context.Context, field graphql.CollectedField, obj *model.AgentSlackChannel) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentSlackChannel_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentSlackChannel_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentSlackChannel",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -52856,6 +52979,10 @@ func (ec *executionContext) fieldContext_InvoiceLine_sku(_ context.Context, fiel
 				return ec.fieldContext_Sku_name(ctx, field)
 			case "price":
 				return ec.fieldContext_Sku_price(ctx, field)
+			case "type":
+				return ec.fieldContext_Sku_type(ctx, field)
+			case "archived":
+				return ec.fieldContext_Sku_archived(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Sku", field.Name)
 		},
@@ -90872,6 +90999,90 @@ func (ec *executionContext) fieldContext_Query_agent(ctx context.Context, field 
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_slackChannelsWithBot(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_slackChannelsWithBot(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		directive0 := func(rctx context.Context) (any, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Query().SlackChannelsWithBot(rctx)
+		}
+
+		directive1 := func(ctx context.Context) (any, error) {
+			roles, err := ec.unmarshalNRole2ᚕgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐRoleᚄ(ctx, []any{"ADMIN", "USER"})
+			if err != nil {
+				var zeroVal []*model.AgentSlackChannel
+				return zeroVal, err
+			}
+			if ec.directives.HasRole == nil {
+				var zeroVal []*model.AgentSlackChannel
+				return zeroVal, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, roles)
+		}
+		directive2 := func(ctx context.Context) (any, error) {
+			if ec.directives.HasTenant == nil {
+				var zeroVal []*model.AgentSlackChannel
+				return zeroVal, errors.New("directive hasTenant is not implemented")
+			}
+			return ec.directives.HasTenant(ctx, nil, directive1)
+		}
+
+		tmp, err := directive2(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.([]*model.AgentSlackChannel); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be []*github.com/customeros/customeros/packages/server/customer-os-api/graphql/model.AgentSlackChannel`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.AgentSlackChannel)
+	fc.Result = res
+	return ec.marshalNAgentSlackChannel2ᚕᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐAgentSlackChannelᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_slackChannelsWithBot(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "channelId":
+				return ec.fieldContext_AgentSlackChannel_channelId(ctx, field)
+			case "name":
+				return ec.fieldContext_AgentSlackChannel_name(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AgentSlackChannel", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_attachment(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_attachment(ctx, field)
 	if err != nil {
@@ -117569,6 +117780,50 @@ func (ec *executionContext) _Agent(ctx context.Context, sel ast.SelectionSet, ob
 	return out
 }
 
+var agentSlackChannelImplementors = []string{"AgentSlackChannel"}
+
+func (ec *executionContext) _AgentSlackChannel(ctx context.Context, sel ast.SelectionSet, obj *model.AgentSlackChannel) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, agentSlackChannelImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AgentSlackChannel")
+		case "channelId":
+			out.Values[i] = ec._AgentSlackChannel_channelId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._AgentSlackChannel_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var attachmentImplementors = []string{"Attachment", "Node"}
 
 func (ec *executionContext) _Attachment(ctx context.Context, sel ast.SelectionSet, obj *model.Attachment) graphql.Marshaler {
@@ -128948,6 +129203,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "slackChannelsWithBot":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_slackChannelsWithBot(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "attachment":
 			field := field
 
@@ -133093,6 +133370,60 @@ func (ec *executionContext) marshalNAgent2ᚖgithubᚗcomᚋcustomerosᚋcustome
 func (ec *executionContext) unmarshalNAgentSaveInput2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐAgentSaveInput(ctx context.Context, v any) (model.AgentSaveInput, error) {
 	res, err := ec.unmarshalInputAgentSaveInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNAgentSlackChannel2ᚕᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐAgentSlackChannelᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.AgentSlackChannel) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNAgentSlackChannel2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐAgentSlackChannel(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNAgentSlackChannel2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐAgentSlackChannel(ctx context.Context, sel ast.SelectionSet, v *model.AgentSlackChannel) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AgentSlackChannel(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNAgentType2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐAgentType(ctx context.Context, v any) (model.AgentType, error) {

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -131,6 +131,11 @@ type AgentSaveInput struct {
 	Icon         *string                `json:"icon,omitempty"`
 }
 
+type AgentSlackChannel struct {
+	ChannelID string `json:"channelId"`
+	Name      string `json:"name"`
+}
+
 type Attachment struct {
 	ID            string     `json:"id"`
 	CreatedAt     time.Time  `json:"createdAt"`

--- a/packages/server/customer-os-api/graphql/resolver/agent.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/agent.resolvers.go
@@ -100,7 +100,7 @@ func (r *queryResolver) SlackChannelsWithBot(ctx context.Context) ([]*model.Agen
 	slackChannels, err := r.Services.CommonServices.SlackService.ListSlackChannelsWithBot(ctx)
 	if err != nil {
 		tracing.TraceErr(span, err)
-		graphql.AddErrorf(ctx, "Failed to get agent")
+		graphql.AddErrorf(ctx, "Failed to get slack channels")
 		return nil, nil
 	}
 

--- a/packages/server/customer-os-api/graphql/resolver/agent.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/agent.resolvers.go
@@ -6,7 +6,6 @@ package resolver
 
 import (
 	"context"
-
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
 	"github.com/customeros/customeros/packages/server/customer-os-api/mapper"
@@ -90,4 +89,28 @@ func (r *queryResolver) Agent(ctx context.Context, id string) (*model.Agent, err
 		return nil, nil
 	}
 	return mapper.MapAgentToModel(agentEntity), nil
+}
+
+// SlackChannelsWithBot is the resolver for the slackChannelsWithBot field.
+func (r *queryResolver) SlackChannelsWithBot(ctx context.Context) ([]*model.AgentSlackChannel, error) {
+	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.SlackChannelsWithBot", graphql.GetOperationContext(ctx))
+	defer span.Finish()
+	tracing.SetDefaultResolverSpanTags(ctx, span)
+
+	slackChannels, err := r.Services.CommonServices.SlackService.ListSlackChannelsWithBot(ctx)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		graphql.AddErrorf(ctx, "Failed to get agent")
+		return nil, nil
+	}
+
+	var agentSlackChannels []*model.AgentSlackChannel
+	for _, slackChannel := range slackChannels {
+		agentSlackChannels = append(agentSlackChannels, &model.AgentSlackChannel{
+			ChannelID: slackChannel.ID,
+			Name:      slackChannel.Name,
+		})
+	}
+
+	return agentSlackChannels, nil
 }

--- a/packages/server/customer-os-api/graphql/schemas/agent.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/agent.graphqls
@@ -1,10 +1,17 @@
 extend type Query {
     agents: [Agent!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
     agent(id: ID!): Agent @hasRole(roles: [ADMIN, USER]) @hasTenant
+
+    slackChannelsWithBot: [AgentSlackChannel!]! @hasRole(roles: [ADMIN, USER]) @hasTenant
 }
 
 extend type Mutation {
     agent_Save(input: AgentSaveInput!): Agent!@hasRole(roles: [ADMIN, USER]) @hasTenant
+}
+
+type AgentSlackChannel {
+    channelId: String!
+    name: String!
 }
 
 enum CapabilityType {

--- a/packages/server/customer-os-common-module/interfaces/slack.go
+++ b/packages/server/customer-os-common-module/interfaces/slack.go
@@ -14,9 +14,9 @@ type SlackService interface {
 	StoreSlackChannel(ctx context.Context, tenant, source, channelId, channelName string, organizationId *string) error
 	SendMessageFromBot(ctx context.Context, channel, blocks string) error
 	GetSlackSettings(ctx context.Context, tenant string) (*SlackSettingsResponse, error)
-	ListSlackChannelsWithBot(ctx context.Context, tenant string) ([]SlackChannelResponse, error)
-	JoinSlackChannelsWithBot(ctx context.Context, tenant, channelId string) error
-	LeaveSlackChannelsWithBot(ctx context.Context, tenant, channelId string) error
+	ListSlackChannelsWithBot(ctx context.Context) ([]SlackChannelResponse, error)
+	JoinSlackChannelsWithBot(ctx context.Context, channelId string) error
+	LeaveSlackChannelsWithBot(ctx context.Context, channelId string) error
 }
 
 type SlackSettingsResponse struct {

--- a/packages/server/customer-os-common-module/services/slack/service.go
+++ b/packages/server/customer-os-common-module/services/slack/service.go
@@ -212,10 +212,12 @@ func (s *slackService) GetSlackSettings(ctx context.Context, tenant string) (*in
 	return &slackSettingsResponse, nil
 }
 
-func (s *slackService) getBotToken(ctx context.Context, tenant string) (string, error) {
+func (s *slackService) getBotToken(ctx context.Context) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SlackService.getBotToken")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	tenant := common.GetTenantFromContext(ctx)
 
 	slackSettingsEntity, err := s.postgresRepositories.SlackSettingsRepository.Get(ctx, tenant)
 	if err != nil {
@@ -232,12 +234,12 @@ func (s *slackService) getBotToken(ctx context.Context, tenant string) (string, 
 	return slackSettingsEntity.AccessToken, nil
 }
 
-func (s *slackService) ListSlackChannelsWithBot(ctx context.Context, tenant string) ([]interfaces.SlackChannelResponse, error) {
+func (s *slackService) ListSlackChannelsWithBot(ctx context.Context) ([]interfaces.SlackChannelResponse, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SlackService.ListSlackChannelsWithBot")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 
-	token, err := s.getBotToken(ctx, tenant)
+	token, err := s.getBotToken(ctx)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return nil, err
@@ -293,14 +295,14 @@ func (s *slackService) ListSlackChannelsWithBot(ctx context.Context, tenant stri
 	return result.Channels, nil
 }
 
-func (s *slackService) JoinSlackChannelsWithBot(ctx context.Context, tenant, channelId string) error {
+func (s *slackService) JoinSlackChannelsWithBot(ctx context.Context, channelId string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SlackService.JoinSlackChannelsWithBot")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 
 	span.LogFields(log.String("channelId", channelId))
 
-	token, err := s.getBotToken(ctx, tenant)
+	token, err := s.getBotToken(ctx)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err
@@ -363,14 +365,14 @@ func (s *slackService) JoinSlackChannelsWithBot(ctx context.Context, tenant, cha
 	return nil
 }
 
-func (s *slackService) LeaveSlackChannelsWithBot(ctx context.Context, tenant, channelId string) error {
+func (s *slackService) LeaveSlackChannelsWithBot(ctx context.Context, channelId string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SlackService.LeaveSlackChannelsWithBot")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 
 	span.LogFields(log.String("channelId", channelId))
 
-	token, err := s.getBotToken(ctx, tenant)
+	token, err := s.getBotToken(ctx)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `slackChannelsWithBot` GraphQL query to list Slack channels with a bot and update Slack service accordingly.
> 
>   - **GraphQL API**:
>     - Add `slackChannelsWithBot` query in `agent.graphqls` to list Slack channels with a bot.
>     - Implement `SlackChannelsWithBot` resolver in `agent.resolvers.go`.
>   - **Models**:
>     - Add `AgentSlackChannel` type in `models_gen.go` with fields `channelId` and `name`.
>   - **Slack Service**:
>     - Modify `SlackService` interface in `interfaces/slack.go` to remove `tenant` parameter from `ListSlackChannelsWithBot`, `JoinSlackChannelsWithBot`, and `LeaveSlackChannelsWithBot`.
>     - Update `service.go` to implement `ListSlackChannelsWithBot` without `tenant` parameter and use context to get tenant.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for de0862e382fa8096ffae91224557149de92c7ec7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->