### PR TITLE
fix support spotter update config

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_detect_support_web_visit.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_detect_support_web_visit.go
@@ -87,6 +87,7 @@ func (c *DetectSupportWebVisitCapability) NewConfig() DetectSupportWebVisitConfi
 
 func (c *DetectSupportWebVisitCapability) DefaultConfig() any {
 	config := c.NewConfig()
+	config.SupportUrls.Value = []string{}
 	config.SupportUrlPatterns.Value = []string{"**support**"}
 	return &config
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Initialize `SupportUrls.Value` to an empty slice in `DefaultConfig()` of `DetectSupportWebVisitCapability`.
> 
>   - **Behavior**:
>     - In `capability_detect_support_web_visit.go`, `DefaultConfig()` now initializes `SupportUrls.Value` to an empty slice.
>   - **Misc**:
>     - No other changes or refactors were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 99f739c7806b0ea348031afbced18921d130b422. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->