### PR TITLE
Fix slack oauth callback

### DIFF
--- a/packages/server/customer-os-api/rest/private/slack.go
+++ b/packages/server/customer-os-api/rest/private/slack.go
@@ -67,10 +67,10 @@ func RequestAccessSlack(s *cosapi_services.Services) gin.HandlerFunc {
 		}
 		slackRequestAccessUrl := "https://slack.com/oauth/v2/authorize?client_id=" + s.Cfg.Common.External.SlackConfig.ClientID + "&scope=" + strings.Join(scopes, ",") + "&user_scope="
 
-		redirectUri := c.Query("redirect_uri")
+		redirectUrl := c.Query("redirect_url")
 
-		if redirectUri != "" {
-			slackRequestAccessUrl += "&redirect_uri=" + url.QueryEscape(redirectUri)
+		if redirectUrl != "" {
+			slackRequestAccessUrl += "&redirect_url=" + url.QueryEscape(redirectUrl)
 		}
 		state := c.Query("state")
 
@@ -99,15 +99,15 @@ func CallbackSlack(s *cosapi_services.Services) gin.HandlerFunc {
 		}
 
 		code := c.Request.URL.Query().Get("code")
-		redirectUri := c.Request.URL.Query().Get("redirect_uri")
+		redirectUrl := c.Request.URL.Query().Get("redirect_url")
 		span.LogKV("code", code)
-		span.LogKV("redirectUri", url.QueryEscape(redirectUri))
+		span.LogKV("redirectUrl", url.QueryEscape(redirectUrl))
 
 		requestData := url.Values{}
 		requestData.Set("code", code)
 		requestData.Set("client_id", s.Cfg.Common.External.SlackConfig.ClientID)
 		requestData.Set("client_secret", s.Cfg.Common.External.SlackConfig.ClientSecret)
-		requestData.Set("redirect_url", url.QueryEscape(redirectUri))
+		requestData.Set("redirect_url", url.QueryEscape(redirectUrl))
 
 		// Encode the form data
 		requestBody := requestData.Encode()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes Slack OAuth callback by changing `redirect_uri` to `redirect_url` in `RequestAccessSlack` and `CallbackSlack`.
> 
>   - **Behavior**:
>     - Fixes Slack OAuth callback by changing `redirect_uri` to `redirect_url` in `RequestAccessSlack` and `CallbackSlack` functions.
>     - Ensures correct parameter name is used for Slack OAuth requests.
>   - **Logging**:
>     - Updates log key from `redirectUri` to `redirectUrl` in `CallbackSlack`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 334d937bd79b6afb831566e4579b8e9767001aee. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->