### PR TITLE
COS-6755: Fix contract name cell

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contracts/Cells/contract/ContractCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contracts/Cells/contract/ContractCell.tsx
@@ -17,13 +17,12 @@ export const ContractCell = observer(({ contractId }: ContractCellProps) => {
   const store = useStore();
 
   const contract = store.contracts.value.get(contractId) as ContractStore;
-  const org = contract.organization;
   const linkRef = useRef<HTMLParagraphElement>(null);
 
   const handleNavigate = () => {
-    if (!org?.id) return;
+    if (!contract?.organizationId) return;
 
-    const href = getHref(org?.id);
+    const href = getHref(contract.organizationId);
 
     if (!href) return;
 
@@ -38,12 +37,9 @@ export const ContractCell = observer(({ contractId }: ContractCellProps) => {
       data-test='Contract-name-in-all-orgs-table'
       className={cn(
         'overflow-ellipsis overflow-hidden font-medium no-underline hover:no-underline cursor-pointer pr-7',
-        {
-          'text-gray-400 cursor-not-allowed': !org?.id,
-        },
       )}
     >
-      {contract?.value?.contractName || `${org?.value?.name}`}
+      {contract?.value?.contractName || `${contract.organization?.value?.name}`}
     </div>
   );
 });

--- a/packages/apps/frontera/src/routes/src/types/__generated__/graphql.types.ts
+++ b/packages/apps/frontera/src/routes/src/types/__generated__/graphql.types.ts
@@ -139,6 +139,7 @@ export type Attachment = Node & {
   mimeType: Scalars['String']['output'];
   size: Scalars['Int64']['output'];
   source: DataSource;
+  /** @deprecated No longer supported */
   sourceOfTruth: DataSource;
 };
 
@@ -272,6 +273,7 @@ export type BillingProfile = Node &
     id: Scalars['ID']['output'];
     legalName: Scalars['String']['output'];
     source: DataSource;
+    /** @deprecated No longer supported */
     sourceOfTruth: DataSource;
     taxId: Scalars['String']['output'];
     updatedAt: Scalars['Time']['output'];
@@ -318,6 +320,7 @@ export type Calendar = {
   link?: Maybe<Scalars['String']['output']>;
   primary: Scalars['Boolean']['output'];
   source: DataSource;
+  /** @deprecated No longer supported */
   sourceOfTruth: DataSource;
   updatedAt: Scalars['Time']['output'];
 };
@@ -489,6 +492,7 @@ export type Comment = {
   externalLinks: Array<ExternalSystem>;
   id: Scalars['ID']['output'];
   source: DataSource;
+  /** @deprecated No longer supported */
   sourceOfTruth: DataSource;
   updatedAt: Scalars['Time']['output'];
 };
@@ -848,6 +852,7 @@ export type Contract = MetadataInterface & {
    */
   name: Scalars['String']['output'];
   opportunities?: Maybe<Array<Opportunity>>;
+  organization: Organization;
   /**
    * Deprecated, use billingDetails instead.
    * @deprecated Use billingDetails instead.
@@ -1926,6 +1931,7 @@ export type InteractionEvent = Node & {
   sentBy: Array<InteractionEventParticipant>;
   sentTo: Array<InteractionEventParticipant>;
   source: DataSource;
+  /** @deprecated No longer supported */
   sourceOfTruth: DataSource;
 };
 
@@ -1949,6 +1955,7 @@ export type InteractionSession = Node & {
   identifier: Scalars['String']['output'];
   name: Scalars['String']['output'];
   source: DataSource;
+  /** @deprecated No longer supported */
   sourceOfTruth: DataSource;
   status: Scalars['String']['output'];
   type?: Maybe<Scalars['String']['output']>;
@@ -2151,6 +2158,7 @@ export type Issue = Node &
     priority?: Maybe<Scalars['String']['output']>;
     reportedBy?: Maybe<IssueParticipant>;
     source: DataSource;
+    /** @deprecated No longer supported */
     sourceOfTruth: DataSource;
     /**
      * Deprecated: Use issueStatus field instead
@@ -2293,6 +2301,7 @@ export type Location = Node &
     rawAddress?: Maybe<Scalars['String']['output']>;
     region?: Maybe<Scalars['String']['output']>;
     source: DataSource;
+    /** @deprecated No longer supported */
     sourceOfTruth: DataSource;
     street?: Maybe<Scalars['String']['output']>;
     timeZone?: Maybe<Scalars['String']['output']>;
@@ -2335,6 +2344,7 @@ export type LogEntry = {
   externalLinks: Array<ExternalSystem>;
   id: Scalars['ID']['output'];
   source: DataSource;
+  /** @deprecated No longer supported */
   sourceOfTruth: DataSource;
   startedAt: Scalars['Time']['output'];
   tags: Array<Tag>;
@@ -2400,6 +2410,7 @@ export type Meeting = Node & {
   note: Array<Note>;
   recording?: Maybe<Attachment>;
   source: DataSource;
+  /** @deprecated No longer supported */
   sourceOfTruth: DataSource;
   startedAt?: Maybe<Scalars['Time']['output']>;
   status: MeetingStatus;
@@ -2510,11 +2521,17 @@ export type Mutation = {
   bankAccount_Create: BankAccount;
   bankAccount_Delete: DeleteResponse;
   bankAccount_Update: BankAccount;
+  /** @deprecated No longer supported */
   billingProfile_Create: Scalars['ID']['output'];
+  /** @deprecated No longer supported */
   billingProfile_LinkEmail: Scalars['ID']['output'];
+  /** @deprecated No longer supported */
   billingProfile_LinkLocation: Scalars['ID']['output'];
+  /** @deprecated No longer supported */
   billingProfile_UnlinkEmail: Scalars['ID']['output'];
+  /** @deprecated No longer supported */
   billingProfile_UnlinkLocation: Scalars['ID']['output'];
+  /** @deprecated No longer supported */
   billingProfile_Update: Scalars['ID']['output'];
   contact_AddNewLocation: Location;
   contact_AddOrganizationById: Contact;
@@ -3435,6 +3452,7 @@ export type Note = {
   id: Scalars['ID']['output'];
   includes: Array<Attachment>;
   source: DataSource;
+  /** @deprecated No longer supported */
   sourceOfTruth: DataSource;
   updatedAt: Scalars['Time']['output'];
 };
@@ -3515,7 +3533,10 @@ export type Opportunity = MetadataInterface & {
   renewedAt?: Maybe<Scalars['Time']['output']>;
   /** Deprecated, use metadata */
   source?: Maybe<DataSource>;
-  /** Deprecated, use metadata */
+  /**
+   * Deprecated, use metadata
+   * @deprecated No longer supported
+   */
   sourceOfTruth?: Maybe<DataSource>;
   stageLastUpdated?: Maybe<Scalars['Time']['output']>;
   /** Deprecated, use metadata */
@@ -4018,6 +4039,7 @@ export type PageView = Node &
     pageUrl: Scalars['String']['output'];
     sessionId: Scalars['ID']['output'];
     source: DataSource;
+    /** @deprecated No longer supported */
     sourceOfTruth: DataSource;
     startedAt: Scalars['Time']['output'];
   };
@@ -4697,6 +4719,7 @@ export type Social = Node &
     id: Scalars['ID']['output'];
     metadata: Metadata;
     source: DataSource;
+    /** @deprecated No longer supported */
     sourceOfTruth: DataSource;
     updatedAt: Scalars['Time']['output'];
     url: Scalars['String']['output'];
@@ -4727,12 +4750,14 @@ export type SourceFields = {
   appSource: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   source: DataSource;
+  /** @deprecated No longer supported */
   sourceOfTruth: DataSource;
 };
 
 export type SourceFieldsInterface = {
   appSource: Scalars['String']['output'];
   source: DataSource;
+  /** @deprecated No longer supported */
   sourceOfTruth: DataSource;
 };
 
@@ -4930,6 +4955,7 @@ export type TenantBillingProfile = Node &
     sendInvoicesBcc: Scalars['String']['output'];
     sendInvoicesFrom: Scalars['String']['output'];
     source: DataSource;
+    /** @deprecated No longer supported */
     sourceOfTruth: DataSource;
     updatedAt: Scalars['Time']['output'];
     vatNumber: Scalars['String']['output'];
@@ -5133,6 +5159,7 @@ export type User = {
   profilePhotoUrl?: Maybe<Scalars['String']['output']>;
   roles: Array<Role>;
   source: DataSource;
+  /** @deprecated No longer supported */
   sourceOfTruth: DataSource;
   test: Scalars['Boolean']['output'];
   timezone?: Maybe<Scalars['String']['output']>;

--- a/packages/apps/frontera/src/store/Contracts/Contract.service.ts
+++ b/packages/apps/frontera/src/store/Contracts/Contract.service.ts
@@ -105,6 +105,11 @@ const CONTRACTS_QUERY = gql`
           source
           lastUpdated
         }
+        organization {
+          metadata {
+            id
+          }
+        }
 
         contractName
         serviceStarted

--- a/packages/apps/frontera/src/store/Contracts/Contract.store.ts
+++ b/packages/apps/frontera/src/store/Contracts/Contract.store.ts
@@ -54,11 +54,11 @@ export class ContractStore implements Store<Contract> {
   }
 
   get organization() {
-    return this.root.organizations
-      .toArray()
-      .find((e) =>
-        e?.contracts?.find((c) => c.metadata.id === this.value.metadata.id),
-      );
+    return this.root.organizations.getById(this.value.organization.metadata.id);
+  }
+
+  get organizationId() {
+    return this.value.organization.metadata.id;
   }
 
   set id(id: string) {
@@ -462,6 +462,11 @@ const defaultValue: Contract = {
   sourceOfTruth: DataSource.Openline,
   status: ContractStatus.Undefined,
   updatedAt: '',
+  organization: {
+    metadata: {
+      id: '',
+    },
+  },
 };
 
 type CONTRACT_QUERY_RESULT = {
@@ -475,6 +480,11 @@ const CONTRACT_QUERY = gql`
         created
         source
         lastUpdated
+      }
+      organization {
+        metadata {
+          id
+        }
       }
 
       contractName

--- a/packages/apps/frontera/src/store/Contracts/Contract.store.ts
+++ b/packages/apps/frontera/src/store/Contracts/Contract.store.ts
@@ -18,6 +18,7 @@ import {
   Currency,
   DataSource,
   Opportunity,
+  Organization,
   ContractStatus,
   ContractUpdateInput,
   ContractRenewalCycle,
@@ -466,7 +467,7 @@ const defaultValue: Contract = {
     metadata: {
       id: '',
     },
-  },
+  } as Organization,
 };
 
 type CONTRACT_QUERY_RESULT = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `ContractCell` to use `organizationId` directly, update GraphQL schema, and adjust store and service for consistency.
> 
>   - **Behavior**:
>     - Refactor `ContractCell` in `ContractCell.tsx` to use `contract.organizationId` directly instead of `org?.id`.
>     - Update `handleNavigate` to use `contract.organizationId` for navigation.
>     - Display contract name or organization name using `contract.organization?.value?.name`.
>   - **GraphQL Schema**:
>     - Add `organization` field to `Contract` type in `graphql.types.ts`.
>     - Mark `sourceOfTruth` in multiple types as deprecated.
>   - **Store and Service**:
>     - Update `Contract.store.ts` to use `organizationId` directly from `contract`.
>     - Modify `CONTRACTS_QUERY` in `Contract.service.ts` to include `organization` metadata.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 9b8429b4cad9fd0bc1be2d5d27cdeb6223d89f2d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->