### PR TITLE
COS-6850: Implement command actions for the agents

### DIFF
--- a/packages/apps/frontera/src/routes/agent/page.tsx
+++ b/packages/apps/frontera/src/routes/agent/page.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useEffect } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 
+import { useKeys } from 'rooks';
 import { observer } from 'mobx-react-lite';
 import { AgentViewUsecase } from '@domain/usecases/agents/agent-view.usecase';
 
@@ -8,6 +9,7 @@ import { cn } from '@ui/utils/cn';
 import { AgentScope } from '@graphql/types';
 import { Icon, IconName } from '@ui/media/Icon';
 import { useStore } from '@shared/hooks/useStore';
+import { useModKey } from '@shared/hooks/useModKey';
 import { Tag, TagLabel } from '@ui/presentation/Tag';
 
 import { goals, Header, configs } from './components';
@@ -55,6 +57,24 @@ export const AgentPage = observer(() => {
       store.ui.commandMenu.setType('AgentCommands');
     }
   }, [id]);
+
+  useKeys(['Shift', 'S'], (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    usecase.toggleActive();
+  });
+
+  useKeys(['Shift', 'R'], (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    store.ui.commandMenu.setType('RenameAgent');
+    store.ui.commandMenu.setOpen(true);
+  });
+
+  useModKey('Backspace', () => {
+    store.ui.commandMenu.setType('ArchiveAgent');
+    store.ui.commandMenu.setOpen(true);
+  });
 
   if (!id) {
     throw new Error('No id provided');

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/AgentCommands.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/AgentCommands.tsx
@@ -1,8 +1,11 @@
+import { useMemo } from 'react';
+
 import { observer } from 'mobx-react-lite';
+import { AgentViewUsecase } from '@domain/usecases/agents/agent-view.usecase.ts';
 
 import { Icon } from '@ui/media/Icon';
 import { useStore } from '@shared/hooks/useStore';
-import { CommandItem } from '@ui/overlay/CommandMenu';
+import { Kbd, CommandKbd, CommandItem } from '@ui/overlay/CommandMenu';
 import { CommandsContainer } from '@shared/components/CommandMenu/commands/shared';
 
 export const AgentCommands = observer(() => {
@@ -10,6 +13,7 @@ export const AgentCommands = observer(() => {
   const id = store.ui.commandMenu.context.ids?.[0];
   const agent = id ? store.agents.getById(id) : null;
   const label = `Agent - ${agent?.value.name}`;
+  const usecase = useMemo(() => new AgentViewUsecase(id ?? ''), [id]);
 
   return (
     <CommandsContainer label={label}>
@@ -18,6 +22,14 @@ export const AgentCommands = observer(() => {
         onSelect={() => {
           store.ui.commandMenu.setType('RenameAgent');
         }}
+        rightAccessory={
+          <>
+            <Kbd>
+              <Icon className={'size-3'} name='arrow-block-up' />
+            </Kbd>
+            <Kbd>R</Kbd>
+          </>
+        }
       >
         Rename agent
       </CommandItem>
@@ -29,12 +41,37 @@ export const AgentCommands = observer(() => {
       {/*>*/}
       {/*  Duplicate agent*/}
       {/*</CommandItem>*/}
+      <CommandItem
+        leftAccessory={<Icon name='columns-03' />}
+        onSelect={() => {
+          usecase.toggleActive();
+          store.ui.commandMenu.setOpen(false);
+        }}
+        rightAccessory={
+          <>
+            <Kbd>
+              <Icon className={'size-3'} name='arrow-block-up' />
+            </Kbd>
+            <Kbd>S</Kbd>
+          </>
+        }
+      >
+        Change agent status
+      </CommandItem>
 
       <CommandItem
         leftAccessory={<Icon name='layers-two-01' />}
         onSelect={() => {
           store.ui.commandMenu.setType('ArchiveAgent');
         }}
+        rightAccessory={
+          <>
+            <CommandKbd />
+            <Kbd>
+              <Icon name='delete' className='size-3' />
+            </Kbd>
+          </>
+        }
       >
         Archive agent
       </CommandItem>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add keyboard shortcuts for agent actions and update command menu to display these shortcuts in `page.tsx` and `AgentCommands.tsx`.
> 
>   - **Keyboard Shortcuts**:
>     - Added `Shift + S` to toggle agent status in `page.tsx`.
>     - Added `Shift + R` to open rename agent command in `page.tsx`.
>     - Added `Mod + Backspace` to open archive agent command in `page.tsx`.
>   - **Command Menu Updates**:
>     - Updated `AgentCommands.tsx` to include visual keyboard shortcuts for renaming, changing status, and archiving agents.
>     - Added `Kbd` components to display shortcuts in `AgentCommands.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 9ad12b9163542b9974df1839d2288463787c12ae. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->