### PR TITLE
COS-6867: Show the default empty state screen when all agents were archived

### DIFF
--- a/packages/apps/frontera/src/routes/agents/page.tsx
+++ b/packages/apps/frontera/src/routes/agents/page.tsx
@@ -25,11 +25,17 @@ export const AgentsPage = observer(() => {
 
   useSlackOauthCallback();
 
-  if (!firstView) {
+  if ((!agents.length && store.agents.isBootstrapped) || !firstView) {
     return (
       <EmptyState
         onClick={() => {
-          setFirstView(true);
+          if (!firstView) {
+            setFirstView(true);
+
+            return;
+          }
+          store.ui.commandMenu.setType('CreateAgent');
+          store.ui.commandMenu.setOpen(true);
         }}
       />
     );


### PR DESCRIPTION
…
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Show `EmptyState` in `AgentsPage` when all agents are archived and update `onClick` behavior.
> 
>   - **Behavior**:
>     - Show `EmptyState` in `AgentsPage` when `agents` array is empty and `store.agents.isBootstrapped` is true.
>     - Update `onClick` in `EmptyState` to set `firstView` and open `commandMenu` for 'CreateAgent'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b55cc0ba12ec41f40e9408aa777746b40e5a1524. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->