### PR TITLE
feat: add support for local customeros subdomain in CORS configuration

### DIFF
--- a/packages/server/realtime/config/prod.exs
+++ b/packages/server/realtime/config/prod.exs
@@ -10,6 +10,7 @@ config :realtime, RealtimeWeb.Endpoint,
   check_origin: [
     "https://app.customeros.dev",
     "https://app.customeros.ai",
+    "https://app.customeros.local",
     "https://frontera.customeros.ai",
     "https://frontera.openline.dev",
     "//*.localcan.dev"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `https://app.customeros.local` to CORS `check_origin` in `prod.exs`.
> 
>   - **CORS Configuration**:
>     - Added `https://app.customeros.local` to `check_origin` in `prod.exs` for local subdomain support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f22f3341d40847ddb170127dfa5f027538a8990c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->