### PR TITLE
COS-6748: Fix saving notes, move related logic to usecase

### DIFF
--- a/packages/apps/frontera/src/domain/services/organization/organizations.service.ts
+++ b/packages/apps/frontera/src/domain/services/organization/organizations.service.ts
@@ -396,8 +396,6 @@ export class OrganizationService {
 
     organization.setNotes(notes);
 
-    organization.value.notes = notes;
-
     const [res, err] = await unwrap(
       this.orgRepo.saveOrganization({
         input: {

--- a/packages/apps/frontera/src/domain/services/organization/organizations.service.ts
+++ b/packages/apps/frontera/src/domain/services/organization/organizations.service.ts
@@ -350,11 +350,11 @@ export class OrganizationService {
       ?.setRenewalAdjustedRate(renewalLikelihood);
 
     const amount =
-      this.root.organizations.getById(orgId)?.value.renewalSummaryArrForecast ??
-      0;
+      this.root.organizations.getById(orgId)?.value
+        ?.renewalSummaryArrForecast ?? 0;
     const potentialAmount =
       this.root.organizations.getById(orgId)?.value
-        .renewalSummaryMaxArrForecast ?? 0;
+        ?.renewalSummaryMaxArrForecast ?? 0;
     const rate =
       amount === 0 || potentialAmount === 0
         ? 0
@@ -384,6 +384,34 @@ export class OrganizationService {
         'Failed to update opportunity renewals',
         'update-opportunity-renewals',
       );
+
+      return [null, err];
+    }
+
+    return [res, err];
+  }
+
+  public async updateNotes(organization: Organization, notes: string) {
+    const prevNotes = organization.value.notes ?? '';
+
+    organization.setNotes(notes);
+
+    organization.value.notes = notes;
+
+    const [res, err] = await unwrap(
+      this.orgRepo.saveOrganization({
+        input: {
+          id: organization.id,
+          notes,
+        },
+      }),
+    );
+
+    if (err) {
+      console.error(err);
+      organization.setNotes(prevNotes);
+
+      this.root.ui.toastError('Failed to update notes', 'update-notes');
 
       return [null, err];
     }

--- a/packages/apps/frontera/src/domain/usecases/organization-details/edit-organization-notes.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/organization-details/edit-organization-notes.usecase.ts
@@ -1,0 +1,48 @@
+import { RootStore } from '@store/root';
+import { action, computed, observable } from 'mobx';
+import { OrganizationService } from '@domain/services';
+
+export class EditOrganizationNotesUsecase {
+  @observable public accessor note = '';
+
+  private root = RootStore.getInstance();
+  private organizationService = new OrganizationService();
+  private organizationId: string;
+
+  constructor(organizationId: string) {
+    this.organizationId = organizationId;
+    this.setNotes = this.setNotes.bind(this);
+  }
+
+  @computed
+  get organization() {
+    if (!this.organizationId) return;
+
+    return this.root.organizations.getById(this.organizationId);
+  }
+
+  @computed
+  get defaultNote() {
+    return this.organization?.value?.notes ?? '';
+  }
+
+  @action
+  public setNotes(newNote: string) {
+    this.note = newNote;
+  }
+
+  @action
+  public execute() {
+    const organization = this.organization;
+
+    if (!organization) {
+      console.error(
+        'EditOrganizationNoteUsecase: execute called without organization',
+      );
+
+      return;
+    }
+
+    this.organizationService.updateNotes(organization, this.note);
+  }
+}

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/AccountPanel.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/AccountPanel.tsx
@@ -124,6 +124,7 @@ const AccountPanelComponent = observer(() => {
         }
       >
         <Contracts />
+        <Notes id={id} />
       </OrganizationPanel>
     </>
   );

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contracts/Contracts.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contracts/Contracts.tsx
@@ -8,8 +8,6 @@ import { ARRForecast } from '@organization/components/Tabs/panels/AccountPanel/A
 import { ContractModalsContextProvider } from '@organization/components/Tabs/panels/AccountPanel/context/ContractModalsContext.tsx';
 import { ContractModalStatusContextProvider } from '@organization/components/Tabs/panels/AccountPanel/context/ContractStatusModalsContext.tsx';
 
-import { Notes } from '../Notes';
-
 export const Contracts = observer(() => {
   const id = useParams()?.id as string;
   const store = useStore();
@@ -42,8 +40,6 @@ export const Contracts = observer(() => {
           </div>
         );
       })}
-
-      <Notes id={id} />
     </>
   );
 });

--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Notes/Notes.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Notes/Notes.tsx
@@ -1,8 +1,10 @@
+import { useMemo } from 'react';
+
 import { observer } from 'mobx-react-lite';
+import { EditOrganizationNotesUsecase } from '@domain/usecases/organization-details/edit-organization-notes.usecase.ts';
 
 import { File02 } from '@ui/media/icons/File02';
 import { Editor } from '@ui/form/Editor/Editor';
-import { useStore } from '@shared/hooks/useStore';
 import { Divider } from '@ui/presentation/Divider/Divider';
 import { FeaturedIcon } from '@ui/media/Icon/FeaturedIcon';
 import { Card, CardFooter, CardContent } from '@ui/presentation/Card/Card';
@@ -12,8 +14,10 @@ interface NotesProps {
 }
 
 export const Notes = observer(({ id }: NotesProps) => {
-  const store = useStore();
-  const organization = store.organizations.value.get(id);
+  const editNotesUsecase = useMemo(
+    () => new EditOrganizationNotesUsecase(id),
+    [id],
+  );
 
   return (
     <Card className='bg-white p-4 w-full cursor-default hover:shadow-md focus-within:shadow-md transition-all duration-200 ease-out'>
@@ -32,14 +36,12 @@ export const Notes = observer(({ id }: NotesProps) => {
             className='cursor-text'
             namespace='opportunity-next-step'
             placeholderClassName='cursor-text'
-            onFocus={() => organization?.draft()}
-            onBlur={() => organization?.commit()}
+            onBlur={() => editNotesUsecase.execute()}
             dataTest='organization-account-notes-editor'
-            defaultHtmlValue={organization?.value?.notes ?? ''}
+            defaultHtmlValue={editNotesUsecase.defaultNote ?? ''}
             placeholder='Write some notes or anything related to this customer'
             onChange={(html) => {
-              if (!organization) return;
-              organization.value.notes = html;
+              editNotesUsecase.setNotes(html);
             }}
           />
         </div>

--- a/packages/apps/frontera/src/store/Organizations/Organization.dto.ts
+++ b/packages/apps/frontera/src/store/Organizations/Organization.dto.ts
@@ -256,6 +256,13 @@ export class Organization extends Entity<OrganizationDatum> {
   }
 
   @action
+  public setNotes(notes: string) {
+    this.draft();
+    this.value.notes = notes;
+    this.commit({ syncOnly: true });
+  }
+
+  @action
   public addSocial(url: string) {
     this.value.socialMedia.push({
       id: crypto.randomUUID(),

--- a/packages/apps/frontera/src/ui/form/Editor/plugins/PastePlugin.tsx
+++ b/packages/apps/frontera/src/ui/form/Editor/plugins/PastePlugin.tsx
@@ -25,6 +25,8 @@ export function LinkPastePlugin() {
         const pastedData = clipboardData?.getData('text/plain');
         const selectedText = selection.getTextContent().trim();
 
+        if (!pastedData) return;
+
         if (selectedText.length && isValidUrl(pastedData)) {
           editor.update(() => {
             const linkNode = $createLinkNode(pastedData);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor organization notes update logic by introducing `EditOrganizationNotesUsecase` and updating related UI components.
> 
>   - **Use Case**:
>     - Introduces `EditOrganizationNotesUsecase` in `edit-organization-notes.usecase.ts` to handle note updates for organizations.
>     - Uses MobX for state management with `observable`, `computed`, and `action` decorators.
>   - **Service**:
>     - Adds `updateNotes()` method in `OrganizationService` to update organization notes and handle errors.
>   - **UI Components**:
>     - Updates `Notes` component in `Notes.tsx` to use `EditOrganizationNotesUsecase` for note editing.
>     - Moves `Notes` component from `Contracts.tsx` to `AccountPanel.tsx`.
>   - **Misc**:
>     - Adds `setNotes()` method in `Organization` class in `Organization.dto.ts`.
>     - Fixes null check for `pastedData` in `LinkPastePlugin` in `PastePlugin.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d289d2ea7b160de3bc09da654886ffd9e2d960d3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->