### PR TITLE
COS-6665: Fix error on industry feedback in the new organization details panel

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/email-composer/email-participant-select.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/email-composer/email-participant-select.usecase.ts
@@ -1,6 +1,5 @@
 import { RootStore } from '@store/root';
 import { action, computed, reaction, observable } from 'mobx';
-import { TagService, OrganizationService } from '@domain/services';
 
 import { validateEmail } from '@utils/email.ts';
 import { SelectOption } from '@ui/utils/types.ts';
@@ -16,8 +15,6 @@ export class EmailParticipantSelectUsecase {
     [];
 
   private root = RootStore.getInstance();
-  private tagService = new TagService();
-  private organizationService = new OrganizationService();
   private organizationId: string;
 
   constructor(organizationId: string) {

--- a/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
+++ b/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
@@ -23,7 +23,6 @@ import { OwnerInput } from '@shared/components/OrganizationDetails/components/ow
 import { Branches } from '@shared/components/OrganizationDetails/components/branches';
 import { AboutTabField } from '@shared/components/OrganizationDetails/components/AboutTabField';
 import {
-  EntityType,
   FlagWrongFields,
   OrganizationRelationship,
 } from '@shared/types/__generated__/graphql.types';
@@ -82,25 +81,8 @@ export const OrganizationDetails = observer(
       [id],
     );
 
-    const handleCreateOption = (value: string) => {
-      store.tags?.create(
-        { name: value },
-        {
-          onSucces: (id) => {
-            organization.draft();
-            organization?.value?.tags?.push({
-              name: value,
-              colorCode:
-                store.tags.getById(id)?.value?.colorCode ?? 'grayModern',
-              metadata: {
-                id,
-              },
-              entityType: EntityType.Organization,
-            });
-            organization.commit();
-          },
-        },
-      );
+    const handleCreateOption = () => {
+      tagsUsecase.create();
     };
 
     const isEnriching = organization.isEnriching;
@@ -274,6 +256,7 @@ export const OrganizationDetails = observer(
               )}
             </div>
             <AboutTabField
+              id={store.ui.focusRow ?? id}
               dataTest={'org-about-industry'}
               placeholder='Industry not found yet'
               value={organization?.value?.industryName}

--- a/packages/apps/frontera/src/routes/src/components/OrganizationDetails/components/AboutTabField.tsx
+++ b/packages/apps/frontera/src/routes/src/components/OrganizationDetails/components/AboutTabField.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from 'react';
-import { useParams } from 'react-router-dom';
 
 import { FlagWrongFieldUsecase } from '@domain/usecases/organization-industry-field/flag-wrong-field.usecase';
 
@@ -9,6 +8,7 @@ import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
 import { ThumbsDown } from '@ui/media/icons/ThumbsDown';
 
 interface FieldMarkerProps {
+  id: string;
   icon: ReactNode;
   dataTest?: string;
   placeholder?: string;
@@ -26,8 +26,8 @@ export const AboutTabField = ({
   dataTest,
   placeholder,
   flaggedAsIncorrect,
+  id,
 }: FieldMarkerProps) => {
-  const id = useParams()?.id as string;
   const label = fieldLabels[field];
 
   return (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix error in organization details panel by updating `handleCreateOption` and `AboutTabField` component, and remove unused imports.
> 
>   - **Behavior**:
>     - Fix error in `OrganizationDetails.tsx` by modifying `handleCreateOption` to use `tagsUsecase.create()`.
>     - Update `AboutTabField.tsx` to use `id` prop instead of `useParams` for `id`.
>   - **Code Cleanup**:
>     - Remove unused imports `TagService` and `OrganizationService` from `email-participant-select.usecase.ts`.
>     - Remove `EntityType` import from `OrganizationDetails.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 04b2acdd3c442d18ca32fa1686810a06576ceab5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->