### PR TITLE
COS-6844: Allow product list to be scrollable + add decimals to price

### DIFF
--- a/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/Workspace/Products/components/ProductsList/ProductRow.tsx
+++ b/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/Workspace/Products/components/ProductsList/ProductRow.tsx
@@ -33,7 +33,9 @@ export const ProductRow = observer(({ id }: { id: string }) => {
         <span className='truncate'>{row.value.name}</span>
       </div>
       <div className='truncate flex items-center'>{row.typeLabel}</div>
-      <div className='truncate flex items-center'>{row.formattedPrice}</div>
+      <div className='truncate flex items-center justify-end'>
+        {row.formattedPrice}
+      </div>
       <div className='w-7'>
         <Menu onOpenChange={(state) => setIsMenuOpen(state)}>
           <MenuButton asChild>

--- a/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/Workspace/Products/components/ProductsList/ProductsList.tsx
+++ b/packages/apps/frontera/src/routes/settings/src/components/Tabs/panels/Workspace/Products/components/ProductsList/ProductsList.tsx
@@ -30,17 +30,22 @@ export const ProductsList = observer(
     }
 
     return (
-      <div>
+      <div
+        className='overflow-y-auto -mr-6 pr-6'
+        style={{ maxHeight: 'calc(100vh - 150px)' }}
+      >
         <div className='grid grid-cols-[minmax(0,1fr)_minmax(0,100px)_minmax(0,110px)_28px] w-full text-sm gap-x-2'>
           <div className='font-medium flex items-center'>Product</div>
           <div className='font-medium flex items-center'>Type</div>
-          <div className='font-medium flex items-center'>Price</div>
+          <div className='font-medium flex items-center justify-end'>Price</div>
           <div className='w-7 h-[28px]' />
         </div>
 
-        {data.map((row) => (
-          <ProductRow id={row.id} key={`product-${row.value.id}`} />
-        ))}
+        <div>
+          {data.map((row) => (
+            <ProductRow id={row.id} key={`product-${row.value.id}`} />
+          ))}
+        </div>
       </div>
     );
   },

--- a/packages/apps/frontera/src/store/Sku/Sku.dto.ts
+++ b/packages/apps/frontera/src/store/Sku/Sku.dto.ts
@@ -4,7 +4,6 @@ import { action, computed, observable } from 'mobx';
 import { SkuDatum } from '@infra/repositories/sku/sku.datum';
 
 import { SkuType, SkuInput } from '@graphql/types';
-import { formatCurrency } from '@utils/getFormattedCurrencyNumber.ts';
 
 import { SkusStore } from './Skus.store.ts';
 
@@ -33,7 +32,12 @@ export class Sku extends Entity<SkuDatum> {
     const currency =
       this.store.root.settings.tenant.value?.baseCurrency ?? 'USD';
 
-    return formatCurrency(this.value.price, 2, currency);
+    return Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(this.value.price);
   }
 
   @action


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make product list scrollable and format prices with two decimal places in the Frontera app.
> 
>   - **UI Enhancements**:
>     - Make product list scrollable in `ProductsList.tsx` by adding `overflow-y-auto` and setting `maxHeight`.
>     - Align price text to the right in `ProductRow.tsx`.
>   - **Price Formatting**:
>     - Use `Intl.NumberFormat` in `Sku.dto.ts` to format prices with two decimal places.
>   - **Misc**:
>     - Remove unused import `formatCurrency` from `Sku.dto.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 048a5483455742ab14a466aa8801652f8bc69e31. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->