### PR TITLE
add icon to open side panel from contact table

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/contactName/ContactNameCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/contactName/ContactNameCell.tsx
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react-lite';
 import { useLocalStorage } from 'usehooks-ts';
 
 import { cn } from '@ui/utils/cn';
+import { Icon } from '@ui/media/Icon';
 import { useStore } from '@shared/hooks/useStore';
 
 interface ContactNameCellProps {
@@ -25,7 +26,7 @@ export const ContactNameCell = observer(
     if (!contactStore) return;
 
     return (
-      <div ref={ref} className='flex'>
+      <div ref={ref} className='flex group/contact-preview items-center'>
         {!contactName && (
           <p
             className='text-gray-700 font-medium no-underline hover:no-underline cursor-pointer'
@@ -60,6 +61,18 @@ export const ContactNameCell = observer(
             {contactName}
           </p>
         )}
+        <Icon
+          name={'eye'}
+          className='text-gray-400 ml-2 opacity-0 group-hover/contact-preview:opacity-100 cursor-pointer'
+          onClick={() => {
+            if (previewCard === true && store.ui.focusRow === contactId) {
+              setPreviewCard(false);
+            } else {
+              store.ui.setFocusRow(contactId);
+              setPreviewCard(true);
+            }
+          }}
+        />
       </div>
     );
   },

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/shared/Filters/abstract/LinkedIn/LinkedInDisplay.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/shared/Filters/abstract/LinkedIn/LinkedInDisplay.tsx
@@ -30,7 +30,7 @@ export const LinkedInDisplay = ({
     : '';
 
   return (
-    <div className='flex items-center group'>
+    <div className='flex items-center group/linkedin'>
       <Tooltip label={url ?? ''}>
         <p
           onClick={() => window.open(url, '_blank', 'noopener')}
@@ -46,7 +46,7 @@ export const LinkedInDisplay = ({
         aria-label='social-link'
         icon={<Copy02 className='text-gray-500' />}
         onClick={() => copyToClipboard(url, 'LinkedIn profile copied')}
-        className='ml-1 rounded-[5px] opacity-0 group-hover:opacity-100'
+        className='ml-1 rounded-[5px] opacity-0 group-hover/linkedin:opacity-100'
       />
     </div>
   );

--- a/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
+++ b/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
@@ -49,7 +49,7 @@ interface OrganizationDetailsProps {
 export const OrganizationDetails = observer(
   ({ id }: OrganizationDetailsProps) => {
     const store = useStore();
-    const [__, setPreviewCard] = useLocalStorage('previewCard', false);
+    const [previewCard, setPreviewCard] = useLocalStorage('previewCard', false);
 
     const [_, copyToClipboard] = useCopyToClipboard();
 
@@ -106,7 +106,7 @@ export const OrganizationDetails = observer(
             <p className='font-semibold text-base mt-0.5 overflow-hidden overflow-ellipsis'>
               {organization?.value?.name ?? ''}
             </p>
-            {!id && (
+            {previewCard && (
               <IconButton
                 size='xs'
                 variant='ghost'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add eye icon to `ContactNameCell` for toggling contact preview and enhance hover effects in `ContactNameCell` and `LinkedInDisplay`.
> 
>   - **Behavior**:
>     - Add `Icon` with eye symbol to `ContactNameCell` to toggle contact preview panel.
>     - Ensure `previewCard` state toggles correctly in `ContactNameCell` and `OrganizationDetails`.
>   - **UI Enhancements**:
>     - Add hover effect to `Icon` in `ContactNameCell` for visibility.
>     - Update hover effect in `LinkedInDisplay` to use `group-hover/linkedin` for consistency.
>   - **State Management**:
>     - Correct `previewCard` state initialization in `OrganizationDetails`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 63ea247ea9c06f0a13312544a542008a9ba32a96. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->