### PR TITLE
Fix slack oauth callback

### DIFF
--- a/packages/server/customer-os-api/rest/private/slack.go
+++ b/packages/server/customer-os-api/rest/private/slack.go
@@ -72,6 +72,11 @@ func RequestAccessSlack(s *cosapi_services.Services) gin.HandlerFunc {
 		if redirectUri != "" {
 			slackRequestAccessUrl += "&redirect_uri=" + url.QueryEscape(redirectUri)
 		}
+		state := c.Query("state")
+
+		if state != "" {
+			slackRequestAccessUrl += "&state=" + url.QueryEscape(state)
+		}
 
 		span.LogFields(log.Object("slackRequestAccessUrl", slackRequestAccessUrl))
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `state` parameter to Slack OAuth request URL in `RequestAccessSlack` function in `slack.go`.
> 
>   - **Behavior**:
>     - Add `state` parameter to Slack OAuth request URL in `RequestAccessSlack` function in `slack.go` if present in query.
>   - **Logging**:
>     - Log `state` parameter in `RequestAccessSlack` function in `slack.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 6ece71b180b6d16222b748debec8e9ae123e34b4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->