### PR TITLE
get organizations by stage

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/organization.go
+++ b/packages/server/customer-os-common-module/interfaces/organization.go
@@ -2,6 +2,7 @@ package interfaces
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"time"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
@@ -35,6 +36,7 @@ type OrganizationService interface {
 
 	GetHiddenOrganizationIds(ctx context.Context, hiddenAfter time.Time) ([]string, error)
 	GetMergedOrganizationIds(ctx context.Context, mergedAfter time.Time) ([]string, error)
+	GetOrganizationsByStage(ctx context.Context, stage enum.OrganizationStage) (*neo4j_entity.OrganizationEntities, error)
 	RequestRefreshLastTouchpoint(ctx context.Context, organizationId string) error
 	RefreshLastTouchpoint(ctx context.Context, organizationId string) error
 	CheckOrganizationExistsWithEmail(ctx context.Context, email string) (bool, string, error)

--- a/packages/server/customer-os-common-module/services/organization/service.go
+++ b/packages/server/customer-os-common-module/services/organization/service.go
@@ -1640,3 +1640,24 @@ func (s *organizationService) calculateLtv(ctx context.Context, tenant string, o
 
 	return nil
 }
+
+func (s *organizationService) GetOrganizationsByStage(ctx context.Context, stage neo4jenum.OrganizationStage) (*neo4jentity.OrganizationEntities, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.GetOrganizationsByStage")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+	span.LogFields(log.String("stage", stage.String()))
+
+	tenant := common.GetTenantFromContext(ctx)
+	dbResults, err := s.neo4j.OrganizationReadRepository.GetOrganizationsByStage(ctx, tenant, stage)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+
+	organizationEntities := make(neo4jentity.OrganizationEntities, 0)
+	for _, dbResult := range dbResults {
+		organizationEntities = append(organizationEntities, *neo4jmapper.MapDbNodeToOrganizationEntity(dbResult))
+	}
+
+	return &organizationEntities, nil
+}

--- a/packages/server/customer-os-neo4j-repository/repository/organization_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/organization_read_repository.go
@@ -3,12 +3,12 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	"strings"
@@ -66,6 +66,7 @@ type OrganizationReadRepository interface {
 	GetLinkedSubOrganizations(ctx context.Context, tenant string, parentOrganizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error)
 	GetLinkedParentOrganizations(ctx context.Context, tenant string, organizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error)
 	GetOrganizationsByDomainAcrossAllTenants(ctx context.Context, domain string) ([]TenantAndOrganizationId, error)
+	GetOrganizationsByStage(ctx context.Context, tenant string, stage neo4jenum.OrganizationStage) ([]*dbtype.Node, error)
 }
 
 type organizationReadRepository struct {
@@ -1369,4 +1370,41 @@ func (r *organizationReadRepository) GetOrganizationsByDomainAcrossAllTenants(ct
 	}
 	span.LogFields(log.Int("result.count", len(output)))
 	return output, nil
+}
+
+func (r *organizationReadRepository) GetOrganizationsByStage(ctx context.Context, tenant string, stage neo4jenum.OrganizationStage) ([]*dbtype.Node, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationsByStage")
+	defer span.Finish()
+	tracing.TagComponentNeo4jRepository(span)
+	tracing.TagTenant(span, tenant)
+	span.LogFields(log.String("stage", stage.String()))
+
+	cypher := `MATCH (org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(:Tenant {name:$tenant})
+			WHERE org.hide = false AND org.stage = $stage
+			RETURN org ORDER BY org.createdAt DESC`
+	params := map[string]any{
+		"tenant": tenant,
+		"stage":  stage.String(),
+	}
+	span.LogFields(log.String("query", cypher))
+	tracing.LogObjectAsJson(span, "params", params)
+
+	session := r.prepareReadSession(ctx)
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
+			return nil, err
+		} else {
+			return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
+		}
+	})
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+
+	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+
+	return result.([]*dbtype.Node), nil
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `GetOrganizationsByStage` method to retrieve organizations by stage in `OrganizationService` and `OrganizationReadRepository`.
> 
>   - **Behavior**:
>     - Add `GetOrganizationsByStage` method to `OrganizationService` interface in `organization.go`.
>     - Implement `GetOrganizationsByStage` in `organizationService` in `service.go` to retrieve organizations by stage using Neo4j.
>   - **Repository**:
>     - Add `GetOrganizationsByStage` method to `OrganizationReadRepository` interface in `organization_read_repository.go`.
>     - Implement `GetOrganizationsByStage` in `organization_read_repository.go` to query Neo4j for organizations by stage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 1ef97a0f192b7564f83c5b28a6542c993b3c53c1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->