### PR TITLE
COS-6741: Fix resetting of the loading state after validation is triggered in the "Add Single Contact" command menu

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/contact-details/create-contact.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/contact-details/create-contact.usecase.ts
@@ -52,28 +52,22 @@ export class CreateContactUsecase {
   }
 
   @action
-  private validateInput(): boolean {
+  private validateInput() {
     const error = this.errors[this.type];
 
     if (!this.inputValue) {
       error.isEmpty = true;
-
-      return false;
     }
 
     if (this.type === 'name') {
-      return true;
+      return;
     }
 
     const pattern = this.PATTERNS[this.type];
 
     if (!pattern.test(this.inputValue)) {
       error.isInvalid = true;
-
-      return false;
     }
-
-    return true;
   }
 
   @action
@@ -123,6 +117,9 @@ export class CreateContactUsecase {
         this.root.ui.commandMenu.clearContext();
         this.root.ui.toastSuccess('Contact created', 'contact-email-created');
       },
+      onError: () => {
+        this.isLoading = false;
+      },
     };
 
     switch (this.type) {
@@ -168,14 +165,17 @@ export class CreateContactUsecase {
   async submit() {
     this.clearErrors();
     this.isLoading = true;
+    this.validateInput();
 
-    if (!this.validateInput()) {
+    if (this.errors[this.type].isEmpty || this.errors[this.type].isInvalid) {
       this.isLoading = false;
 
       return;
     }
 
     if (this.type !== 'name' && !(await this.checkExisting())) {
+      this.isLoading = false;
+
       return;
     }
 

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/AddSingleContact.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/AddSingleContact.tsx
@@ -134,6 +134,10 @@ export const AddSingleContact = observer(() => {
               if (e.key === 'Escape') {
                 handleClose(e);
               }
+
+              if (e.key === 'Enter') {
+                handleSubmit();
+              }
               e.stopPropagation();
             }}
           />

--- a/packages/apps/frontera/src/store/Contacts/Contacts.store.ts
+++ b/packages/apps/frontera/src/store/Contacts/Contacts.store.ts
@@ -302,7 +302,7 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
   @action
   async create(
     organizationId: string,
-    options?: { onSuccess?: (serverId: string) => void },
+    options?: { onError?: () => void; onSuccess?: (serverId: string) => void },
     input?: ContactInput,
   ) {
     let serverId: string | undefined;
@@ -332,6 +332,7 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
       });
     } catch (e) {
       runInAction(() => {
+        options?.onError?.();
         this.error = (e as Error)?.message;
       });
     } finally {
@@ -344,7 +345,7 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
   @action
   async createWithEmail(
     organizationId: string,
-    options?: { onSuccess?: (serverId: string) => void },
+    options?: { onError?: () => void; onSuccess?: (serverId: string) => void },
     input?: ContactInput,
   ) {
     let serverId: string | undefined;
@@ -397,6 +398,7 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
       });
     } catch (e) {
       runInAction(() => {
+        options?.onError?.();
         this.error = (e as Error)?.message;
       });
     } finally {
@@ -415,6 +417,7 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
     socialUrl: string;
     organizationId: string;
     options?: {
+      onError?: () => void;
       onSuccess?: (serverId: string) => void;
     };
   }) {
@@ -462,6 +465,7 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
         `We couldn't create this contact. Please try again.`,
         'create-contract-error',
       );
+      options?.onError?.();
       runInAction(() => {
         this.error = (e as Error)?.message;
       });


### PR DESCRIPTION
…
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes loading state reset and improves error handling in 'Add Single Contact' feature by updating `validateInput` and adding `onError` callbacks.
> 
>   - **Behavior**:
>     - Fixes loading state reset in `submit()` of `CreateContactUsecase` by removing boolean return from `validateInput()`.
>     - Adds `onError` callback to handle errors in `create`, `createWithEmail`, and `createWithSocial` in `Contacts.store.ts`.
>     - Handles `Enter` key to trigger `handleSubmit()` in `AddSingleContact.tsx`.
>   - **Validation**:
>     - `validateInput()` in `create-contact.usecase.ts` no longer returns a boolean, directly sets error states.
>   - **Error Handling**:
>     - Adds `onError` callback in `Contacts.store.ts` methods to reset `isLoading` on error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 421e7526bbf1f8a57f4424b5ba44f7d418189073. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->