### PR TITLE
add agent scopes

### DIFF
--- a/packages/server/customer-os-common-module/enum/agents.go
+++ b/packages/server/customer-os-common-module/enum/agents.go
@@ -55,3 +55,26 @@ func GetAgentGoal(s string) (AgentGoal, error) {
 		return "", fmt.Errorf("invalid Agent Goal: %s", s)
 	}
 }
+
+type AgentScope string
+
+const (
+	AgentScopePersonal  AgentScope = "personal"
+	AgentScopeWorkspace AgentScope = "workspace"
+)
+
+func (t AgentScope) String() string {
+	return string(t)
+}
+
+func GetAgentScope(s string) (AgentScope, error) {
+	switch AgentScope(s) {
+	case
+		AgentScopePersonal,
+		AgentScopeWorkspace:
+		return AgentScope(s), nil
+
+	default:
+		return "", fmt.Errorf("invalid Agent Scope: %s", s)
+	}
+}

--- a/packages/server/customer-os-common-module/services/agent/agent_registry_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_registry_service.go
@@ -34,6 +34,7 @@ type AgentMetadata struct {
 	Version string `toml:"version"`
 	Name    string `toml:"name"`
 	Type    string `toml:"type"`
+	Scope   string `toml:"scope"`
 	Icon    string `toml:"icon"`
 }
 

--- a/packages/server/customer-os-common-module/services/agent/agent_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_service.go
@@ -116,7 +116,7 @@ func (a *agentService) CreateAgent(ctx context.Context, agentType enum.AgentType
 	}
 
 	if agentRegistry.Scope == enum.AgentScopePersonal {
-		agent.User = common.GetUserIdFromContext(ctx)
+		agent.Owner = common.GetUserIdFromContext(ctx)
 	}
 
 	// build capabilities from registry

