### PR TITLE
COS-6856: Add a toggle next to "Send a Slack notification" to enable or disable the capability

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-slack-channel.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-slack-channel.usecase.ts
@@ -28,12 +28,14 @@ export class AddSlackChannelUsecase {
   @observable accessor slackChannelError = '';
 
   constructor(private agentId: string) {
-    this.toggle = this.toggle.bind(this);
+    this.togglePopover = this.togglePopover.bind(this);
     this.close = this.close.bind(this);
     this.selectChannel = this.selectChannel.bind(this);
     this.setInputValue = this.setInputValue.bind(this);
     this.enableSlack = this.enableSlack.bind(this);
     this.disableSlack = this.disableSlack.bind(this);
+    this.toggleSendSlackNotificationActive =
+      this.toggleSendSlackNotificationActive.bind(this);
     this.execute = this.execute.bind(this);
 
     this.init();
@@ -68,6 +70,15 @@ export class AddSlackChannelUsecase {
   }
 
   @computed
+  get slackNotificationActive() {
+    return this.root.agents
+      .getById(this.agentId)
+      ?.value.capabilities?.find(
+        (c) => c.type === CapabilityType.WebVisitorSendSlackNotification,
+      )?.active;
+  }
+
+  @computed
   get capabilityErrors() {
     return this.root.agents
       .getById(this.agentId)
@@ -77,7 +88,7 @@ export class AddSlackChannelUsecase {
   }
 
   @action
-  toggle(open: boolean) {
+  togglePopover(open: boolean) {
     this.isOpen = open;
   }
 
@@ -198,6 +209,45 @@ export class AddSlackChannelUsecase {
 
   disableSlack() {
     this.root.settings.slack.disableSync();
+  }
+
+  async toggleSendSlackNotificationActive() {
+    const span = Tracer.span(
+      'AddSlackChannelUsecase.toggleSendSlackNotificationActive',
+    );
+
+    const agent = this.root.agents.getById(this.agentId);
+
+    if (!agent) {
+      console.error(
+        'AddSlackChannelUsecase.toggleSendSlackNotificationActive: Agent not found',
+      );
+
+      return;
+    }
+
+    agent?.toggleCapabilityStatus(
+      CapabilityType.WebVisitorSendSlackNotification,
+    );
+
+    const [res, err] = await this.agentService.saveAgent(agent);
+
+    if (err) {
+      agent?.toggleCapabilityStatus(
+        CapabilityType.WebVisitorSendSlackNotification,
+      );
+
+      console.error(
+        'AddSlackChannelUsecase.toggleSendSlackNotificationActive: Error saving agent. aborting execution',
+      );
+    }
+
+    if (res) {
+      agent.put(res?.agent_Save);
+      this.init();
+    }
+
+    span.end();
   }
 
   async execute() {

--- a/packages/apps/frontera/src/routes/agent/components/Capabilities/SendSlackNotificationCapability.tsx
+++ b/packages/apps/frontera/src/routes/agent/components/Capabilities/SendSlackNotificationCapability.tsx
@@ -9,6 +9,7 @@ import {
 } from '@domain/usecases/agents/capabilities/add-slack-channel.usecase';
 
 import { Icon } from '@ui/media/Icon';
+import { Switch } from '@ui/form/Switch';
 import { Combobox } from '@ui/form/Combobox';
 import { Slack } from '@ui/media/logos/Slack';
 import { Button } from '@ui/form/Button/Button';
@@ -23,10 +24,17 @@ export const SendSlackNotificationCapability = observer(() => {
   if (!usecase.isSlackEnabled) {
     return (
       <div>
-        <h2 className='text-sm font-medium mb-4'>
-          Send Slack notification{` `}
-          <span className='text-grayModern-500'>(optional)</span>
-        </h2>
+        <div className='flex items-center justify-between mb-4'>
+          <h2 className='text-sm font-medium '>
+            Send Slack notification{` `}
+            <span className='text-grayModern-500'>(optional)</span>
+          </h2>
+          <Switch
+            size='sm'
+            checked={usecase.slackNotificationActive}
+            onChange={usecase.toggleSendSlackNotificationActive}
+          />
+        </div>
 
         {usecase.capabilityErrors && (
           <div className='bg-error-50 text-error-700 px-2 py-1 rounded-[4px] mb-4'>
@@ -57,11 +65,17 @@ export const SendSlackNotificationCapability = observer(() => {
 
   return (
     <div>
-      <h2 className='text-sm font-medium mb-4'>
-        Send Slack notification{` `}
-        <span className='text-grayModern-500'>(optional)</span>
-      </h2>
-
+      <div className='flex items-center justify-between mb-4'>
+        <h2 className='text-sm font-medium '>
+          Send Slack notification{` `}
+          <span className='text-grayModern-500'>(optional)</span>
+        </h2>
+        <Switch
+          size='sm'
+          checked={usecase.slackNotificationActive}
+          onChange={usecase.toggleSendSlackNotificationActive}
+        />
+      </div>
       <div className='flex flex-col gap-4 w-full'>
         <div>
           <p className='text-sm font-medium'>Slack notifications</p>
@@ -72,7 +86,7 @@ export const SendSlackNotificationCapability = observer(() => {
         </div>
 
         <div className='w-full flex-1'>
-          <Popover open={usecase.isOpen} onOpenChange={usecase.toggle}>
+          <Popover open={usecase.isOpen} onOpenChange={usecase.togglePopover}>
             <PopoverTrigger className={'flex items-center w-full'}>
               <div className='flex w-full items-center bg-white border border-grayModern-200 px-2 py-1 rounded-md'>
                 <Slack className='mr-3 text-gray-500' />

--- a/packages/apps/frontera/src/store/Agents/Agent.dto.ts
+++ b/packages/apps/frontera/src/store/Agents/Agent.dto.ts
@@ -160,6 +160,27 @@ export class Agent extends Entity<AgentDatum> {
     this.commit({ syncOnly: true });
   }
 
+  public toggleCapabilityStatus(capabilityType: CapabilityType) {
+    this.draft();
+
+    const foundIndex = this.value.capabilities.findIndex(
+      (c) => c.type === capabilityType,
+    );
+
+    if (foundIndex === -1) {
+      console.error(
+        'Agent.toggleCapabilityStatus: Capability not found. will not set',
+      );
+
+      return;
+    }
+
+    this.value.capabilities[foundIndex].active =
+      !this.value.capabilities[foundIndex].active;
+
+    this.commit({ syncOnly: true });
+  }
+
   public toPayload(): Omit<
     AgentDatum,
     'createdAt' | 'updatedAt' | 'isConfigured' | 'goalType' | 'scope'


### PR DESCRIPTION
.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add toggle switch to enable/disable Slack notifications in `SendSlackNotificationCapability` and update related use cases and models.
> 
>   - **Behavior**:
>     - Adds `toggleSendSlackNotificationActive` method in `AddSlackChannelUsecase` to toggle Slack notification capability.
>     - Updates `SendSlackNotificationCapability` component to include a `Switch` for enabling/disabling Slack notifications.
>   - **Models**:
>     - Adds `toggleCapabilityStatus` method in `Agent` class to toggle capability active status.
>   - **Misc**:
>     - Renames `toggle` to `togglePopover` in `add-slack-channel.usecase.ts` and `SendSlackNotificationCapability.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for e4b0d0c32790af519cef12c258aab35aaab797dd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->