### PR TITLE
Add authentication check in Slack OAuth callback hook

### DIFF
--- a/packages/apps/frontera/src/routes/agents/hooks/useSlackOauthCallback.ts
+++ b/packages/apps/frontera/src/routes/agents/hooks/useSlackOauthCallback.ts
@@ -20,6 +20,8 @@ export const useSlackOauthCallback = () => {
     const capabilityId = queryParams.get('cid');
     const slackCode = queryParams.get('code');
 
+    if (!store.session.isAuthenticated) return;
+
     if (slackCode) {
       store.settings.slack.oauthCallback(slackCode);
     }
@@ -29,5 +31,5 @@ export const useSlackOauthCallback = () => {
         `/agents/${agentId}${capabilityId ? `?cid=${capabilityId}` : ''}`,
       );
     }
-  }, []);
+  }, [store.session.isAuthenticated]);
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add authentication check in `useSlackOauthCallback` to ensure user is authenticated before proceeding with Slack OAuth callback.
> 
>   - **Behavior**:
>     - Adds authentication check in `useSlackOauthCallback` to ensure `store.session.isAuthenticated` is true before proceeding.
>     - If not authenticated, the function returns early, preventing further execution.
>   - **Dependencies**:
>     - Updates dependency array of `useEffect` to include `store.session.isAuthenticated`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 1e95c5b7615b87b839663ee360044d5c72e4c0c6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->