### PR TITLE
fix unmarshal

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capabilities_config.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capabilities_config.go
@@ -1,7 +1,5 @@
 package agent_capability
 
-type NoConfig struct{}
-
 type CapabilityOutput struct {
 	ExecutionValidated bool `json:"executionValidated"`
 	Completed          bool `json:"completed"`

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
@@ -37,7 +37,7 @@ func NewAnalyzeWebSessionCapability(
 
 // Compile-time interface checks
 var (
-	_ interfaces.AgentCapability[AnalyzeWebSessionInput, AnalyzeWebSessionOutput, NoConfig] = (*AnalyzeWebSessionCapability)(nil)
+	_ interfaces.AgentCapability[AnalyzeWebSessionInput, AnalyzeWebSessionOutput, postgres_entity.NoConfig] = (*AnalyzeWebSessionCapability)(nil)
 )
 
 func (c *AnalyzeWebSessionCapability) Type() enum.AgentCapability {
@@ -52,12 +52,12 @@ func (c *AnalyzeWebSessionCapability) NewInput() AnalyzeWebSessionInput {
 	return AnalyzeWebSessionInput{}
 }
 
-func (c *AnalyzeWebSessionCapability) NewConfig() NoConfig {
-	return NoConfig{}
+func (c *AnalyzeWebSessionCapability) NewConfig() postgres_entity.NoConfig {
+	return postgres_entity.NoConfig{}
 }
 
 func (c *AnalyzeWebSessionCapability) DefaultConfig() any {
-	return &NoConfig{}
+	return &postgres_entity.NoConfig{}
 }
 
 func (c *AnalyzeWebSessionCapability) ValidateInput(data AnalyzeWebSessionInput) error {
@@ -73,7 +73,7 @@ func (c *AnalyzeWebSessionCapability) ValidateInput(data AnalyzeWebSessionInput)
 	return nil
 }
 
-func (c *AnalyzeWebSessionCapability) ValidateConfig(config NoConfig) error {
+func (c *AnalyzeWebSessionCapability) ValidateConfig(config postgres_entity.NoConfig) error {
 	return nil
 }
 
@@ -96,7 +96,7 @@ type AnalyzeWebSessionOutput struct {
 	Referrer          string   `json:"referrer"`
 }
 
-func (c *AnalyzeWebSessionCapability) Execute(ctx context.Context, data AnalyzeWebSessionInput, config NoConfig) (AnalyzeWebSessionOutput, error) {
+func (c *AnalyzeWebSessionCapability) Execute(ctx context.Context, data AnalyzeWebSessionInput, config postgres_entity.NoConfig) (AnalyzeWebSessionOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AnalyzeWebSessionCapability.Execute")
 	defer span.Finish()
 	tracing.TagComponentService(span)

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_create_and_enrich_company.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_create_and_enrich_company.go
@@ -3,6 +3,7 @@ package agent_capability
 import (
 	"context"
 
+	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
@@ -27,7 +28,7 @@ func NewCreateOrganizationCapability(orgService interfaces.OrganizationService) 
 
 // Compile-time interface checks
 var (
-	_ interfaces.AgentCapability[CreateOrganizationInput, CreateOrganizationOutput, NoConfig] = (*CreateOrganizationCapability)(nil)
+	_ interfaces.AgentCapability[CreateOrganizationInput, CreateOrganizationOutput, postgres_entity.NoConfig] = (*CreateOrganizationCapability)(nil)
 )
 
 func (c *CreateOrganizationCapability) Type() enum.AgentCapability {
@@ -42,12 +43,12 @@ func (c *CreateOrganizationCapability) NewInput() CreateOrganizationInput {
 	return CreateOrganizationInput{}
 }
 
-func (c *CreateOrganizationCapability) NewConfig() NoConfig {
-	return NoConfig{}
+func (c *CreateOrganizationCapability) NewConfig() postgres_entity.NoConfig {
+	return postgres_entity.NoConfig{}
 }
 
 func (c *CreateOrganizationCapability) DefaultConfig() any {
-	return &NoConfig{}
+	return &postgres_entity.NoConfig{}
 }
 
 func (c *CreateOrganizationCapability) ValidateInput(input CreateOrganizationInput) error {
@@ -60,7 +61,7 @@ func (c *CreateOrganizationCapability) ValidateInput(input CreateOrganizationInp
 	return nil
 }
 
-func (c *CreateOrganizationCapability) ValidateConfig(config NoConfig) error {
+func (c *CreateOrganizationCapability) ValidateConfig(config postgres_entity.NoConfig) error {
 	return nil
 }
 
@@ -73,7 +74,7 @@ type CreateOrganizationOutput struct {
 	OrganizationID string `json:"organizationId"`
 }
 
-func (c *CreateOrganizationCapability) Execute(ctx context.Context, data CreateOrganizationInput, config NoConfig) (CreateOrganizationOutput, error) {
+func (c *CreateOrganizationCapability) Execute(ctx context.Context, data CreateOrganizationInput, config postgres_entity.NoConfig) (CreateOrganizationOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "CreateOrganizationCapability.Execute")
 	defer span.Finish()
 	tracing.TagComponentService(span)

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_create_markdown_timeline_event.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_create_markdown_timeline_event.go
@@ -3,6 +3,7 @@ package agent_capability
 import (
 	"context"
 
+	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
@@ -36,19 +37,19 @@ func NewCreateMarkdownTimelineEventCapability(markdownService interfaces.Markdow
 
 // Compile-time interface check
 var (
-	_ interfaces.AgentCapability[CreateMarkdownTimelineEventInput, CreateMarkdownTimelineEventOutput, NoConfig] = (*CreateMarkdownTimelineEventCapability)(nil)
+	_ interfaces.AgentCapability[CreateMarkdownTimelineEventInput, CreateMarkdownTimelineEventOutput, postgres_entity.NoConfig] = (*CreateMarkdownTimelineEventCapability)(nil)
 )
 
 func (c *CreateMarkdownTimelineEventCapability) NewInput() CreateMarkdownTimelineEventInput {
 	return CreateMarkdownTimelineEventInput{}
 }
 
-func (c *CreateMarkdownTimelineEventCapability) NewConfig() NoConfig {
-	return NoConfig{}
+func (c *CreateMarkdownTimelineEventCapability) NewConfig() postgres_entity.NoConfig {
+	return postgres_entity.NoConfig{}
 }
 
 func (c *CreateMarkdownTimelineEventCapability) DefaultConfig() any {
-	return &NoConfig{}
+	return &postgres_entity.NoConfig{}
 }
 
 func (c *CreateMarkdownTimelineEventCapability) Type() enum.AgentCapability {
@@ -59,7 +60,7 @@ func (c *CreateMarkdownTimelineEventCapability) Name() string {
 	return "Add event to timeline"
 }
 
-func (c *CreateMarkdownTimelineEventCapability) ValidateConfig(config NoConfig) error {
+func (c *CreateMarkdownTimelineEventCapability) ValidateConfig(config postgres_entity.NoConfig) error {
 	return nil
 }
 
@@ -73,7 +74,7 @@ func (c *CreateMarkdownTimelineEventCapability) ValidateInput(input CreateMarkdo
 	return nil
 }
 
-func (c *CreateMarkdownTimelineEventCapability) Execute(ctx context.Context, data CreateMarkdownTimelineEventInput, config NoConfig) (CreateMarkdownTimelineEventOutput, error) {
+func (c *CreateMarkdownTimelineEventCapability) Execute(ctx context.Context, data CreateMarkdownTimelineEventInput, config postgres_entity.NoConfig) (CreateMarkdownTimelineEventOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "CreateMarkdownTimelineEventCapability.Execute")
 	defer span.Finish()
 	tracing.TagComponentService(span)

--- a/packages/server/customer-os-common-module/services/agent_capability/execution_service.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/execution_service.go
@@ -31,7 +31,7 @@ func (f *agentCapabilityExecutionService) Execute(
 
 	switch capability.Type {
 	case enum.CapabilityAnalyzeWebSessionIntent:
-		executor, ok := GetTypedExecutor[AnalyzeWebSessionInput, AnalyzeWebSessionOutput, NoConfig](executors, capability.Type)
+		executor, ok := GetTypedExecutor[AnalyzeWebSessionInput, AnalyzeWebSessionOutput, postgres_entity.NoConfig](executors, capability.Type)
 		if !ok {
 			return nil, f.handleGetTypedExecutorError(ctx, enum.CapabilityAnalyzeWebSessionIntent)
 		}
@@ -45,14 +45,14 @@ func (f *agentCapabilityExecutionService) Execute(
 		return executeCapability(ctx, capability, params, executor)
 
 	case enum.CapabilityCreateAndEnrichCompany:
-		executor, ok := GetTypedExecutor[CreateOrganizationInput, CreateOrganizationOutput, NoConfig](executors, capability.Type)
+		executor, ok := GetTypedExecutor[CreateOrganizationInput, CreateOrganizationOutput, postgres_entity.NoConfig](executors, capability.Type)
 		if !ok {
 			return nil, f.handleGetTypedExecutorError(ctx, enum.CapabilityCreateAndEnrichCompany)
 		}
 		return executeCapability(ctx, capability, params, executor)
 
 	case enum.CapabilityCreateMarkdownTimelineEvent:
-		executor, ok := GetTypedExecutor[CreateMarkdownTimelineEventInput, CreateMarkdownTimelineEventOutput, NoConfig](executors, capability.Type)
+		executor, ok := GetTypedExecutor[CreateMarkdownTimelineEventInput, CreateMarkdownTimelineEventOutput, postgres_entity.NoConfig](executors, capability.Type)
 		if !ok {
 			return nil, f.handleGetTypedExecutorError(ctx, enum.CapabilityCreateMarkdownTimelineEvent)
 		}

--- a/packages/server/customer-os-postgres-repository/entity/agents.go
+++ b/packages/server/customer-os-postgres-repository/entity/agents.go
@@ -45,6 +45,8 @@ type Capability struct {
 	Description string               `json:"description"`
 }
 
+type NoConfig struct{}
+
 func (c *Capability) SetConfig(config interface{}) error {
 	if config == nil || config == "" {
 		c.Config = nil
@@ -99,6 +101,9 @@ func replaceNullWithEmptyString(m map[string]interface{}) {
 
 func (c *Capability) GetConfig(configPtr interface{}) error {
 	if c.Config == nil || string(c.Config) == "" {
+		return nil
+	}
+	if _, ok := configPtr.(*NoConfig); ok {
 		return nil
 	}
 	return json.Unmarshal(c.Config, configPtr)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor to use `postgres_entity.NoConfig` across capability-related files, removing local `NoConfig` definitions.
> 
>   - **Refactoring**:
>     - Replace local `NoConfig` with `postgres_entity.NoConfig` in `capability_analyze_web_session.go`, `capability_create_and_enrich_company.go`, `capability_create_markdown_timeline_event.go`, and `execution_service.go`.
>     - Remove local `NoConfig` type definition from `capabilities_config.go`.
>   - **Entity Changes**:
>     - Add `NoConfig` type to `agents.go` in `postgres_entity` package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 0494601badc0902fb580b2b360cc2a46dd472fd3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->