### PR TITLE
fix pdf generation

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
@@ -56,7 +56,7 @@ func (c *EvaluateICPFitConfig) Validate() bool {
 		c.QualificationCriteria.Error = ""
 	}
 	if len(c.ICPCompanyExamples.Value) < MinICPCompanyExamples {
-		c.ICPCompanyExamples.Error = "Please provide at least 5 companies that match your ICP."
+		c.ICPCompanyExamples.Error = "Add at least 5 ideal customer websites"
 		isValid = false
 	} else {
 		c.ICPCompanyExamples.Error = ""

--- a/packages/server/customer-os-common-module/services/invoice/utils.go
+++ b/packages/server/customer-os-common-module/services/invoice/utils.go
@@ -31,7 +31,7 @@ func FillInvoiceHtmlTemplate(ctx context.Context, tmpFile *os.File, invoiceData 
 	}
 
 	// Build the full path to the template file
-	templatePath := filepath.Join(currentDir, "/subscriptions/invoice/pdf_template/index.html")
+	templatePath := filepath.Join(currentDir, "/services/invoice/pdf_template/index.html")
 	templateContent, err := ioutil.ReadFile(templatePath)
 	if err != nil {
 		return errors.Wrap(err, "ioutil.ReadFile")
@@ -85,7 +85,7 @@ func ConvertInvoiceHtmlToPdf(ctx context.Context, fsc interfaces.FileService, pd
 	if err != nil {
 		return nil, errors.Wrap(err, "os.Getwd")
 	}
-	resourcesPath := filepath.Join(currentDir, "/subscriptions/invoice/pdf_template")
+	resourcesPath := filepath.Join(currentDir, "/services/invoice/pdf_template")
 
 	// Prepare HTTP request
 	url := pdfConverterUrl + "/forms/chromium/convert/html"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes PDF generation path and updates validation message in `capability_evaluate_icp_fit.go` and `utils.go`.
> 
>   - **Validation Message**:
>     - Update error message in `Validate()` in `capability_evaluate_icp_fit.go` to "Add at least 5 ideal customer websites".
>   - **PDF Generation**:
>     - Correct `templatePath` and `resourcesPath` in `FillInvoiceHtmlTemplate()` and `ConvertInvoiceHtmlToPdf()` in `utils.go` to use `/services/invoice/pdf_template` instead of `/subscriptions/invoice/pdf_template`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 44072dc0567c6a7798dd9c3a9a1c9337bf4d2631. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->