### PR TITLE
Fix slack

### DIFF
--- a/packages/server/customer-os-api/rest/private/slack.go
+++ b/packages/server/customer-os-api/rest/private/slack.go
@@ -94,12 +94,15 @@ func CallbackSlack(s *cosapi_services.Services) gin.HandlerFunc {
 		}
 
 		code := c.Request.URL.Query().Get("code")
+		redirectUri := c.Request.URL.Query().Get("redirect_uri")
 		span.LogKV("code", code)
+		span.LogKV("redirectUri", redirectUri)
 
 		requestData := url.Values{}
 		requestData.Set("code", code)
 		requestData.Set("client_id", s.Cfg.Common.External.SlackConfig.ClientID)
 		requestData.Set("client_secret", s.Cfg.Common.External.SlackConfig.ClientSecret)
+		requestData.Set("redirect_url", redirectUri)
 
 		// Encode the form data
 		requestBody := requestData.Encode()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `redirect_uri` handling in `CallbackSlack` function to include it in Slack OAuth API request.
> 
>   - **Behavior**:
>     - In `CallbackSlack` function, added handling for `redirect_uri` parameter from request.
>     - `redirect_uri` is logged and included in the request to Slack's OAuth API as `redirect_url`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f3bf872639c1f1cea5b53dddd4b4fee3ef6c526f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->