### PR TITLE
check org before creating

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/organization.go
+++ b/packages/server/customer-os-common-module/interfaces/organization.go
@@ -18,6 +18,7 @@ type OrganizationService interface {
 
 	GetById(ctx context.Context, tenant, organizationId string) (*neo4j_entity.OrganizationEntity, error)
 	GetPrimaryDomainByOrgID(ctx context.Context, organizationId string) (string, error)
+	GetOrganizationByDomain(ctx context.Context, domain string, includePrimaryDomainCheck bool) (*neo4j_entity.OrganizationEntity, error)
 
 	CreateFromGlobalOrganization(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, globalOrgId uint64, dataFields data_fields.OrganizationFields) (string, error)
 	Save(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, id *string, dataFields data_fields.OrganizationFields) (string, error)

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
@@ -97,35 +97,39 @@ func (c *AnalyzeWebSessionCapability) Execute(ctx context.Context, data AnalyzeW
 	tracing.LogObjectAsJson(span, "input", data)
 	tracing.LogObjectAsJson(span, "config", config)
 
+	result := AnalyzeWebSessionOutput{}
+
 	if err := c.ValidateConfig(config); err != nil {
 		tracing.TraceErr(span, errors.Wrap(err, "invalid config"))
-		return AnalyzeWebSessionOutput{}, err
+		return result, err
 	}
 	if err := c.ValidateInput(data); err != nil {
 		tracing.TraceErr(span, errors.Wrap(err, "invalid input"))
-		return AnalyzeWebSessionOutput{}, err
+		return result, err
 	}
+
+	result.ExecutionValidated = true
 
 	// analyze session
 	result, err := c.sessionAnalytics(ctx, data.SessionID)
 	if err != nil {
 		tracing.TraceErr(span, err)
-		return AnalyzeWebSessionOutput{}, err
+		return result, err
 	}
 
 	// determine if a new company visit
 	isNewCompany, err := c.isNewCompanyVisit(ctx, data.Domain)
 	if err != nil {
 		tracing.TraceErr(span, err)
-		return AnalyzeWebSessionOutput{}, err
+		return result, err
 	}
 	result.IsNewCompanyVisit = isNewCompany
 
-	// determene if a new person visit
+	// determine if a new person visit
 	isNewVisitor, err := c.isNewWebsiteVisitor(ctx, data.VisitorID)
 	if err != nil {
 		tracing.TraceErr(span, err)
-		return AnalyzeWebSessionOutput{}, err
+		return result, err
 	}
 	result.IsNewPersonVisit = isNewVisitor
 
@@ -143,6 +147,7 @@ func (c *AnalyzeWebSessionCapability) Execute(ctx context.Context, data AnalyzeW
 		return result, err
 	}
 
+	result.Completed = true
 	tracing.LogObjectAsJson(span, "result", result)
 	return result, nil
 }

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
@@ -110,6 +110,15 @@ func (c *AnalyzeWebSessionCapability) Execute(ctx context.Context, data AnalyzeW
 
 	result.ExecutionValidated = true
 
+	// update session with organization id
+	if data.OrganizationID != "" {
+		err := c.postgresRepositories.WebSessionRepository.UpdateSessionWithOrganization(ctx, data.SessionID, data.OrganizationID)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return result, err
+		}
+	}
+
 	// analyze session
 	result, err := c.sessionAnalytics(ctx, data.SessionID)
 	if err != nil {

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_create_organization.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_create_organization.go
@@ -16,7 +16,6 @@ import (
 
 type CreateOrganizationCapability struct {
 	organizationService interfaces.OrganizationService
-	domainService       interfaces.DomainService
 }
 
 type CreateOrganizationInput struct {
@@ -28,10 +27,9 @@ type CreateOrganizationOutput struct {
 	OrganizationID string `json:"organizationId"`
 }
 
-func NewCreateOrganizationCapability(orgService interfaces.OrganizationService, domainService interfaces.DomainService) *CreateOrganizationCapability {
+func NewCreateOrganizationCapability(orgService interfaces.OrganizationService) *CreateOrganizationCapability {
 	return &CreateOrganizationCapability{
 		organizationService: orgService,
-		domainService:       domainService,
 	}
 }
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_create_organization.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_create_organization.go
@@ -88,7 +88,20 @@ func (c *CreateOrganizationCapability) Execute(ctx context.Context, data CreateO
 
 	result.ExecutionValidated = true
 
-	// TODO
+	// Check if the domain is already linked to an organization
+	organizationEntity, err := c.organizationService.GetOrganizationByDomain(ctx, data.Domain, true)
+
+	// organization found
+	if organizationEntity != nil {
+		// if organization is hidden, return early
+		if organizationEntity.Hide {
+			return result, errors.New("Identified organization is archived")
+		}
+		result.OrganizationID = organizationEntity.ID
+		result.Completed = true
+		tracing.LogObjectAsJson(span, "result", result)
+		return result, nil
+	}
 
 	orgID, err := c.organizationService.Save(ctx, nil, nil, data_fields.OrganizationFields{
 		Domains: []string{data.Domain},
@@ -99,7 +112,6 @@ func (c *CreateOrganizationCapability) Execute(ctx context.Context, data CreateO
 	}
 
 	result.OrganizationID = orgID
-
 	result.Completed = true
 	tracing.LogObjectAsJson(span, "result", result)
 	return result, nil

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_create_organization.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_create_organization.go
@@ -16,6 +16,7 @@ import (
 
 type CreateOrganizationCapability struct {
 	organizationService interfaces.OrganizationService
+	domainService       interfaces.DomainService
 }
 
 type CreateOrganizationInput struct {
@@ -27,9 +28,10 @@ type CreateOrganizationOutput struct {
 	OrganizationID string `json:"organizationId"`
 }
 
-func NewCreateOrganizationCapability(orgService interfaces.OrganizationService) *CreateOrganizationCapability {
+func NewCreateOrganizationCapability(orgService interfaces.OrganizationService, domainService interfaces.DomainService) *CreateOrganizationCapability {
 	return &CreateOrganizationCapability{
 		organizationService: orgService,
+		domainService:       domainService,
 	}
 }
 
@@ -84,6 +86,10 @@ func (c *CreateOrganizationCapability) Execute(ctx context.Context, data CreateO
 		return result, err
 	}
 
+	result.ExecutionValidated = true
+
+	// TODO
+
 	orgID, err := c.organizationService.Save(ctx, nil, nil, data_fields.OrganizationFields{
 		Domains: []string{data.Domain},
 	})
@@ -94,6 +100,7 @@ func (c *CreateOrganizationCapability) Execute(ctx context.Context, data CreateO
 
 	result.OrganizationID = orgID
 
+	result.Completed = true
 	tracing.LogObjectAsJson(span, "result", result)
 	return result, nil
 }

--- a/packages/server/customer-os-common-module/services/organization/service.go
+++ b/packages/server/customer-os-common-module/services/organization/service.go
@@ -1661,3 +1661,30 @@ func (s *organizationService) GetOrganizationsByStage(ctx context.Context, stage
 
 	return &organizationEntities, nil
 }
+
+func (s *organizationService) GetOrganizationByDomain(ctx context.Context, domain string, includePrimaryDomainCheck bool) (*neo4jentity.OrganizationEntity, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.GetOrganizationByDomain")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+	span.LogFields(log.String("domain", domain), log.Bool("includePrimaryDomainCheck", includePrimaryDomainCheck))
+
+	tenant := common.GetTenantFromContext(ctx)
+
+	dbResult, err := s.neo4j.OrganizationReadRepository.GetOrganizationByDomain(ctx, nil, tenant, domain)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+	if dbResult != nil {
+		return neo4jmapper.MapDbNodeToOrganizationEntity(dbResult), nil
+	}
+
+	if includePrimaryDomainCheck {
+		_, _, primaryDomain := s.domain.CheckDomainWithMailsherpa(ctx, domain)
+		if primaryDomain != "" && primaryDomain != domain {
+			return s.GetOrganizationByDomain(ctx, primaryDomain, false)
+		}
+	}
+
+	return nil, nil
+}

--- a/packages/server/customer-os-postgres-repository/entity/web_session.go
+++ b/packages/server/customer-os-postgres-repository/entity/web_session.go
@@ -13,6 +13,7 @@ type WebSession struct {
 	IP                    string         `gorm:"column:ip;type:varchar(255);" json:"ip"`
 	Hostname              string         `gorm:"column:hostname;type:varchar(255);" json:"hostname"`
 	Domain                *string        `gorm:"column:domain;type:varchar(255);index:idx_domain" json:"domain"`
+	OrganizationId        *string        `gorm:"column:organization_id;varchar(255);index:idx_organization_id" json:"organizationId"`
 	Referrer              *string        `gorm:"column:referrer;type:varchar(255);" json:"referrer"`
 	QueryParams           *string        `gorm:"column:query_params;type:varchar(255);" json:"queryParams"`
 	UniquePageViews       pq.StringArray `gorm:"column:unique_page_views;type:text[];" json:"uniquePageViews"`
@@ -25,7 +26,8 @@ type WebSession struct {
 	PublishedEvent        bool           `gorm:"column:published_event;type:boolean;default:false" json:"publishedEvent"`
 	SentSlackNotification *time.Time     `gorm:"column:sent_slack_notification;type:timestamp;" json:"sentSlackNotification"`
 	IntentSignals         int8           `gorm:"column:intent_signals;type:smallint;default:0" json:"intentSignals"`
-	CreatedAt             time.Time      `gorm:"default:CURRENT_TIMESTAMP"`
+	CreatedAt             time.Time      `gorm:"default:CURRENT_TIMESTAMP" json:"createdAt"`
+	UpdatedAt             *time.Time     `gorm:"column:updated_at;autoUpdateTime" json:"updatedAt"`
 }
 
 func (WebSession) TableName() string {

--- a/packages/server/customer-os-postgres-repository/repository/websession_events_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/websession_events_repository.go
@@ -23,6 +23,7 @@ type WebSessionRepository interface {
 	UpdateLastActivity(ctx context.Context, sessionID, eventType string) (*postgres_entity.WebSession, error)
 	UpdateSessionEnd(ctx context.Context, sessionID string, endTime time.Time) (*postgres_entity.WebSession, error)
 	UpdateSessionWithDomain(ctx context.Context, sessionID, domain string) (*postgres_entity.WebSession, error)
+	UpdateSessionWithOrganization(ctx context.Context, sessionID, organizationId string) error
 	UpdateSessionPageViews(ctx context.Context, sessionID, tenant string, pageViews []string) (*postgres_entity.WebSession, error)
 	UpdateIntentSignal(ctx context.Context, sessionID, tenant string, intentSignal int8) (*postgres_entity.WebSession, error)
 }
@@ -228,6 +229,25 @@ func (r *webSessionEventsRepository) UpdateSessionWithDomain(ctx context.Context
 	}
 
 	return &updatedSession, nil
+}
+
+func (r *webSessionEventsRepository) UpdateSessionWithOrganization(ctx context.Context, sessionID, organizationId string) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.UpdateSessionWithOrganization")
+	defer span.Finish()
+	tracing.TagComponentPostgresRepository(span)
+
+	// Perform a single-column update on organization_id for the matching session
+	result := r.gormDb.Model(&postgres_entity.WebSession{}).
+		Where("id = ?", sessionID).
+		Update("organization_id", &organizationId)
+
+	if result.Error != nil {
+		// Log the error with tracing and return it
+		tracing.TraceErr(span, result.Error)
+		return result.Error
+	}
+
+	return nil
 }
 
 func (r *webSessionEventsRepository) UpdateSessionPageViews(ctx context.Context, sessionID, tenant string, pageViews []string) (*postgres_entity.WebSession, error) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add domain-based organization existence check and update web sessions with organization IDs to prevent duplicate organizations.
> 
>   - **Behavior**:
>     - `CreateOrganizationCapability.Execute()` checks if a domain is linked to an existing organization using `GetOrganizationByDomain()` before creating a new one.
>     - `AnalyzeWebSessionCapability.Execute()` updates web sessions with `OrganizationId` if provided.
>   - **Interfaces**:
>     - Add `GetOrganizationByDomain()` to `OrganizationService` interface.
>   - **Services**:
>     - Implement `GetOrganizationByDomain()` in `organizationService` to check for existing organizations by domain.
>   - **Entities**:
>     - Add `OrganizationId` field to `WebSession` entity.
>   - **Repositories**:
>     - Add `UpdateSessionWithOrganization()` to `WebSessionRepository` to update sessions with organization IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 333c080abb1b84830fdbd2ce4e95a719d36c351d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->