### PR TITLE
COS-6842: Remove the FE validation on the Qualification and Disqualification criteria

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/agents/capabilities/edit-icp-disqualification-criteria.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/agents/capabilities/edit-icp-disqualification-criteria.usecase.ts
@@ -11,19 +11,12 @@ export class EditIcpDisqualificationCriteriaUsecase {
   private root = RootStore.getInstance();
   private agentId: string = '';
   @observable accessor inputValue: string = '';
-  @observable accessor validationError: string = '';
   @observable accessor disqualificationCriteriaError: string = '';
 
   constructor() {
     this.execute = this.execute.bind(this);
-    this.validate = this.validate.bind(this);
     this.setInputValue = this.setInputValue.bind(this);
     this.init = this.init.bind(this);
-  }
-
-  @computed
-  get isInvalid() {
-    return this.validationError.length > 0;
   }
 
   @action
@@ -37,24 +30,6 @@ export class EditIcpDisqualificationCriteriaUsecase {
       .getById(this.agentId)
       ?.value.capabilities.find((c) => c.type === CapabilityType.IcpQualify)
       ?.errors;
-  }
-
-  @action
-  validate() {
-    const span = Tracer.span('EditIcpDisqualificationCriteriaUsecase.validate');
-
-    if (this.inputValue.length === 0) {
-      this.validationError = 'Houston we have a blank...';
-      span.end();
-
-      return false;
-    } else {
-      this.validationError = '';
-    }
-
-    span.end();
-
-    return true;
   }
 
   @action
@@ -128,32 +103,27 @@ export class EditIcpDisqualificationCriteriaUsecase {
       return;
     }
 
-    const isValid = this.validate();
+    agent?.setCapabilityConfig(
+      CapabilityType.IcpQualify,
+      'disqualificationCriteria',
+      this.inputValue,
+    );
 
-    if (!isValid) {
-      return;
+    const [res, err] = await this.service.saveAgent(agent);
+
+    if (err) {
+      this.root.ui.toastError(
+        'Could not save disqualification criteria',
+        'disqualification-criteria-err',
+      );
+      console.error(
+        'EditIcpDisqualificationCriteriaUsecase.execute: Error saving agent. aborting execution',
+      );
     }
 
-    if (isValid) {
-      this.validationError = '';
-      agent?.setCapabilityConfig(
-        CapabilityType.IcpQualify,
-        'disqualificationCriteria',
-        this.inputValue,
-      );
-
-      const [res, err] = await this.service.saveAgent(agent);
-
-      if (err) {
-        console.error(
-          'EditIcpDisqualificationCriteriaUsecase.execute: Error saving agent. aborting execution',
-        );
-      }
-
-      if (res) {
-        agent.put(res?.agent_Save);
-        this.init(this.agentId);
-      }
+    if (res) {
+      agent.put(res?.agent_Save);
+      this.init(this.agentId);
     }
 
     span.end();

--- a/packages/apps/frontera/src/domain/usecases/agents/capabilities/edit-icp-qualification-criteria.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/agents/capabilities/edit-icp-qualification-criteria.usecase.ts
@@ -11,17 +11,10 @@ export class EditIcpQualificationCriteriaUsecase {
   private root = RootStore.getInstance();
   private agentId: string = '';
   @observable accessor inputValue: string = '';
-  @observable accessor validationError: string = '';
   @observable accessor qualificationCriteriaError: string = '';
   constructor() {
     this.execute = this.execute.bind(this);
-    this.validate = this.validate.bind(this);
     this.setInputValue = this.setInputValue.bind(this);
-  }
-
-  @computed
-  get isInvalid() {
-    return this.validationError.length > 0;
   }
 
   @action
@@ -35,24 +28,6 @@ export class EditIcpQualificationCriteriaUsecase {
       .getById(this.agentId)
       ?.value.capabilities.find((c) => c.type === CapabilityType.IcpQualify)
       ?.errors;
-  }
-
-  @action
-  validate() {
-    const span = Tracer.span('EditIcpQualificationCriteriaUsecase.validate');
-
-    if (this.inputValue.length === 0) {
-      this.validationError = 'Houston we have a blank...';
-      span.end();
-
-      return false;
-    } else {
-      this.validationError = '';
-    }
-
-    span.end();
-
-    return true;
   }
 
   @action
@@ -126,32 +101,23 @@ export class EditIcpQualificationCriteriaUsecase {
       return;
     }
 
-    const isValid = this.validate();
+    agent?.setCapabilityConfig(
+      CapabilityType.IcpQualify,
+      'qualificationCriteria',
+      this.inputValue,
+    );
 
-    if (!isValid) {
-      return;
+    const [res, err] = await this.service.saveAgent(agent);
+
+    if (err) {
+      console.error(
+        'EditIcpQualificationCriteriaUsecase.execute: Error saving agent. aborting execution',
+      );
     }
 
-    if (isValid) {
-      this.validationError = '';
-      agent?.setCapabilityConfig(
-        CapabilityType.IcpQualify,
-        'qualificationCriteria',
-        this.inputValue,
-      );
-
-      const [res, err] = await this.service.saveAgent(agent);
-
-      if (err) {
-        console.error(
-          'EditIcpQualificationCriteriaUsecase.execute: Error saving agent. aborting execution',
-        );
-      }
-
-      if (res) {
-        agent.put(res?.agent_Save);
-        this.init(this.agentId);
-      }
+    if (res) {
+      agent.put(res?.agent_Save);
+      this.init(this.agentId);
     }
 
     span.end();

--- a/packages/apps/frontera/src/routes/agent/components/Capabilities/EvaluateCompanyIcpFit/EvaluateCompanyICPFit.tsx
+++ b/packages/apps/frontera/src/routes/agent/components/Capabilities/EvaluateCompanyIcpFit/EvaluateCompanyICPFit.tsx
@@ -21,8 +21,6 @@ import {
 
 import { IdealCustomersModal } from './IdealCustomersModal';
 
-// import { IdealCustomersModal } from './IdealCustomersModal';
-
 const disqualificationCriteriaUsecase =
   new EditIcpDisqualificationCriteriaUsecase();
 const qualificationCriteriaUsecase = new EditIcpQualificationCriteriaUsecase();
@@ -135,19 +133,13 @@ export const EvaluateCompanyIcpFit = observer(() => {
                 className='mt-3 px-2 py-1 text-sm bg-transparent resize-none min-h-[72px]  overflow-y-hidden'
                 onChange={(e) => {
                   qualificationCriteriaUsecase.setInputValue(e.target.value);
-
-                  if (qualificationCriteriaUsecase.validationError) {
-                    qualificationCriteriaUsecase.validate();
-                  }
                 }}
               />
-              {(qualificationCriteriaUsecase.capabilityErrors ||
-                qualificationCriteriaUsecase.validationError) && (
+              {qualificationCriteriaUsecase.capabilityErrors && (
                 <div className='bg-error-50 text-error-700 px-2 py-1 rounded-[4px] '>
                   <Icon stroke='none' className='mr-2' name='dot-single' />
                   <span className='text-sm'>
                     {qualificationCriteriaUsecase.capabilityErrors}
-                    {qualificationCriteriaUsecase.validationError}
                   </span>
                 </div>
               )}
@@ -172,19 +164,13 @@ export const EvaluateCompanyIcpFit = observer(() => {
                 className='mt-3 px-2 py-1 text-sm bg-transparent resize-none min-h-[72px]  overflow-y-hidden'
                 onChange={(e) => {
                   disqualificationCriteriaUsecase.setInputValue(e.target.value);
-
-                  if (disqualificationCriteriaUsecase.validationError) {
-                    disqualificationCriteriaUsecase.validate();
-                  }
                 }}
               />
-              {(disqualificationCriteriaUsecase.capabilityErrors ||
-                disqualificationCriteriaUsecase.validationError) && (
+              {disqualificationCriteriaUsecase.capabilityErrors && (
                 <div className='bg-error-50 text-error-700 px-2 py-1 rounded-[4px] '>
                   <Icon stroke='none' className='mr-2' name='dot-single' />
                   <span className='text-sm'>
                     {disqualificationCriteriaUsecase.capabilityErrors}
-                    {disqualificationCriteriaUsecase.validationError}
                   </span>
                 </div>
               )}


### PR DESCRIPTION
…
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove front-end validation for qualification and disqualification criteria in `EditIcpDisqualificationCriteriaUsecase`, `EditIcpQualificationCriteriaUsecase`, and `EvaluateCompanyICPFit.tsx`.
> 
>   - **Behavior**:
>     - Removed front-end validation logic from `EditIcpDisqualificationCriteriaUsecase` and `EditIcpQualificationCriteriaUsecase`.
>     - Removed validation error handling in `EvaluateCompanyICPFit.tsx`.
>   - **Code Simplification**:
>     - Deleted `validate()` method and `validationError` observable in both `EditIcpDisqualificationCriteriaUsecase` and `EditIcpQualificationCriteriaUsecase`.
>     - Removed `isInvalid` computed property in both use cases.
>     - Removed validation error display logic in `EvaluateCompanyICPFit.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 9a1a0f9e32432ecaf37e0aa9b5c4e574be60ebda. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->