### PR TITLE
set contract name

### DIFF
--- a/packages/server/customer-os-common-module/services/contract/service.go
+++ b/packages/server/customer-os-common-module/services/contract/service.go
@@ -93,7 +93,7 @@ func (s *contractService) Save(ctx context.Context, id *string, dataFields data_
 	createFlow := false
 	contractId := ""
 
-	if id == nil || *id == "" {
+	if utils.IfNotNilString(id) == "" {
 		createFlow = true
 		span.LogKV("flow", "create")
 		contractId, err = s.neo4j.CommonReadRepository.GenerateId(ctx, tenant, model.NodeLabelContract)
@@ -101,7 +101,7 @@ func (s *contractService) Save(ctx context.Context, id *string, dataFields data_
 			tracing.TraceErr(span, err)
 			return "", err
 		}
-		// set missing fields for create flow
+		// set default fields for create flow
 		if dataFields.CreatedAt == nil {
 			dataFields.CreatedAt = utils.NowPtr()
 		} else {
@@ -112,6 +112,17 @@ func (s *contractService) Save(ctx context.Context, id *string, dataFields data_
 		}
 		if utils.IfNotNilString(dataFields.Source) == "" {
 			dataFields.Source = utils.StringPtr(neo4jentity.DataSourceOpenline.String())
+		}
+		if utils.IfNotNilString(dataFields.Name) == "" {
+			if utils.IfNotNilString(dataFields.OrganizationId) != "" {
+				organizationEntity, err := s.organization.GetById(ctx, tenant, utils.IfNotNilString(dataFields.OrganizationId))
+				if err != nil {
+					tracing.TraceErr(span, errors.Wrap(err, "unable to get organization"))
+					s.log.Errorf("unable to get organization: %s", err.Error())
+					return "", err
+				}
+				dataFields.Name = utils.StringPtr(organizationEntity.Name)
+			}
 		}
 	} else {
 		span.LogKV("flow", "update")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set default contract name to organization's name during creation in `contractService.Save()` if `Name` is empty.
> 
>   - **Behavior**:
>     - In `contractService.Save()`, set `dataFields.Name` to the organization's name if `Name` is empty and `OrganizationId` is provided.
>     - This change applies only during the contract creation flow.
>   - **Misc**:
>     - Update comment from "set missing fields for create flow" to "set default fields for create flow" in `contractService.Save()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 532d5f90ec16da2f16646e75420462eb39f127c0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->