### PR TITLE
COS-6805: LinkedIn connection labels have merged

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/connectedUsers/ConnectedUsersCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/connectedUsers/ConnectedUsersCell.tsx
@@ -2,7 +2,6 @@ import { observer } from 'mobx-react-lite';
 
 import { User } from '@graphql/types';
 import { useStore } from '@shared/hooks/useStore';
-import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
 
 interface ConnectedUsersProps {
   users: User[];
@@ -11,36 +10,29 @@ interface ConnectedUsersProps {
 export const ConnectedUsers = observer(({ users }: ConnectedUsersProps) => {
   const store = useStore();
 
-  if (!users.length) return <p className='text-gray-400'>No one</p>;
+  if (!users.length) return <p className='text-gray-400'> No one </p>;
 
-  const usersDisplayed = users
-    ?.map(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (l: any) => store.users.value.get(l.id)?.name,
-    )
-    .join(', ');
+  const usersDisplayed = users?.map(
+    (l: User) => store.users.value.get(l.id)?.name,
+  );
 
   return (
-    <Tooltip
-      label={
-        users.length > 1
-          ? users
-              .slice(1, users.length)
-              ?.map((e) => e?.name)
-              .join(', ')
+    <p
+      className='flex w-fit gap-x-1'
+      title={
+        usersDisplayed?.length > 1
+          ? usersDisplayed?.map((e) => e).join(', ')
           : ''
       }
     >
-      <div className='flex w-fit'>
-        <div className='bg-gray-100 rounded-md w-fit px-1.5 '>
-          {usersDisplayed}
+      {usersDisplayed?.map((name, i) => (
+        <div
+          key={`connected-user-${i}`}
+          className='bg-gray-100 rounded-md w-fit px-1.5 '
+        >
+          {name}
         </div>
-        {users?.length > 1 && (
-          <div className='rounded-md w-fit px-1.5 ml-1 text-gray-500'>
-            +{users?.length - 1}
-          </div>
-        )}
-      </div>
-    </Tooltip>
+      ))}
+    </p>
   );
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplified `ConnectedUsersCell.tsx` by removing `Tooltip` and using `title` attribute for displaying multiple user names.
> 
>   - **Behavior**:
>     - Removed `Tooltip` component from `ConnectedUsersCell.tsx`.
>     - Simplified user display logic by using `title` attribute on `p` element for multiple users.
>     - Adjusted `usersDisplayed` to map directly to user names.
>   - **Code Simplification**:
>     - Removed unnecessary `slice` and `join` operations for user names.
>     - Removed conditional rendering for additional user count display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c55a95b812a63af01b875677de15e8281fb042bc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->