### PR TITLE
Refactor Slack OAuth handling to use encoded state parameter for impr…

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-slack-channel.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-slack-channel.usecase.ts
@@ -189,7 +189,9 @@ export class AddSlackChannelUsecase {
     }
 
     this.root.settings.slack.enableSync(
-      `https://app.customeros.ai/agents?id=${this.agentId}&cid=${capabilityId}`,
+      `https://app.customeros.ai/agents?state=${encodeURIComponent(
+        `${this.agentId}?cid=${capabilityId}`,
+      )}`,
     );
   }
 

--- a/packages/apps/frontera/src/routes/agents/hooks/useSlackOauthCallback.ts
+++ b/packages/apps/frontera/src/routes/agents/hooks/useSlackOauthCallback.ts
@@ -16,9 +16,9 @@ export const useSlackOauthCallback = () => {
   const [queryParams] = useSearchParams();
 
   useEffect(() => {
-    const agentId = queryParams.get('id');
-    const capabilityId = queryParams.get('cid');
+    const state = queryParams.get('state');
     const slackCode = queryParams.get('code');
+    const path = decodeURIComponent(state ?? '');
 
     if (!store.session.isAuthenticated) return;
 
@@ -26,10 +26,8 @@ export const useSlackOauthCallback = () => {
       store.settings.slack.oauthCallback(slackCode);
     }
 
-    if (agentId) {
-      navigate(
-        `/agents/${agentId}${capabilityId ? `?cid=${capabilityId}` : ''}`,
-      );
+    if (path) {
+      navigate(`/agents/${path}`);
     }
   }, [store.session.isAuthenticated]);
 };

--- a/packages/apps/frontera/src/store/Settings/Slack.store.ts
+++ b/packages/apps/frontera/src/store/Settings/Slack.store.ts
@@ -77,10 +77,10 @@ export class Slack {
     try {
       this.isLoading = true;
 
+      const redirectUri = redirect_uri ?? 'https://app.customeros.ai/settings';
+
       const { data } = await this.transportLayer.http.get(
-        `/sa/slack/requestAccess?redirect_uri=${
-          redirect_uri ?? 'https://app.customeros.ai/settings'
-        }`,
+        `/sa/slack/requestAccess?redirect_uri=${redirectUri}`,
       );
 
       window.location.href = data.url;


### PR DESCRIPTION
…oved URL management
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor Slack OAuth handling to use encoded state parameter for improved URL management, affecting URL construction and parsing in `add-slack-channel.usecase.ts`, `useSlackOauthCallback.ts`, and `Slack.store.ts`.
> 
>   - **Behavior**:
>     - Refactor Slack OAuth URL in `add-slack-channel.usecase.ts` to use encoded `state` parameter instead of separate `id` and `cid`.
>     - Update `useSlackOauthCallback` to decode `state` parameter for navigation.
>   - **Functions**:
>     - Modify `enableSync` in `Slack.store.ts` to use `redirectUri` with encoded `state`.
>   - **Misc**:
>     - Remove separate handling of `agentId` and `capabilityId` in favor of `state` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 963aeea1c9a1934179b50749ac5d703871add343. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->