### PR TITLE
refactor: update Slack OAuth redirect URLs to use environment variable

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-slack-channel.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-slack-channel.usecase.ts
@@ -189,9 +189,8 @@ export class AddSlackChannelUsecase {
     }
 
     this.root.settings.slack.enableSync(
-      `https://app.customeros.ai/agents?state=${encodeURIComponent(
-        `${this.agentId}:cid=${capabilityId}`,
-      )}`,
+      `${import.meta.env.VITE_CLIENT_APP_URL}/agents`,
+      encodeURIComponent(`${this.agentId}:cid=${capabilityId}`),
     );
   }
 

--- a/packages/apps/frontera/src/routes/agent/page.tsx
+++ b/packages/apps/frontera/src/routes/agent/page.tsx
@@ -7,7 +7,6 @@ import { AgentViewUsecase } from '@domain/usecases/agents/agent-view.usecase';
 
 import { cn } from '@ui/utils/cn';
 import { Icon, IconName } from '@ui/media/Icon';
-import { CapabilityType } from '@graphql/types';
 import { useStore } from '@shared/hooks/useStore';
 
 import { Header, capabilities } from './components';
@@ -77,44 +76,41 @@ export const AgentPage = observer(() => {
           <h2 className='mb-2 font-medium text-sm'>This agent will:</h2>
 
           <ul className='space-y-1'>
-            {agent?.value.capabilities.map((capability) =>
-              capability.type !==
-              CapabilityType.WebVisitorSendSlackNotification ? (
-                <div
-                  key={capability.id}
-                  onClick={() => {
-                    if (capability.config.length) {
-                      usecase.setActiveCapability(capability);
-                      navigate(`?cid=${capability.id}`);
+            {agent?.value.capabilities.map((capability) => (
+              <div
+                key={capability.id}
+                onClick={() => {
+                  if (capability.config.length) {
+                    usecase.setActiveCapability(capability);
+                    navigate(`?cid=${capability.id}`);
+                  }
+                }}
+                className={cn(
+                  'flex items-center px-2 py-1 justify-between rounded-lg select-none',
+                  capability.config.length &&
+                    'hover:bg-grayModern-200 cursor-pointer',
+                  capability.id === usecase?.activeCapability?.id &&
+                    'bg-grayModern-100 hover:bg-grayModern-100',
+                )}
+              >
+                <div className='flex items-center gap-2'>
+                  <Icon
+                    stroke={capability.errors ? 'currentColor' : 'none'}
+                    name={capability.errors ? 'radio-dot' : 'dot-single'}
+                    className={
+                      capability.errors
+                        ? 'text-error-500'
+                        : 'text-grayModern-500'
                     }
-                  }}
-                  className={cn(
-                    'flex items-center px-2 py-1 justify-between rounded-lg select-none',
-                    capability.config.length &&
-                      'hover:bg-grayModern-200 cursor-pointer',
-                    capability.id === usecase?.activeCapability?.id &&
-                      'bg-grayModern-100 hover:bg-grayModern-100',
-                  )}
-                >
-                  <div className='flex items-center gap-2'>
-                    <Icon
-                      stroke={capability.errors ? 'currentColor' : 'none'}
-                      name={capability.errors ? 'radio-dot' : 'dot-single'}
-                      className={
-                        capability.errors
-                          ? 'text-error-500'
-                          : 'text-grayModern-500'
-                      }
-                    />
-                    <p className='text-sm'>{capability.name ?? 'Unknown'}</p>
-                  </div>
-
-                  {capability.config.length > 0 && (
-                    <Icon name='settings-02' className='text-grayModern-500' />
-                  )}
+                  />
+                  <p className='text-sm'>{capability.name ?? 'Unknown'}</p>
                 </div>
-              ) : null,
-            )}
+
+                {capability.config.length > 0 && (
+                  <Icon name='settings-02' className='text-grayModern-500' />
+                )}
+              </div>
+            ))}
           </ul>
         </div>
 

--- a/packages/apps/frontera/src/routes/agents/hooks/useSlackOauthCallback.ts
+++ b/packages/apps/frontera/src/routes/agents/hooks/useSlackOauthCallback.ts
@@ -25,12 +25,12 @@ export const useSlackOauthCallback = () => {
     if (slackCode) {
       store.settings.slack.oauthCallback(
         slackCode,
-        `https://app.customeros.ai/agents?state=${state}`,
+        `${import.meta.env.VITE_CLIENT_APP_URL}/agents`,
       );
     }
 
     if (id) {
-      navigate(`/agents/${id}?cid=${cid}`);
+      navigate(`/agents/${id}?${cid}`);
     }
   }, [store.session.isAuthenticated]);
 };

--- a/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/AuthPanel/AuthPanel.tsx
+++ b/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/AuthPanel/AuthPanel.tsx
@@ -17,7 +17,7 @@ export const AuthPanel = observer(() => {
     if (queryParams && queryParams.has('code')) {
       store.settings.slack.oauthCallback(
         queryParams.get('code') as string,
-        'https://app.customeros.ai/settings',
+        `${import.meta.env.VITE_CLIENT_APP_URL}/settings`,
       );
     }
   }, [queryParams]);

--- a/packages/apps/frontera/src/store/Settings/Slack.store.ts
+++ b/packages/apps/frontera/src/store/Settings/Slack.store.ts
@@ -56,7 +56,7 @@ export class Slack {
     try {
       this.isLoading = true;
       await this.transportLayer.http.post(
-        `/sa/slack/oauth/callback?code=${code}&redirect_uri=${redirect_uri}`,
+        `/sa/slack/oauth/callback?code=${code}&redirect_url=${redirect_uri}`,
       );
       this.load();
       this.root.common.fetchSlackChannels();
@@ -71,7 +71,7 @@ export class Slack {
     }
   }
 
-  async enableSync(redirect_uri?: string) {
+  async enableSync(redirect_uri?: string, state?: string) {
     Tracer.span('Slack.enableSync');
 
     try {
@@ -80,7 +80,7 @@ export class Slack {
       const redirectUri = redirect_uri ?? 'https://app.customeros.ai/settings';
 
       const { data } = await this.transportLayer.http.get(
-        `/sa/slack/requestAccess?redirect_uri=${redirectUri}`,
+        `/sa/slack/requestAccess?redirect_url=${redirectUri}&state=${state}`,
       );
 
       window.location.href = data.url;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor Slack OAuth redirect URLs to use environment variable `VITE_CLIENT_APP_URL` and update related functions for consistency.
> 
>   - **Behavior**:
>     - Update Slack OAuth redirect URLs to use `import.meta.env.VITE_CLIENT_APP_URL` in `add-slack-channel.usecase.ts`, `useSlackOauthCallback.ts`, and `AuthPanel.tsx`.
>     - Modify `navigate` function in `useSlackOauthCallback.ts` to use `?${cid}` instead of `?cid=${cid}`.
>   - **Functions**:
>     - Update `enableSync()` and `oauthCallback()` in `Slack.store.ts` to use `redirect_url` instead of `redirect_uri`.
>     - Add `state` parameter to `enableSync()` in `Slack.store.ts`.
>   - **Misc**:
>     - Remove unused import `CapabilityType` from `page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c6a7e423867c8c46d38b2ce7118f0e1f731aaf8f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->