### PR TITLE
fix: remove fetchPriority from AvatarCell and set default id in Table…

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/avatar/AvatarCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/avatar/AvatarCell.tsx
@@ -51,7 +51,6 @@ export const AvatarCell = observer(
                 alt={fullName}
                 loading='lazy'
                 decoding='async'
-                fetchPriority='low'
                 onError={() => setStatus('error')}
                 onLoad={() => setStatus('loaded')}
                 className={cn('w-full h-full object-contain rounded-full', {

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/avatar/AvatarCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/organizations/Cells/avatar/AvatarCell.tsx
@@ -51,7 +51,6 @@ export const AvatarCell = memo(
               alt={fullName}
               loading='lazy'
               decoding='async'
-              fetchPriority='low'
               onError={() => setStatus('error')}
               onLoad={() => setStatus('loaded')}
               className={cn('w-full h-full object-contain', {

--- a/packages/apps/frontera/src/ui/presentation/Table/Table.tsx
+++ b/packages/apps/frontera/src/ui/presentation/Table/Table.tsx
@@ -90,7 +90,7 @@ interface TableProps<T extends object> {
 }
 
 export const Table = <T extends object>({
-  id,
+  id = '1',
   data,
   columns,
   dataTest,
@@ -234,7 +234,9 @@ export const Table = <T extends object>({
   const virtualRows = rowVirtualizer.getVirtualItems();
 
   useEffect(() => {
-    rowVirtualizer.scrollToIndex(0);
+    if (data.length > 0) {
+      rowVirtualizer?.scrollToIndex(0);
+    }
   }, [id]);
 
   useEffect(() => {


### PR DESCRIPTION
… component
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `fetchPriority` from `AvatarCell` components and set default `id` in `Table` component.
> 
>   - **AvatarCell Components**:
>     - Removed `fetchPriority='low'` from `AvatarCell` in `contacts/Cells/avatar/AvatarCell.tsx` and `organizations/Cells/avatar/AvatarCell.tsx`.
>   - **Table Component**:
>     - Set default `id` to `'1'` in `Table` component in `Table.tsx`.
>     - Added check to `useEffect` to only call `scrollToIndex(0)` if `data.length > 0` in `Table.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 6a6c14bdc9f0eda373e882f5ea454d2998dfb676. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->