### PR TITLE
COS-6647: Fixed the issue causing the contract start date to shift

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/ContractDetails/ContractBillingDetailsForm.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/ContractDetails/ContractBillingDetailsForm.tsx
@@ -115,14 +115,11 @@ export const ContractBillingDetailsForm = observer(
               </span>
 
               <DatePickerUnderline
-                value={toZonedTime(
-                  contractStore?.tempValue?.serviceStarted,
-                  'UTC',
-                )}
+                value={contractStore?.tempValue?.serviceStarted}
                 onChange={(date) =>
                   contractStore?.updateTemp((prev) => ({
                     ...prev,
-                    serviceStarted: date,
+                    serviceStarted: date ? date.toISOString() : null,
                   }))
                 }
               />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes contract start date shifting by removing UTC conversion in `ContractBillingDetailsForm.tsx`.
> 
>   - **Behavior**:
>     - Fixes contract start date shifting issue in `ContractBillingDetailsForm.tsx` by removing `toZonedTime` conversion to UTC.
>     - Ensures `serviceStarted` date is stored as ISO string without timezone conversion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3c95275737c88fc459d6802a414f328d19d899fc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->