### PR TITLE
COS-6851: Hovering over the agent cards should have their relevant -400 colour ring

### DIFF
--- a/packages/apps/frontera/src/store/Agents/Agent.dto.ts
+++ b/packages/apps/frontera/src/store/Agents/Agent.dto.ts
@@ -207,52 +207,52 @@ export class Agent extends Entity<AgentDatum> {
       [ring: string, bg: string, iconColor: string]
     > = {
       grayModern: [
-        'group-hover:ring-grayModern-400',
+        'hover:ring-grayModern-400',
         'group-hover:bg-grayModern-50',
         'group-hover:text-grayModern-500',
       ],
       error: [
-        'group-hover:ring-error-400',
+        'hover:ring-error-400',
         'group-hover:bg-error-50',
         'group-hover:text-error-500',
       ],
       warning: [
-        'group-hover:ring-warning-400',
+        'hover:ring-warning-400',
         'group-hover:bg-warning-50',
         'group-hover:text-warning-500',
       ],
       success: [
-        'group-hover:ring-success-400',
+        'hover:ring-success-400',
         'group-hover:bg-success-50',
         'group-hover:text-success-500',
       ],
       grayWarm: [
-        'group-hover:ring-grayWarm-400',
+        'hover:ring-grayWarm-400',
         'group-hover:bg-grayWarm-50',
         'group-hover:text-grayWarm-500',
       ],
       moss: [
-        'group-hover:ring-moss-400',
+        'hover:ring-moss-400',
         'group-hover:bg-moss-50',
         'group-hover:text-moss-500',
       ],
       blueLight: [
-        'group-hover:ring-blueLight-400',
+        'hover:ring-blueLight-400',
         'group-hover:bg-blueLight-50',
         'group-hover:text-blueLight-500',
       ],
       indigo: [
-        'group-hover:ring-indigo-400',
+        'hover:ring-indigo-400',
         'group-hover:bg-indigo-50',
         'group-hover:text-indigo-500',
       ],
       violet: [
-        'group-hover:ring-violet-400',
+        'hover:ring-violet-400',
         'group-hover:bg-violet-50',
         'group-hover:text-violet-500',
       ],
       pink: [
-        'group-hover:ring-pink-400',
+        'hover:ring-pink-400',
         'group-hover:bg-pink-50',
         'group-hover:text-pink-500',
       ],


### PR DESCRIPTION
…
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Changes CSS class names in `Agent.dto.ts` to apply `hover:ring-*-400` for agent card hover effects.
> 
>   - **Behavior**:
>     - Changes CSS class names in `Agent.dto.ts` to apply `hover:ring-*-400` instead of `group-hover:ring-*-400` for agent card hover effects.
>     - Affects color types: `grayModern`, `error`, `warning`, `success`, `grayWarm`, `moss`, `blueLight`, `indigo`, `violet`, `pink`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for cf281cd5b188d47d9c07feb25c915333ee508eaa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->