### PR TITLE
COS-6768: Show a 'Link copied' toast after copying the link to the timeline event.

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/action/generic/GenericActionTypePreview.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/action/generic/GenericActionTypePreview.tsx
@@ -1,7 +1,6 @@
 import Markdown from 'react-markdown';
 import { Children, isValidElement } from 'react';
 
-import copy from 'copy-to-clipboard';
 import { MarkdownEventType } from '@store/TimelineEvents/MarkdownEvent/types';
 
 import { XClose } from '@ui/media/icons/XClose';
@@ -10,12 +9,14 @@ import { IconButton } from '@ui/form/IconButton';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
 import { getExternalUrl } from '@utils/getExternalLink.ts';
 import { CardHeader, CardContent } from '@ui/presentation/Card/Card';
+import { useCopyToClipboard } from '@shared/hooks/useCopyToClipboard';
 import {
   useTimelineEventPreviewStateContext,
   useTimelineEventPreviewMethodsContext,
 } from '@organization/components/Timeline/shared/TimelineEventPreview/context/TimelineEventPreviewContext';
 
 export const GenericActionTypePreview = () => {
+  const [_, copy] = useCopyToClipboard();
   const { modalContent } = useTimelineEventPreviewStateContext();
   const { closeModal } = useTimelineEventPreviewMethodsContext();
   const event = modalContent as MarkdownEventType;
@@ -36,8 +37,8 @@ export const GenericActionTypePreview = () => {
                   color='gray.500'
                   className='mr-1'
                   aria-label='Copy link to this event'
-                  onClick={() => copy(window.location.href)}
                   icon={<Link01 className='text-gray-500 size-4' />}
+                  onClick={() => copy(window.location.href, 'Link copied')}
                 />
               </div>
             </Tooltip>

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/intercom/IntercomThreadPreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/intercom/IntercomThreadPreviewModal.tsx
@@ -1,4 +1,3 @@
-import copy from 'copy-to-clipboard';
 import { convert } from 'html-to-text';
 
 import { cn } from '@ui/utils/cn';
@@ -11,6 +10,7 @@ import { Divider } from '@ui/presentation/Divider/Divider';
 import { IconButton } from '@ui/form/IconButton/IconButton';
 import { getGraphQLClient } from '@shared/util/getGraphQLClient';
 import { CardHeader, CardContent } from '@ui/presentation/Card/Card';
+import { useCopyToClipboard } from '@shared/hooks/useCopyToClipboard';
 import { useGetTimelineEventsQuery } from '@organization/graphql/getTimelineEvents.generated';
 import {
   UserParticipant,
@@ -40,6 +40,7 @@ export const IntercomThreadPreviewModal = () => {
   const client = getGraphQLClient();
   const { modalContent } = useTimelineEventPreviewStateContext();
   const { closeModal } = useTimelineEventPreviewMethodsContext();
+  const [_, copy] = useCopyToClipboard();
 
   const event = modalContent as InteractionEvent;
 
@@ -99,8 +100,8 @@ export const IntercomThreadPreviewModal = () => {
                   className='mr-1'
                   color='gray.500'
                   aria-label='Copy link to this thread'
-                  onClick={() => copy(window.location.href)}
                   icon={<Link01 className='text-gray-500' />}
+                  onClick={() => copy(window.location.href, 'Link copied')}
                 />
               </div>
             </Tooltip>

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/invoice/InvoicePreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/invoice/InvoicePreviewModal.tsx
@@ -46,7 +46,7 @@ export const InvoicePreviewModal = observer(() => {
                 colorScheme='gray'
                 aria-label='Copy invoice link'
                 icon={<Link01 color='text-inherit' />}
-                onClick={() => copy(window.location.href)}
+                onClick={() => copy(window.location.href, 'Link copied')}
               />
             </Tooltip>
             <Tooltip

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/logEntry/LogEntryPreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/logEntry/LogEntryPreviewModal.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import copy from 'copy-to-clipboard';
 import noteImg from '@assets/images/note-img-preview.png';
 
 import { Link01 } from '@ui/media/icons/Link01';
@@ -11,6 +10,7 @@ import { useStore } from '@shared/hooks/useStore';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
 import { Tag, User, EntityType } from '@graphql/types';
 import { IconButton } from '@ui/form/IconButton/IconButton';
+import { useCopyToClipboard } from '@shared/hooks/useCopyToClipboard';
 import { LogEntryWithAliases } from '@organization/components/Timeline/types';
 import { HtmlContentRenderer } from '@ui/presentation/HtmlContentRenderer/HtmlContentRenderer';
 import { useLogEntryUpdateContext } from '@organization/components/Timeline/PastZone/events/logEntry/context/LogEntryUpdateModalContext';
@@ -43,6 +43,7 @@ export const LogEntryPreviewModal = ({
   const [mentionsQuery, setMentionsQuery] = useState<string | null>('');
   const { modalContent } = useTimelineEventPreviewStateContext();
   const { closeModal } = useTimelineEventPreviewMethodsContext();
+  const [_, copy] = useCopyToClipboard();
 
   const logEntryId = searchParams.get('events') ?? '';
   const logEntry = store.timelineEvents.logEntries.value.get(logEntryId);
@@ -98,8 +99,8 @@ export const LogEntryPreviewModal = ({
                   variant='ghost'
                   aria-label='Copy link to this entry'
                   className='text-sm text-gray-500 mr-1'
-                  onClick={() => copy(window.location.href)}
                   icon={<Link01 className='text-gray-500' />}
+                  onClick={() => copy(window.location.href, 'Link copied')}
                 />
               </div>
             </Tooltip>

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/markdownEvent/MarkdownEventPreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/markdownEvent/MarkdownEventPreviewModal.tsx
@@ -1,4 +1,3 @@
-import copy from 'copy-to-clipboard';
 import { MarkdownEventType } from '@store/TimelineEvents/MarkdownEvent/types';
 
 import { XClose } from '@ui/media/icons/XClose';
@@ -6,6 +5,7 @@ import { Link01 } from '@ui/media/icons/Link01';
 import { IconButton } from '@ui/form/IconButton';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
 import { CardHeader, CardContent } from '@ui/presentation/Card/Card';
+import { useCopyToClipboard } from '@shared/hooks/useCopyToClipboard';
 import { MarkdownRenderer } from '@organization/components/Timeline/PastZone/events/markdownEvent/MarkdownRenderer';
 import {
   useTimelineEventPreviewStateContext,
@@ -16,6 +16,7 @@ export const MarkdownEventPreviewModal = () => {
   const { modalContent } = useTimelineEventPreviewStateContext();
   const { closeModal } = useTimelineEventPreviewMethodsContext();
   const event = modalContent as MarkdownEventType;
+  const [_, copy] = useCopyToClipboard();
 
   return (
     <div className='overflow-hidden rounded-xl pb-6'>
@@ -38,8 +39,8 @@ export const MarkdownEventPreviewModal = () => {
                   color='gray.500'
                   className='mr-1'
                   aria-label='Copy link to this event'
-                  onClick={() => copy(window.location.href)}
                   icon={<Link01 className='text-gray-500 size-4' />}
+                  onClick={() => copy(window.location.href, 'Link copied')}
                 />
               </div>
             </Tooltip>

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/meeting/MeetingPreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/meeting/MeetingPreviewModal.tsx
@@ -148,8 +148,8 @@ export const MeetingPreviewModal = ({
               size='xs'
               variant='ghost'
               aria-label='copy link'
-              onClick={() => copy(window.location.href)}
               icon={<Link01 className='text-gray-500' />}
+              onClick={() => copy(window.location.href, 'Link copied')}
             />
           </Tooltip>
           <Tooltip label='Close'>

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/slack/SlackThreadPreviewModal.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/PastZone/events/slack/SlackThreadPreviewModal.tsx
@@ -1,5 +1,3 @@
-import copy from 'copy-to-clipboard';
-
 import { DateTimeUtils } from '@utils/date';
 import { Link01 } from '@ui/media/icons/Link01';
 import { XClose } from '@ui/media/icons/XClose';
@@ -8,6 +6,7 @@ import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
 import { Divider } from '@ui/presentation/Divider/Divider';
 import { getGraphQLClient } from '@shared/util/getGraphQLClient';
 import { CardHeader, CardContent } from '@ui/presentation/Card/Card';
+import { useCopyToClipboard } from '@shared/hooks/useCopyToClipboard';
 import { InteractionEvent, InteractionEventParticipant } from '@graphql/types';
 import { useGetTimelineEventsQuery } from '@organization/graphql/getTimelineEvents.generated';
 import { SlackMessageCard } from '@organization/components/Timeline/PastZone/events/slack/SlackMessageCard';
@@ -28,6 +27,7 @@ export const SlackThreadPreviewModal = () => {
   const { modalContent } = useTimelineEventPreviewStateContext();
   const { closeModal } = useTimelineEventPreviewMethodsContext();
   const event = modalContent as InteractionEvent;
+  const [_, copy] = useCopyToClipboard();
 
   const timelineEventsIds =
     event?.interactionSession?.events?.map((e) => e.id) || [];
@@ -59,8 +59,8 @@ export const SlackThreadPreviewModal = () => {
                   color='gray.500'
                   className='mr-1'
                   aria-label='Copy link to this thread'
-                  onClick={() => copy(window.location.href)}
                   icon={<Link01 className='text-gray-500 size-4' />}
+                  onClick={() => copy(window.location.href, 'Link copied')}
                 />
               </div>
             </Tooltip>

--- a/packages/apps/frontera/src/routes/organization/src/components/Timeline/shared/TimelineEventPreview/header/TimelineEventPreviewHeader.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Timeline/shared/TimelineEventPreview/header/TimelineEventPreviewHeader.tsx
@@ -46,8 +46,8 @@ export const TimelineEventPreviewHeader = ({
                   className='mr-1'
                   colorScheme='gray'
                   aria-label={copyLabel}
-                  onClick={() => copy(window.location.href)}
                   icon={<Link01 className='text-gray-500' />}
+                  onClick={() => copy(window.location.href, 'Link copied')}
                 />
               </div>
             </Tooltip>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds 'Link copied' toast notification when copying links in timeline event components using `useCopyToClipboard` hook.
> 
>   - **Behavior**:
>     - Adds 'Link copied' toast notification when copying links in `GenericActionTypePreview.tsx`, `IntercomThreadPreviewModal.tsx`, and `InvoicePreviewModal.tsx`.
>     - Replaces `copy-to-clipboard` with `useCopyToClipboard` hook in 8 components including `LogEntryPreviewModal.tsx` and `SlackThreadPreviewModal.tsx`.
>   - **Components**:
>     - Updates `IconButton` click handlers to use `useCopyToClipboard` in `MarkdownEventPreviewModal.tsx` and `MeetingPreviewModal.tsx`.
>     - Modifies `TimelineEventPreviewHeader.tsx` to include toast notification on link copy.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8a6340e2dbb1ff9efc6c7d1a035650fd177dbd3d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->