### PR TITLE
refactor: remove unused searchResults observable from Contacts and Or…

### DIFF
--- a/packages/apps/frontera/src/store/Contacts/Contacts.store.ts
+++ b/packages/apps/frontera/src/store/Contacts/Contacts.store.ts
@@ -17,7 +17,6 @@ import { TargetsContactsView } from './__views__/TargetsContacts.view';
 export class ContactsStore extends Store<ContactDatum, Contact> {
   private chunkSize = 50;
   private service = ContactService.getInstance();
-  @observable accessor searchResults: Map<string, string[]> = new Map();
   @observable accessor cursors: Map<string, number> = new Map();
   @observable accessor availableCounts: Map<string, number> = new Map();
 

--- a/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
+++ b/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
@@ -32,7 +32,6 @@ type SaveOrganizationPayload = SaveOrganizationMutationVariables['input'];
 export class OrganizationsStore extends Store<OrganizationDatum, Organization> {
   chunkSize = 50;
   private repository = OrganizationRepository.getInstance();
-  @observable accessor searchResults: Map<string, string[]> = new Map();
   @observable accessor cursors: Map<string, number> = new Map();
   @observable accessor availableCounts: Map<string, number> = new Map();
 

--- a/packages/apps/frontera/src/store/_store.ts
+++ b/packages/apps/frontera/src/store/_store.ts
@@ -34,7 +34,7 @@ export class Store<T extends object, E extends Entity<T> = Entity<T>> {
   @observable accessor isBootstrapping = false;
   @observable accessor error: string | null = null;
   @observable accessor value: Map<string, E> = new Map();
-  @observable accessor range: [startIndex: number, endIndex: number] = [0, 0];
+  @observable accessor searchResults: Map<string, string[]> = new Map();
 
   channel?: Channel;
   options: StoreOptions<T>;
@@ -235,8 +235,13 @@ export class Store<T extends object, E extends Entity<T> = Entity<T>> {
           set(record, 'id', id);
           this.value.set(id, record);
 
+          this.searchResults.forEach((v) => {
+            if (v.includes(id)) return;
+            v.unshift(id);
+          });
           this.size++;
           this.version++;
+
           setTimeout(() => {
             this.invalidate(id);
           }, 1000);
@@ -374,12 +379,6 @@ export class Store<T extends object, E extends Entity<T> = Entity<T>> {
       });
     });
   }
-
-  @action
-  public setActiveRange = (startIndex: number, endIndex: number) => {
-    this.range[0] = startIndex;
-    this.range[1] = endIndex;
-  };
 
   private makeChangesetOperation(id: string) {
     const lhs = this.snapshots.get(id)!;


### PR DESCRIPTION
…ganizations stores
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to centralize `searchResults` observable in `Store` class and remove it from `ContactsStore` and `OrganizationsStore`.
> 
>   - **Refactor**:
>     - Remove `searchResults` observable from `ContactsStore` and `OrganizationsStore`.
>     - Add `searchResults` observable to `Store` class.
>   - **Misc**:
>     - Remove `setActiveRange` function from `Store` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c53f5dcd7f5c7f83c550a7b1e92fab447535769c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->