### PR TITLE
COS-6763: Truncate long contract names in the contract modal when contract name input is not focused

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/ContractDetails/ContractDetailsModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/ContractDetails/ContractDetailsModal.tsx
@@ -320,7 +320,7 @@ export const ContractDetailsModal = observer(
               placeholder='Add contract name'
               onFocus={(e) => e.target.select()}
               value={contractStore?.tempValue?.contractName}
-              className='font-semibold no-border-bottom hover:border-none focus:border-none max-h-6 min-h-0 w-full overflow-hidden overflow-ellipsis'
+              className='font-semibold no-border-bottom hover:border-none focus:border-none max-h-6 min-h-0 w-full overflow-hidden overflow-ellipsis truncate'
               onChange={(e) =>
                 contractStore?.updateTemp((prev) => ({
                   ...prev,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `truncate` class to contract name `Input` in `ContractDetailsModal.tsx` to truncate long contract names when not focused.
> 
>   - **Behavior**:
>     - Adds `truncate` class to contract name `Input` in `ContractDetailsModal.tsx` to ensure long contract names are truncated when not focused.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8f80d791127d40fce11c4131d143e682e8160383. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->