### PR TITLE
Use global org data on creating new org

### DIFF
--- a/packages/server/customer-os-common-module/services/organization/service.go
+++ b/packages/server/customer-os-common-module/services/organization/service.go
@@ -401,7 +401,11 @@ func (s *organizationService) Save(ctx context.Context, txWithPostCommit *utils.
 		input.CustomerOsId = utils.StringPtr(customerOsId)
 	}
 
-	// Adjust input fields
+	if !createFlow {
+		s.adjustIcpFitFields(ctx, &input, existingOrganizationEntity)
+	}
+
+	// Adjust name if it is empty
 	if common.GetAppSourceFromContext(ctx) != constants.AppSourceCustomerOsApi {
 		if input.Name != nil {
 			input.Name = utils.StringPtr(utils.CleanName(*input.Name))
@@ -1728,4 +1732,37 @@ func (s *organizationService) GetOrganizationByDomain(ctx context.Context, domai
 	}
 
 	return nil, nil
+}
+
+func (s *organizationService) adjustIcpFitFields(ctx context.Context, dataFields *data_fields.OrganizationFields, currentOrganizationEntity *neo4jentity.OrganizationEntity) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.adjustIcpFitFields")
+	defer span.Finish()
+
+	if dataFields.Relationship != nil {
+		if *dataFields.Relationship == neo4jenum.OrganizationRelationshipNotAFit {
+			dataFields.IcpFit = utils.ToPtr(enum.IcpNotFit)
+			if currentOrganizationEntity.IcpFit == enum.IcpIsFit && dataFields.IcpFitReasons == nil {
+				dataFields.IcpFitReasons = utils.ToPtr([]string{})
+			}
+		}
+		if *dataFields.Relationship == neo4jenum.OrganizationRelationshipCustomer {
+			dataFields.IcpFit = utils.ToPtr(enum.IcpIsFit)
+			if currentOrganizationEntity.IcpFit == enum.IcpNotFit && dataFields.IcpFitReasons == nil {
+				dataFields.IcpFitReasons = utils.ToPtr([]string{})
+			}
+		}
+		if *dataFields.Relationship == neo4jenum.OrganizationRelationshipProspect || *dataFields.Relationship == neo4jenum.OrganizationRelationshipFormerCustomer {
+			if dataFields.Stage != nil {
+				if *dataFields.Stage == neo4jenum.Lead {
+					dataFields.IcpFit = utils.ToPtr(enum.IcpNotSet)
+					dataFields.IcpFitReasons = utils.ToPtr([]string{})
+				} else if *dataFields.Stage != neo4jenum.Lead {
+					dataFields.IcpFit = utils.ToPtr(enum.IcpIsFit)
+					if currentOrganizationEntity.IcpFit == enum.IcpNotFit && dataFields.IcpFitReasons == nil {
+						dataFields.IcpFitReasons = utils.ToPtr([]string{})
+					}
+				}
+			}
+		}
+	}
 }

--- a/packages/server/customer-os-common-module/services/organization/service.go
+++ b/packages/server/customer-os-common-module/services/organization/service.go
@@ -319,23 +319,6 @@ func (s *organizationService) Save(ctx context.Context, txWithPostCommit *utils.
 	}
 	tracing.TagEntity(span, organizationId)
 
