### PR TITLE
COS-6679: Handle fallback for avatars in the table in case images don't load

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/avatar/AvatarCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/avatar/AvatarCell.tsx
@@ -39,7 +39,7 @@ export const AvatarCell = observer(
             }
           }}
           className={cn(
-            'w-6 h-6 flex items-center justify-center rounded border border-gray-200 cursor-pointer focus:outline-none',
+            'w-6 h-6 flex items-center justify-center  border border-gray-200 cursor-pointer focus:outline-none rounded-full',
             {
               'animate-pulse': isEnriching,
               'cursor-default': !canNavigate,
@@ -56,7 +56,7 @@ export const AvatarCell = observer(
                 fetchPriority='low'
                 onError={() => setStatus('error')}
                 onLoad={() => setStatus('loaded')}
-                className={cn('w-full h-full object-contain', {
+                className={cn('w-full h-full object-contain rounded-full', {
                   'opacity-0 size-0': status === 'loading',
                   'opacity-100': status === 'loaded',
                 })}

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/avatar/AvatarCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/avatar/AvatarCell.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { observer } from 'mobx-react-lite';
 import { useLocalStorage } from 'usehooks-ts';
 
@@ -21,6 +23,7 @@ export const AvatarCell = observer(
     const fullName = name || 'Unnamed';
     const contactStore = store.contacts.value.get(id);
     const [previewCard, setPreviewCard] = useLocalStorage('previewCard', false);
+    const [status, setStatus] = useState('loading');
 
     const isEnriching = contactStore?.isEnriching;
 
@@ -43,16 +46,24 @@ export const AvatarCell = observer(
             },
           )}
         >
-          {src ? (
-            <Image
-              src={src}
-              alt={fullName}
-              loading='lazy'
-              decoding='async'
-              fetchPriority='low'
-              className='w-full h-full object-contain'
-            />
-          ) : (
+          {src && status !== 'error' && (
+            <>
+              <Image
+                src={src}
+                alt={fullName}
+                loading='lazy'
+                decoding='async'
+                fetchPriority='low'
+                onError={() => setStatus('error')}
+                onLoad={() => setStatus('loaded')}
+                className={cn('w-full h-full object-contain', {
+                  'opacity-0 size-0': status === 'loading',
+                  'opacity-100': status === 'loaded',
+                })}
+              />
+            </>
+          )}
+          {(!src || status === 'error' || status === 'loading') && (
             <User02 className='w-4 h-4 text-gray-700' />
           )}
         </div>

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/avatar/AvatarCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/avatar/AvatarCell.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useLocalStorage } from 'usehooks-ts';
@@ -25,6 +25,7 @@ export const AvatarCell = memo(
 
     const src = icon || logo;
     const fullName = name || 'Unnamed';
+    const [status, setStatus] = useState('loading');
 
     const handleNavigate = () => {
       const lastPositionParams = tabs[id];
@@ -44,16 +45,23 @@ export const AvatarCell = memo(
             },
           )}
         >
-          {src ? (
+          {src && status !== 'error' && (
             <Image
               src={src}
               alt={fullName}
               loading='lazy'
               decoding='async'
               fetchPriority='low'
-              className='w-full h-full object-contain'
+              onError={() => setStatus('error')}
+              onLoad={() => setStatus('loaded')}
+              className={cn('w-full h-full object-contain', {
+                'opacity-0 size-0': status === 'loading',
+                'opacity-100': status === 'loaded',
+              })}
             />
-          ) : (
+          )}
+
+          {(!src || status === 'error' || status === 'loading') && (
             <Building06 className='w-4 h-4 text-gray-700' />
           )}
         </div>


### PR DESCRIPTION
…
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds fallback logic for avatar images in `AvatarCell` components for contacts and organizations, displaying default icons if images fail to load.
> 
>   - **Behavior**:
>     - Adds `status` state in `AvatarCell` components for contacts and organizations to handle image loading states.
>     - Displays default icon (`User02` for contacts, `Building06` for organizations) if image fails to load or is loading.
>     - Uses `onError` and `onLoad` handlers in `Image` component to update `status`.
>   - **Components**:
>     - Updates `AvatarCell` in `contacts/Cells/avatar/AvatarCell.tsx` and `organizations/Cells/avatar/AvatarCell.tsx` to include fallback logic for avatars.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8b4b1371e28fc4179e4e63f8de82ea5d1b396c13. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->