### PR TITLE
feat: add regex pattern for localcan.dev URLs in production config

### DIFF
--- a/packages/server/realtime/config/prod.exs
+++ b/packages/server/realtime/config/prod.exs
@@ -11,7 +11,8 @@ config :realtime, RealtimeWeb.Endpoint,
     "https://app.customeros.dev",
     "https://app.customeros.ai",
     "https://frontera.customeros.ai",
-    "https://frontera.openline.dev"
+    "https://frontera.openline.dev",
+    ~r/^https?:\/\/([a-z0-9-]+)\.localcan\.dev$/
   ]
 
 # Configures Swoosh API Client


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add regex pattern to `check_origin` in `prod.exs` for `localcan.dev` subdomains.
> 
>   - **Configuration**:
>     - Added regex pattern `~r/^https?:\\/\\/([a-z0-9-]+)\\.localcan\\.dev$/` to `check_origin` in `prod.exs` to allow matching `localcan.dev` subdomains.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for fc9aa9d3686170e37194bd093c7da1a6287798c6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->