### PR TITLE
COS-6743: Fix order of header elements on organization details panel

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
+++ b/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
@@ -107,39 +107,41 @@ export const OrganizationDetails = observer(
             <p className='font-semibold text-base mt-0.5 overflow-hidden overflow-ellipsis'>
               {organization?.value?.name ?? ''}
             </p>
-            {previewCard && (
-              <IconButton
-                size='xs'
-                variant='ghost'
-                icon={<Icon name='x-close' />}
-                onClick={() => setPreviewCard(false)}
-                aria-label='close preview organization'
-              />
-            )}
 
-            {organization.value?.referenceId && (
-              <div className='ml-4'>
-                <Tooltip asChild={false} label={'Copy ID'}>
-                  <Tag
-                    variant='outline'
-                    colorScheme='gray'
-                    className='cursor-pointer w-full max-w-[100px]'
-                    onClick={() => {
-                      copyToClipboard(
-                        organization.value?.referenceId ?? '',
-                        'Reference ID copied ',
-                      );
-                    }}
-                  >
-                    <TagLabel className='truncate overflow-hidden whitespace-nowrap'>
-                      {organization.value?.referenceId}
-                    </TagLabel>
-                  </Tag>
-                </Tooltip>
-              </div>
-            )}
+            <div className='flex items-center justify-between gap-x-2'>
+              {organization.value?.referenceId && (
+                <div className='ml-4'>
+                  <Tooltip asChild={false} label={'Copy ID'}>
+                    <Tag
+                      variant='outline'
+                      colorScheme='gray'
+                      className='cursor-pointer w-full max-w-[100px]'
+                      onClick={() => {
+                        copyToClipboard(
+                          organization.value?.referenceId ?? '',
+                          'Reference ID copied ',
+                        );
+                      }}
+                    >
+                      <TagLabel className='truncate overflow-hidden whitespace-nowrap'>
+                        {organization.value?.referenceId}
+                      </TagLabel>
+                    </Tag>
+                  </Tooltip>
+                </div>
+              )}
 
-            <IcpBadge id={store.ui.focusRow ?? id} />
+              <IcpBadge id={store.ui.focusRow ?? id} />
+              {previewCard && (
+                <IconButton
+                  size='xs'
+                  variant='ghost'
+                  icon={<Icon name='x-close' />}
+                  onClick={() => setPreviewCard(false)}
+                  aria-label='close preview organization'
+                />
+              )}
+            </div>
           </div>
 
           <Domains />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reorder header elements in `OrganizationDetails.tsx` to group `referenceId` and `IcpBadge`, followed by `IconButton`.
> 
>   - **UI Changes**:
>     - Reorder elements in the header of `OrganizationDetails.tsx`.
>     - Group `referenceId` and `IcpBadge` together, followed by `IconButton`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 415e152f03c231c390bcff97dfcb769755c24645. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->