### PR TITLE
Switch flow participant squedule to new queue

### DIFF
--- a/packages/server/customer-os-common-module/services/events/publisher.go
+++ b/packages/server/customer-os-common-module/services/events/publisher.go
@@ -23,6 +23,7 @@ const (
 	NotificationRoutingKey    = "notification"
 
 	EventsExchangeName                      = "customeros"
+	EventsDirectExchangeName                = "customeros-direct"
 	EventsRoutingKey                        = "event"
 	EventsQueueName                         = "events"
 	EventsFlowParticipantScheduleQueueName  = "events-flow-participant-schedule"

--- a/packages/server/events-subscribers/listeners/flow_listener.go
+++ b/packages/server/events-subscribers/listeners/flow_listener.go
@@ -43,7 +43,7 @@ func Handle_FlowOn(ctx context.Context, services *service.CommonServices, input 
 	}
 
 	for _, v := range *flowParticipants {
-		err := services.Events.Publisher.PublishEventOnExchange(ctx, v.Id, model.FLOW_PARTICIPANT, dto.FlowParticipantSchedule{}, events.EventsExchangeName, events.EventsFlowParticipantScheduleRoutingKey)
+		err := services.Events.Publisher.PublishEventOnExchange(ctx, v.Id, model.FLOW_PARTICIPANT, dto.FlowParticipantSchedule{}, events.EventsDirectExchangeName, events.EventsFlowParticipantScheduleRoutingKey)
 		if err != nil {
 			tracing.TraceErr(span, err)
 			return err


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch flow participant schedule events to use `EventsDirectExchangeName` in `flow_listener.go`.
> 
>   - **Behavior**:
>     - Change exchange for flow participant schedule events in `Handle_FlowOn()` in `flow_listener.go` from `EventsExchangeName` to `EventsDirectExchangeName`.
>   - **Constants**:
>     - Add `EventsDirectExchangeName` constant in `publisher.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3159aa6802633987d4e6603bd629279ee435d8dd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->