### PR TITLE
COS-6646: Improve email participant display in timeline stubs

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/email/EmailStub.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/email/EmailStub.tsx
@@ -39,6 +39,14 @@ export const EmailStub: FC<{ email: InteractionEventWithDate }> = ({
     [email?.sentTo],
   );
 
+  const cleanTo = useMemo(
+    () =>
+      getEmailParticipantsNameAndEmail(to || [])
+        .map((e) => e.label || e.email)
+        .filter((data) => Boolean(data)),
+    [cc],
+  );
+
   const cleanCC = useMemo(
     () =>
       getEmailParticipantsNameAndEmail(cc || [])
@@ -77,19 +85,17 @@ export const EmailStub: FC<{ email: InteractionEventWithDate }> = ({
                 )}
               </span>{' '}
               <span className='text-[#6C757D]'>emailed</span>{' '}
-              <span className='font-medium mr-2'>
-                {getEmailParticipantsName(to)}
-              </span>{' '}
+              <span className='font-medium mr-2'>{cleanTo?.join(', ')}</span>{' '}
               {!!cleanBCC.length && (
                 <>
                   <span className='text-[#6C757D]'>BCC:</span>{' '}
-                  <span>{cleanBCC}</span>
+                  <span>{cleanBCC.join(', ')}</span>
                 </>
               )}
               {!!cleanCC.length && (
                 <>
                   <span className='text-[#6C757D]'>CC:</span>{' '}
-                  <span>{cleanCC}</span>
+                  <span>{cleanCC.join(', ')}</span>
                 </>
               )}
             </p>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve email participant display in `EmailStub` by formatting names and emails with commas for better readability.
> 
>   - **Behavior**:
>     - Improve email participant display in `EmailStub` by using `cleanTo`, `cleanCC`, and `cleanBCC` to show names and emails.
>     - Participants are joined with commas for better readability.
>   - **Functions**:
>     - Use `getEmailParticipantsNameAndEmail` to extract and format participant names and emails.
>   - **Misc**:
>     - Minor refactoring in `EmailStub.tsx` to enhance code clarity and maintainability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 50979fa1e16ee391ffd2d8f7d61a794fb72095e2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->