### PR TITLE
COS-6761: Increase the length of organization description to 7 lines

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
+++ b/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
@@ -149,7 +149,7 @@ export const OrganizationDetails = observer(
           <div className='flex flex-col w-full flex-1 items-start justify-start gap-3 mt-2'>
             {!!organization?.value?.description && (
               <TruncatedText
-                maxLines={4}
+                maxLines={7}
                 className='text-sm'
                 data-test='org-about-description'
                 text={organization.value.description}

--- a/packages/apps/frontera/src/ui/presentation/TruncatedText/TruncatedText.tsx
+++ b/packages/apps/frontera/src/ui/presentation/TruncatedText/TruncatedText.tsx
@@ -37,12 +37,13 @@ export const TruncatedText = ({
     <div className='w-full'>
       <div
         ref={textRef}
-        className={cn(
-          {
-            [`line-clamp-${maxLines}`]: !isExpanded,
-          },
-          className && className,
-        )}
+        className={cn('overflow-hidden', className ? className : '')}
+        style={{
+          display: '-webkit-box',
+          lineClamp: isExpanded ? 'none' : maxLines,
+          WebkitLineClamp: isExpanded ? 'none' : maxLines,
+          WebkitBoxOrient: 'vertical',
+        }}
         {...rest}
       >
         {text}
@@ -50,7 +51,10 @@ export const TruncatedText = ({
       {showButton && (
         <button
           onClick={toggleExpand}
-          className={cn(className, 'inline-block text-primary-700 underline')}
+          className={cn(
+            'inline-block text-primary-700 underline',
+            className ? className : '',
+          )}
         >
           {isExpanded ? 'Show less' : 'Show more'}
         </button>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase organization description length to 7 lines and update `TruncatedText` component styling.
> 
>   - **Behavior**:
>     - Increase `maxLines` from 4 to 7 in `OrganizationDetails.tsx` for organization description.
>   - **Components**:
>     - Update `TruncatedText` in `TruncatedText.tsx` to support new `maxLines` value and adjust styling logic for line clamping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d3ff5e571741fbccb2cb33484b458f324bb244ea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->