### PR TITLE
Remove persister calls

### DIFF
--- a/packages/apps/frontera/src/store/Sku/Skus.store.ts
+++ b/packages/apps/frontera/src/store/Sku/Skus.store.ts
@@ -41,7 +41,6 @@ export class SkusStore extends Store<SkuDatum, Sku> {
     } finally {
       runInAction(() => {
         this.isLoading = false;
-        this.persistGroup();
       });
     }
   }

--- a/packages/apps/frontera/src/store/TableViewDefs/TableViewDef.store.ts
+++ b/packages/apps/frontera/src/store/TableViewDefs/TableViewDef.store.ts
@@ -187,7 +187,6 @@ export class TableViewDefStore extends Store<TableViewDefDatum, TableViewDef> {
     } finally {
       runInAction(() => {
         this.isLoading = false;
-        this.persistGroup();
       });
     }
   }

--- a/packages/apps/frontera/src/store/_store.ts
+++ b/packages/apps/frontera/src/store/_store.ts
@@ -4,7 +4,7 @@ import type { Transport } from '@infra/transport';
 import set from 'lodash/set';
 import { match } from 'ts-pattern';
 import { getDiff, applyDiff } from 'recursive-diff';
-import { when, action, reaction, observable, runInAction } from 'mobx';
+import { when, action, observable, runInAction } from 'mobx';
 
 import type { RootStore } from './root';
 import type { Entity, EntityFactoryClass } from './record';
@@ -74,13 +74,6 @@ export class Store<T extends object, E extends Entity<T> = Entity<T>> {
       () => this.isBootstrapped,
       () => {
         this.persister?.setItem('isBootstrapped', true);
-      },
-    );
-
-    reaction(
-      () => `${this.size}-${this.version}`,
-      () => {
-        this.persistGroup();
       },
     );
 
@@ -339,46 +332,46 @@ export class Store<T extends object, E extends Entity<T> = Entity<T>> {
 
     this.root.transactions.commit(operation, {
       ...opts,
-      persist: () => this.persist(id),
+      // persist: () => this.persist(id),
     });
     this.version++;
   }
 
-  private async persist(id: string) {
-    try {
-      const record = this.value.get(id);
+  // private async persist(id: string) {
+  //   try {
+  //     const record = this.value.get(id);
 
-      if (!record) return;
-      const data = record.toRaw();
+  //     if (!record) return;
+  //     const data = record.toRaw();
 
-      const persisted = await this.persister?.getItem<Map<string, T>>('data');
+  //     const persisted = await this.persister?.getItem<Map<string, T>>('data');
 
-      persisted?.set(id, data);
-      await this.persister?.setItem('data', persisted);
-    } catch (e) {
-      console.error('Failed to persist', e);
-    }
-  }
+  //     persisted?.set(id, data);
+  //     await this.persister?.setItem('data', persisted);
+  //   } catch (e) {
+  //     console.error('Failed to persist', e);
+  //   }
+  // }
 
-  public persistGroup() {
-    this.persister?.getItem<Map<string, T>>('data', (err) => {
-      if (err) {
-        console.error('Failed to get persisted data', err);
+  // public persistGroup() {
+  //   this.persister?.getItem<Map<string, T>>('data', (err) => {
+  //     if (err) {
+  //       console.error('Failed to get persisted data', err);
 
-        return;
-      }
+  //       return;
+  //     }
 
-      const persisted = new Map<string, T>();
+  //     const persisted = new Map<string, T>();
 
-      this.value.forEach((v, k) => persisted.set(k, v.toRaw()));
+  //     this.value.forEach((v, k) => persisted.set(k, v.toRaw()));
 
-      this.persister?.setItem('data', persisted, (err) => {
-        if (err) {
-          console.error('Failed to persist store data', err);
-        }
-      });
-    });
-  }
+  //     this.persister?.setItem('data', persisted, (err) => {
+  //       if (err) {
+  //         console.error('Failed to persist store data', err);
+  //       }
+  //     });
+  //   });
+  // }
 
   private makeChangesetOperation(id: string) {
     const lhs = this.snapshots.get(id)!;

--- a/packages/apps/frontera/src/store/persister.ts
+++ b/packages/apps/frontera/src/store/persister.ts
@@ -4,7 +4,7 @@ export type PersisterInstance = LocalForage;
 
 export class Persister {
   static DB_NAME = 'customerDB';
-  private static version = 0.3;
+  private static version = 0.4;
   private static instances: Map<string, PersisterInstance> = new Map();
   private static sharedInstances: Map<string, PersisterInstance> = new Map();
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `persistGroup` calls and related persistence logic from store classes, updating `Persister` version to 0.4.
> 
>   - **Behavior**:
>     - Remove `persistGroup` calls in `SkusStore` and `TableViewDefStore`.
>     - Comment out `persist` and `persistGroup` methods in `Store` class.
>   - **Persister**:
>     - Increment version from 0.3 to 0.4 in `persister.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 869c193ff004f22842c3e513cebd96c31e83eb01. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->