### PR TITLE
fix icp errors

### DIFF
--- a/packages/server/customer-os-common-module/services/agent/agent_registry_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_registry_service.go
@@ -25,7 +25,7 @@ const (
 type Agent struct {
 	Agent        AgentMetadata   `toml:"agent"`
 	Goal         GoalConfig      `toml:"goal"`
-	Watchers     WatchersConfig  `toml:"watchers"`
+	Listeners    ListenersConfig `toml:"listeners"`
 	Capabilities CapabilityTypes `toml:"capabilities"`
 	Plays        Plays           `toml:"plays"`
 }
@@ -42,7 +42,7 @@ type GoalConfig struct {
 	CompletionEvents []string `toml:"completion_events"`
 }
 
-type WatchersConfig struct {
+type ListenersConfig struct {
 	Events []string `toml:"events"`
 }
 
@@ -124,7 +124,7 @@ func (r *agentRegistryService) processAgentConfigFile(ctx context.Context, filen
 		AgentName:        agentConfig.Agent.Name,
 		Goal:             agentConfig.Goal.Goal,
 		CompletionEvents: agentConfig.Goal.CompletionEvents,
-		ListenerEvents:   agentConfig.Watchers.Events,
+		ListenerEvents:   agentConfig.Listeners.Events,
 		Capabilities:     agentConfig.Capabilities.Types,
 		Version:          agentConfig.Agent.Version,
 		Filename:         filename,

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
@@ -118,7 +118,7 @@ func (c *EvaluateICPFitCapability) ValidateInput(input EvaluateICPFitInput) erro
 		return errors.New("missing required input: PrimaryDomain")
 	case input.CompanyName == "":
 		return errors.New("missing required input: CompanyName")
-	case input.CompanyDescriptions.Description1 == "":
+	case input.CompanyDescriptions.Description1 == "" && input.CompanyDescriptions.Description2 == "":
 		return errors.New("missing required input: CompanyDescription")
 	case input.IndustryNAICSName == "":
 		return errors.New("missing required input: IndustryNAICSName")
@@ -145,6 +145,11 @@ func (c *EvaluateICPFitCapability) Execute(ctx context.Context, executionContain
 
 	result := EvaluateICPFitOutput{
 		IcpFit: enum.IcpNotSet,
+	}
+
+	if executionContainer.InputData.EmployeeCount == 0 {
+		result.IcpFit = enum.IcpNotFit
+		return true, result, nil
 	}
 
 	if err := c.ValidateInput(executionContainer.InputData); err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renamed `WatchersConfig` to `ListenersConfig` and added validation for `CompanyDescriptions` and `EmployeeCount` in ICP evaluation.
> 
>   - **Renames**:
>     - `WatchersConfig` to `ListenersConfig` in `agent_registry_service.go`.
>     - `Watchers` to `Listeners` in `Agent` struct in `agent_registry_service.go`.
>   - **Validation**:
>     - In `capability_evaluate_icp_fit.go`, `ValidateInput()` now checks if `CompanyDescriptions.Description1` and `Description2` are both empty.
>     - `Execute()` in `capability_evaluate_icp_fit.go` returns `IcpNotFit` if `EmployeeCount` is 0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 4cdefe775ee5490824105bf2dc19dc8147cd7946. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->