### PR TITLE
fix webhook rest routes

### DIFF
--- a/packages/server/customer-os-api/server/customer_routes.go
+++ b/packages/server/customer-os-api/server/customer_routes.go
@@ -16,7 +16,6 @@ const (
 	BillingPath      = "/billing/v1"
 	CustomerBasePath = "/customerbase/v1"
 	EnrichPath       = "/enrich/v1"
-	FlowsPath        = "/flows/v1"
 	MailstackPath    = "/mailstack/v1"
 	OutreachPath     = "/outreach/v1"
 	RevealPath       = "/reveal/v1"
@@ -126,8 +125,8 @@ func registerFlowRoutes(ctx context.Context, r *gin.Engine, s *cosapi_services.S
 	// webhook admin
 	registerRoute(ctx, r, RouteConfig{
 		method:    "GET",
-		path:      fmt.Sprintf("%s/hooks", FlowsPath),
-		handler:   h.Webhooks.GetActiveWebhooks(CustomerOSAPIURL(), FlowsPath),
+		path:      fmt.Sprintf("%s/hooks", WebhooksPath),
+		handler:   h.Webhooks.GetActiveWebhooks(CustomerOSAPIURL(), WebhooksPath),
 		routeType: RouteCustomer,
 		services:  s,
 		cache:     s.Cache,
@@ -135,8 +134,8 @@ func registerFlowRoutes(ctx context.Context, r *gin.Engine, s *cosapi_services.S
 
 	registerRoute(ctx, r, RouteConfig{
 		method:    "POST",
-		path:      fmt.Sprintf("%s/hooks", FlowsPath),
-		handler:   h.Webhooks.CreateWebhook(CustomerOSAPIURL(), FlowsPath),
+		path:      fmt.Sprintf("%s/hooks", WebhooksPath),
+		handler:   h.Webhooks.CreateWebhook(CustomerOSAPIURL(), WebhooksPath),
 		routeType: RouteCustomer,
 		services:  s,
 		cache:     s.Cache,
@@ -144,8 +143,8 @@ func registerFlowRoutes(ctx context.Context, r *gin.Engine, s *cosapi_services.S
 
 	registerRoute(ctx, r, RouteConfig{
 		method:    "POST",
-		path:      fmt.Sprintf("%s/:tenantId/i/:integrationId/rotate", FlowsPath),
-		handler:   h.Webhooks.RotateWebhook(CustomerOSAPIURL(), FlowsPath),
+		path:      fmt.Sprintf("%s/:tenantId/i/:integrationId/rotate", WebhooksPath),
+		handler:   h.Webhooks.RotateWebhook(CustomerOSAPIURL(), WebhooksPath),
 		routeType: RouteCustomer,
 		services:  s,
 		cache:     s.Cache,
@@ -153,7 +152,7 @@ func registerFlowRoutes(ctx context.Context, r *gin.Engine, s *cosapi_services.S
 
 	registerRoute(ctx, r, RouteConfig{
 		method:    "DELETE",
-		path:      fmt.Sprintf("%s/:tenantId/i/:integrationId", FlowsPath),
+		path:      fmt.Sprintf("%s/:tenantId/i/:integrationId", WebhooksPath),
 		handler:   h.Webhooks.DeactivateWebhook(),
 		routeType: RouteCustomer,
 		services:  s,

--- a/packages/server/customer-os-api/server/public_routes.go
+++ b/packages/server/customer-os-api/server/public_routes.go
@@ -60,8 +60,8 @@ func registerPublicRoutes(ctx context.Context, r *gin.Engine, s *cosapi_services
 
 	registerRoute(ctx, r, RouteConfig{
 		method:    "POST",
-		path:      fmt.Sprintf("%s/:tenantId/i/:integrationId", FlowsPath),
-		handler:   h.Webhooks.HandleWebhook(FlowsPath),
+		path:      fmt.Sprintf("%s/:tenantId/i/:integrationId", WebhooksPath),
+		handler:   h.Webhooks.HandleWebhook(WebhooksPath),
 		routeType: RoutePublic,
 	})
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix webhook routes by replacing `FlowsPath` with `WebhooksPath` in `customer_routes.go` and `public_routes.go`.
> 
>   - **Routes**:
>     - Change webhook routes in `customer_routes.go` to use `WebhooksPath` instead of `FlowsPath` for `GET`, `POST`, and `DELETE` methods.
>     - Update `public_routes.go` to use `WebhooksPath` for handling webhooks.
>   - **Constants**:
>     - Remove `FlowsPath` constant from `customer_routes.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 29d0837ce3a4339b50e0924df52bb114b0246eea. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->