### PR TITLE
fix no company name in icp

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_gather_company_intelligence.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_gather_company_intelligence.go
@@ -127,7 +127,7 @@ func (c *GatherCompanyIntelligenceCapability) Execute(ctx context.Context, execu
 		return true, result, err
 	}
 
-	result.CompanyCity = company.Name
+	result.CompanyName = company.Name
 	result.PrimaryDomain = company.PrimaryDomain
 	result.CompanyDescriptions.Description1 = company.Description
 	result.CompanyDescriptions.Description2 = company.SourceDescription1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes incorrect assignment of `CompanyName` in `Execute()` of `GatherCompanyIntelligenceCapability`.
> 
>   - **Bug Fix**:
>     - Corrects assignment in `Execute()` of `GatherCompanyIntelligenceCapability` from `CompanyCity` to `CompanyName` using `company.Name`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f1523f5f59a1fcc32bab6a72904e41a273b40c8e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->