### PR TITLE
COS-6793: Switcher/Nav UI improvements

### DIFF
--- a/packages/apps/frontera/src/routes/finder/page.tsx
+++ b/packages/apps/frontera/src/routes/finder/page.tsx
@@ -112,6 +112,7 @@ export const FinderPage = observer(() => {
             </div>
             <FinderTable />
           </div>
+
           {store.ui.showPreviewCard && !store.ui.isSearching && (
             <PreviewCard>
               {tableViewDef?.value.tableType === TableViewType.Contacts && (

--- a/packages/apps/frontera/src/routes/finder/src/components/FinderTable/FinderTable.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/FinderTable/FinderTable.tsx
@@ -256,6 +256,12 @@ export const FinderTable = observer(() => {
     if (selectedIds.length > 0) return;
 
     if (tableType === TableViewType.Organizations) {
+      if (!store.ui.showPreviewCard) {
+        if (index !== null) {
+          store.ui.setFocusRow(data?.[index]?.id);
+        }
+      }
+
       if (typeof index !== 'number') {
         store.ui.commandMenu.setType('OrganizationHub');
 
@@ -272,6 +278,12 @@ export const FinderTable = observer(() => {
     }
 
     if (tableType === TableViewType.Contacts) {
+      if (!store.ui.showPreviewCard) {
+        if (index !== null) {
+          store.ui.setFocusRow(data?.[index]?.id);
+        }
+      }
+
       if (typeof index !== 'number') {
         store.ui.commandMenu.setType('ContactHub');
 
@@ -327,6 +339,7 @@ export const FinderTable = observer(() => {
   useEffect(() => {
     return () => {
       store.ui.setShowPreviewCard(false);
+      store.ui.setShortcutsPanel(false);
     };
   }, [preset]);
 

--- a/packages/apps/frontera/src/routes/organization/src/components/OrganizationSidenav/OrganizationSidenav.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/OrganizationSidenav/OrganizationSidenav.tsx
@@ -44,6 +44,7 @@ export const OrganizationSidenav = observer(() => {
 
   const parentOrgId = organization?.value?.parentId;
   const parentOrgName = organization?.value?.parentName;
+  const isPlatformOwner = store?.globalCache?.value?.isPlatformOwner ?? false;
 
   const presets = {
     targetsPreset: store.tableViewDefs.targetsPreset,
@@ -54,12 +55,16 @@ export const OrganizationSidenav = observer(() => {
     flowSequencesPreset: store.tableViewDefs.flowsPreset,
   };
 
-  useKeyboardNavigation(presets, {
-    when:
-      !store.ui.commandMenu.isOpen &&
-      !store.ui.isEditingTableCell &&
-      !store.ui.isFilteringTable,
-  });
+  useKeyboardNavigation(
+    presets,
+    {
+      when:
+        !store.ui.commandMenu.isOpen &&
+        !store.ui.isEditingTableCell &&
+        !store.ui.isFilteringTable,
+    },
+    isPlatformOwner,
+  );
 
   if (!organization) return null;
 

--- a/packages/apps/frontera/src/routes/prospects/page.tsx
+++ b/packages/apps/frontera/src/routes/prospects/page.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
+import { useUnmount } from 'usehooks-ts';
 import { observer } from 'mobx-react-lite';
 import { FinderTable } from '@finder/components/FinderTable';
 import { FinderFilters } from '@finder/components/FinderFilters/FinderFilters';
@@ -11,7 +12,9 @@ import { useStore } from '@shared/hooks/useStore';
 import { ButtonGroup } from '@ui/form/ButtonGroup';
 import { Columns03 } from '@ui/media/icons/Columns03';
 import { TableIdType, TableViewType } from '@graphql/types';
+import { PreviewCard } from '@shared/components/PreviewCard';
 import { ViewSettings } from '@shared/components/ViewSettings';
+import { ShortcutsPanel } from '@shared/components/PreviewCard/components/ShortcutsPanel';
 
 import { Search } from './src/components/Search';
 import { ProspectsBoard } from './src/components/ProspectsBoard';
@@ -25,10 +28,14 @@ export const ProspectsBoardPage = observer(() => {
     store.tableViewDefs.opportunitiesTablePreset ?? '',
   );
 
+  useUnmount(() => {
+    store.ui.setShortcutsPanel(false);
+  });
+
   const showFinder = searchParams.get('show') === 'finder';
 
   return (
-    <div className='flex flex-col text-gray-700 overflow-auto bg-white'>
+    <div className='flex flex-col text-gray-700 overflow-hidden bg-white'>
       <div className='flex justify-between pr-4 border-b border-b-gray-200 bg-gray-25'>
         <Search />
 
@@ -61,42 +68,42 @@ export const ProspectsBoardPage = observer(() => {
           </ButtonGroup>
         </div>
       </div>
-      <div
-        className={cn(
-          'flex justify-between items-center py-2 border-b-gray-200 mx-4',
-          {
-            'border-b ': !showFinder,
-          },
+
+      <div className='flex'>
+        <div className=' w-full overflow-auto'>
+          <div className='flex justify-between mx-4 my-2 items-start'>
+            {showFinder && (
+              <FinderFilters
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                type={TableViewType.Opportunities as any}
+                tableId={TableIdType.OpportunitiesRecords}
+              />
+            )}
+            <div
+              className={cn({
+                'my-[1px]': !showFinder,
+              })}
+            >
+              <ViewSettings
+                type={TableViewType.Opportunities}
+                tableId={
+                  showFinder
+                    ? TableIdType.OpportunitiesRecords
+                    : TableIdType.Opportunities
+                }
+              />
+            </div>
+          </div>
+          {showFinder && <FinderTable />}
+          {!showFinder && <ProspectsBoard />}
+        </div>
+
+        {store.ui.showShortcutsPanel && (
+          <PreviewCard>
+            <ShortcutsPanel />
+          </PreviewCard>
         )}
-      >
-        <div>
-          {showFinder && (
-            <FinderFilters
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              type={TableViewType.Opportunities as any}
-              tableId={TableIdType.OpportunitiesRecords}
-            />
-          )}
-        </div>
-
-        <div
-          className={cn({
-            'my-[1px]': !showFinder,
-          })}
-        >
-          <ViewSettings
-            type={TableViewType.Opportunities}
-            tableId={
-              showFinder
-                ? TableIdType.OpportunitiesRecords
-                : TableIdType.Opportunities
-            }
-          />
-        </div>
       </div>
-
-      {showFinder && <FinderTable />}
-      {!showFinder && <ProspectsBoard />}
     </div>
   );
 });

--- a/packages/apps/frontera/src/routes/settings/src/components/SettingsSidenav/SettingsSidenav.tsx
+++ b/packages/apps/frontera/src/routes/settings/src/components/SettingsSidenav/SettingsSidenav.tsx
@@ -48,13 +48,17 @@ export const SettingsSidenav = observer(() => {
     flowSequencesPreset: store.tableViewDefs.flowsPreset,
   };
 
-  useKeyboardNavigation(presets, {
-    when:
-      !hasCampaign &&
-      !store.ui.commandMenu.isOpen &&
-      !store.ui.isEditingTableCell &&
-      !store.ui.isFilteringTable,
-  });
+  useKeyboardNavigation(
+    presets,
+    {
+      when:
+        !hasCampaign &&
+        !store.ui.commandMenu.isOpen &&
+        !store.ui.isEditingTableCell &&
+        !store.ui.isFilteringTable,
+    },
+    store.globalCache.value?.isPlatformOwner ?? false,
+  );
 
   return (
     <div className='px-2 pt-[6px] h-full w-[200px] bg-white flex flex-col relative border-r border-gray-200'>

--- a/packages/apps/frontera/src/routes/settings/src/components/SettingsSidenav/components/WorkspaceSection/WorkspaceSection.tsx
+++ b/packages/apps/frontera/src/routes/settings/src/components/SettingsSidenav/components/WorkspaceSection/WorkspaceSection.tsx
@@ -1,4 +1,3 @@
-import { useStore } from '@shared/hooks/useStore';
 import { Building03 } from '@ui/media/icons/Building03';
 import { SidenavItem } from '@shared/components/RootSidenav/components/SidenavItem';
 
@@ -14,9 +13,6 @@ export const WorkspaceSection = ({
   handleItemClick,
   checkIsActive,
 }: WorkspaceSectionProps) => {
-  const store = useStore();
-  const isPlatformOwner = store?.globalCache?.value?.isPlatformOwner ?? false;
-
   return (
     <div className='flex flex-col gap-2'>
       <div className='flex items-center gap-2 px-3'>
@@ -51,14 +47,6 @@ export const WorkspaceSection = ({
           isActive={checkIsActive('products')}
           onClick={handleItemClick('products')}
         />
-        {isPlatformOwner && (
-          <SidenavItem
-            label='Impersonate'
-            isActive={checkIsActive('impersonate')}
-            dataTest='sideNav-settings-impersonate'
-            onClick={handleItemClick('impersonate')}
-          />
-        )}
       </div>
     </div>
   );

--- a/packages/apps/frontera/src/routes/src/components/PreviewCard/PreviewCard.tsx
+++ b/packages/apps/frontera/src/routes/src/components/PreviewCard/PreviewCard.tsx
@@ -10,7 +10,7 @@ export const PreviewCard = ({ children }: PreviewCardProps) => {
   return (
     <div
       data-state={previewCard ? 'open' : 'closed'}
-      className='data-[state=open]:animate-slideLeftAndFade data-[state=closed]:animate-slideRightAndFade flex flex-col border border-r-0 border-t-0 border-gray-200 bg-white max-w-[450px] min-w-[450px]'
+      className='data-[state=open]:animate-slideLeftAndFade data-[state=closed]:animate-slideRightAndFade flex flex-col border border-r-0 border-t-0 border-gray-200 bg-white max-w-[400px] min-w-[400px]'
     >
       {children}
     </div>

--- a/packages/apps/frontera/src/routes/src/components/PreviewCard/components/ShortcutsPanel.tsx
+++ b/packages/apps/frontera/src/routes/src/components/PreviewCard/components/ShortcutsPanel.tsx
@@ -60,11 +60,8 @@ export const ShortcutsPanel = observer(() => {
   });
 
   return (
-    <div
-      style={{ paddingBottom: '10px' }}
-      className={cn('border-transparent', 'p-4')}
-    >
-      <div className='flex items-center justify-between'>
+    <div className={cn('border-transparent')}>
+      <div className='flex items-center justify-between pt-4 px-4'>
         <p className='text-base font-medium'>Keyboard shortcuts</p>
         <IconButton
           size='xs'
@@ -74,7 +71,7 @@ export const ShortcutsPanel = observer(() => {
           onClick={() => store.ui.setShortcutsPanel(false)}
         />
       </div>
-      <div className='mt-2 flex items-center gap-x-2'>
+      <div className='mt-2 flex items-center gap-x-2 px-4'>
         <Icon name={'search-sm'} className='size-4 text-gray-500' />
         <Input
           autoFocus
@@ -86,7 +83,10 @@ export const ShortcutsPanel = observer(() => {
           onChange={(e) => setSearchTerm(e.target.value)}
         />
       </div>
-      <div className='w-full bg-white overflow-y-auto h-screen'>
+      <div
+        style={{ height: `calc(100vh - 118px)` }}
+        className='w-full bg-white overflow-y-auto h-screen px-4 pb-6'
+      >
         <div className='mt-2'>
           {filteredSections.length > 0 ? (
             filteredSections.map((section, idx) => (

--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/RootSidenav.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/RootSidenav.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
@@ -26,6 +25,7 @@ export const RootSidenav = observer(() => {
   const preset = searchParams?.get('preset');
 
   const tableViewDef = store.tableViewDefs.getById(preset ?? '1');
+  const isPlatformOwner = store?.globalCache?.value?.isPlatformOwner ?? false;
 
   const presets = {
     targetsPreset: store.tableViewDefs.targetsPreset,
@@ -37,31 +37,23 @@ export const RootSidenav = observer(() => {
     flowSequencesPreset: store.tableViewDefs.flowsPreset,
   };
 
-  useKeyboardNavigation(presets, {
-    when:
-      store.ui.isSearching !== tableViewDef?.value?.tableType?.toLowerCase() &&
-      !store.ui.commandMenu.isOpen &&
-      !store.ui.isEditingTableCell &&
-      !store.ui.isFilteringTable,
-  });
-
-  const [isWorkspaceNameHidden, setIsWorkspaceNameHidden] = useState(false);
-  const isPlatformOwner = store?.globalCache?.value?.isPlatformOwner ?? false;
+  useKeyboardNavigation(
+    presets,
+    {
+      when:
+        store.ui.isSearching !==
+          tableViewDef?.value?.tableType?.toLowerCase() &&
+        !store.ui.commandMenu.isOpen &&
+        !store.ui.isEditingTableCell &&
+        !store.ui.isFilteringTable,
+    },
+    isPlatformOwner,
+  );
 
   return (
     <div className='pb-4 h-full w-12.5 bg-white flex flex-col border-r border-gray-200 overflow-hidden'>
       <LogoSection />
-      {isPlatformOwner && !isWorkspaceNameHidden && (
-        <div className='px-4 text-xs font-bold'>
-          Workspace: {store?.session?.value?.tenant}
-          <button
-            className='text-blue-600 underline'
-            onClick={() => setIsWorkspaceNameHidden(true)}
-          >
-            Hide workspace name
-          </button>
-        </div>
-      )}
+
       <NavigationSections
         preferences={preferences}
         checkIsActive={checkIsActive}

--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/LogoSection.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/LogoSection.tsx
@@ -11,6 +11,7 @@ import logoCustomerOs from '../../../../../src/assets/customer-os-small.png';
 
 export const LogoSection = observer(() => {
   const store = useStore();
+  const isPlatformOwner = store?.globalCache?.value?.isPlatformOwner ?? false;
 
   return (
     <div className='flex justify-between'>
@@ -27,7 +28,7 @@ export const LogoSection = observer(() => {
           {store.settings.tenant.value?.workspaceName || 'CustomerOS'}
         </span>
 
-        {store.common?.impersonateAccounts?.length > 1 && (
+        {store.common?.impersonateAccounts?.length > 1 && isPlatformOwner && (
           <Tooltip label='Switch workspaces (G then W)'>
             <IconButton
               size='xxs'

--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/SettingsSection.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/SettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
 
@@ -16,6 +16,8 @@ import {
 export const SettingsSection = observer(() => {
   const store = useStore();
   const navigate = useNavigate();
+
+  const location = useLocation();
 
   const handleSignOutClick = () => {
     store.session.clearSession();
@@ -70,6 +72,7 @@ export const SettingsSection = observer(() => {
             <MenuItem
               className='group'
               data-test='help-item-settings'
+              disabled={location.pathname?.includes('agent')}
               onClick={() => store.ui.setShortcutsPanel(true)}
             >
               <div

--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/hooks/useKeyboardNavigation.ts
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/hooks/useKeyboardNavigation.ts
@@ -20,6 +20,7 @@ interface Presets {
 export const useKeyboardNavigation = (
   presets: Presets,
   options: KeyboardNavigationOptions = { when: true },
+  isPlatformOwner: boolean,
 ) => {
   const navigate = useNavigate();
   const store = useStore();
@@ -86,7 +87,9 @@ export const useKeyboardNavigation = (
       store.ui.commandMenu.setType('SwitchWorkspace');
       store.ui.commandMenu.setOpen(true);
     },
-    options,
+    {
+      when: options.when && isPlatformOwner,
+    },
   );
 
   // useSequentialShortcut(


### PR DESCRIPTION
COS-6794: Fixed blank companies side panel
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> UI improvements and bug fixes in Frontera app, enhancing navigation, side panels, and keyboard shortcuts handling.
> 
>   - **UI Improvements**:
>     - Adjusted `PreviewCard` width to 400px in `PreviewCard.tsx`.
>     - Enhanced `ShortcutsPanel` layout and search functionality in `ShortcutsPanel.tsx`.
>     - Improved layout and overflow handling in `ProspectsBoardPage` in `page.tsx`.
>   - **Navigation Enhancements**:
>     - Added `isPlatformOwner` check to `useKeyboardNavigation` in `useKeyboardNavigation.ts` for conditional navigation.
>     - Updated `OrganizationSidenav` and `SettingsSidenav` to use `useKeyboardNavigation` with `isPlatformOwner`.
>   - **Bug Fixes**:
>     - Fixed blank companies side panel issue in `FinderTable.tsx` by setting focus row when `showPreviewCard` is false.
>     - Ensured `setShortcutsPanel` is false on unmount in `ProspectsBoardPage` and `FinderTable`.
>   - **Miscellaneous**:
>     - Removed unused imports and variables in several files.
>     - Minor style adjustments and code cleanup in `LogoSection.tsx` and `SettingsSection.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 760f1f213fc73cf7f7eebf16c8f7dc206f70a532. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->