### PR TITLE
Socials used incorrectly between companies

### DIFF
--- a/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaList.tsx
+++ b/packages/apps/frontera/src/routes/organization/src/components/Tabs/shared/SocialMediaList/SocialMediaList.tsx
@@ -18,7 +18,7 @@ export const SocialMediaList = observer(
   ({ isReadOnly, dataTest }: SocialMediaListProps) => {
     const store = useStore();
     const id = useParams()?.id as string;
-    const organization = store.organizations.getById(store.ui.focusRow ?? id);
+    const organization = store.organizations.getById(id ?? store.ui.focusRow);
 
     if (!organization || !organization?.value) return null;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prioritize `id` from `useParams` over `store.ui.focusRow` in `SocialMediaList.tsx` to ensure correct organization retrieval.
> 
>   - **Behavior**:
>     - In `SocialMediaList.tsx`, change order of parameters in `getById` to prioritize `id` from `useParams` over `store.ui.focusRow`.
>     - Ensures correct organization is retrieved when both `id` and `focusRow` are available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 6446af73f3c17e713f421d325dc74d8dd6a0dfe8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->