### PR TITLE
COS-6617: Move About panel owner assignment to use case pattern

### DIFF
--- a/packages/apps/frontera/src/domain/services/organization/organizations.service.ts
+++ b/packages/apps/frontera/src/domain/services/organization/organizations.service.ts
@@ -248,4 +248,34 @@ export class OrganizationService {
 
     return [res, err];
   }
+
+  public async updateOwner(organization: Organization, ownerId?: string) {
+    const previousOwnerId = organization.value.owner?.id;
+
+    organization.updateOwner(ownerId);
+
+    const [res, err] = await unwrap(
+      this.orgInfraRepo.saveOrganization({
+        input: {
+          id: organization.id,
+          ownerId,
+        },
+      }),
+    );
+
+    if (err) {
+      console.error(err);
+
+      organization.updateOwner(previousOwnerId);
+
+      this.root.ui.toastError(
+        "We couldn't update owner of this organization",
+        `${ownerId}-update-owner`,
+      );
+
+      return [null, err];
+    }
+
+    return [res, err];
+  }
 }

--- a/packages/apps/frontera/src/domain/usecases/organization-about-panel/edit-organization-owner.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/organization-about-panel/edit-organization-owner.usecase.ts
@@ -1,0 +1,110 @@
+import { RootStore } from '@store/root';
+import { OrganizationService } from '@domain/services';
+import { action, computed, reaction, observable } from 'mobx';
+
+import { SelectOption } from '@shared/types/SelectOptions';
+
+export class EditOrganizationOwnerUsecase {
+  @observable public accessor searchTerm = '';
+  @observable public accessor isMenuOpen = false;
+  @observable public accessor initialUsers: { label: string; value: string }[] =
+    [];
+
+  private root = RootStore.getInstance();
+  private organizationService = new OrganizationService();
+  private organizationId: string;
+
+  constructor(organizationId: string) {
+    this.organizationId = organizationId;
+    this.select = this.select.bind(this);
+    this.toggleMenu = this.toggleMenu.bind(this);
+    this.setSearchTerm = this.setSearchTerm.bind(this);
+    this.computeInitialOptions = this.computeInitialOptions.bind(this);
+
+    reaction(
+      () => this.root.users.tenantUsers.length,
+
+      this.computeInitialOptions,
+    );
+    this.computeInitialOptions();
+  }
+
+  @computed
+  get organization() {
+    if (!this.organizationId) return;
+
+    return this.root.organizations.getById(this.organizationId);
+  }
+
+  @computed
+  get selectedUser() {
+    return (
+      this.organization?.owner && {
+        value: this.organization?.owner?.id,
+        label: this.organization?.owner?.name,
+      }
+    );
+  }
+
+  @action
+  private computeInitialOptions() {
+    this.initialUsers = this.root.users.tenantUsers
+      .filter(
+        (e) =>
+          Boolean(e.value.firstName) ||
+          Boolean(e.value.lastName) ||
+          Boolean(e.value.name),
+      )
+
+      .map((user) => {
+        return {
+          value: user.id,
+          label: user.name,
+        };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }
+
+  @computed
+  get userOptions() {
+    return this.initialUsers.filter((user) =>
+      user.label.toLowerCase().includes(this.searchTerm.toLowerCase()),
+    );
+  }
+
+  @action
+  public setSearchTerm(searchTerm: string) {
+    this.searchTerm = searchTerm;
+  }
+
+  @action
+  public toggleMenu(isOpen: boolean) {
+    this.isMenuOpen = isOpen;
+  }
+
+  @action
+  public reset() {
+    this.setSearchTerm('');
+  }
+
+  @action
+  public close() {
+    this.reset();
+    this.root.ui.commandMenu.setOpen(false);
+  }
+
+  @action
+  public select(option: SelectOption) {
+    const organization = this.organization;
+
+    if (!organization) {
+      console.error(
+        'EditOrganizationOwnerUsecase: select called without organization',
+      );
+
+      return;
+    }
+
+    this.organizationService.updateOwner(organization, option?.value);
+  }
+}

--- a/packages/apps/frontera/src/infra/repositories/organization/mutations/saveOrganization.generated.ts
+++ b/packages/apps/frontera/src/infra/repositories/organization/mutations/saveOrganization.generated.ts
@@ -1,0 +1,13 @@
+import * as Types from '../../../../routes/src/types/__generated__/graphql.types';
+
+export type SaveOrganizationMutationVariables = Types.Exact<{
+  input: Types.OrganizationSaveInput;
+}>;
+
+export type SaveOrganizationMutation = {
+  __typename?: 'Mutation';
+  organization_Save: {
+    __typename?: 'Organization';
+    metadata: { __typename?: 'Metadata'; id: string };
+  };
+};

--- a/packages/apps/frontera/src/infra/repositories/organization/mutations/saveOrganization.graphql
+++ b/packages/apps/frontera/src/infra/repositories/organization/mutations/saveOrganization.graphql
@@ -1,0 +1,7 @@
+mutation saveOrganization($input: OrganizationSaveInput!) {
+  organization_Save(input: $input) {
+    metadata {
+      id
+    }
+  }
+}

--- a/packages/apps/frontera/src/infra/repositories/organization/organization.repository.ts
+++ b/packages/apps/frontera/src/infra/repositories/organization/organization.repository.ts
@@ -4,6 +4,7 @@ import AddDomainDocument from './mutations/addDomain.graphql';
 import CheckDomainDocument from './queries/checkDomain.graphql';
 import RemoveDomainDocument from './mutations/removeDomain.graphql';
 import RemoveDomainsDocument from './mutations/removeDomains.graphql';
+import SaveOrganizationDocument from './mutations/saveOrganization.graphql';
 import {
   CheckDomainQuery,
   CheckDomainQueryVariables,
@@ -20,6 +21,10 @@ import {
   RemoveDomainsMutation,
   RemoveDomainsMutationVariables,
 } from './mutations/removeDomains.generated';
+import {
+  SaveOrganizationMutation,
+  SaveOrganizationMutationVariables,
+} from './mutations/saveOrganization.generated.ts';
 
 export class OrganizationRepository {
   static instance: OrganizationRepository | null = null;
@@ -59,5 +64,12 @@ export class OrganizationRepository {
       RemoveDomainsMutation,
       RemoveDomainsMutationVariables
     >(RemoveDomainsDocument, payload);
+  }
+
+  async saveOrganization(payload: SaveOrganizationMutationVariables) {
+    return this.transport.graphql.request<
+      SaveOrganizationMutation,
+      SaveOrganizationMutationVariables
+    >(SaveOrganizationDocument, payload);
   }
 }

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/AboutPanel.tsx
@@ -303,11 +303,7 @@ export const AboutPanel = observer(() => {
               </p>
             </Tooltip>
           )}
-          <OwnerInput
-            id={id}
-            dataTest='org-about-org-owner'
-            owner={organization?.value.owner}
-          />
+          <OwnerInput id={id} dataTest='org-about-org-owner' />
 
           {showParentRelationshipSelector &&
             organization?.value?.subsidiaries?.length > 0 && (

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/components/owner/OwnerInput.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/components/owner/OwnerInput.tsx
@@ -1,59 +1,28 @@
-import { useState } from 'react';
+import { useMemo } from 'react';
 
 import { observer } from 'mobx-react-lite';
+import { EditOrganizationOwnerUsecase } from '@domain/usecases/organization-about-panel/edit-organization-owner.usecase';
 
-import { cn } from '@ui/utils/cn.ts';
-import { User } from '@graphql/types';
+import { cn } from '@ui/utils/cn';
 import { Combobox } from '@ui/form/Combobox';
 import { Key01 } from '@ui/media/icons/Key01';
-import { useStore } from '@shared/hooks/useStore';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
-import { SelectOption } from '@shared/types/SelectOptions';
 import { Popover, PopoverContent, PopoverTrigger } from '@ui/overlay/Popover';
 
-type Owner = Pick<User, 'id' | 'firstName' | 'lastName'> | null;
 interface OwnerProps {
   id: string;
-  owner?: Owner;
   dataTest?: string;
 }
 
-export const OwnerInput = observer(({ id, owner, dataTest }: OwnerProps) => {
-  const store = useStore();
-  const [inputValue, setInputValue] = useState('');
-  const [isOpen, setIsOpen] = useState(false);
-
-  const users = store.users.tenantUsers.filter(
-    (e) =>
-      Boolean(e.value.firstName) ||
-      Boolean(e.value.lastName) ||
-      Boolean(e.value.name),
-  );
-
-  const options = users
-    ?.map((user) => ({
-      value: user.id,
-      label: user.name,
-    }))
-    ?.sort((a, b) => a.label.localeCompare(b.label));
-
-  const value = owner ? options?.find((o) => o.value === owner.id) : null;
-
-  const handleSelect = (option: SelectOption[]) => {
-    const organization = store.organizations.value.get(id);
-
-    if (!organization) return;
-    const filteredOptions = option.filter((e) => e.value !== value?.value);
-
-    const targetOwner = store.users.value.get(filteredOptions[0]?.value);
-
-    organization.value.owner = option[0]?.value ? targetOwner?.value : null;
-    organization.commit();
-  };
+export const OwnerInput = observer(({ id, dataTest }: OwnerProps) => {
+  const usecase = useMemo(() => new EditOrganizationOwnerUsecase(id), [id]);
 
   return (
     <>
-      <Popover open={isOpen} onOpenChange={(open) => setIsOpen(open)}>
+      <Popover
+        open={usecase.isMenuOpen}
+        onOpenChange={(open) => usecase.toggleMenu(open)}
+      >
         <Tooltip label='Owner' align='start'>
           <PopoverTrigger className={cn('flex items-center')}>
             <Key01 className='mr-3 text-gray-500' />
@@ -61,8 +30,8 @@ export const OwnerInput = observer(({ id, owner, dataTest }: OwnerProps) => {
               data-test={dataTest}
               className='flex flex-wrap  w-fit items-center'
             >
-              {value ? (
-                <div className='text-sm'>{value.label}</div>
+              {usecase.selectedUser ? (
+                <div className='text-sm'>{usecase.selectedUser.label}</div>
               ) : (
                 <span className='text-gray-400 text-sm'>Owner</span>
               )}
@@ -71,15 +40,14 @@ export const OwnerInput = observer(({ id, owner, dataTest }: OwnerProps) => {
         </Tooltip>
         <PopoverContent align='start' className='min-w-[264px] max-w-[320px]'>
           <Combobox
-            isMulti
-            value={value}
-            options={options}
             placeholder='Owner'
-            inputValue={inputValue}
-            onInputChange={setInputValue}
+            value={usecase.selectedUser}
+            options={usecase.userOptions}
+            inputValue={usecase.searchTerm}
+            onInputChange={usecase.setSearchTerm}
             onChange={(newValue) => {
-              handleSelect(newValue);
-              setIsOpen(false);
+              usecase.select(newValue);
+              usecase.toggleMenu(false);
             }}
             noOptionsMessage={({ inputValue }) => (
               <div className='text-gray-700 px-3 py-1 mt-0.5 rounded-md bg-grayModern-100 gap-1 flex items-center'>

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/email/EmailStub.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/email/EmailStub.tsx
@@ -44,7 +44,7 @@ export const EmailStub: FC<{ email: InteractionEventWithDate }> = ({
       getEmailParticipantsNameAndEmail(to || [])
         .map((e) => e.label || e.email)
         .filter((data) => Boolean(data)),
-    [cc],
+    [to],
   );
 
   const cleanCC = useMemo(

--- a/packages/apps/frontera/src/routes/src/types/__generated__/graphql.types.ts
+++ b/packages/apps/frontera/src/routes/src/types/__generated__/graphql.types.ts
@@ -116,6 +116,12 @@ export type AgentSaveInput = {
   visible?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+export type AgentSlackChannel = {
+  __typename?: 'AgentSlackChannel';
+  channelId: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+};
+
 export enum AgentType {
   WebVisitIdentifier = 'WEB_VISIT_IDENTIFIER',
 }
@@ -4181,6 +4187,7 @@ export type Query = {
   remindersForOrganization: Array<Reminder>;
   serviceLineItem: ServiceLineItem;
   skus: Array<Sku>;
+  slackChannelsWithBot: Array<AgentSlackChannel>;
   slack_Channels: SlackChannelPage;
   tableViewDefs: Array<TableViewDef>;
   /** @deprecated Use tags_ByEntityType */

--- a/packages/apps/frontera/src/store/Organizations/Organization.dto.ts
+++ b/packages/apps/frontera/src/store/Organizations/Organization.dto.ts
@@ -290,6 +290,19 @@ export class Organization extends Entity<OrganizationDatum> {
     this.commit({ syncOnly: true });
   }
 
+  @action
+  public updateOwner(id?: string) {
+    this.draft();
+
+    if (!this.value.owner) {
+      this.value.owner = undefined;
+    }
+    this.value.owner = id
+      ? this.store.root.users.value.get(id)?.value
+      : undefined;
+    this.commit({ syncOnly: true });
+  }
+
   static default(
     payload?: OrganizationDatum | SaveOrganizationMutationVariables['input'],
   ): OrganizationDatum {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor owner assignment in the About panel to use a new use case pattern, updating service, UI components, and repository logic.
> 
>   - **Behavior**:
>     - Introduces `EditOrganizationOwnerUsecase` in `edit-organization-owner.usecase.ts` to handle owner assignment logic.
>     - Updates `updateOwner()` in `organizations.service.ts` to use `orgInfraRepo.saveOrganization` for saving owner changes.
>     - Removes direct owner prop from `OwnerInput` in `AboutPanel.tsx`.
>   - **UI Components**:
>     - Refactors `OwnerInput` in `OwnerInput.tsx` to use `EditOrganizationOwnerUsecase` for managing owner selection and search.
>     - Updates `AboutPanel.tsx` to remove owner prop from `OwnerInput`.
>   - **GraphQL**:
>     - Adds `saveOrganization.graphql` and `saveOrganization.generated.ts` for GraphQL mutation to save organization owner.
>   - **Repository**:
>     - Adds `saveOrganization()` method in `organization.repository.ts` to handle GraphQL mutation for saving organization data.
>   - **Models**:
>     - Adds `updateOwner()` method in `Organization.dto.ts` to update owner in the organization model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c69b351b66ba6f93b06c5e098409c099c1b2242d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->