### PR TITLE
COS-6637: Add subdomains counter next to domains collapse/expand button

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/components/domains/Domains.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AboutPanel/components/domains/Domains.tsx
@@ -104,9 +104,12 @@ export const Domains = observer(() => {
               </span>
             </a>
             <div
-              className={cn('flex opacity-0 group-hover:opacity-100 gap-1', {
-                '!opacity-100': showMenus[domainGroup.primaryDomain.domain],
-              })}
+              className={cn(
+                'flex opacity-0 group-hover:opacity-100 gap-1 items-center',
+                {
+                  '!opacity-100': showMenus[domainGroup.primaryDomain.domain],
+                },
+              )}
             >
               <div>
                 {domainGroup.subdomains?.length > 0 && (
@@ -131,6 +134,11 @@ export const Domains = observer(() => {
                   />
                 )}
               </div>
+              {domainGroup.subdomains?.length > 0 && (
+                <span className='text-xs font-medium mr-1'>
+                  +{domainGroup.subdomains.length}
+                </span>
+              )}
               <Menu
                 onOpenChange={(isOpen) =>
                   handleMenuOpen(domainGroup.primaryDomain.domain, isOpen)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add subdomain count display next to expand/collapse button in `Domains` component.
> 
>   - **UI Enhancement**:
>     - Adds subdomain count display next to the expand/collapse button in `Domains` component in `Domains.tsx`.
>     - Displays `+{domainGroup.subdomains.length}` when subdomains are present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 90443a9c671a1f7dc2f5f102636d1c0eeb931992. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->