### PR TITLE
[COS-6818] Vitest teardown - orgs, tags, contacts

### DIFF
--- a/packages/apps/frontera/src/store/Contacts/__tests__/Contacts.integration.ts
+++ b/packages/apps/frontera/src/store/Contacts/__tests__/Contacts.integration.ts
@@ -14,14 +14,19 @@ const jobRolesService = JobRolesService.getInstance();
 describe('ContactsService - Integration Tests', () => {
   it('create contact', async () => {
     const contact_social_url =
-      'https://www.linkedin.com/in/Vitest_' + crypto.randomUUID();
+      'https://www.linkedin.com/in/Vitest-' + crypto.randomUUID();
 
-    const { contact_Create } = await contactService.createContact({
-      contactInput: { socialUrl: contact_social_url },
-    });
-    const contact = await contactService.getContact(contact_Create);
+    const { contactId } = await VitestHelper.createContactForTest(
+      contactService,
+      {
+        input: {
+          socialUrl: contact_social_url,
+        },
+      },
+    );
+    const contact = await contactService.getContact(contactId);
 
-    expect(contact?.id).toBe(contact_Create);
+    expect(contact?.id).toBe(contactId);
     expect(contact?.createdAt).not.toBeNull();
     expect(contact?.createdAt).not.toBe('');
     expect(contact?.updatedAt).not.toBeNull();
@@ -62,32 +67,37 @@ describe('ContactsService - Integration Tests', () => {
   });
 
   it('creates contact for organization', async () => {
-    const { id, name } = await VitestHelper.createOrganizationForTest(
-      organizationsRepository,
-    );
-    const { contact_CreateForOrganization } =
-      await contactService.createContactForOrganization({
-        organizationId: id,
-        input: {},
-      });
-    const contact = await contactService.getContact(
-      contact_CreateForOrganization.id,
-    );
+    const { organizationId, organizationName } =
+      await VitestHelper.createOrganizationForTest(organizationsRepository);
 
-    expect(contact?.primaryOrganizationName).toBe(name);
+    const { contactId } =
+      await VitestHelper.createContactForOrganizationForTest(
+        contactService,
+        organizationId,
+      );
+
+    // const { contact_CreateForOrganization } =
+    //   await contactService.createContactForOrganization({
+    //     organizationId: organizationId,
+    //     input: {},
+    //   });
+    const contact = await contactService.getContact(contactId);
+
+    expect(contact?.primaryOrganizationName).toBe(organizationName);
   });
 
   it('update contact', async () => {
-    const { id } = await VitestHelper.createOrganizationForTest(
+    const { organizationId } = await VitestHelper.createOrganizationForTest(
       organizationsRepository,
     );
     const contact_social_url = 'Vitest_' + crypto.randomUUID();
-    const { contact_CreateForOrganization } =
-      await contactService.createContactForOrganization({
-        organizationId: id,
-        input: { socialUrl: contact_social_url },
-      });
 
+    const { contactId } =
+      await VitestHelper.createContactForOrganizationForTest(
+        contactService,
+        organizationId,
+        { input: { socialUrl: contact_social_url } },
+      );
     const contact_name = 'Vitest_' + crypto.randomUUID();
     const contact_description = 'Vitest_' + crypto.randomUUID();
     const contact_prefix = 'Mr.';
@@ -97,7 +107,7 @@ describe('ContactsService - Integration Tests', () => {
 
     await contactService.updateContact({
       input: {
-        id: contact_CreateForOrganization.id,
+        id: contactId,
         name: contact_name,
         description: contact_description,
         prefix: contact_prefix,
@@ -108,9 +118,7 @@ describe('ContactsService - Integration Tests', () => {
       },
     });
 
-    const contact = await contactService.getContact(
-      contact_CreateForOrganization.id,
-    );
+    const contact = await contactService.getContact(contactId);
 
     expect.soft(contact?.name).toBe(contact_name);
     expect.soft(contact?.description).toBe(contact_description);
@@ -122,63 +130,63 @@ describe('ContactsService - Integration Tests', () => {
   });
 
   it('gets contacts', async () => {
-    const { id } = await VitestHelper.createOrganizationForTest(
+    const { organizationId } = await VitestHelper.createOrganizationForTest(
       organizationsRepository,
     );
 
     const contact_first_social_url = 'Vitest_' + crypto.randomUUID();
 
-    const firstContact = await contactService.createContactForOrganization({
-      organizationId: id,
-      input: { socialUrl: contact_first_social_url },
-    });
-    const firstContactId = firstContact.contact_CreateForOrganization.id;
+    const firstContact = await VitestHelper.createContactForOrganizationForTest(
+      contactService,
+      organizationId,
+      { input: { socialUrl: contact_first_social_url } },
+    );
+    const firstContactId = firstContact.contactId;
 
     const contact_second_social_url = 'Vitest_' + crypto.randomUUID();
 
-    const secondContact = await contactService.createContactForOrganization({
-      organizationId: id,
-      input: { socialUrl: contact_second_social_url },
-    });
+    const secondContact =
+      await VitestHelper.createContactForOrganizationForTest(
+        contactService,
+        organizationId,
+        { input: { socialUrl: contact_second_social_url } },
+      );
 
-    const secondContactId: string =
-      secondContact.contact_CreateForOrganization.id;
+    const secondContactId: string = secondContact.contactId;
     const contact_third_social_url = 'Vitest_' + crypto.randomUUID();
 
-    const thirdContact = await contactService.createContactForOrganization({
-      organizationId: id,
-      input: { socialUrl: contact_third_social_url },
-    });
+    const thirdContact = await VitestHelper.createContactForOrganizationForTest(
+      contactService,
+      organizationId,
+      { input: { socialUrl: contact_third_social_url } },
+    );
 
-    const thirdContactId: string =
-      thirdContact.contact_CreateForOrganization.id;
+    const thirdContactId: string = thirdContact.contactId;
     const { ui_contacts } = await contactService.getContactsByIds({
       ids: [firstContactId, secondContactId, thirdContactId],
     });
     const contactIds = ui_contacts?.map((contact) => contact.id);
 
     expect(contactIds).toBeDefined();
-    expect(contactIds).toContain(firstContact.contact_CreateForOrganization.id);
-    expect(contactIds).toContain(
-      secondContact.contact_CreateForOrganization.id,
-    );
-    expect(contactIds).toContain(thirdContact.contact_CreateForOrganization.id);
+    expect(contactIds).toContain(firstContactId);
+    expect(contactIds).toContain(secondContactId);
+    expect(contactIds).toContain(thirdContactId);
   });
 
   it('adds job roles to contact', async () => {
-    const { id, name } = await VitestHelper.createOrganizationForTest(
-      organizationsRepository,
-    );
+    const { organizationId, organizationName } =
+      await VitestHelper.createOrganizationForTest(organizationsRepository);
     const contact_social_url = 'Vitest_' + crypto.randomUUID();
 
-    const { contact_CreateForOrganization } =
-      await contactService.createContactForOrganization({
-        organizationId: id,
-        input: { socialUrl: contact_social_url },
-      });
+    const { contactId } =
+      await VitestHelper.createContactForOrganizationForTest(
+        contactService,
+        organizationId,
+        { input: { socialUrl: contact_social_url } },
+      );
 
     const contactBeforeFirstJobRole = await contactService.getContact(
-      contact_CreateForOrganization.id,
+      contactId,
     );
 
     expect(contactBeforeFirstJobRole.primaryOrganizationJobRoleTitle).toBe('');
@@ -191,11 +199,11 @@ describe('ContactsService - Integration Tests', () => {
     expect(
       contactBeforeFirstJobRole.primaryOrganizationJobRoleEndDate,
     ).toBeNull();
-    expect(contactBeforeFirstJobRole.primaryOrganizationName).toBe(name);
-
-    const contactAfterCreation = await contactService.getContact(
-      contact_CreateForOrganization.id,
+    expect(contactBeforeFirstJobRole.primaryOrganizationName).toBe(
+      organizationName,
     );
+
+    const contactAfterCreation = await contactService.getContact(contactId);
     const jobRoleBeforeUpdate = await jobRolesService.getJobRoles({
       ids: contactAfterCreation.jobRoleIds[0],
     });
@@ -216,15 +224,13 @@ describe('ContactsService - Integration Tests', () => {
       input: {
         description: jobRoleCreateOneDescription,
         jobTitle: jobRoleCreateOneTitle,
-        organizationId: id,
+        organizationId: organizationId,
         startedAt: jobRoleCreateOneStartedAt,
         contactId: contactBeforeFirstJobRole.id,
       },
     });
 
-    const contactAfterFirstJobRole = await contactService.getContact(
-      contact_CreateForOrganization.id,
-    );
+    const contactAfterFirstJobRole = await contactService.getContact(contactId);
 
     expect(contactAfterFirstJobRole.jobRoleIds.length).toBe(1);
 
@@ -235,48 +241,49 @@ describe('ContactsService - Integration Tests', () => {
     expect(jobRole.jobRoles[0].description).toBe(jobRoleCreateOneDescription);
     expect(jobRole.jobRoles[0].jobTitle).toBe(jobRoleCreateOneTitle);
     expect(jobRole.jobRoles[0].primary).toBe(true);
-    expect(jobRole.jobRoles[0].startedAt).toBe(jobRoleCreateOneStartedAt);
+    expect(new Date(jobRole.jobRoles[0].startedAt).toISOString()).toBe(
+      new Date(jobRoleCreateOneStartedAt).toISOString(),
+    );
     expect(jobRole.jobRoles[0].contact?.metadata.id).toBe(
       contactBeforeFirstJobRole.id,
     );
   });
 
   it('links contact to organization', async () => {
-    const { id, name } = await VitestHelper.createOrganizationForTest(
-      organizationsRepository,
+    const { organizationId, organizationName } =
+      await VitestHelper.createOrganizationForTest(organizationsRepository);
+    const { contactId } = await VitestHelper.createContactForTest(
+      contactService,
     );
-    const { contact_Create } = await contactService.createContact({
-      contactInput: {},
-    });
 
-    await organizationsRepository.getOrganization(id);
+    await organizationsRepository.getOrganization(organizationId);
 
-    const contactBeforeLink = await contactService.getContact(contact_Create);
+    const contactBeforeLink = await contactService.getContact(contactId);
 
     expect(contactBeforeLink.primaryOrganizationName).toBeNull;
 
     await contactService.linkOrganization({
       input: {
-        contactId: contact_Create,
-        organizationId: id,
+        contactId: contactId,
+        organizationId: organizationId,
       },
     });
     expect(
-      (await contactService.getContact(contact_Create)).primaryOrganizationId,
-    ).toBe(id);
+      (await contactService.getContact(contactId)).primaryOrganizationId,
+    ).toBe(organizationId);
     expect(
-      (await contactService.getContact(contact_Create)).primaryOrganizationName,
-    ).toBe(name);
+      (await contactService.getContact(contactId)).primaryOrganizationName,
+    ).toBe(organizationName);
   });
 
   it('updates contact email', async () => {
-    const { contact_Create } = await contactService.createContact({
-      contactInput: {},
-    });
+    const { contactId } = await VitestHelper.createContactForTest(
+      contactService,
+    );
     const emailOne = 'Vitest_' + crypto.randomUUID() + '@example.com';
 
     await contactService.updateContactEmail({
-      contactId: contact_Create,
+      contactId: contactId,
       previousEmail: '',
       input: {
         email: emailOne,
@@ -285,14 +292,12 @@ describe('ContactsService - Integration Tests', () => {
       },
     });
 
-    const contactAfterEmailUpdate = await contactService.getContact(
-      contact_Create,
-    );
+    const contactAfterEmailUpdate = await contactService.getContact(contactId);
 
-    expect(contactAfterEmailUpdate.emails.length).toBe(1);
+    expect(contactAfterEmailUpdate.emails.length).toBe(2);
     expect(contactAfterEmailUpdate.emails[0].id).not.toBeNull();
     expect(contactAfterEmailUpdate.emails[0].email).toBe(emailOne);
-    expect(contactAfterEmailUpdate.emails[0].primary).toBe(true);
+    expect(contactAfterEmailUpdate.emails[0].primary).toBe(false);
     expect(
       contactAfterEmailUpdate.emails[0].emailValidationDetails.verified,
     ).toBe(false);
@@ -340,7 +345,7 @@ describe('ContactsService - Integration Tests', () => {
     const emailTwo = 'Vitest_' + crypto.randomUUID() + '@example.com';
 
     await contactService.updateContactEmail({
-      contactId: contact_Create,
+      contactId: contactId,
       previousEmail: '',
       input: {
         email: emailTwo,
@@ -350,10 +355,10 @@ describe('ContactsService - Integration Tests', () => {
     });
 
     const contactAfterSecondEmailUpdate = await contactService.getContact(
-      contact_Create,
+      contactId,
     );
 
-    expect(contactAfterSecondEmailUpdate?.emails.length).toBe(2);
+    expect(contactAfterSecondEmailUpdate?.emails.length).toBe(3);
 
     let emailOneEntry = contactAfterSecondEmailUpdate?.emails.find(
       (email) => email.email === emailOne,
@@ -366,21 +371,21 @@ describe('ContactsService - Integration Tests', () => {
     expect(emailTwoEntry).toBeDefined();
 
     expect(emailOneEntry?.id).not.toBeNull();
-    expect(emailOneEntry?.primary).toBe(true);
+    expect(emailOneEntry?.primary).toBe(false);
 
     expect(emailTwoEntry?.id).not.toBeNull();
     expect(emailTwoEntry?.primary).toBe(false);
 
     await contactService.setPrimaryEmail({
-      contactId: contact_Create,
+      contactId: contactId,
       email: emailTwo,
     });
 
     const contactAfterSecondEmailSetPrimary = await contactService.getContact(
-      contact_Create,
+      contactId,
     );
 
-    expect(contactAfterSecondEmailSetPrimary?.emails.length).toBe(2);
+    expect(contactAfterSecondEmailSetPrimary?.emails.length).toBe(3);
 
     emailOneEntry = contactAfterSecondEmailSetPrimary?.emails.find(
       (email) => email.email === emailOne,
@@ -404,22 +409,23 @@ describe('ContactsService - Integration Tests', () => {
   });
 
   it('checks successful response from better contact', async () => {
-    const { id } = await VitestHelper.createOrganizationForTest(
+    const { organizationId } = await VitestHelper.createOrganizationForTest(
       organizationsRepository,
     );
     const contact_social_url = 'Vitest_' + crypto.randomUUID();
 
-    const { contact_CreateForOrganization } =
-      await contactService.createContactForOrganization({
-        organizationId: id,
-        input: { socialUrl: contact_social_url },
-      });
+    const { contactId } =
+      await VitestHelper.createContactForOrganizationForTest(
+        contactService,
+        organizationId,
+        { input: { socialUrl: contact_social_url } },
+      );
 
-    await contactService.getContact(contact_CreateForOrganization.id);
+    await contactService.getContact(contactId);
 
     const { contact_FindWorkEmail } = await contactService.findEmail({
-      contactId: contact_CreateForOrganization.id,
-      organizationId: id,
+      contactId: contactId,
+      organizationId: organizationId,
     });
 
     expect(
@@ -429,16 +435,17 @@ describe('ContactsService - Integration Tests', () => {
   });
 
   it('does CRUD ops for phone number', async () => {
-    const { id } = await VitestHelper.createOrganizationForTest(
+    const { organizationId } = await VitestHelper.createOrganizationForTest(
       organizationsRepository,
     );
     const contact_social_url = 'Vitest_' + crypto.randomUUID();
 
-    const { contact_CreateForOrganization } =
-      await contactService.createContactForOrganization({
-        organizationId: id,
-        input: { socialUrl: contact_social_url },
-      });
+    const { contactId } =
+      await VitestHelper.createContactForOrganizationForTest(
+        contactService,
+        organizationId,
+        { input: { socialUrl: contact_social_url } },
+      );
 
     //also here the phonenumber is not used anymore in our app until we reimplement it in BE
 
@@ -460,7 +467,7 @@ describe('ContactsService - Integration Tests', () => {
     const expectedFirstPhoneNumberLabel = PhoneNumberLabel.Mobile;
 
     const firstAddedNumber = await contactService.addPhoneNumber({
-      contactId: contact_CreateForOrganization.id,
+      contactId: contactId,
       input: {
         phoneNumber: expectedCreateFirstPhoneNumber,
         label: expectedFirstPhoneNumberLabel,
@@ -686,23 +693,21 @@ describe('ContactsService - Integration Tests', () => {
   // });
 
   it('creates and updates tags for contact', async () => {
-    const { id, name } = await VitestHelper.createOrganizationForTest(
-      organizationsRepository,
-    );
+    const { organizationId, organizationName } =
+      await VitestHelper.createOrganizationForTest(organizationsRepository);
 
-    const { contact_CreateForOrganization } =
-      await contactService.createContactForOrganization({
-        organizationId: id,
-        input: {},
-      });
-    const contactCreated = await contactService.getContact(
-      contact_CreateForOrganization.id,
-    );
+    const { contactId } =
+      await VitestHelper.createContactForOrganizationForTest(
+        contactService,
+        organizationId,
+        { input: {} },
+      );
+    const contactCreated = await contactService.getContact(contactId);
 
     expect(contactCreated?.tags).toEqual([]);
-    expect(contactCreated.primaryOrganizationName).toBe(name);
+    expect(contactCreated.primaryOrganizationName).toBe(organizationName);
 
-    const firstTagName = crypto.randomUUID();
+    const firstTagName = 'Vitest_' + crypto.randomUUID();
 
     await contactService.addTagsToContact({
       input: {
@@ -711,14 +716,12 @@ describe('ContactsService - Integration Tests', () => {
       },
     });
 
-    const contactAddedFirstTag = await contactService.getContact(
-      contact_CreateForOrganization.id,
-    );
+    const contactAddedFirstTag = await contactService.getContact(contactId);
 
     expect(contactAddedFirstTag.tags?.length).toBe(1);
     expect(contactAddedFirstTag.tags?.[0]?.name).toBe(firstTagName);
 
-    const secondTagName = crypto.randomUUID();
+    const secondTagName = 'Vitest_' + crypto.randomUUID();
 
     await contactService.addTagsToContact({
       input: {
@@ -727,9 +730,7 @@ describe('ContactsService - Integration Tests', () => {
       },
     });
 
-    const contactAddedSecondTag = await contactService.getContact(
-      contact_CreateForOrganization.id,
-    );
+    const contactAddedSecondTag = await contactService.getContact(contactId);
 
     expect(contactAddedSecondTag?.tags?.length).toBe(2);
 
@@ -740,9 +741,7 @@ describe('ContactsService - Integration Tests', () => {
       },
     });
 
-    const contactRemovedFirstTag = await contactService.getContact(
-      contact_CreateForOrganization.id,
-    );
+    const contactRemovedFirstTag = await contactService.getContact(contactId);
 
     expect(contactRemovedFirstTag?.tags?.length).toBe(1);
     expect(contactRemovedFirstTag?.tags?.[0]?.name).toBe(secondTagName);

--- a/packages/apps/frontera/src/store/Contacts/__tests__/contactsTestState.ts
+++ b/packages/apps/frontera/src/store/Contacts/__tests__/contactsTestState.ts
@@ -1,0 +1,11 @@
+export const contactsTestState = {
+  createdContactsIds: new Set<string>(),
+};
+
+export const trackContact = (organizationId: string) => {
+  contactsTestState.createdContactsIds.add(organizationId);
+};
+
+export const getCreatedContact = () => {
+  return Array.from(contactsTestState.createdContactsIds);
+};

--- a/packages/apps/frontera/src/store/Organizations/__tests__/Organizations.integration.ts
+++ b/packages/apps/frontera/src/store/Organizations/__tests__/Organizations.integration.ts
@@ -1,4 +1,5 @@
 import { it, expect, describe } from 'vitest';
+import { Transport } from '@infra/transport.ts';
 import { VitestHelper } from '@store/vitest-helper.ts';
 import { OrganizationRepository } from '@infra/repositories/organization';
 
@@ -10,7 +11,6 @@ import {
   OpportunityRenewalLikelihood,
 } from '@graphql/types';
 
-import { Transport } from '../../../infra/transport';
 import { UserService } from '../../Users/User.service';
 import { ContractService } from '../../Contracts/Contract.service';
 import { ContractLineItemService } from '../../ContractLineItems/ContractLineItem.service';
@@ -44,9 +44,8 @@ describe('organizationRepository - Integration Tests', () => {
   });
 
   it('checks create empty organization', async () => {
-    const { id, name } = await VitestHelper.createOrganizationForTest(
-      organizationRepository,
-    );
+    const { organizationId, organizationName } =
+      await VitestHelper.createOrganizationForTest(organizationRepository);
 
     const sleep = (ms: number) =>
       new Promise((resolve) => setTimeout(resolve, ms));
@@ -58,7 +57,9 @@ describe('organizationRepository - Integration Tests', () => {
 
     while (retries < maxRetries && !assertionsPassed) {
       try {
-        const organization = await organizationRepository.getOrganization(id);
+        const organization = await organizationRepository.getOrganization(
+          organizationId,
+        );
 
         expect.soft(organization.churnedAt).toBeNull();
         expect.soft(organization.ltv).toBe(0);
@@ -79,7 +80,7 @@ describe('organizationRepository - Integration Tests', () => {
         expect.soft(organization?.leadSource).toBe('');
         expect.soft(organization?.locations).toEqual([]);
         expect.soft(organization?.logoUrl).toBe('');
-        expect.soft(organization?.name).toBe(name);
+        expect.soft(organization?.name).toBe(organizationName);
         expect.soft(organization?.owner).toBeNull();
         expect.soft(organization?.parentId).toBeNull();
         expect.soft(organization?.parentName).toBeNull();
@@ -107,7 +108,7 @@ describe('organizationRepository - Integration Tests', () => {
   });
 
   it('adds tags to organization', async () => {
-    const { id } = await VitestHelper.createOrganizationForTest(
+    const { organizationId } = await VitestHelper.createOrganizationForTest(
       organizationRepository,
     );
 
@@ -115,25 +116,27 @@ describe('organizationRepository - Integration Tests', () => {
 
     await organizationRepository.addTag({
       input: {
-        organizationId: id,
+        organizationId: organizationId,
         tag: { name: organization_tag_name },
       },
     });
 
     let organization;
 
-    organization = await organizationRepository.getOrganization(id);
+    organization = await organizationRepository.getOrganization(organizationId);
     expect(organization?.tags?.[0].name).toEqual(organization_tag_name);
 
     if (organization?.tags?.[0]?.metadata.id) {
       await organizationRepository.removeTag({
         input: {
-          organizationId: id,
+          organizationId: organizationId,
           tag: { id: organization?.tags[0].metadata.id },
         },
       });
 
-      organization = await organizationRepository.getOrganization(id);
+      organization = await organizationRepository.getOrganization(
+        organizationId,
+      );
       expect(organization?.tags).toEqual([]);
     } else {
       throw new Error(
@@ -199,8 +202,8 @@ describe('organizationRepository - Integration Tests', () => {
 
     await organizationRepository.addSubsidiary({
       input: {
-        organizationId: parent.id,
-        subsidiaryId: subsidiary.id,
+        organizationId: parent.organizationId,
+        subsidiaryId: subsidiary.organizationId,
       },
     });
 
@@ -215,9 +218,13 @@ describe('organizationRepository - Integration Tests', () => {
 
     while (retries < maxRetries && !assertionsPassed) {
       try {
-        organization = await organizationRepository.getOrganization(parent.id);
+        organization = await organizationRepository.getOrganization(
+          parent.organizationId,
+        );
 
-        expect(organization?.subsidiaries[0]).toEqual(subsidiary.id);
+        expect(organization?.subsidiaries[0]).toEqual(
+          subsidiary.organizationId,
+        );
 
         assertionsPassed = true;
       } catch (error) {
@@ -232,13 +239,15 @@ describe('organizationRepository - Integration Tests', () => {
     }
 
     await organizationRepository.removeSubsidiary({
-      organizationId: parent.id,
-      subsidiaryId: subsidiary.id,
+      organizationId: parent.organizationId,
+      subsidiaryId: subsidiary.organizationId,
     });
 
     while (retries < maxRetries && !assertionsPassed) {
       try {
-        organization = await organizationRepository.getOrganization(parent.id);
+        organization = await organizationRepository.getOrganization(
+          parent.organizationId,
+        );
 
         expect(organization?.subsidiaries).toHaveLength(0);
 
@@ -258,9 +267,8 @@ describe('organizationRepository - Integration Tests', () => {
   it('retrieve archived organizations', async () => {
     const testStartDate = new Date().toISOString();
 
-    const { name, id } = await VitestHelper.createOrganizationForTest(
-      organizationRepository,
-    );
+    const { organizationName, organizationId } =
+      await VitestHelper.createOrganizationForTest(organizationRepository);
 
     const sleep = (ms: number) =>
       new Promise((resolve) => setTimeout(resolve, ms));
@@ -286,7 +294,7 @@ describe('organizationRepository - Integration Tests', () => {
       );
     };
 
-    let organizationExistsInDashboard = hasName(name);
+    let organizationExistsInDashboard = hasName(organizationName);
 
     expect(organizationExistsInDashboard).toBe(true);
 
@@ -295,12 +303,12 @@ describe('organizationRepository - Integration Tests', () => {
         date: testStartDate,
       });
 
-    expect(archived_organizations.organizations_HiddenAfter.includes(id)).toBe(
-      false,
-    );
+    expect(
+      archived_organizations.organizations_HiddenAfter.includes(organizationId),
+    ).toBe(false);
 
     await organizationRepository.hideOrganizations({
-      ids: [id],
+      ids: [organizationId],
     });
 
     retrieved_organizations = await organizationRepository.getOrganizations({
@@ -312,7 +320,7 @@ describe('organizationRepository - Integration Tests', () => {
       },
     });
 
-    organizationExistsInDashboard = hasName(name);
+    organizationExistsInDashboard = hasName(organizationName);
 
     expect(organizationExistsInDashboard).toBe(false);
 
@@ -321,33 +329,33 @@ describe('organizationRepository - Integration Tests', () => {
         date: testStartDate,
       });
 
-    expect(archived_organizations.organizations_HiddenAfter.includes(id)).toBe(
-      true,
-    );
+    expect(
+      archived_organizations.organizations_HiddenAfter.includes(organizationId),
+    ).toBe(true);
   });
 
-  it.skip('updates onboarding status to organization', async () => {
-    const { id } = await VitestHelper.createOrganizationForTest(
+  it('updates onboarding status to organization', async () => {
+    const { organizationId } = await VitestHelper.createOrganizationForTest(
       organizationRepository,
     );
 
     let organization;
 
-    organization = await organizationRepository.getOrganization(id);
+    organization = await organizationRepository.getOrganization(organizationId);
     expect(organization.onboardingStatus).toBe('NOT_APPLICABLE');
     await organizationRepository.updateOnboardingStatus({
       input: {
-        organizationId: id,
+        organizationId: organizationId,
         status: OnboardingStatus.Stuck,
       },
     });
 
-    organization = await organizationRepository.getOrganization(id);
+    organization = await organizationRepository.getOrganization(organizationId);
     expect(organization?.onboardingStatus).toBe('STUCK');
   });
 
   it('updates updateAllOpportunityRenewals', async () => {
-    const { id } = await VitestHelper.createOrganizationForTest(
+    const { organizationId } = await VitestHelper.createOrganizationForTest(
       organizationRepository,
     );
 
@@ -358,7 +366,7 @@ describe('organizationRepository - Integration Tests', () => {
 
     const { contract_Create } = await contractService.createContract({
       input: {
-        organizationId: id,
+        organizationId: organizationId,
         committedPeriodInMonths: 3,
         currency: Currency.Usd,
         name: contract_name,
@@ -381,7 +389,7 @@ describe('organizationRepository - Integration Tests', () => {
 
     await organizationRepository.updateAllOpportunityRenewals({
       input: {
-        organizationId: id,
+        organizationId: organizationId,
         renewalAdjustedRate: 53,
         renewalLikelihood: OpportunityRenewalLikelihood.HighRenewal,
       },
@@ -389,7 +397,7 @@ describe('organizationRepository - Integration Tests', () => {
 
     await organizationRepository.updateAllOpportunityRenewals({
       input: {
-        organizationId: id,
+        organizationId: organizationId,
         renewalAdjustedRate: 53,
         renewalLikelihood: OpportunityRenewalLikelihood.HighRenewal,
       },
@@ -417,11 +425,13 @@ describe('organizationRepository - Integration Tests', () => {
   });
 
   it('adds updates owner of the organization', async () => {
-    const { id } = await VitestHelper.createOrganizationForTest(
+    const { organizationId } = await VitestHelper.createOrganizationForTest(
       organizationRepository,
     );
 
-    let organization = await organizationRepository.getOrganization(id);
+    let organization = await organizationRepository.getOrganization(
+      organizationId,
+    );
 
     expect(organization?.owner).toBeNull();
 
@@ -431,12 +441,12 @@ describe('organizationRepository - Integration Tests', () => {
 
     await organizationRepository.saveOrganization({
       input: {
-        id,
+        id: organizationId,
         ownerId: user.users.content[0].id,
       },
     });
 
-    organization = await organizationRepository.getOrganization(id);
+    organization = await organizationRepository.getOrganization(organizationId);
     expect(organization?.owner?.id).toBe(user.users.content[0].id);
   });
 });

--- a/packages/apps/frontera/src/store/vitest-helper.ts
+++ b/packages/apps/frontera/src/store/vitest-helper.ts
@@ -1,11 +1,15 @@
 // import { expect } from 'vitest';
 import { OrganizationRepository } from '@infra/repositories/organization';
+import { ContactService } from '@store/Contacts/__service__/Contacts.service.ts';
+import { contactsTestState } from '@store/Contacts/__tests__/contactsTestState.ts';
 import { organizationsTestState } from '@store/Organizations/__tests__/organizationsTestState.ts';
 
 export class VitestHelper {
   static async createOrganizationForTest(
     organizationRepository: OrganizationRepository,
-    input?: { input: { id?: string; name?: string; ownerId?: string } },
+    input?: {
+      input: { name?: string; ownerId?: string; organizationId?: string };
+    },
   ) {
     const organization_name = 'vitest-' + crypto.randomUUID();
     const organization_domain = 'vitest-' + crypto.randomUUID() + '.com';
@@ -17,16 +21,101 @@ export class VitestHelper {
     const { metadata } = organization_Save;
 
     trackOrganization(metadata.id);
-    // console.info(
-    //   `\nOrganization ${organization_name} was created for test "${
-    //     expect.getState().currentTestName
-    //   }": `,
-    // );
 
-    return { id: metadata.id, name: organization_name };
+    return {
+      organizationId: metadata.id,
+      organizationName: organization_name,
+    };
+  }
+
+  static async createContactForTest(
+    contactService: ContactService,
+    input?: {
+      input: {
+        id?: string;
+        lastName?: string;
+        firstName?: string;
+        socialUrl?: string;
+      };
+    },
+  ) {
+    const first_name = 'vitest-' + crypto.randomUUID();
+    const last_name = 'vitest-' + crypto.randomUUID();
+    const contact_social_url =
+      'https://www.linkedin.com/in/Vitest-' + crypto.randomUUID();
+    const email = `${first_name}@${crypto.randomUUID()}.com`;
+
+    const { contact_Create: contactId } = await contactService.createContact({
+      contactInput: input?.input || {
+        firstName: first_name,
+        lastName: last_name,
+        email: {
+          email,
+          primary: true,
+        },
+        socialUrl: contact_social_url,
+      },
+    });
+
+    trackContact(contactId);
+
+    return {
+      contactId: contactId,
+      firstName: first_name,
+      lastName: last_name,
+      email,
+    };
+  }
+
+  static async createContactForOrganizationForTest(
+    contactService: ContactService,
+    organizationId: string,
+    input?: {
+      input: {
+        id?: string;
+        lastName?: string;
+        firstName?: string;
+        socialUrl?: string;
+      };
+    },
+  ) {
+    const first_name = 'vitest-' + crypto.randomUUID();
+    const last_name = 'vitest-' + crypto.randomUUID();
+    const contact_social_url =
+      'https://www.linkedin.com/in/Vitest-' + crypto.randomUUID();
+    const email = `${first_name}@${crypto.randomUUID()}.com`;
+
+    const {
+      contact_CreateForOrganization: { id: contactId },
+    } = await contactService.createContactForOrganization({
+      input: input?.input || {
+        firstName: first_name,
+        lastName: last_name,
+        email: {
+          email,
+          primary: true,
+        },
+        socialUrl: contact_social_url,
+      },
+      organizationId,
+    });
+
+    trackContact(contactId);
+
+    return {
+      contactId: contactId,
+      firstName: first_name,
+      lastName: last_name,
+      email,
+      organizationId,
+    };
   }
 }
 
 export const trackOrganization = (organizationId: string) => {
   organizationsTestState.createdOrganizationIds.add(organizationId);
+};
+
+export const trackContact = (contactId: string) => {
+  contactsTestState.createdContactsIds.add(contactId);
 };

--- a/packages/apps/frontera/src/store/vitest-hooks.ts
+++ b/packages/apps/frontera/src/store/vitest-hooks.ts
@@ -1,10 +1,13 @@
 import { afterAll } from 'vitest';
 import { OrganizationRepository } from '@infra/repositories/organization';
+import { ContactService } from '@store/Contacts/__service__/Contacts.service.ts';
+import { contactsTestState } from '@store/Contacts/__tests__/contactsTestState.ts';
 import { organizationsTestState } from '@store/Organizations/__tests__/organizationsTestState.ts';
 
 import { TagService } from './Tags/__service__/Tag.service';
 
 const organizationsRepository = OrganizationRepository.getInstance();
+const contactService = ContactService.getInstance();
 const tagService = TagService.getInstance();
 
 afterAll(async () => {
@@ -12,7 +15,7 @@ afterAll(async () => {
     .getTags()
     .then((res) =>
       res.tags
-        .filter((tag) => tag.name.includes('IT_'))
+        .filter((tag) => tag.name.includes('Vitest_'))
         .map((tag) => tag.metadata.id),
     );
 
@@ -29,6 +32,16 @@ afterAll(async () => {
       await organizationsRepository.hideOrganizations({ ids: [id] });
     } catch (error) {
       console.error(`Failed to cleanup company ${id}:`, error);
+    }
+  }
+
+  const contactIds = Array.from(contactsTestState.createdContactsIds);
+
+  for (const id of contactIds) {
+    try {
+      await contactService.archiveContact({ contactId: id });
+    } catch (error) {
+      console.error(`Failed to cleanup contact ${id}:`, error);
     }
   }
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor integration tests for Contacts and Organizations using Vitest, introducing helper functions for test data creation and ensuring cleanup post-tests.
> 
>   - **Integration Tests**:
>     - Refactor `Contacts.integration.ts` and `Organizations.integration.ts` to use `VitestHelper` for creating test data.
>     - Replace direct service calls with helper functions like `createContactForTest` and `createOrganizationForTest`.
>     - Update tests to use new helper functions for creating contacts and organizations.
>   - **Helper Functions**:
>     - Add `createContactForTest`, `createContactForOrganizationForTest`, and `createOrganizationForTest` in `vitest-helper.ts`.
>     - Track created contacts and organizations using `contactsTestState` and `organizationsTestState`.
>   - **Cleanup**:
>     - Implement cleanup logic in `vitest-hooks.ts` to archive contacts and hide organizations after tests.
>     - Delete tags created during tests in `vitest-hooks.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 9e38e266086b2c9e66c4b6c2fbd9dbbe2bb36cd2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->