### PR TITLE
refactor: setView in Organizations and Contacts stores

### DIFF
--- a/packages/apps/frontera/src/domain/services/organization/organizations.service.ts
+++ b/packages/apps/frontera/src/domain/services/organization/organizations.service.ts
@@ -288,25 +288,21 @@ export class OrganizationService {
     return [res, err];
   }
 
-  public async saveOragnization(
+  public async setRelationshipAndStage(
     payload: Partial<OrganizationDatum>,
     orgId: string,
   ) {
-    const prevRelationship =
-      this.root.organizations.getById(orgId)?.value.relationship;
+    const organization = this.root.organizations.getById(orgId);
+    const prevRelationship = organization?.value.relationship;
 
-    this.root.organizations
-      .getById(orgId)
-      ?.setRelationship(
-        payload.relationship ?? OrganizationRelationship.Prospect,
-      );
-    this.root.organizations
-      .getById(orgId)
-      ?.setStage(
-        payload.stage ??
-          this.root.organizations.getById(orgId)?.value.stage ??
-          OrganizationStage.Target,
-      );
+    organization?.setRelationship(
+      payload.relationship ?? OrganizationRelationship.Prospect,
+    );
+    organization?.setStage(
+      payload.stage ??
+        this.root.organizations.getById(orgId)?.value.stage ??
+        OrganizationStage.Target,
+    );
 
     const [res, err] = await unwrap(
       this.orgRepo.saveOrganization({

--- a/packages/apps/frontera/src/domain/usecases/command-menu/edit-organization-relationship.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/command-menu/edit-organization-relationship.usecase.ts
@@ -13,7 +13,7 @@ export class EditOrganizationRelationshipUseCase {
 
   @action
   public execute(relationship: OrganizationRelationship) {
-    this.orgService.saveOragnization(
+    this.orgService.setRelationshipAndStage(
       { relationship: relationship },
       this.orgId,
     );

--- a/packages/apps/frontera/src/domain/usecases/command-menu/edit-organization-stage.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/command-menu/edit-organization-stage.usecase.ts
@@ -13,6 +13,6 @@ export class EditOrganizationStageUseCase {
 
   @action
   public execute(stage: OrganizationStage) {
-    this.orgService.saveOragnization({ stage: stage }, this.orgId);
+    this.orgService.setRelationshipAndStage({ stage: stage }, this.orgId);
   }
 }

--- a/packages/apps/frontera/src/domain/usecases/organization-details/save-organization-relationship-and-stage.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/organization-details/save-organization-relationship-and-stage.usecase.ts
@@ -2,7 +2,7 @@ import { action } from 'mobx';
 import { OrganizationService } from '@domain/services';
 import { OrganizationDatum } from '@store/Organizations/Organization.dto';
 
-export class SaveOrganizationUseCase {
+export class SaveOrganizationRelationshipAndStageUsecase {
   private orgService = new OrganizationService();
   private orgId: string;
 

--- a/packages/apps/frontera/src/domain/usecases/organization-details/save-organization.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/organization-details/save-organization.usecase.ts
@@ -12,6 +12,6 @@ export class SaveOrganizationUseCase {
 
   @action
   public execute(payload: Partial<OrganizationDatum>) {
-    this.orgService.saveOragnization(payload, this.orgId);
+    this.orgService.setRelationshipAndStage(payload, this.orgId);
   }
 }

--- a/packages/apps/frontera/src/routes/src/components/Devtools/Devtools.tsx
+++ b/packages/apps/frontera/src/routes/src/components/Devtools/Devtools.tsx
@@ -49,13 +49,17 @@ export const Devtools = observer(() => {
   const store = useStore();
   const { open, onOpen, onClose, onToggle } = useDisclosure();
 
+  const ENABLED = import.meta.env.DEV;
+
   const defaultWidht = window.innerWidth / 2;
   const defaultX = window.innerWidth - defaultWidht * 1.5;
   const defaultY = window.innerHeight / 3;
 
-  useKey('`', onToggle);
+  useKey('`', onToggle, { when: ENABLED });
 
   useEffect(() => {
+    if (!ENABLED) return;
+
     const handleGqlReq = (e: unknown) => {
       const reqId = get(e, 'detail.reqId');
       const reqName = get(e, 'detail.name');
@@ -86,6 +90,7 @@ export const Devtools = observer(() => {
     window.addEventListener('gql-res', handleGqlRes);
 
     return () => {
+      if (!ENABLED) return;
       window.removeEventListener('gql-req', handleGqlReq);
       window.removeEventListener('gql-res', handleGqlRes);
     };
@@ -145,6 +150,8 @@ export const Devtools = observer(() => {
       .with('agents', () => get(entity, 'value.name', 'Unnamed'))
       .with('common.slackChannels', () => get(entity, 'name', 'Unnamed'))
       .otherwise(() => 'Unnamed');
+
+  if (!ENABLED) return null;
 
   return createPortal(
     open ? (

--- a/packages/apps/frontera/src/routes/src/components/Devtools/Devtools.tsx
+++ b/packages/apps/frontera/src/routes/src/components/Devtools/Devtools.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
+import { useMemo, useEffect } from 'react';
 
 import { toJS } from 'mobx';
 import get from 'lodash/get';
@@ -9,6 +9,7 @@ import { Tracer } from '@infra/tracer';
 import { type RootStore } from '@store/root';
 import { Observer, observer } from 'mobx-react-lite';
 import { CommonStore } from '@store/Common/Common.store';
+import { useFeatureIsOn } from '@growthbook/growthbook-react';
 
 import { cn } from '@ui/utils/cn';
 import { X } from '@ui/media/icons/X';
@@ -47,9 +48,13 @@ type StoreReturnType =
 
 export const Devtools = observer(() => {
   const store = useStore();
+  const hasFlagEnabled = useFeatureIsOn('devtools');
   const { open, onOpen, onClose, onToggle } = useDisclosure();
 
-  const ENABLED = import.meta.env.DEV;
+  const ENABLED = useMemo(
+    () => import.meta.env.DEV || hasFlagEnabled,
+    [hasFlagEnabled],
+  );
 
   const defaultWidht = window.innerWidth / 2;
   const defaultX = window.innerWidth - defaultWidht * 1.5;

--- a/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
+++ b/packages/apps/frontera/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
@@ -3,8 +3,8 @@ import { useMemo } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useLocalStorage } from 'usehooks-ts';
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
-import { SaveOrganizationUseCase } from '@domain/usecases/organization-details/save-organization.usecase';
 import { EditOrganizationTagUsecase } from '@domain/usecases/organization-details/edit-organization-tag.usecase';
+import { SaveOrganizationRelationshipAndStageUsecase } from '@domain/usecases/organization-details/save-organization-relationship-and-stage.usecase';
 
 import { cn } from '@ui/utils/cn';
 import { Icon } from '@ui/media/Icon';
@@ -77,8 +77,8 @@ export const OrganizationDetails = observer(
     );
 
     const tagsUsecase = useMemo(() => new EditOrganizationTagUsecase(id), [id]);
-    const saveOrganizationUseCase = useMemo(
-      () => new SaveOrganizationUseCase(id),
+    const saveRelationshipAndStageUsecase = useMemo(
+      () => new SaveOrganizationRelationshipAndStageUsecase(id),
       [id],
     );
 
@@ -206,7 +206,7 @@ export const OrganizationDetails = observer(
                       <MenuItem
                         key={option.value}
                         onClick={() => {
-                          saveOrganizationUseCase.execute({
+                          saveRelationshipAndStageUsecase.execute({
                             relationship: option.value,
                           });
                         }}
@@ -241,7 +241,7 @@ export const OrganizationDetails = observer(
                         <MenuItem
                           key={option.value}
                           onClick={() => {
-                            saveOrganizationUseCase.execute({
+                            saveRelationshipAndStageUsecase.execute({
                               stage: option.value,
                             });
                           }}

--- a/packages/apps/frontera/src/routes/src/components/Providers/Providers.tsx
+++ b/packages/apps/frontera/src/routes/src/components/Providers/Providers.tsx
@@ -16,8 +16,6 @@ interface ProvidersProps {
   children: React.ReactNode;
 }
 
-const IS_DEV = import.meta.env.DEV;
-
 export const Providers = ({ children, isProduction }: ProvidersProps) => {
   const [queryClient] = useState(
     () =>
@@ -33,7 +31,7 @@ export const Providers = ({ children, isProduction }: ProvidersProps) => {
   return (
     <QueryClientProvider client={queryClient}>
       <StoreProvider>
-        {IS_DEV && <Devtools />}
+        <Devtools />
         <PhoenixSocketProvider>
           <RecoilRoot>
             <IntegrationsProvider>

--- a/packages/apps/frontera/src/store/Contacts/Contacts.store.ts
+++ b/packages/apps/frontera/src/store/Contacts/Contacts.store.ts
@@ -15,7 +15,7 @@ import { FlowContactsView } from './__views__/FlowContacts.view';
 import { TargetsContactsView } from './__views__/TargetsContacts.view';
 
 export class ContactsStore extends Store<ContactDatum, Contact> {
-  private chunkSize = 50;
+  private chunkSize = 1000;
   private service = ContactService.getInstance();
   @observable accessor cursors: Map<string, number> = new Map();
   @observable accessor availableCounts: Map<string, number> = new Map();
@@ -52,28 +52,6 @@ export class ContactsStore extends Store<ContactDatum, Contact> {
     ids.forEach((id) => {
       this.softDelete(id);
     });
-  };
-
-  public setView = async (
-    key: string,
-    filterFn: (records: Contact[]) => Contact[],
-  ) => {
-    const ids = this.searchResults.get(key);
-    const cursor = this.cursors.get(key) ?? 0;
-    const chunkedIds = (ids ?? []).slice(
-      0,
-      this.chunkSize * cursor + this.chunkSize,
-    );
-
-    const records: Contact[] = [];
-
-    chunkedIds.forEach((id) => {
-      if (this.value?.has(id)) {
-        records.push(this.value.get(id) as Contact);
-      }
-    });
-
-    this.views.set(key, filterFn(records));
   };
 
   public getById(id: string) {

--- a/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
+++ b/packages/apps/frontera/src/store/Organizations/Organizations.store.ts
@@ -30,7 +30,7 @@ import { Organization, type OrganizationDatum } from './Organization.dto';
 type SaveOrganizationPayload = SaveOrganizationMutationVariables['input'];
 
 export class OrganizationsStore extends Store<OrganizationDatum, Organization> {
-  chunkSize = 50;
+  chunkSize = 1000;
   private repository = OrganizationRepository.getInstance();
   @observable accessor cursors: Map<string, number> = new Map();
   @observable accessor availableCounts: Map<string, number> = new Map();
@@ -77,28 +77,6 @@ export class OrganizationsStore extends Store<OrganizationDatum, Organization> {
 
     return this.value.get(id) as Organization;
   }
-
-  public setView = async (
-    key: string,
-    filterFn: (records: Organization[]) => Organization[],
-  ) => {
-    const ids = this.searchResults.get(key);
-    const cursor = this.cursors.get(key) ?? 0;
-    const chunkedIds = (ids ?? []).slice(
-      0,
-      this.chunkSize * cursor + this.chunkSize,
-    );
-
-    const records: Organization[] = [];
-
-    chunkedIds.forEach((id) => {
-      if (this.value?.has(id)) {
-        records.push(this.value.get(id) as Organization);
-      }
-    });
-
-    this.views.set(key, filterFn(records));
-  };
 
   // temporary unused
   @action


### PR DESCRIPTION
…nd update references
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `setView` in `Organizations` and `Contacts` stores, rename `saveOragnization` to `setRelationshipAndStage`, and update related components and use cases.
> 
>   - **Refactoring**:
>     - Remove `setView` method from `Contacts.store.ts` and `Organizations.store.ts`.
>     - Increase `chunkSize` from 50 to 1000 in `Contacts.store.ts` and `Organizations.store.ts`.
>   - **Method Renaming**:
>     - Rename `saveOragnization` to `setRelationshipAndStage` in `organizations.service.ts`.
>     - Update references in `edit-organization-relationship.usecase.ts`, `edit-organization-stage.usecase.ts`, and `save-organization-relationship-and-stage.usecase.ts`.
>   - **Component Updates**:
>     - Use `useFeatureIsOn` to conditionally render `Devtools` in `Devtools.tsx` and `Providers.tsx`.
>     - Update `OrganizationDetails.tsx` to use `SaveOrganizationRelationshipAndStageUsecase`.
>   - **Miscellaneous**:
>     - Remove unused import in `Devtools.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2973ca47f1cd33d50afc0b2a74e593dab0b7f211. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->