### PR TITLE
COS-6681: Restore lost domain functionality on the About panel

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
+++ b/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
@@ -144,7 +144,7 @@ export const OrganizationDetails = observer(
             </div>
           </div>
 
-          <Domains />
+          <Domains id={id} />
 
           <div className='flex flex-col w-full flex-1 items-start justify-start gap-3 mt-2'>
             {!!organization?.value?.description && (

--- a/packages/apps/frontera/src/routes/src/components/OrganizationDetails/components/domains/Domains.tsx
+++ b/packages/apps/frontera/src/routes/src/components/OrganizationDetails/components/domains/Domains.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
 
@@ -24,9 +23,8 @@ import {
 
 import { Subdomain } from './Subdomain.tsx';
 
-export const Domains = observer(() => {
+export const Domains = observer(({ id }: { id: string }) => {
   const store = useStore();
-  const id = useParams()?.id as string;
 
   // Track expanded state for each domain group
   const [expandedDomains, setExpandedDomains] = useState<
@@ -34,7 +32,7 @@ export const Domains = observer(() => {
   >({});
   const [showMenus, setShowMenus] = useState<Record<string, boolean>>({});
 
-  const organization = store.organizations.getById(store.ui.focusRow ?? id);
+  const organization = store.organizations.getById(id);
 
   if (!organization || !organization?.value) return null;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Restore domain functionality in the About panel by passing `id` prop to `Domains` component and removing `useParams`.
> 
>   - **Behavior**:
>     - Pass `id` prop to `Domains` component in `OrganizationDetails.tsx` to restore domain functionality.
>     - Remove `useParams` from `Domains.tsx` and use `id` prop for organization retrieval.
>   - **Components**:
>     - Modify `Domains` component to accept `id` as a prop instead of using `useParams`.
>     - Update `organization` retrieval logic in `Domains.tsx` to use `id` prop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8d6ea89edcbf0e0ea9f963f9393b13b74ecfcca5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->