### PR TITLE
change: display only firstType of social

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaList.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaList.tsx
@@ -6,6 +6,7 @@ import { useStore } from '@shared/hooks/useStore';
 import { SelectOption } from '@shared/types/SelectOptions.ts';
 import { Social } from '@shared/types/__generated__/graphql.types.ts';
 
+import { isKnownUrl } from './util.ts';
 import { SocialMediaItem } from './SocialMediaItem.tsx';
 
 interface SocialMediaListProps {
@@ -55,33 +56,7 @@ export const SocialMediaList = observer(
 const getSocialDomain = (url: string) => {
   if (!url || typeof url !== 'string') return null;
 
-  if (!url.startsWith('http://') && !url.startsWith('https://')) {
-    url = `https://${url}`;
-  }
-
-  const domainMap = {
-    twitter: 'twitter',
-    facebook: 'facebook',
-    linkedin: 'linkedin',
-    github: 'github',
-    instagram: 'instagram',
-    youtube: 'youtube',
-    pinterest: 'pinterest',
-    angel: 'angellist',
-    notion: 'notion',
-    clubhouse: 'clubhouse',
-    discord: 'discord',
-    slack: 'slack',
-    tiktok: 'tiktok',
-    telegram: 'telegram',
-    snapchat: 'snapchat',
-    reddit: 'reddit',
-    google: 'google',
-  };
-
-  const hostname = new URL(url).hostname;
-
-  return Object.keys(domainMap).find((key) => hostname.includes(key)) || null;
+  return isKnownUrl(url.trim().toLowerCase()) || null;
 };
 
 const filterUniqueSocials = (socialArray = []) => {

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaList.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaList.tsx
@@ -3,6 +3,8 @@ import { useParams } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 
 import { useStore } from '@shared/hooks/useStore';
+import { SelectOption } from '@shared/types/SelectOptions.ts';
+import { Social } from '@shared/types/__generated__/graphql.types.ts';
 
 import { SocialMediaItem } from './SocialMediaItem.tsx';
 
@@ -10,20 +12,28 @@ interface SocialMediaListProps {
   dataTest?: string;
   isReadOnly?: boolean;
   leftElement?: React.ReactNode;
-  value?: { label: string; value: string }[];
 }
 
 export const SocialMediaList = observer(
-  ({ value, isReadOnly, dataTest, leftElement }: SocialMediaListProps) => {
+  ({ isReadOnly, dataTest, leftElement }: SocialMediaListProps) => {
     const store = useStore();
     const id = useParams()?.id as string;
     const organization = store.organizations.getById(store.ui.focusRow ?? id);
 
     if (!organization || !organization?.value) return null;
 
+    const filteredSocials = filterUniqueSocials(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      organization.value.socialMedia as any,
+    );
+    const socialOptions = filteredSocials.map((social) => ({
+      value: social.id,
+      label: social.url,
+    }));
+
     return (
       <div className='flex flex-wrap gap-2'>
-        {value?.map(({ value: v, label: l }) => (
+        {socialOptions.map(({ value: v, label: l }: SelectOption) => (
           <div key={v} className='w-auto '>
             <SocialMediaItem
               id={v}
@@ -39,3 +49,52 @@ export const SocialMediaList = observer(
     );
   },
 );
+
+//this function will be moved in the BE in the future
+
+const getSocialDomain = (url: string) => {
+  if (!url || typeof url !== 'string') return null;
+
+  if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    url = `https://${url}`;
+  }
+
+  const domainMap = {
+    twitter: 'twitter',
+    facebook: 'facebook',
+    linkedin: 'linkedin',
+    github: 'github',
+    instagram: 'instagram',
+    youtube: 'youtube',
+    pinterest: 'pinterest',
+    angel: 'angellist',
+    notion: 'notion',
+    clubhouse: 'clubhouse',
+    discord: 'discord',
+    slack: 'slack',
+    tiktok: 'tiktok',
+    telegram: 'telegram',
+    snapchat: 'snapchat',
+    reddit: 'reddit',
+    google: 'google',
+  };
+
+  const hostname = new URL(url).hostname;
+
+  return Object.keys(domainMap).find((key) => hostname.includes(key)) || null;
+};
+
+const filterUniqueSocials = (socialArray = []) => {
+  const uniqueSocials = new Map();
+
+  socialArray.forEach((social: Social) => {
+    if (!social || typeof social !== 'object' || !social.url) return;
+    const domain = getSocialDomain(social.url);
+
+    if (domain && !uniqueSocials.has(domain)) {
+      uniqueSocials.set(domain, social);
+    }
+  });
+
+  return Array.from(uniqueSocials.values());
+};

--- a/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
+++ b/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
@@ -151,10 +151,6 @@ export const OrganizationDetails = observer(
             <SocialMediaList
               dataTest='org-about-social-link'
               leftElement={<Icon name='share-07' className='text-gray-500' />}
-              value={organization?.value.socialMedia.map((s) => ({
-                value: s.id,
-                label: s.url,
-              }))}
             />
             <Tags
               dataTest='org-about-tags'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `SocialMediaList` now filters and displays unique social media entries by domain, removing the `value` prop.
> 
>   - **Behavior**:
>     - `SocialMediaList` now filters and displays only the first occurrence of each social media domain using `filterUniqueSocials()`.
>     - Removed `value` prop from `SocialMediaList` in `OrganizationDetails`.
>   - **Functions**:
>     - Added `filterUniqueSocials()` and `getSocialDomain()` to `SocialMediaList.tsx` to filter unique social media entries.
>   - **Misc**:
>     - Removed unused `value` prop from `SocialMediaListProps`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3e65ddaeb6252d4bf2f0f1bd2d4548d24625e3c0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->