### PR TITLE
Support redirect uri on activate slack

### DIFF
--- a/packages/server/customer-os-api/rest/private/slack.go
+++ b/packages/server/customer-os-api/rest/private/slack.go
@@ -70,7 +70,7 @@ func RequestAccessSlack(s *cosapi_services.Services) gin.HandlerFunc {
 		redirectUri := c.Query("redirect_uri")
 
 		if redirectUri != "" {
-			slackRequestAccessUrl += "&redirect_uri=" + redirectUri
+			slackRequestAccessUrl += "&redirect_uri=" + url.QueryEscape(redirectUri)
 		}
 
 		span.LogFields(log.Object("slackRequestAccessUrl", slackRequestAccessUrl))

--- a/packages/server/customer-os-api/rest/private/slack.go
+++ b/packages/server/customer-os-api/rest/private/slack.go
@@ -67,6 +67,12 @@ func RequestAccessSlack(s *cosapi_services.Services) gin.HandlerFunc {
 		}
 		slackRequestAccessUrl := "https://slack.com/oauth/v2/authorize?client_id=" + s.Cfg.Common.External.SlackConfig.ClientID + "&scope=" + strings.Join(scopes, ",") + "&user_scope="
 
+		redirectUri := c.Query("redirect_uri")
+
+		if redirectUri != "" {
+			slackRequestAccessUrl += "&redirect_uri=" + redirectUri
+		}
+
 		span.LogFields(log.Object("slackRequestAccessUrl", slackRequestAccessUrl))
 
 		c.JSON(http.StatusOK, gin.H{"url": slackRequestAccessUrl})


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `redirect_uri` parameter in Slack OAuth URL in `RequestAccessSlack()` in `slack.go`.
> 
>   - **Behavior**:
>     - Adds support for `redirect_uri` parameter in Slack OAuth URL in `RequestAccessSlack()` in `slack.go`.
>     - If `redirect_uri` is provided in the query, it is appended to the Slack OAuth URL.
>   - **Logging**:
>     - Logs the complete Slack OAuth URL including `redirect_uri` if present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8d8fe43504a4f4c1687454630452bb0046c23eb5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->