### PR TITLE
skip default tenant setup on second login

### DIFF
--- a/packages/runner/sync-slack/service/sync_from_source_service.go
+++ b/packages/runner/sync-slack/service/sync_from_source_service.go
@@ -423,7 +423,7 @@ func (s *syncFromSourceService) getSlackToken(ctx context.Context, tenant string
 		return "", err
 	}
 	if slackSettings == nil || slackSettings.AccessToken == "" {
-		return "", errors.New("slack api token found")
+		return "", errors.New("slack api token not found")
 	}
 	return slackSettings.AccessToken, nil
 }

--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -482,7 +482,7 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 		return
 	}
 
-	if !isPersonalEmail {
+	if !isPersonalEmail && isNewTenant {
 		err = services.CommonServices.RegistrationService.PrepareDefaultTenantSetup(ctx, signInRequest.LoggedInEmail)
 		if err != nil {
 			tracing.TraceErr(span, err)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix error message in `getSlackToken()` and skip default tenant setup on second login in `signIn()`.
> 
>   - **Behavior**:
>     - Fix error message in `getSlackToken()` in `sync_from_source_service.go` to correctly indicate when a Slack API token is not found.
>     - Modify `signIn()` in `registration.go` to skip default tenant setup on second login if `isNewTenant` is false.
>   - **Misc**:
>     - Minor logic adjustment in `signIn()` to check `isNewTenant` before preparing default tenant setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c773e636aebd84d85e48af80a9da9a0efa87b3d4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->