### PR TITLE
Fix send email from timeline

### DIFF
--- a/packages/apps/frontera/middleware/index.js
+++ b/packages/apps/frontera/middleware/index.js
@@ -206,6 +206,20 @@ async function createServer() {
     followRedirects: true,
   });
 
+  const internalApiProxy = createProxyMiddleware({
+    pathFilter: '/internal',
+    pathRewrite: { '^/internal': '' },
+    target: process.env.INTERNAL_API_PATH,
+    changeOrigin: true,
+    headers: {
+      'X-Openline-API-KEY': process.env.INTERNAL_API_PATH,
+    },
+    logger: console,
+    preserveHeaderKeyCase: true,
+    followRedirects: true,
+  });
+
+  // deprecated
   const settingsApiProxy = createProxyMiddleware({
     pathFilter: '/sa',
     pathRewrite: { '^/sa': '' },
@@ -219,6 +233,7 @@ async function createServer() {
     followRedirects: true,
   });
 
+  // deprecated
   const userAdminApiProxy = createProxyMiddleware({
     pathFilter: '/ua',
     pathRewrite: { '^/ua': '' },
@@ -232,6 +247,7 @@ async function createServer() {
     followRedirects: true,
   });
 
+  // deprecated
   const fileStorageApiProxy = createProxyMiddleware({
     pathFilter: '/fs',
     pathRewrite: { '^/fs': '' },
@@ -247,6 +263,7 @@ async function createServer() {
 
   app.use(customerOsApiGqlProxy);
   app.use(customerOsApiRestProxy);
+  app.use(internalApiProxy);
   app.use(settingsApiProxy);
   app.use(userAdminApiProxy);
   app.use(fileStorageApiProxy);

--- a/packages/apps/frontera/src/store/Mail/Mail.store.ts
+++ b/packages/apps/frontera/src/store/Mail/Mail.store.ts
@@ -43,15 +43,11 @@ export class MailStore {
 
     try {
       this.isLoading = true;
-      await this.transport.http.post(
-        `/cos/internal/v1/mail/send`,
-        decoratedPayload,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-          },
+      await this.transport.http.post(`/internal/mail/send`, decoratedPayload, {
+        headers: {
+          'Content-Type': 'application/json',
         },
-      );
+      });
 
       runInAction(() => {
         this.root.ui.toastSuccess(

--- a/packages/server/customer-os-api/rest/private/mail.go
+++ b/packages/server/customer-os-api/rest/private/mail.go
@@ -38,7 +38,7 @@ func NewMailHandler(services *cosapi_services.Services, responseHandler *respons
 
 func (h *MailHandler) SendEmail() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		ctx, span := tracing.StartHttpServerTracerSpanWithHeader(c, "mail/send", c.Request.Header)
+		ctx, span := tracing.StartHttpServerTracerSpanWithHeader(c, "/mail/send", c.Request.Header)
 		defer span.Finish()
 		tracing.TagComponentRest(span)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated email sending functionality by adding new proxy middleware and changing API endpoint in `Mail.store.ts` and `mail.go`.
> 
>   - **Middleware**:
>     - Added `internalApiProxy` in `index.js` to handle requests to `/internal` path.
>     - Deprecated `settingsApiProxy`, `userAdminApiProxy`, and `fileStorageApiProxy` in `index.js`.
>   - **Mail Store**:
>     - Updated `send()` method in `Mail.store.ts` to use `/internal/mail/send` endpoint.
>   - **API**:
>     - Updated `SendEmail()` in `mail.go` to use `/mail/send` endpoint for tracing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 175bc73c6d045aadfa216a46db8b88a1725a41c2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->