### PR TITLE
COS-6790: Fix closing product popover on combobox input click

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/Products/components/AddNewProductMenu.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/Products/components/AddNewProductMenu.tsx
@@ -25,65 +25,65 @@ export const AddNewProductMenu = observer(
     }));
 
     return (
-      <>
-        <Popover open={isOpen} onOpenChange={(open) => setIsOpen(open)}>
-          <PopoverTrigger>
-            <IconButton
-              size='xxs'
-              icon={<Plus />}
-              className='ml-1'
-              variant='outline'
-              colorScheme='gray'
-              aria-label='Add a product'
-              dataTest='contract-card-add-sli'
-            />
-          </PopoverTrigger>
-          <PopoverContent
-            align='end'
-            side='bottom'
-            className='py-1 min-w-[254px] max-w-[420px] z-[99999999]'
-          >
-            <Combobox
-              escapeClearsValue
-              options={options}
-              closeMenuOnSelect
-              placeholder={'Search for a product'}
-              onKeyDown={(e) => {
-                if (e.key === 'Escape') setIsOpen(false);
-              }}
-              noOptionsMessage={() => (
-                <div className='py-2 cursor-default'>
-                  {options.length
-                    ? 'No products found.'
-                    : 'No products yet. Create them in Settings.'}
-                </div>
-              )}
-              formatOptionLabel={(option) => (
-                <div className='inline-flex items-center'>
-                  <span title={option.label} className='truncate max-w-[280px]'>
-                    {option.label}
-                  </span>
-                  <span className='mx-0.5'>•</span>
-                  <span className='text-gray-500'>{option.sku.typeLabel}</span>
-                </div>
-              )}
-              onChange={(newValue) => {
-                contractLineItemsStore.create({
-                  billingCycle:
-                    newValue?.sku.value.type === SkuType.Subscription
-                      ? BilledType.Monthly
-                      : BilledType.Once,
-                  contractId,
-                  skuId: newValue?.sku.id,
-                  price: newValue?.sku.value.price,
-                  serviceStarted: new Date(Date.now() + 86400000).toISOString(),
-                });
-                setIsOpen(false);
-              }}
-            />
-          </PopoverContent>
-        </Popover>
-      </>
+      <Popover open={isOpen} onOpenChange={(open) => setIsOpen(open)}>
+        <PopoverTrigger>
+          <IconButton
+            size='xxs'
+            icon={<Plus />}
+            className='ml-1'
+            variant='outline'
+            colorScheme='gray'
+            aria-label='Add a product'
+            dataTest='contract-card-add-sli'
+          />
+        </PopoverTrigger>
+        <PopoverContent
+          align='end'
+          side='bottom'
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+          className='py-1 min-w-[254px] max-w-[420px] z-[99999999]'
+        >
+          <Combobox
+            escapeClearsValue
+            options={options}
+            closeMenuOnSelect
+            placeholder={'Search for a product'}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') setIsOpen(false);
+            }}
+            noOptionsMessage={() => (
+              <div className='py-2 cursor-default'>
+                {options.length
+                  ? 'No products found.'
+                  : 'No products yet. Create them in Settings.'}
+              </div>
+            )}
+            formatOptionLabel={(option) => (
+              <div className='inline-flex items-center'>
+                <span title={option.label} className='truncate max-w-[280px]'>
+                  {option.label}
+                </span>
+                <span className='mx-0.5'>•</span>
+                <span className='text-gray-500'>{option.sku.typeLabel}</span>
+              </div>
+            )}
+            onChange={(newValue) => {
+              contractLineItemsStore.create({
+                billingCycle:
+                  newValue?.sku.value.type === SkuType.Subscription
+                    ? BilledType.Monthly
+                    : BilledType.Once,
+                contractId,
+                skuId: newValue?.sku.id,
+                price: newValue?.sku.value.price,
+                serviceStarted: new Date(Date.now() + 86400000).toISOString(),
+              });
+              setIsOpen(false);
+            }}
+          />
+        </PopoverContent>
+      </Popover>
     );
   },
 );

--- a/packages/apps/frontera/src/routes/settings/page.tsx
+++ b/packages/apps/frontera/src/routes/settings/page.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { useStore } from '@shared/hooks/useStore';
@@ -10,7 +11,9 @@ export const SettingsPage = () => {
   const store = useStore();
   const tab = searchParams?.get('tab') ?? 'workspace';
 
-  store.ui.commandMenu.setType('GlobalHub');
+  useEffect(() => {
+    store.ui.commandMenu.setType('GlobalHub');
+  }, []);
 
   return (
     <TabsContainer>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes product popover closing issue on combobox input click and ensures command menu type initialization in settings page.
> 
>   - **Behavior**:
>     - Fixes issue where clicking on combobox input would close the product popover in `AddNewProductMenu.tsx` by adding `stopPropagation()` to `onClick` and `onMouseDown` events.
>     - Ensures `commandMenu` type is set to 'GlobalHub' on `SettingsPage` load using `useEffect` hook in `page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f841dee058300e64c7d4172eba2a0c74d0b14326. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->