### PR TITLE
fix: replace root:org with finder

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/organization/OrganizationNameCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/organization/OrganizationNameCell.tsx
@@ -19,7 +19,7 @@ export const OrganizationNameCell = observer(
 
     const [tabs] = useLocalStorage<{
       [key: string]: string;
-    }>(`customeros-player-last-position`, { root: 'organization' });
+    }>(`customeros-player-last-position`, { root: 'finder' });
     const linkRef = useRef<HTMLAnchorElement>(null);
 
     const lastPositionParams = tabs[orgId];

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/opportunities/Cells/organization/OrganizationCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/opportunities/Cells/organization/OrganizationCell.tsx
@@ -20,7 +20,7 @@ export const OrganizationCell = ({
 }: OrganizationCellProps) => {
   const [tabs] = useLocalStorage<{
     [key: string]: string;
-  }>(`customeros-player-last-position`, { root: 'organization' });
+  }>(`customeros-player-last-position`, { root: 'finder' });
   const navigate = useNavigate();
 
   const linkRef = useRef<HTMLParagraphElement>(null);

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/avatar/AvatarCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/avatar/AvatarCell.tsx
@@ -21,7 +21,7 @@ export const AvatarCell = memo(
 
     const [tabs] = useLocalStorage<{
       [key: string]: string;
-    }>(`customeros-player-last-position`, { root: 'organization' });
+    }>(`customeros-player-last-position`, { root: 'finder' });
 
     const src = icon || logo;
     const fullName = name || 'Unnamed';

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/organization/OrganizationCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/organization/OrganizationCell.tsx
@@ -21,7 +21,7 @@ export const OrganizationCell = observer(({ id }: OrganizationCellProps) => {
 
   const [tabs] = useLocalStorage<{
     [key: string]: string;
-  }>(`customeros-player-last-position`, { root: 'organization' });
+  }>(`customeros-player-last-position`, { root: 'finder' });
   const navigate = useNavigate();
 
   const fullName = name || 'Unnamed';

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/shared/Cells/organization/OrganizationCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/shared/Cells/organization/OrganizationCell.tsx
@@ -16,7 +16,7 @@ export const OrganizationCell = observer(({ id }: OrganizationCellProps) => {
   const orgName = store.organizations.getById(id)?.value?.name;
   const [tabs] = useLocalStorage<{
     [key: string]: string;
-  }>(`customeros-player-last-position`, { root: 'organization' });
+  }>(`customeros-player-last-position`, { root: 'finder' });
   const linkRef = useRef<HTMLAnchorElement>(null);
 
   const lastPositionParams = tabs[id];

--- a/packages/apps/frontera/src/routes/finder/src/components/TableViewsToggleNavigation/TableViewsToggleNavigation.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/TableViewsToggleNavigation/TableViewsToggleNavigation.tsx
@@ -15,7 +15,7 @@ export const TableViewsToggleNavigation = observer(() => {
   const preset = searchParams.get('preset');
   const [tabs, setLastActivePosition] = useLocalStorage<{
     [key: string]: string;
-  }>('customeros-player-last-position', { root: 'organizations' });
+  }>('customeros-player-last-position', { root: 'finder' });
 
   const tableViewDefs = store.tableViewDefs.toArray();
   const tableViewDef = store.tableViewDefs.getById(preset || '')?.value;

--- a/packages/apps/frontera/src/routes/settings/src/components/SettingsSidenav/SettingsSidenav.tsx
+++ b/packages/apps/frontera/src/routes/settings/src/components/SettingsSidenav/SettingsSidenav.tsx
@@ -24,7 +24,7 @@ export const SettingsSidenav = observer(() => {
 
   const [lastActivePosition, setLastActivePosition] = useLocalStorage(
     `customeros-player-last-position`,
-    { ['settings']: 'oauth', root: 'organization' },
+    { ['settings']: 'oauth', root: 'finder' },
   );
 
   const hasCampaign = searchParams?.get('campaign') || false;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `root` parameter in `useLocalStorage` from 'organization' to 'finder' across multiple components.
> 
>   - **Behavior**:
>     - Change `root` parameter in `useLocalStorage` from 'organization' to 'finder' in `OrganizationNameCell.tsx`, `OrganizationCell.tsx`, and `AvatarCell.tsx`.
>     - Affects components in `contacts`, `opportunities`, `organizations`, and `shared` directories.
>     - Updates `TableViewsToggleNavigation.tsx` and `SettingsSidenav.tsx` similarly.
>   - **Misc**:
>     - No functional changes other than the `root` parameter update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d094fa71a2115a6c872a983daebfb3180d0ec50f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->