-	// validate stage and relationship combination all the time (from input or existing computed )
-	stageStr := input.GetStageStr()
-	relationshipStr := input.GetRelationshipStr()
-	if stageStr != "" || relationshipStr != "" {
-		if stageStr == "" && existingOrganizationEntity != nil && existingOrganizationEntity.Stage != "" {
-			stageStr = existingOrganizationEntity.Stage.String()
-		}
-		if relationshipStr == "" && existingOrganizationEntity != nil && existingOrganizationEntity.Relationship != "" {
-			relationshipStr = existingOrganizationEntity.Relationship.String()
-		}
-	}
-	if !neo4jentity.OrganizationStageAndRelationshipCompatible(ctx, stageStr, relationshipStr) {
-		err := errors.New("Stage and Relationship are not compatible")
-		tracing.TraceErr(span, err)
-		return "", err
-	}
-
 	// adapt fields for creating new organization
 	if createFlow {
 		if utils.IfNotNilString(input.AppSource) == "" {
@@ -348,6 +331,36 @@ func (s *organizationService) Save(ctx context.Context, txWithPostCommit *utils.
 				input.Source = utils.StringPtr(neo4jentity.DataSourceOpenline.String())
 			}
 		}
+
+		input.Hide = utils.BoolPtr(false)
+
+		// load initial data from global organizations by domains
+		if input.GlobalOrgId == nil {
+			globalOrganizations, err := s.postgres.GlobalOrganizationRepository.GetByPrimaryDomains(ctx, domains)
+			if err != nil {
+				tracing.TraceErr(span, errors.Wrap(err, "failed to get global orgs by primary domains"))
+			}
+			if globalOrganizations != nil && len(globalOrganizations) > 0 {
+				globalOrganization := (globalOrganizations)[0]
+				input.Name = utils.StringPtr(globalOrganization.Name)
+				input.PrimaryDomain = utils.StringPtr(globalOrganization.PrimaryDomain)
+				input.Description = utils.StringPtr(globalOrganization.Description)
+				input.Website = utils.StringPtr(globalOrganization.Website)
+				input.LogoUrl = utils.StringPtr(globalOrganization.LogoUrl)
+				input.IconUrl = utils.StringPtr(globalOrganization.IconUrl)
+				input.LinkedInUrl = utils.StringPtr(globalOrganization.LinkedInUrl)
+				input.LinkedInAlias = utils.StringPtr(globalOrganization.LinkedInAlias)
+				input.Domains = utils.StringToSlice(globalOrganization.OtherDomains)
+				input.IndustryCode = utils.StringPtrNillable(globalOrganization.IndustryNaicsCode)
+				if globalOrganization.YearFounded > 0 {
+					input.YearFounded = utils.Int64Ptr(int64(globalOrganization.YearFounded))
+				}
+				if globalOrganization.EmployeeCount > 0 {
+					input.Employees = utils.Int64Ptr(int64(globalOrganization.EmployeeCount))
+				}
+			}
+		}
+
 		// if no name is provided, we try to extract if from domain
 		if utils.IfNotNilString(input.Name) == "" {
 			domain := primaryDomain
@@ -363,13 +376,19 @@ func (s *organizationService) Save(ctx context.Context, txWithPostCommit *utils.
 				input.Name = utils.StringPtr(utils.CapitalizeAllParts(utils.GetDomainWithoutTLD(websiteDomain), []string{"-", "_", "."}))
 			}
 		}
-		input.Hide = utils.BoolPtr(false)
+
 		if input.Relationship == nil {
 			input.Relationship = utils.ToPtr(neo4jenum.OrganizationRelationshipProspect)
 		}
 		if input.Stage == nil {
 			input.Stage = utils.ToPtr(input.Relationship.DefaultStage())
 		}
+	}
+
+	err = s.validateRelationshipAndStageCompatibility(ctx, input, existingOrganizationEntity)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", err
 	}
 
 	// generate customerOsId if not provided or if it is empty in the db
@@ -589,6 +608,29 @@ func (s *organizationService) Save(ctx context.Context, txWithPostCommit *utils.
 	}
 
 	return organizationId, nil
+}
+
+func (s *organizationService) validateRelationshipAndStageCompatibility(ctx context.Context, input data_fields.OrganizationFields, existingOrganizationEntity *neo4jentity.OrganizationEntity) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.validateRelationshipAndStageCompatibility")
+	defer span.Finish()
+
+	// validate stage and relationship combination all the time (from input or existing computed )
+	stageStr := input.GetStageStr()
+	relationshipStr := input.GetRelationshipStr()
+	if stageStr != "" || relationshipStr != "" {
+		if stageStr == "" && existingOrganizationEntity != nil && existingOrganizationEntity.Stage != "" {
+			stageStr = existingOrganizationEntity.Stage.String()
+		}
+		if relationshipStr == "" && existingOrganizationEntity != nil && existingOrganizationEntity.Relationship != "" {
+			relationshipStr = existingOrganizationEntity.Relationship.String()
+		}
+	}
+	if !neo4jentity.OrganizationStageAndRelationshipCompatible(ctx, stageStr, relationshipStr) {
+		err := errors.New("Stage and Relationship are not compatible")
+		tracing.TraceErr(span, err)
+		return err
+	}
+	return nil
 }
 
 func (s *organizationService) Hide(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, organizationId string) error {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance organization creation by using global data and refactoring validation logic in `service.go`.
> 
>   - **Behavior**:
>     - Use global organization data to populate fields when creating a new organization in `Save()`.
>     - Set `input.Hide` to `false` during organization creation.
>     - Validate stage and relationship compatibility using `validateRelationshipAndStageCompatibility()`.
>   - **Functions**:
>     - Extract stage and relationship validation logic into `validateRelationshipAndStageCompatibility()`.
>     - Add `adjustIcpFitFields()` to adjust ICP fit fields based on relationship and stage.
>   - **Misc**:
>     - Remove redundant stage and relationship validation logic from `Save()`.
>     - Adjust name cleaning logic in `Save()` to handle empty names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2d6457e72a9e6dcd6c7f40329fea97b8d01fef20. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->