### PR TITLE
Fixes around linkedin token

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/contact_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/contact_service.go
@@ -531,6 +531,12 @@ func (s *contactService) processAutomationRunResult(ctx context.Context, automat
 		return
 	}
 
+	userEntity := neo4jmapper.MapDbNodeToUserEntity(useByEmailNode)
+
+	if userEntity.Roles == nil || utils.Contains(userEntity.Roles, "IMPERSONATED") {
+		return
+	}
+
 	var results []string
 
 	err = json.Unmarshal([]byte(result.ResultData), &results)

--- a/packages/server/browser-automation-api/src/infrastructure/middleware/auth-middleware.ts
+++ b/packages/server/browser-automation-api/src/infrastructure/middleware/auth-middleware.ts
@@ -56,17 +56,17 @@ export class AuthMiddleware {
         username
       );
 
-      if (user.roles.includes("IMPERSONATED")) {
-        return res.status(401).json({
-          success: false,
-          message: "Unauthorized. User is impersonated.",
-        });
-      }
-
       if (!user) {
         return res.status(401).json({
           success: false,
           message: "Unauthorized. User not found.",
+        });
+      }
+
+      if (user.roles.includes("IMPERSONATED")) {
+        return res.status(401).json({
+          success: false,
+          message: "Unauthorized. User is impersonated.",
         });
       }
 

--- a/packages/server/browser-automation-api/src/infrastructure/middleware/auth-middleware.ts
+++ b/packages/server/browser-automation-api/src/infrastructure/middleware/auth-middleware.ts
@@ -56,6 +56,13 @@ export class AuthMiddleware {
         username
       );
 
+      if (user.roles.includes("IMPERSONATED")) {
+        return res.status(401).json({
+          success: false,
+          message: "Unauthorized. User is impersonated.",
+        });
+      }
+
       if (!user) {
         return res.status(401).json({
           success: false,

--- a/packages/server/customer-os-api/graphql/schemas/cache.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/cache.graphqls
@@ -6,7 +6,7 @@ extend type Query {
 type GlobalCache {
     user:                   User!
     isPlatformOwner:        Boolean!
-    isOwner:                Boolean! #derecated. not used on UI
+    isOwner:                Boolean! #deprecated. not used on UI
     inactiveEmailTokens:    [GlobalCacheEmailToken!]!
     activeEmailTokens:      [GlobalCacheEmailToken!]!
     mailboxes:              [String!]!

--- a/packages/server/customer-os-api/graphql/schemas/cache.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/cache.graphqls
@@ -6,7 +6,7 @@ extend type Query {
 type GlobalCache {
     user:                   User!
     isPlatformOwner:        Boolean!
-    isOwner:                Boolean!
+    isOwner:                Boolean! #derecated. not used on UI
     inactiveEmailTokens:    [GlobalCacheEmailToken!]!
     activeEmailTokens:      [GlobalCacheEmailToken!]!
     mailboxes:              [String!]!

--- a/packages/server/customer-os-common-module/services/authentication/authentication_service.go
+++ b/packages/server/customer-os-common-module/services/authentication/authentication_service.go
@@ -63,9 +63,11 @@ func (a *authenticationService) CreateUserInTenant(ctx context.Context, txWithPo
 
 	span.LogKV("user_already_exists", false)
 
+	internal := false
 	roles := []string{"USER"}
 
 	if impersonating {
+		internal = true
 		roles = append(roles, "IMPERSONATED")
 	} else {
 		roles = append(roles, "OWNER")
@@ -82,6 +84,7 @@ func (a *authenticationService) CreateUserInTenant(ctx context.Context, txWithPo
 			FirstName: &firstName,
 			LastName:  &lastName,
 			Roles:     common_utils.ToPtr(roles),
+			Internal:  &internal,
 		})
 		if err != nil {
 			return "", err


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance handling of 'IMPERSONATED' user roles across services and mark a deprecated field in GraphQL schema.
> 
>   - **Behavior**:
>     - In `contact_service.go`, `processAutomationRunResult()` now returns early if user roles include "IMPERSONATED".
>     - In `auth-middleware.ts`, `checkApiKey()` returns 401 if user roles include "IMPERSONATED".
>   - **Authentication**:
>     - In `authentication_service.go`, `CreateUserInTenant()` sets `internal` to true and adds "IMPERSONATED" to roles if `impersonating` is true.
>   - **GraphQL Schema**:
>     - Mark `isOwner` field as deprecated in `cache.graphqls`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 1157ed16197b7192034aa3910f742280ae0c4503. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->