### PR TITLE
feat: add reaction to fetch impersonate accounts based on isPlatformOwner

### DIFF
--- a/packages/apps/frontera/src/store/Common/Common.store.ts
+++ b/packages/apps/frontera/src/store/Common/Common.store.ts
@@ -1,6 +1,6 @@
 import { Tracer } from '@infra/tracer';
 import { RootStore } from '@store/root';
-import { computed, observable, runInAction } from 'mobx';
+import { computed, reaction, observable, runInAction } from 'mobx';
 import {
   CommonRepository,
   SlackChannelDatum,
@@ -15,7 +15,16 @@ export class CommonStore {
     new Map();
   @observable accessor impersonateAccounts: TenantImpersonateDatum[] = [];
 
-  constructor(private root: RootStore) {}
+  constructor(private root: RootStore) {
+    reaction(
+      () => this.root.globalCache.value?.isPlatformOwner,
+      () => {
+        if (this.root.globalCache.value?.isPlatformOwner) {
+          this.fetchImpersonateAccounts.bind(this)();
+        }
+      },
+    );
+  }
 
   @computed
   get slackChannelsArray() {
@@ -69,9 +78,6 @@ export class CommonStore {
   }
 
   async bootstrap() {
-    if (this.root.globalCache.value?.isPlatformOwner) {
-      await this.fetchImpersonateAccounts();
-    }
     await this.fetchSlackChannels();
   }
 }


### PR DESCRIPTION
…ner status
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a reaction in `CommonStore` to fetch impersonate accounts based on `isPlatformOwner` status, removing the logic from `bootstrap()`.
> 
>   - **Behavior**:
>     - Adds a `reaction` in `CommonStore` constructor to fetch impersonate accounts when `isPlatformOwner` is true.
>     - Removes conditional fetch of impersonate accounts from `bootstrap()`.
>   - **Files**:
>     - `Common.store.ts`: Updates constructor and `bootstrap()` method in `CommonStore`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for ca60b8f7b8563b223bf0dc0d2781bcfb9b88b3ef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->