### PR TITLE
Refactor Slack OAuth handling to streamline query parameter processing

### DIFF
--- a/packages/apps/frontera/src/routes/agent/components/Capabilities/SendSlackNotificationCapability.tsx
+++ b/packages/apps/frontera/src/routes/agent/components/Capabilities/SendSlackNotificationCapability.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useMemo, useEffect } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
 import {
@@ -12,13 +12,22 @@ import { Icon } from '@ui/media/Icon';
 import { Combobox } from '@ui/form/Combobox';
 import { Slack } from '@ui/media/logos/Slack';
 import { Button } from '@ui/form/Button/Button';
+import { useStore } from '@shared/hooks/useStore';
 import { Tag, TagLabel } from '@ui/presentation/Tag';
 import { Popover, PopoverTrigger, PopoverContent } from '@ui/overlay/Popover';
 
 export const SendSlackNotificationCapability = observer(() => {
   const { id } = useParams<{ id: string }>();
+  const [queryParams] = useSearchParams();
+  const store = useStore();
 
   const usecase = useMemo(() => new AddSlackChannelUsecase(id!), [id]);
+
+  useEffect(() => {
+    if (queryParams && queryParams.has('code')) {
+      store.settings.slack.oauthCallback(queryParams.get('code') as string);
+    }
+  }, [queryParams]);
 
   if (!usecase.isSlackEnabled) {
     return (

--- a/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/AuthPanel/AuthPanel.tsx
+++ b/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/AuthPanel/AuthPanel.tsx
@@ -14,11 +14,7 @@ export const AuthPanel = observer(() => {
   const [queryParams] = useSearchParams();
 
   useEffect(() => {
-    if (
-      queryParams &&
-      queryParams.has('redirect_slack') &&
-      queryParams.has('code')
-    ) {
+    if (queryParams && queryParams.has('code')) {
       store.settings.slack.oauthCallback(queryParams.get('code') as string);
     }
   }, [queryParams]);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor Slack OAuth handling in `SendSlackNotificationCapability.tsx` and `AuthPanel.tsx` to streamline query parameter processing by checking only for the 'code' parameter.
> 
>   - **Behavior**:
>     - Simplified Slack OAuth query parameter processing in `SendSlackNotificationCapability.tsx` and `AuthPanel.tsx` by checking only for the 'code' parameter.
>   - **Components**:
>     - In `SendSlackNotificationCapability.tsx`, added `useEffect` to handle 'code' parameter and call `store.settings.slack.oauthCallback`.
>     - In `AuthPanel.tsx`, refactored `useEffect` to streamline 'code' parameter handling for Slack OAuth callback.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 4e934a709304e163e2707987ca98554710515e45. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->