### PR TITLE
Default icon and colors for agents

### DIFF
--- a/packages/server/customer-os-postgres-repository/repository/agent_registry_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agent_registry_repository.go
@@ -214,7 +214,8 @@ func registerSupportAgent() postgres_entity.AgentRegistry {
 		Type:     enum.AgentSupport,
 		Name:     "Tag support visitors",
 		Goal:     enum.AgentGoalTagSupport.String(),
-		Icon:     "",
+		Icon:     "life-buoy-01",
+		Color:    "grayModern",
 		IsActive: true,
 		CapabilitiesConfig: postgres_entity.CapabilitiesConfig{
 			Capabilities: []postgres_entity.Capability{


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set default icon and color for support agents in `registerSupportAgent()` in `agent_registry_repository.go`.
> 
>   - **Behavior**:
>     - Set default `Icon` to `"life-buoy-01"` and `Color` to `"grayModern"` for support agents in `registerSupportAgent()` in `agent_registry_repository.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2fac1cf1c44d099b2397b891c04a4e86a7b2ccd3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->