### PR TITLE
Use agents to validate tracking

### DIFF
--- a/packages/server/customer-os-api/caches/origin_tenant_cache.go
+++ b/packages/server/customer-os-api/caches/origin_tenant_cache.go
@@ -1,0 +1,37 @@
+package caches
+
+import (
+	"github.com/coocood/freecache"
+)
+
+const (
+	oneMB       = 1 * 1024 * 1024
+	expire1Hour = 60 * 60 // 1 hour in seconds
+)
+
+// OriginTenantCache wraps a freecache.Cache to store origin → tenant mappings.
+type OriginTenantCache struct {
+	cache *freecache.Cache
+}
+
+// NewOriginTenantCache creates a new OriginTenantCache with 1 MB of cache space.
+func NewOriginTenantCache() *OriginTenantCache {
+	return &OriginTenantCache{
+		cache: freecache.NewCache(oneMB),
+	}
+}
+
+// SetTenantForOrigin stores tenant (value) mapped by origin (key), expiring after 1 hour.
+func (o *OriginTenantCache) SetTenantForOrigin(origin, tenant string) {
+	_ = o.cache.Set([]byte(origin), []byte(tenant), expire1Hour)
+}
+
+// GetTenantForOrigin retrieves the tenant associated with the given origin key.
+// Returns an empty string if not found or if an error occurs.
+func (o *OriginTenantCache) GetTenantForOrigin(origin string) string {
+	value, err := o.cache.Get([]byte(origin))
+	if err != nil {
+		return ""
+	}
+	return string(value)
+}

--- a/packages/server/customer-os-api/rest/public/reveal_website_events.go
+++ b/packages/server/customer-os-api/rest/public/reveal_website_events.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-api/caches"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/agent_capability"
 	"net/http"
 	"strings"
 
@@ -23,11 +25,13 @@ import (
 type WebsiteTrackerEventsHandler struct {
 	services        *cosapi_services.Services
 	responseHandler *response.Response
+	cache           *caches.OriginTenantCache
 }
 
 func NewWebsiteTrackerEventsHandler(services *cosapi_services.Services, responseHandler *response.Response) *WebsiteTrackerEventsHandler {
 	return &WebsiteTrackerEventsHandler{
 		services: services,
+		cache:    caches.NewOriginTenantCache(),
 	}
 }
 
@@ -117,18 +121,49 @@ func (h *WebsiteTrackerEventsHandler) validateTrackingAllowed(ctx context.Contex
 	span, ctx := opentracing.StartSpanFromContext(ctx, "WebsiteTrackerEventsHandler.assignEventsToSession")
 	defer span.Finish()
 	tracing.TagComponentRest(span)
+	span.LogKV("origin", origin)
 
-	tenant, err := h.services.Repositories.PostgresRepositories.TrackingAllowedOriginRepository.GetTenantForOrigin(ctx, origin)
+	cleanedOrigin := utils.CleanUrlBasePath(origin)
+
+	tenant := h.cache.GetTenantForOrigin(cleanedOrigin)
+	if tenant != "" {
+		span.LogKV("result.tenant.cached", tenant)
+		return tenant, nil
+	}
+
+	agents, err := h.services.Repositories.PostgresRepositories.AgentsRepository.GetActiveAgentsByTypes(ctx, []enum.AgentType{enum.AgentVisitorID})
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to get tenant for origin"))
+		tracing.TraceErr(span, errors.Wrap(err, "failed to get agents"))
 		return "", err
+	}
+
+	// check if agent has intent to identify visitor
+	for _, agent := range agents {
+		for _, capability := range agent.CapabilitiesConfig.Capabilities {
+			if capability.Type == enum.CapabilityIdentifyWebVisitor {
+				// unmarshal capability config
+				var config agent_capability.IdentifyWebsiteVisitorConfig
+				if err = json.Unmarshal([]byte(capability.Config), &config); err != nil {
+					tracing.TraceErr(span, errors.Wrap(err, "failed to unmarshal capability config"))
+					return "", err
+				}
+				for _, website := range config.Websites.Value {
+					if utils.CleanUrlBasePath(website) == cleanedOrigin {
+						tenant = agent.Tenant
+						h.cache.SetTenantForOrigin(cleanedOrigin, tenant)
+						break
+					}
+				}
+			}
+		}
 	}
 
 	if tenant == "" {
-		err = fmt.Errorf("tenant not found for origin")
+		err = fmt.Errorf("tenant not found for origin: %s", origin)
 		tracing.TraceErr(span, err)
 		return "", err
 	}
+	span.LogKV("result.tenant", tenant)
 	return tenant, nil
 }
 

--- a/packages/server/customer-os-postgres-repository/entity/tracking_allowed_origin.go
+++ b/packages/server/customer-os-postgres-repository/entity/tracking_allowed_origin.go
@@ -2,6 +2,7 @@ package postgres_entity
 
 import "time"
 
+// Deprecated: TrackingAllowedOrigin is deprecated and will be removed in a future release.
 type TrackingAllowedOrigin struct {
 	ID        string    `gorm:"primaryKey;type:uuid;default:gen_random_uuid()" json:"id"`
 	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`

--- a/packages/server/customer-os-postgres-repository/repository/tracking_allowed_origin_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/tracking_allowed_origin_repository.go
@@ -11,6 +11,7 @@ import (
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 )
 
+// Deprecated: to be removed
 type TrackingAllowedOriginRepository interface {
 	GetTenantForOrigin(ctx context.Context, origin string) (string, error)
 	Create(ctx context.Context, whitelist postgres_entity.TrackingAllowedOrigin) (*postgres_entity.TrackingAllowedOrigin, error)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces caching for origin-tenant mappings, uses agents for validation, and deprecates old tracking allowed origin repository.
> 
>   - **Caching**:
>     - Introduces `OriginTenantCache` in `origin_tenant_cache.go` to cache origin to tenant mappings with 1-hour expiration.
>     - Utilized in `WebsiteTrackerEventsHandler` in `reveal_website_events.go` to reduce database queries.
>   - **Agent-based Validation**:
>     - Updates `validateTrackingAllowed` in `reveal_website_events.go` to use agents for identifying tenants based on origin.
>     - Retrieves active agents and checks capabilities to identify web visitors.
>   - **Deprecation**:
>     - Marks `TrackingAllowedOrigin` and `TrackingAllowedOriginRepository` as deprecated in `tracking_allowed_origin.go` and `tracking_allowed_origin_repository.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 686bb120b681dcdb4a29990bc586903ac747b5f8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->