### PR TITLE
fix

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
@@ -93,6 +93,7 @@ func (c *EvaluateICPFitCapability) NewConfig() EvaluateICPFitConfig {
 
 func (c *EvaluateICPFitCapability) DefaultConfig() any {
 	config := c.NewConfig()
+	config.ICPCompanyExamples.Value = []string{}
 	return &config
 }
 

--- a/packages/server/customer-os-postgres-repository/repository/agents_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agents_repository.go
@@ -268,7 +268,7 @@ func (f *agentsRepository) Update(ctx context.Context, agent postgres_entity.Age
 
 	err := f.gormDb.Transaction(func(tx *gorm.DB) error {
 		// Update agent
-		if err := tx.Model(&agent).Omit("Capabilities").Save(&agent).Error; err != nil {
+		if err := tx.Model(&agent).Omit("Capabilities").Omit("Listeners").Save(&agent).Error; err != nil {
 			return err
 		}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Initialize `ICPCompanyExamples.Value` as empty in `DefaultConfig()` and omit `Listeners` in `Update()` method in `agents_repository.go`.
> 
>   - **Behavior**:
>     - In `capability_evaluate_icp_fit.go`, `DefaultConfig()` now initializes `ICPCompanyExamples.Value` as an empty slice.
>     - In `agents_repository.go`, `Update()` method now omits `Listeners` when saving an agent.
>   - **Misc**:
>     - Minor code adjustments to ensure correct default behavior and database operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 16bd906018b2b6e915305414b9b068faf604390f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->