### PR TITLE
COS-6631: Replace avatar component on organizations and contacts table

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/avatar/AvatarCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/avatar/AvatarCell.tsx
@@ -1,9 +1,9 @@
 import { observer } from 'mobx-react-lite';
 
 import { cn } from '@ui/utils/cn';
-import { Avatar } from '@ui/media/Avatar/Avatar';
+import { Image } from '@ui/media/Image/Image';
+import { User02 } from '@ui/media/icons/User02';
 import { useStore } from '@shared/hooks/useStore';
-import { User01 } from '@ui/media/icons/User01.tsx';
 
 interface AvatarCellProps {
   id: string;
@@ -24,18 +24,13 @@ export const AvatarCell = observer(
 
     return (
       <div className='items-center ml-[1px]'>
-        <Avatar
-          size='xs'
-          textSize='xs'
-          tabIndex={-1}
-          icon={<User01 />}
-          src={src || undefined}
-          variant='outlineCircle'
-          name={isEnriching ? '' : fullName}
+        <div
           className={cn(
-            'text-gray-700 cursor-pointer focus:outline-none',
-            !canNavigate && 'cursor-default',
-            isEnriching && 'animate-pulse',
+            'w-6 h-6 flex items-center justify-center rounded border border-gray-200 cursor-pointer focus:outline-none',
+            {
+              'animate-pulse': isEnriching,
+              'cursor-default': !canNavigate,
+            },
           )}
           onClick={() => {
             if (
@@ -48,7 +43,20 @@ export const AvatarCell = observer(
               store.ui.setContactPreviewCardOpen(true);
             }
           }}
-        />
+        >
+          {src ? (
+            <Image
+              src={src}
+              alt={fullName}
+              loading='lazy'
+              decoding='async'
+              fetchPriority='low'
+              className='w-full h-full object-contain'
+            />
+          ) : (
+            <User02 className='w-4 h-4 text-gray-700' />
+          )}
+        </div>
       </div>
     );
   },

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/avatar/AvatarCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/avatar/AvatarCell.tsx
@@ -3,9 +3,8 @@ import { useNavigate } from 'react-router-dom';
 
 import { useLocalStorage } from 'usehooks-ts';
 
-import { cn } from '@ui/utils/cn.ts';
+import { cn } from '@ui/utils/cn';
 import { Image } from '@ui/media/Image/Image';
-import { Avatar } from '@ui/media/Avatar/Avatar';
 import { Building06 } from '@ui/media/icons/Building06';
 import {
   Popover,
@@ -45,21 +44,30 @@ export const AvatarCell = memo(
       <div className='items-center ml-[1px]'>
         <Popover open={isOpen} onOpenChange={setIsOpen}>
           <PopoverTrigger>
-            <Avatar
-              size='xs'
-              textSize='xs'
-              tabIndex={-1}
-              src={src || undefined}
-              variant='outlineSquare'
+            <div
               onClick={handleNavigate}
-              name={isEnriching ? '' : fullName}
               onMouseEnter={() => setIsOpen(true)}
               onMouseLeave={() => setIsOpen(false)}
-              icon={<Building06 className='text-gray-700' />}
-              className={cn('text-gray-700 cursor-pointer focus:outline-none', {
-                'animate-pulse': isEnriching,
-              })}
-            />
+              className={cn(
+                'w-6 h-6 flex items-center justify-center rounded border border-gray-200 cursor-pointer focus:outline-none',
+                {
+                  'animate-pulse': isEnriching,
+                },
+              )}
+            >
+              {src ? (
+                <Image
+                  src={src}
+                  alt={fullName}
+                  loading='lazy'
+                  decoding='async'
+                  fetchPriority='low'
+                  className='w-full h-full object-contain'
+                />
+              ) : (
+                <Building06 className='w-4 h-4 text-gray-700' />
+              )}
+            </div>
           </PopoverTrigger>
 
           <PopoverContent


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `Avatar` with `div` containing `Image` or icon in `AvatarCell` components for contacts and organizations, updating behavior and styling.
> 
>   - **Components**:
>     - Replace `Avatar` with `div` containing `Image` or icon in `AvatarCell` for contacts and organizations.
>     - Use `Image` component for displaying `src` and fallback to `User02` or `Building06` icons.
>   - **Behavior**:
>     - `AvatarCell` for contacts: Click toggles contact preview card.
>     - `AvatarCell` for organizations: Click navigates to organization page, with popover on hover.
>   - **Styling**:
>     - Update CSS classes for new `div` structure in both `AvatarCell` components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 41002a692c90170b9e2987c25898690fca750625. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->