### PR TITLE
Fix postgres queries

### DIFF
--- a/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
@@ -147,7 +147,7 @@ func (a *agentRunnerService) Run(ctx context.Context, agent postgres_entity.Agen
 
 	if capErr != nil {
 		tracing.TraceErr(span, capErr)
-		_, dbErr := a.postgresRepositories.AgentExecutionRepository.Fail(ctx, executionID, capErr.Error())
+		dbErr := a.postgresRepositories.AgentExecutionRepository.Fail(ctx, executionID, capErr.Error())
 		if dbErr != nil {
 			tracing.TraceErr(span, errors.Wrap(dbErr, "unable to update agent execution record"))
 			return dbErr
@@ -156,7 +156,7 @@ func (a *agentRunnerService) Run(ctx context.Context, agent postgres_entity.Agen
 	}
 
 	// update agentExecutionRecord
-	_, err = a.postgresRepositories.AgentExecutionRepository.Finish(ctx, executionID)
+	err = a.postgresRepositories.AgentExecutionRepository.Finish(ctx, executionID)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err

--- a/packages/server/customer-os-postgres-repository/repository/agent_execution_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agent_execution_repository.go
@@ -18,8 +18,8 @@ type AgentExecutionRepository interface {
 	Create(ctx context.Context, executionRecord postgres_entity.AgentExecution) (*postgres_entity.AgentExecution, error)
 	Find(ctx context.Context, executionRecord postgres_entity.AgentExecution) (*postgres_entity.AgentExecution, error)
 	GetById(ctx context.Context, executionID string) (*postgres_entity.AgentExecution, error)
-	Fail(ctx context.Context, executionID, errorMessage string) (*postgres_entity.AgentExecution, error)
-	Finish(ctx context.Context, executionID string) (*postgres_entity.AgentExecution, error)
+	Fail(ctx context.Context, executionID, errorMessage string) error
+	Finish(ctx context.Context, executionID string) error
 	Completed(ctx context.Context, executionID string, goalAchieved bool) (*postgres_entity.AgentExecution, error)
 }
 
@@ -90,13 +90,12 @@ func (f *agentExecutionRepository) Completed(ctx context.Context, executionID st
 	return &updatedRecord, nil
 }
 
-func (f *agentExecutionRepository) Finish(ctx context.Context, executionID string) (*postgres_entity.AgentExecution, error) {
+func (f *agentExecutionRepository) Finish(ctx context.Context, executionID string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.Finish")
 	defer span.Finish()
 	tracing.TagComponentPostgresRepository(span)
 	span.LogFields(log.String("executionID", executionID))
 
-	var updatedRecord postgres_entity.AgentExecution
 	// only running agent executions can be finished
 	err := f.gormDb.
 		Model(&postgres_entity.AgentExecution{}).
@@ -105,23 +104,20 @@ func (f *agentExecutionRepository) Finish(ctx context.Context, executionID strin
 		Updates(map[string]interface{}{
 			"status": enum.AgentExecutionFinished.String(),
 		}).
-		First(&updatedRecord, "id = ?", executionID).
 		Error
 	if err != nil {
 		tracing.TraceErr(span, err)
-		return nil, err
 	}
 
-	return &updatedRecord, nil
+	return err
 }
 
-func (f *agentExecutionRepository) Fail(ctx context.Context, executionID, errorMessage string) (*postgres_entity.AgentExecution, error) {
+func (f *agentExecutionRepository) Fail(ctx context.Context, executionID, errorMessage string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.Fail")
 	defer span.Finish()
 	tracing.TagComponentPostgresRepository(span)
 	span.LogFields(log.String("executionID", executionID))
 
-	var updatedRecord postgres_entity.AgentExecution
 	// only running agent executions can be finished
 	err := f.gormDb.
 		Model(&postgres_entity.AgentExecution{}).
@@ -132,14 +128,12 @@ func (f *agentExecutionRepository) Fail(ctx context.Context, executionID, errorM
 			"error_message": errorMessage,
 			"goal_achieved": false,
 		}).
-		First(&updatedRecord, "id = ?", executionID).
 		Error
 	if err != nil {
 		tracing.TraceErr(span, err)
-		return nil, err
 	}
 
-	return &updatedRecord, nil
+	return err
 }
 
 func (f *agentExecutionRepository) Find(ctx context.Context, executionRecord postgres_entity.AgentExecution) (*postgres_entity.AgentExecution, error) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Simplify error handling in `agent_runner_service.go` by modifying `Fail` and `Finish` methods in `agent_execution_repository.go` to return only `error`.
> 
>   - **Behavior**:
>     - Modify `Fail` and `Finish` methods in `agent_execution_repository.go` to return only `error` instead of `(*postgres_entity.AgentExecution, error)`.
>     - Update `Run` method in `agent_runner_service.go` to handle new error-only return type for `Fail` and `Finish` methods.
>   - **Repository Interface**:
>     - Change `Fail` and `Finish` signatures in `AgentExecutionRepository` interface to return `error` only.
>   - **Misc**:
>     - Remove unused `updatedRecord` variable in `Fail` and `Finish` methods in `agent_execution_repository.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 059675888c9e03b35696433c96b76400487be906. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->