### PR TITLE
COS-6610: Prevent text selection during shift+click row selection

### DIFF
--- a/packages/apps/frontera/src/ui/presentation/Table/Table.tsx
+++ b/packages/apps/frontera/src/ui/presentation/Table/Table.tsx
@@ -135,6 +135,7 @@ export const Table = <T extends object>({
   useKey(
     'Shift',
     (e) => {
+      e.preventDefault();
       setIsShiftPressed(e.type === 'keydown');
     },
     { eventTypes: ['keydown', 'keyup'] },
@@ -462,6 +463,7 @@ export const Table = <T extends object>({
           totalItems={totalItems}
           rowVirtualizer={rowVirtualizer}
           includesAvatar={includesAvatar}
+          isShiftPressed={isShiftPressed}
           focusedRowIndex={focusedRowIndex}
           fullRowSelection={fullRowSelection}
           setSelectedIndex={setSelectedIndex}
@@ -487,6 +489,7 @@ interface TableBodyProps<T extends object> {
   isLoading?: boolean;
   tableId?: TableIdType;
   table: TableInstance<T>;
+  isShiftPressed?: boolean;
   includesAvatar?: boolean;
   fullRowSelection?: boolean;
   enableRowSelection?: boolean;
@@ -510,6 +513,7 @@ const TableBody = <T extends object>({
   onFullRowSelection,
   setFocusedRowIndex,
   enableRowSelection,
+  isShiftPressed,
   includesAvatar,
   tableId,
 }: TableBodyProps<T>) => {
@@ -563,6 +567,7 @@ const TableBody = <T extends object>({
               focusStyle,
               'group/row',
               row?.getIsSelected() && 'bg-gray-50',
+              isShiftPressed && 'select-none',
             )}
             onClick={
               fullRowSelection
@@ -591,7 +596,9 @@ const TableBody = <T extends object>({
                         'cursor-pointer group-hover/row:opacity-100 group-hover/row:visible opacity-0',
                         row?.getIsSelected() && 'opacity-100',
                       )}
-                      onClick={() => {
+                      onClick={(e) => {
+                        e.preventDefault();
+
                         const isSelected = row?.getIsSelected();
 
                         row?.getToggleSelectedHandler()(!isSelected);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents text selection during shift+click row selection in `Table` by using `e.preventDefault()` and `select-none` class.
> 
>   - **Behavior**:
>     - Prevents text selection during shift+click row selection by adding `e.preventDefault()` in `useKey` for 'Shift' key in `Table` component.
>     - Applies `select-none` class to rows in `TableBody` when `isShiftPressed` is true.
>   - **Props**:
>     - Adds `isShiftPressed` prop to `TableBodyProps` and passes it from `Table` to `TableBody`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 764839b7f5bff7286f00d52de948e8f7c61753ac. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->