### PR TITLE
prefilter lead producer

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_event_producers/new_lead_producer.go
+++ b/packages/server/customer-os-common-module/services/agent_event_producers/new_lead_producer.go
@@ -121,6 +121,25 @@ func (p *NewLeadProducer) processLeads(ctx context.Context, record neo4j_reposit
 		span.LogKV("message", "Organization is not a global organization")
 		return
 	}
+	// precheck if global organziation has required fields
+	for _, globalOrg := range globalOrgs {
+		if globalOrg.Description == "" {
+			span.LogKV("message", "Global organization has no description")
+			return
+		}
+		if globalOrg.EmployeeCount == 0 {
+			span.LogKV("message", "Global organization has no employee count")
+			return
+		}
+		if globalOrg.IndustryNaicsName == "" {
+			span.LogKV("message", "Global organization has no industry naics name")
+			return
+		}
+		if globalOrg.CountryA2 == "" {
+			span.LogKV("message", "Global organization has no country a2")
+			return
+		}
+	}
 
 	err = p.events.Publisher.PublishFanoutEvent(innerCtx, record.OrganizationId, model.ORGANIZATION, dto.NewLead{})
 	if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds pre-filtering in `processLeads()` to ensure global organizations have required fields before event publishing.
> 
>   - **Behavior**:
>     - Adds pre-filtering in `processLeads()` in `new_lead_producer.go` to check if global organizations have required fields (`Description`, `EmployeeCount`, `IndustryNaicsName`, `CountryA2`).
>     - Logs specific messages if any required field is missing and halts further processing for that organization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for df3d1ccd0597d48bb5ae2cbdd3aa2f554a34c08a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->