### PR TITLE
Fix slack oauth callback

### DIFF
--- a/packages/server/customer-os-api/rest/private/slack.go
+++ b/packages/server/customer-os-api/rest/private/slack.go
@@ -67,15 +67,16 @@ func RequestAccessSlack(s *cosapi_services.Services) gin.HandlerFunc {
 		}
 		slackRequestAccessUrl := "https://slack.com/oauth/v2/authorize?client_id=" + s.Cfg.Common.External.SlackConfig.ClientID + "&scope=" + strings.Join(scopes, ",") + "&user_scope="
 
+		state := c.Query("state")
+
+		if state != "" {
+			slackRequestAccessUrl += "&state=" + state
+		}
+
 		redirectUrl := c.Query("redirect_url")
 
 		if redirectUrl != "" {
 			slackRequestAccessUrl += "&redirect_url=" + url.QueryEscape(redirectUrl)
-		}
-		state := c.Query("state")
-
-		if state != "" {
-			slackRequestAccessUrl += "&state=" + url.QueryEscape(state)
 		}
 
 		span.LogFields(log.Object("slackRequestAccessUrl", slackRequestAccessUrl))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `state` parameter handling in `RequestAccessSlack` by appending it directly to the URL without encoding.
> 
>   - **Behavior**:
>     - Fixes `state` parameter handling in `RequestAccessSlack` in `slack.go` by appending it directly to `slackRequestAccessUrl` without URL encoding.
>   - **Misc**:
>     - Reorders code to append `state` before `redirect_url` in `RequestAccessSlack`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 33ef9a39a9358d2e3abab1cb305f24b2544c85f7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->