### PR TITLE
COS-6659: Fix primary email status filtering

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/ContactDetails/components/EmailsSection/EmailValidationMessage.tsx
+++ b/packages/apps/frontera/src/routes/src/components/ContactDetails/components/EmailsSection/EmailValidationMessage.tsx
@@ -90,7 +90,8 @@ function checkEmailStatus(emailData?: EmailValidationDetails, email?: string) {
   if (emailData?.deliverable === EmailDeliverable.Deliverable) {
     if (emailData.isFirewalled) return emailStatuses.DELIVERABLE_FIREWALL;
     if (emailData.isFreeAccount) return emailStatuses.DELIVERABLE_FREE_ACCOUNT;
-    if (!emailData.isRisky) return emailStatuses.DELIVERABLE_NO_RISK;
+
+    return emailStatuses.DELIVERABLE_NO_RISK;
   }
 
   if (emailData?.deliverable === EmailDeliverable.Unknown) {

--- a/packages/apps/frontera/src/routes/src/components/ContactDetails/components/EmailsSection/EmailValidationMessage.tsx
+++ b/packages/apps/frontera/src/routes/src/components/ContactDetails/components/EmailsSection/EmailValidationMessage.tsx
@@ -90,8 +90,7 @@ function checkEmailStatus(emailData?: EmailValidationDetails, email?: string) {
   if (emailData?.deliverable === EmailDeliverable.Deliverable) {
     if (emailData.isFirewalled) return emailStatuses.DELIVERABLE_FIREWALL;
     if (emailData.isFreeAccount) return emailStatuses.DELIVERABLE_FREE_ACCOUNT;
-
-    return emailStatuses.DELIVERABLE_NO_RISK;
+    if (!emailData.isRisky) return emailStatuses.DELIVERABLE_NO_RISK;
   }
 
   if (emailData?.deliverable === EmailDeliverable.Unknown) {

--- a/packages/apps/frontera/src/store/Contacts/__views__/filterFns.ts
+++ b/packages/apps/frontera/src/store/Contacts/__views__/filterFns.ts
@@ -467,7 +467,8 @@ function isDeliverableV2(
     return false;
 
   const statusChecks: Record<string, () => boolean> = {
-    [EmailVerificationStatus.NoRisk]: () => !data.isRisky,
+    [EmailVerificationStatus.NoRisk]: () =>
+      data?.deliverable === EmailDeliverable.Deliverable, // validation rules https://www.figma.com/design/uWolaNIV9vDhQ5PfQGNC7o/Views?node-id=3127-7449&p=f&t=at3ByiH8XZGopHZV-0
     [EmailVerificationStatus.FirewallProtected]: () => !!data.isFirewalled,
     [EmailVerificationStatus.FreeAccount]: () => !!data.isFreeAccount,
     [EmailVerificationStatus.GroupMailbox]: () => data.verifyingCheckAll,

--- a/packages/apps/frontera/src/store/Contacts/__views__/filterFns.ts
+++ b/packages/apps/frontera/src/store/Contacts/__views__/filterFns.ts
@@ -275,7 +275,7 @@ const getFilterFn = (
           if (emailValidationData === undefined) return false;
 
           return match(filter.operation)
-            .with(ComparisonOperator.Contains, () =>
+            .with(ComparisonOperator.In, () =>
               filterValues?.some(
                 (id: string) =>
                   isDeliverableV2(id, emailValidationData) ||
@@ -283,12 +283,12 @@ const getFilterFn = (
                   isDeliverableUnknownV2(id, emailValidationData),
               ),
             )
-            .with(ComparisonOperator.NotContains, () =>
-              filterValues?.some(
+            .with(ComparisonOperator.NotIn, () =>
+              filterValues?.every(
                 (id: string) =>
-                  isDeliverableV2(id, emailValidationData) ||
-                  isNotDeliverableV2(id, emailValidationData) ||
-                  isDeliverableUnknownV2(id, emailValidationData),
+                  !isDeliverableV2(id, emailValidationData) &&
+                  !isNotDeliverableV2(id, emailValidationData) &&
+                  !isDeliverableUnknownV2(id, emailValidationData),
               ),
             )
             .with(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix primary email status filtering in `getFilterFn` by updating comparison operators and logic.
> 
>   - **Behavior**:
>     - In `getFilterFn`, replace `ComparisonOperator.Contains` with `ComparisonOperator.In` and `ComparisonOperator.NotContains` with `ComparisonOperator.NotIn` for email validation filtering.
>     - Modify logic to use `some` for `ComparisonOperator.In` and `every` for `ComparisonOperator.NotIn`.
>   - **Functions**:
>     - Update `isDeliverableV2` to check `data.deliverable` for `EmailVerificationStatus.NoRisk`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8da680e67ef02e6a0942a55eff9182786fb0ff3d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->