### PR TITLE
NewWebSessionListener UI improvements

### DIFF
--- a/packages/apps/frontera/src/routes/agent/components/Listeners/NewWebSessionListener.tsx
+++ b/packages/apps/frontera/src/routes/agent/components/Listeners/NewWebSessionListener.tsx
@@ -88,17 +88,6 @@ export const NewWebSessionListener = observer(() => {
             </div>
           ))}
 
-          {usecase.websitesError.length > 0 && (
-            <p className='text-sm text-error-500 ml-2'>
-              <Icon
-                stroke='none'
-                name='dot-single'
-                className='text-error-500 mr-2'
-              />
-              {usecase.websitesError}
-            </p>
-          )}
-
           <Button
             size='xs'
             variant='ghost'
@@ -108,6 +97,11 @@ export const NewWebSessionListener = observer(() => {
           >
             Add website
           </Button>
+          {usecase.websitesError.length > 0 && (
+            <p className='text-sm text-error-500 ml-2'>
+              {usecase.websitesError}
+            </p>
+          )}
         </div>
 
         <div className='w-full h-[1px] bg-grayModern-200 my-4' />

--- a/packages/apps/frontera/src/routes/agent/components/Listeners/NewWebSessionListener.tsx
+++ b/packages/apps/frontera/src/routes/agent/components/Listeners/NewWebSessionListener.tsx
@@ -154,7 +154,7 @@ export const NewWebSessionListener = observer(() => {
                 autoFocus
                 ref={inputRef}
                 variant='unstyled'
-                placeholder='website'
+                placeholder='Website'
                 invalid={usecase.isInvalid}
                 onChange={(e) => usecase.setWebsite(e.target.value)}
               />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> UI improvements in `NewWebSessionListener.tsx` by repositioning error message and updating input placeholder.
> 
>   - **UI Improvements**:
>     - Moved `usecase.websitesError` message to appear after the 'Add website' button in `NewWebSessionListener.tsx`.
>     - Changed input placeholder from 'website' to 'Website' in `NewWebSessionListener.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for fb77560706e818225b373ebdfbd6c9874899e446. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->