### PR TITLE
COS-6643: Change order of opportunities List/Board buttons

### DIFF
--- a/packages/apps/frontera/src/routes/prospects/page.tsx
+++ b/packages/apps/frontera/src/routes/prospects/page.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react-lite';
 import { FinderTable } from '@finder/components/FinderTable';
 import { FinderFilters } from '@finder/components/FinderFilters/FinderFilters';
 
-import { cn } from '@ui/utils/cn.ts';
+import { cn } from '@ui/utils/cn';
 import { Button } from '@ui/form/Button/Button';
 import { Menu01 } from '@ui/media/icons/Menu01';
 import { useStore } from '@shared/hooks/useStore';
@@ -36,6 +36,17 @@ export const ProspectsBoardPage = observer(() => {
           <ButtonGroup className='flex items-center w-[252px]'>
             <Button
               size='xs'
+              dataTest='prospects-board-button'
+              onClick={() => navigate('/prospects')}
+              className={cn('px-4 w-full flex-1', {
+                selected: !showFinder,
+              })}
+            >
+              <Columns03 />
+              Board
+            </Button>
+            <Button
+              size='xs'
               dataTest={'prospects-list-button'}
               className={cn('px-4 w-full flex-1', {
                 selected: showFinder,
@@ -46,17 +57,6 @@ export const ProspectsBoardPage = observer(() => {
             >
               <Menu01 />
               List
-            </Button>
-            <Button
-              size='xs'
-              dataTest='prospects-board-button'
-              onClick={() => navigate('/prospects')}
-              className={cn('px-4 w-full flex-1', {
-                selected: !showFinder,
-              })}
-            >
-              <Columns03 />
-              Board
             </Button>
           </ButtonGroup>
         </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reorder 'Board' and 'List' buttons in `ProspectsBoardPage` and fix import path for `cn` utility.
> 
>   - **UI Changes**:
>     - Reorder 'Board' and 'List' buttons in `ProspectsBoardPage` in `page.tsx`.
>   - **Imports**:
>     - Fix import path for `cn` utility in `page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 6c4fa35a029ca9c7504de3f262031228f8ea7870. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->