### PR TITLE
Fix agents init

### DIFF
--- a/packages/server/customer-os-api/graphql/resolver/agent.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/agent.resolvers.go
@@ -6,6 +6,7 @@ package resolver
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
@@ -121,6 +122,19 @@ func (r *queryResolver) SlackChannelsWithBot(ctx context.Context) ([]*model.Agen
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.SlackChannelsWithBot", graphql.GetOperationContext(ctx))
 	defer span.Finish()
 	tracing.SetDefaultResolverSpanTags(ctx, span)
+
+	tenant := common.GetTenantFromContext(ctx)
+
+	slackSettingsEntity, err := r.Services.Repositories.PostgresRepositories.SlackSettingsRepository.Get(ctx, tenant)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		graphql.AddErrorf(ctx, "Failed to get slack settings")
+		return nil, nil
+	}
+
+	if slackSettingsEntity == nil {
+		return []*model.AgentSlackChannel{}, nil
+	}
 
 	slackChannels, err := r.Services.CommonServices.SlackService.ListSlackChannelsWithBot(ctx)
 	if err != nil {

--- a/packages/server/customer-os-common-module/services/agent_capability/capabilities_config.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capabilities_config.go
@@ -23,7 +23,11 @@ func GetCapabilityConfigStruct(capabilityType enum.AgentCapabilityType) any {
 			},
 		}
 	case enum.CapabilityIdentifyWebVisitor:
-		return &IdentifyWebsiteVisitorConfig{}
+		return &IdentifyWebsiteVisitorConfig{
+			Websites: WebsitesConfig{
+				Value: []string{},
+			},
+		}
 	case enum.CapabilityApplyTag:
 		return &ApplyTagConfig{}
 	case enum.CapabilityIcpQualify:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes Slack settings handling in `SlackChannelsWithBot` and initializes `IdentifyWebsiteVisitorConfig` with empty websites list.
> 
>   - **Behavior**:
>     - In `SlackChannelsWithBot` resolver in `agent.resolvers.go`, added check for Slack settings using `GetTenantFromContext` and `SlackSettingsRepository.Get()`. Returns empty list if settings are missing.
>     - In `capabilities_config.go`, initializes `IdentifyWebsiteVisitorConfig` with an empty `Websites` list.
>   - **Imports**:
>     - Added import for `common` package in `agent.resolvers.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a4497b6e3c6967fc0c61d01c0af78d36cd1a6d56. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->