### PR TITLE
Fix QB products sync

### DIFF
--- a/packages/server/events-subscribers/listeners/sku_listener.go
+++ b/packages/server/events-subscribers/listeners/sku_listener.go
@@ -6,6 +6,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/events-subscribers/model"
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -26,6 +27,17 @@ func OnSkuUpdate(ctx context.Context, dependencies *model.DependencyContainer, i
 		return err
 	}
 
+	quickbooksSettingsEntity, err := dependencies.CommonServices.PostgresRepositories.QuickbooksSettingsRepository.Get(ctx, tenant)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	if quickbooksSettingsEntity == nil {
+		span.LogFields(log.String("error", "Quickbooks settings not found"))
+		return nil
+	}
+
 	skuEntity, err := dependencies.CommonServices.PostgresRepositories.SkuRepository.Get(ctx, tenant, skuId)
 	if err != nil {
 		tracing.TraceErr(span, err)
@@ -38,6 +50,13 @@ func OnSkuUpdate(ctx context.Context, dependencies *model.DependencyContainer, i
 		return err
 	}
 
+	if qbProduct == nil || qbProduct.Product == nil {
+		span.LogFields(log.Object("qbProduct", qbProduct))
+		err := errors.New("Quickbooks product could not be saved")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
 	if skuEntity != nil && skuEntity.QuickbooksId == "" {
 		skuEntity.QuickbooksId = qbProduct.Product.Id
 		_, err = dependencies.CommonServices.PostgresRepositories.SkuRepository.Save(ctx, skuEntity)
@@ -45,6 +64,8 @@ func OnSkuUpdate(ctx context.Context, dependencies *model.DependencyContainer, i
 			tracing.TraceErr(span, err)
 			return err
 		}
+	} else {
+		span.LogFields(log.String("info", "Quickbooks ID already exists"))
 	}
 
 	return nil


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `OnSkuUpdate` in `sku_listener.go` to handle missing Quickbooks settings and product save failures with logging.
> 
>   - **Behavior**:
>     - In `OnSkuUpdate` in `sku_listener.go`, added check for Quickbooks settings existence. Logs error and returns if not found.
>     - Added check for Quickbooks product existence. Logs error and returns if product cannot be saved.
>     - Logs info if Quickbooks ID already exists for SKU.
>   - **Imports**:
>     - Added `github.com/opentracing/opentracing-go/log` import for logging purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 272d0eb37c4921cd64784d14886ab0c645169d86. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->