--- a/packages/server/customer-os-common-module/services/agent/agent_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_service.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/agent_listeners"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgresentity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -17,6 +16,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/agent_capability"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/agent_listeners"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/events"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
@@ -104,6 +104,7 @@ func (a *agentService) CreateAgent(ctx context.Context, agentType enum.AgentType
 	// build new agent
 	agent := postgresentity.Agent{
 		Type:        agentType,
+		Scope:       agentRegistry.Scope,
 		Tenant:      tenant,
 		Name:        agentRegistry.AgentName,
 		Goal:        agentRegistry.Goal,
@@ -112,6 +113,10 @@ func (a *agentService) CreateAgent(ctx context.Context, agentType enum.AgentType
 		Icon:        agentRegistry.Icon,
 		Color:       utils.GetRandomColor(),
 		RegistryID:  agentRegistry.ID,
+	}
+
+	if agentRegistry.Scope == enum.AgentScopePersonal {
+		agent.User = common.GetUserIdFromContext(ctx)
 	}
 
 	// build capabilities from registry

--- a/packages/server/customer-os-postgres-repository/entity/agent_registry.go
+++ b/packages/server/customer-os-postgres-repository/entity/agent_registry.go
@@ -10,17 +10,18 @@ import (
 )
 
 type AgentRegistry struct {
-	ID               string         `gorm:"primaryKey;type:varchar(21)" json:"id"`
-	Type             enum.AgentType `gorm:"column:type;type:varchar(255);not null;index" json:"type" binding:"required"`
-	AgentName        string         `gorm:"column:agent_name;type:varchar(255)" json:"agentName"`
-	Filename         string         `gorm:"column:filename;type:varchar(255)" json:"filename"`
-	CompletionEvents pq.StringArray `gorm:"column:completion_events;type:varchar[]" json:"completionEvents"`
-	ListenerEvents   pq.StringArray `gorm:"column:listener_events;type:varchar[]" json:"listenerEvents"`
-	Capabilities     pq.StringArray `gorm:"column:capabilities;type:varchar[]" json:"capabilities"`
-	Version          string         `gorm:"column:version;type:varchar(21)" json:"version"`
-	Goal             enum.AgentGoal `gorm:"column:goal;type:varchar(255)" json:"goal"`
-	IsActive         bool           `gorm:"column:is_active;type:boolean;default:true" json:"isActive"`
-	Icon             string         `gorm:"column:icon;type:text" json:"icon"`
+	ID               string          `gorm:"primaryKey;type:varchar(21)" json:"id"`
+	Type             enum.AgentType  `gorm:"column:type;type:varchar(255);not null;index" json:"type" binding:"required"`
+	AgentName        string          `gorm:"column:agent_name;type:varchar(255)" json:"agentName"`
+	Scope            enum.AgentScope `gorm:"column:agent_scope;type:varchar(255)" json:"agentScope"`
+	Filename         string          `gorm:"column:filename;type:varchar(255)" json:"filename"`
+	CompletionEvents pq.StringArray  `gorm:"column:completion_events;type:varchar[]" json:"completionEvents"`
+	ListenerEvents   pq.StringArray  `gorm:"column:listener_events;type:varchar[]" json:"listenerEvents"`
+	Capabilities     pq.StringArray  `gorm:"column:capabilities;type:varchar[]" json:"capabilities"`
+	Version          string          `gorm:"column:version;type:varchar(21)" json:"version"`
+	Goal             enum.AgentGoal  `gorm:"column:goal;type:varchar(255)" json:"goal"`
+	IsActive         bool            `gorm:"column:is_active;type:boolean;default:true" json:"isActive"`
+	Icon             string          `gorm:"column:icon;type:text" json:"icon"`
 }
 
 func (AgentRegistry) TableName() string {

--- a/packages/server/customer-os-postgres-repository/entity/agents.go
+++ b/packages/server/customer-os-postgres-repository/entity/agents.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	"github.com/lib/pq"
 	"gorm.io/gorm"
 )
 
@@ -17,7 +18,8 @@ type Agent struct {
 	Type         enum.AgentType  `gorm:"column:type;type:varchar(50);not null;" json:"type"`
 	Scope        enum.AgentScope `gorm:"column:agent_scope;type:varchar(255)" json:"agentScope"`
 	Tenant       string          `gorm:"column:tenant;type:varchar(255);not null" json:"tenant" binding:"required"`
-	User         string          `gorm:"column:user;type:varchar(255)" json:"user"`
+	Owner        string          `gorm:"column:owner;type:varchar(255)" json:"owner"`
+	Managers     pq.StringArray  `gorm:"column:managers;type:varchar[]" json:"managers"`
 	Name         string          `gorm:"column:name;type:varchar(255);not null" json:"name" binding:"required"`
 	Configured   bool            `gorm:"column:configured;type:boolean;default:false" json:"capabilitiesConfigured"`
 	Goal         enum.AgentGoal  `gorm:"column:goal;type:text" json:"goal"`

--- a/packages/server/customer-os-postgres-repository/entity/agents.go
+++ b/packages/server/customer-os-postgres-repository/entity/agents.go
@@ -12,26 +12,27 @@ import (
 	"gorm.io/gorm"
 )
 
-// Agent entity without the embedded capabilities
 type Agent struct {
-	ID           string         `gorm:"primaryKey;type:varchar(32)" json:"id"`
-	Type         enum.AgentType `gorm:"column:type;type:varchar(50);not null;" json:"type"`
-	Tenant       string         `gorm:"column:tenant;type:varchar(255);not null" json:"tenant" binding:"required"`
-	Name         string         `gorm:"column:name;type:varchar(255);not null" json:"name" binding:"required"`
-	Configured   bool           `gorm:"column:configured;type:boolean;default:false" json:"capabilitiesConfigured"`
-	Goal         enum.AgentGoal `gorm:"column:goal;type:text" json:"goal"`
-	Status       string         `gorm:"column:status;type:varchar(32)" json:"status"`
-	IsActive     bool           `gorm:"column:is_active;type:boolean;default:false" json:"isActive"`
-	FlowID       string         `gorm:"column:flow_id;type:varchar(255)" json:"flowId"`
-	VisibleInUI  bool           `gorm:"column:visible_in_ui;type:boolean;default:true" json:"visibleInUI"`
-	CreatedAt    time.Time      `gorm:"column:created_at;autoCreateTime" json:"createdAt"`
-	UpdatedAt    *time.Time     `gorm:"column:updated_at;autoUpdateTime" json:"updatedAt"`
-	ErrorMessage *string        `gorm:"column:error_message;type:varchar(255)" json:"errorMessage"`
-	Color        string         `gorm:"column:color;type:varchar(255)" json:"color"`
-	Icon         string         `gorm:"column:icon;type:varchar(255)" json:"icon"`
-	RegistryID   string         `gorm:"column:registry_id;type:varchar(32)" json:"registryId"`
-	Capabilities []Capability   `gorm:"foreignKey:AgentID" json:"capabilities"`
-	Listeners    []Listener     `gorm:"foreignKey:AgentID" json:"listeners"`
+	ID           string          `gorm:"primaryKey;type:varchar(32)" json:"id"`
+	Type         enum.AgentType  `gorm:"column:type;type:varchar(50);not null;" json:"type"`
+	Scope        enum.AgentScope `gorm:"column:agent_scope;type:varchar(255)" json:"agentScope"`
+	Tenant       string          `gorm:"column:tenant;type:varchar(255);not null" json:"tenant" binding:"required"`
+	User         string          `gorm:"column:user;type:varchar(255)" json:"user"`
+	Name         string          `gorm:"column:name;type:varchar(255);not null" json:"name" binding:"required"`
+	Configured   bool            `gorm:"column:configured;type:boolean;default:false" json:"capabilitiesConfigured"`
+	Goal         enum.AgentGoal  `gorm:"column:goal;type:text" json:"goal"`
+	Status       string          `gorm:"column:status;type:varchar(32)" json:"status"`
+	IsActive     bool            `gorm:"column:is_active;type:boolean;default:false" json:"isActive"`
+	FlowID       string          `gorm:"column:flow_id;type:varchar(255)" json:"flowId"`
+	VisibleInUI  bool            `gorm:"column:visible_in_ui;type:boolean;default:true" json:"visibleInUI"`
+	CreatedAt    time.Time       `gorm:"column:created_at;autoCreateTime" json:"createdAt"`
+	UpdatedAt    *time.Time      `gorm:"column:updated_at;autoUpdateTime" json:"updatedAt"`
+	ErrorMessage *string         `gorm:"column:error_message;type:varchar(255)" json:"errorMessage"`
+	Color        string          `gorm:"column:color;type:varchar(255)" json:"color"`
+	Icon         string          `gorm:"column:icon;type:varchar(255)" json:"icon"`
+	RegistryID   string          `gorm:"column:registry_id;type:varchar(32)" json:"registryId"`
+	Capabilities []Capability    `gorm:"foreignKey:AgentID" json:"capabilities"`
+	Listeners    []Listener      `gorm:"foreignKey:AgentID" json:"listeners"`
 }
 
 func (Agent) TableName() string {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `AgentScope` to categorize agents as 'personal' or 'workspace', updating enums, services, and database entities accordingly.
> 
>   - **Enums**:
>     - Add `AgentScope` type with values `AgentScopePersonal` and `AgentScopeWorkspace` in `agents.go`.
>     - Add `GetAgentScope()` function to validate `AgentScope` values.
>   - **Services**:
>     - Update `AgentMetadata` in `agent_registry_service.go` to include `Scope` field.
>     - Modify `CreateAgent()` in `agent_service.go` to set `Scope` and `Owner` based on `AgentScope`.
>   - **Database Entities**:
>     - Add `Scope` field to `AgentRegistry` and `Agent` structs in `agent_registry.go` and `agents.go`.
>     - Update `Agent` struct to include `Owner` and `Managers` fields in `agents.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b4365fc4759c2ef72b0630387a721668258688a9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->