### PR TITLE
COS-6825: Refine prospects page layout and styling

### DIFF
--- a/packages/apps/frontera/src/routes/prospects/page.tsx
+++ b/packages/apps/frontera/src/routes/prospects/page.tsx
@@ -72,13 +72,15 @@ export const ProspectsBoardPage = observer(() => {
       <div className='flex'>
         <div className=' w-full overflow-auto'>
           <div className='flex justify-between mx-4 my-2 items-start'>
-            {showFinder && (
-              <FinderFilters
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                type={TableViewType.Opportunities as any}
-                tableId={TableIdType.OpportunitiesRecords}
-              />
-            )}
+            <div className='flex items-center gap-2'>
+              {showFinder && (
+                <FinderFilters
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  type={TableViewType.Opportunities as any}
+                  tableId={TableIdType.OpportunitiesRecords}
+                />
+              )}
+            </div>
             <div
               className={cn({
                 'my-[1px]': !showFinder,

--- a/packages/apps/frontera/src/routes/prospects/src/components/PipelineMetrics/PipelineMetrics.tsx
+++ b/packages/apps/frontera/src/routes/prospects/src/components/PipelineMetrics/PipelineMetrics.tsx
@@ -15,7 +15,7 @@ export const PipelineMetrics = ({
   totalWeightedArr = 0,
 }: PipelineMetricsProps) => {
   return (
-    <div className='px-3 py-2 mx-4 mt-4 mb-4 bg-gray-100 flex justify-center gap-4 rounded-[4px] '>
+    <div className='px-3 py-2 mx-4 mb-4 bg-gray-100 flex justify-center gap-4 rounded-[4px] '>
       <span className=''>
         <span
           className='font-semibold'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refine layout and styling on the prospects page by adjusting component spacing in `page.tsx` and `PipelineMetrics.tsx`.
> 
>   - **Layout Changes**:
>     - Wrap `FinderFilters` in a `div` with `flex` and `gap-2` in `page.tsx` to improve layout spacing.
>   - **Styling Adjustments**:
>     - Remove `mt-4` from `PipelineMetrics` `div` in `PipelineMetrics.tsx` to adjust vertical spacing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a6aaadcadcac5f2133e1e46dbd455f75eea2009b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->