### PR TITLE
COS-6863: Implement modals for Workspace/Personal scopes

### DIFF
--- a/packages/apps/frontera/src/routes/agent/components/Scope/Scope.tsx
+++ b/packages/apps/frontera/src/routes/agent/components/Scope/Scope.tsx
@@ -1,0 +1,77 @@
+import { useState, ReactNode } from 'react';
+
+import { AgentScope } from '@graphql/types';
+import { Icon, IconName } from '@ui/media/Icon';
+import { Tag, TagLabel } from '@ui/presentation/Tag';
+import { InfoDialog } from '@ui/overlay/AlertDialog/InfoDialog';
+
+export const Scope = ({ scope }: { scope: AgentScope }) => {
+  const [isOpen, setOpen] = useState(false);
+
+  return (
+    <>
+      <Tag
+        variant='subtle'
+        color='grayModern'
+        className={'cursor-pointer'}
+        onClick={() => setOpen(true)}
+      >
+        <TagLabel className='flex items-center gap-1'>
+          <Icon className='size-3' name={scopeMap[scope].icon} />
+          {scopeMap[scope].label}
+        </TagLabel>
+      </Tag>
+      <InfoDialog
+        isOpen={isOpen}
+        confirmButtonLabel={'Got it'}
+        onClose={() => setOpen(false)}
+        onConfirm={() => setOpen(false)}
+        body={scopeMap[scope].description}
+        label={`${scopeMap[scope].label} agents`}
+      />
+    </>
+  );
+};
+type ScopeMapType = {
+  label: string;
+  icon: IconName;
+  description: ReactNode;
+};
+
+const scopeMap: Record<AgentScope, ScopeMapType> = {
+  [AgentScope.Workspace]: {
+    label: 'Workspace',
+    icon: 'building-05',
+    description: (
+      <div className='text-sm'>
+        <p className='mb-4'>
+          This agent type manages team-wide information available to your entire
+          team.
+        </p>
+        <p>
+          For example, when someone visits your company website, the agent
+          shares the details with everyone on your team, ensuring that all
+          members have the same up-to-date information.
+        </p>
+      </div>
+    ),
+  },
+  [AgentScope.Personal]: {
+    label: 'Personal',
+    icon: 'user-01',
+    description: (
+      <div className='text-sm'>
+        <p className='mb-4'>
+          This agent type works with your personal account to manage and share
+          relevant information with your team.
+        </p>
+        <p>
+          This agent type works with your personal account to manage and share
+          relevant information with your team. For example, when you're in a
+          meeting, an agent picks out the key points and shares the details with
+          everyone on your team, keeping everyone up to date.
+        </p>
+      </div>
+    ),
+  },
+};

--- a/packages/apps/frontera/src/routes/agent/components/Scope/Scope.tsx
+++ b/packages/apps/frontera/src/routes/agent/components/Scope/Scope.tsx
@@ -11,6 +11,8 @@ export const Scope = ({ scope }: { scope: AgentScope }) => {
   return (
     <>
       <Tag
+        tabIndex={0}
+        role={'button'}
         variant='subtle'
         color='grayModern'
         className={'cursor-pointer'}

--- a/packages/apps/frontera/src/routes/agent/components/Scope/index.ts
+++ b/packages/apps/frontera/src/routes/agent/components/Scope/index.ts
@@ -1,0 +1,1 @@
+export * from './Scope';

--- a/packages/apps/frontera/src/routes/agent/page.tsx
+++ b/packages/apps/frontera/src/routes/agent/page.tsx
@@ -6,12 +6,11 @@ import { observer } from 'mobx-react-lite';
 import { AgentViewUsecase } from '@domain/usecases/agents/agent-view.usecase';
 
 import { cn } from '@ui/utils/cn';
-import { AgentScope } from '@graphql/types';
 import { Icon, IconName } from '@ui/media/Icon';
 import { useStore } from '@shared/hooks/useStore';
 import { useModKey } from '@shared/hooks/useModKey';
-import { Tag, TagLabel } from '@ui/presentation/Tag';
 
+import { Scope } from './components/Scope';
 import { goals, Header, configs } from './components';
 
 export const AgentPage = observer(() => {
@@ -100,21 +99,7 @@ export const AgentPage = observer(() => {
           <div className='mb-2'>
             <div className='mb-1 flex items-center justify-between'>
               <h2 className='font-medium text-sm'>About this agent</h2>
-              <Tag variant='subtle' color='grayModern'>
-                <TagLabel className='flex items-center gap-1'>
-                  <Icon
-                    className='size-3'
-                    name={
-                      agent?.value?.scope === AgentScope.Workspace
-                        ? 'building-05'
-                        : 'user-01'
-                    }
-                  />
-                  {agent?.value?.scope === AgentScope.Workspace
-                    ? 'Workspace'
-                    : 'Personal'}
-                </TagLabel>
-              </Tag>
+              {agent?.value.scope && <Scope scope={agent.value.scope} />}
             </div>
             <p className='pb-2 text-sm'>{agent?.value.goal ?? 'Unknown'}</p>
           </div>

--- a/packages/apps/frontera/src/ui/overlay/AlertDialog/InfoDialog/InfoDialog.tsx
+++ b/packages/apps/frontera/src/ui/overlay/AlertDialog/InfoDialog/InfoDialog.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler } from 'react';
+import { ReactNode, MouseEventHandler } from 'react';
 
 import { Button } from '@ui/form/Button/Button';
 
@@ -16,12 +16,12 @@ import {
 interface InfoDialogProps {
   label?: string;
   isOpen: boolean;
+  body?: ReactNode;
   onClose: () => void;
   description?: string;
-  body?: React.ReactNode;
+  children?: ReactNode;
   hideCloseButton?: boolean;
   confirmButtonLabel: string;
-  children?: React.ReactNode;
   onConfirm: MouseEventHandler<HTMLButtonElement>;
 }
 
@@ -45,9 +45,7 @@ export const InfoDialog = ({
               {label && (
                 <p className='pb-0 font-semibold line-clamp-2'>{label}</p>
               )}
-              {!hideCloseButton && (
-                <AlertDialogCloseIconButton className='mt-[3px]' />
-              )}
+              {!hideCloseButton && <AlertDialogCloseIconButton />}
             </div>
             <AlertDialogHeader className='font-bold'>
               {description && (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `Scope` component for Workspace/Personal modals and update `InfoDialog` to use `ReactNode` for `body`.
> 
>   - **Components**:
>     - Add `Scope` component in `Scope.tsx` to handle Workspace and Personal scopes with modals.
>     - Replace inline scope logic in `page.tsx` with `Scope` component.
>   - **Dialogs**:
>     - Update `InfoDialog` in `InfoDialog.tsx` to use `ReactNode` for `body` prop.
>   - **Exports**:
>     - Add index file to export `Scope` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b11ca6bd49930db0bed2b83a58452be0d7562faa. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->