### PR TITLE
Fix unmarshalling empty configs

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/execution_service.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/execution_service.go
@@ -117,24 +117,27 @@ func executeCapability[I, O, C any](
 	allParams map[string]any,
 	cap interfaces.AgentCapability[I, O, C],
 ) (map[string]any, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "agentCapabilityExecutionService.executeCapability")
+	span, ctx := opentracing.StartSpanFromContext(ctx, fmt.Sprintf("agentCapabilityExecutionService.executeCapability.%s", capability.Type.String()))
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 
 	input := cap.NewInput()
 	err := utils.MapToStruct(allParams, &input)
 	if err != nil {
+		tracing.TraceErr(span, err)
 		return nil, err
 	}
 
 	config := cap.NewConfig()
 	err = capability.GetConfig(&config)
 	if err != nil {
+		tracing.TraceErr(span, err)
 		return nil, err
 	}
 
 	output, err := cap.Execute(ctx, input, config)
 	if err != nil {
+		tracing.TraceErr(span, err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-postgres-repository/entity/agents.go
+++ b/packages/server/customer-os-postgres-repository/entity/agents.go
@@ -98,6 +98,9 @@ func replaceNullWithEmptyString(m map[string]interface{}) {
 }
 
 func (c *Capability) GetConfig(configPtr interface{}) error {
+	if c.Config == nil || string(c.Config) == "" {
+		return nil
+	}
 	return json.Unmarshal(c.Config, configPtr)
 }
 

--- a/packages/server/customer-os-postgres-repository/repository/invoice_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/invoice_repository.go
@@ -26,6 +26,6 @@ func (r *invoiceRepository) Reserve(ctx context.Context, invoiceNumber postgres_
 	defer span.Finish()
 	tracing.TagComponentPostgresRepository(span)
 
-	err := r.gormDb.Save(&invoiceNumber).Error
+	err := r.gormDb.Create(&invoiceNumber).Error
 	return err
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix unmarshalling of empty configs and correct invoice reservation operation in the server module.
> 
>   - **Behavior**:
>     - Fix unmarshalling of empty `Config` in `GetConfig()` in `agents.go` by returning early if `Config` is `nil` or empty.
>     - Change database operation from `Save` to `Create` in `Reserve()` in `invoice_repository.go` to correctly handle invoice number reservation.
>   - **Tracing**:
>     - Add error tracing in `executeCapability()` in `execution_service.go` for input, config, and execution errors.
>     - Update span name in `executeCapability()` to include capability type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2d5bf5b64e164af6c54bac050d46adbfe38f8daa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->