### PR TITLE
fix saving booleans in agents

### DIFF
--- a/packages/server/customer-os-common-module/services/agent/service.go
+++ b/packages/server/customer-os-common-module/services/agent/service.go
@@ -101,8 +101,11 @@ func (a *agentService) CreateAgent(ctx context.Context, agentType enum.AgentType
 		IsActive:    false,
 		VisibleInUI: true,
 		Icon:        agentRegistry.Icon,
-		Color:       utils.GetRandomColor(),
+		Color:       agentRegistry.Color,
 		RegistryID:  agentRegistry.ID,
+	}
+	if agent.Color == "" {
+		agent.Color = utils.GetRandomColor()
 	}
 
 	// build capabilities from registry
@@ -171,6 +174,7 @@ func (a *agentService) UpdateAgent(ctx context.Context, agentId string, agentFie
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 	tracing.TagEntity(span, agentId)
 	tracing.LogObjectAsJson(span, "agentFields", agentFields)
+	tracing.LogObjectAsJson(span, "capabilitiesConfig", capabilitiesConfig)
 
 	agentEntity, err := a.postgresRepositories.AgentsRepository.GetById(ctx, agentId)
 	if err != nil {

--- a/packages/server/customer-os-postgres-repository/entity/agent_registry.go
+++ b/packages/server/customer-os-postgres-repository/entity/agent_registry.go
@@ -53,6 +53,7 @@ type AgentRegistry struct {
 	Goal               string             `gorm:"column:goal;type:text" json:"goal"`
 	IsActive           bool               `gorm:"column:is_active;type:boolean;default:true" json:"isActive"`
 	Icon               string             `gorm:"column:icon;type:text" json:"icon"`
+	Color              string             `gorm:"column:color;type:text" json:"color"`
 }
 
 func (AgentRegistry) TableName() string {

--- a/packages/server/customer-os-postgres-repository/repository/agent_registry_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agent_registry_repository.go
@@ -183,7 +183,8 @@ func registerVisitorIdAgent() postgres_entity.AgentRegistry {
 		Type:     enum.AgentVisitorID,
 		Name:     "Identify website visitors",
 		Goal:     enum.AgentGoalIdentifyVisitors.String(),
-		Icon:     "",
+		Icon:     "radar",
+		Color:    "grayModern",
 		IsActive: true,
 		CapabilitiesConfig: postgres_entity.CapabilitiesConfig{
 			Capabilities: []postgres_entity.Capability{

--- a/packages/server/customer-os-postgres-repository/repository/agents_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agents_repository.go
@@ -205,6 +205,7 @@ func (f *agentsRepository) Update(ctx context.Context, agent postgres_entity.Age
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentsRepository.Update")
 	defer span.Finish()
 	tracing.TagComponentPostgresRepository(span)
+	tracing.LogObjectAsJson(span, "agentEntity", agent)
 
 	if agent.ID == "" {
 		err := errors.New("agent ID is missing") // Fixed error message to match the context
@@ -216,7 +217,7 @@ func (f *agentsRepository) Update(ctx context.Context, agent postgres_entity.Age
 	err := f.gormDb.
 		Model(&postgres_entity.Agents{}).
 		Where("id = ?", agent.ID).
-		Updates(agent).
+		Save(agent).
 		First(&updatedAgents, "id = ?", agent.ID).
 		Error
 	if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of `Color` attribute in agent creation and updates logging for better traceability.
> 
>   - **Behavior**:
>     - In `service.go`, `CreateAgent()` now sets `Color` from `agentRegistry` and defaults to a random color if not provided.
>     - In `agent_registry_repository.go`, `registerVisitorIdAgent()` now sets `Color` to `grayModern`.
>   - **Logging**:
>     - Added logging of `capabilitiesConfig` in `UpdateAgent()` in `service.go`.
>     - Added logging of `agentEntity` in `Update()` in `agents_repository.go`.
>   - **Models**:
>     - Added `Color` field to `AgentRegistry` in `agent_registry.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 32dde332e831f60fb826006f57803cc443811d98. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->