### PR TITLE
fix:default listener for support spotter

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/agents/agent-view.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/agents/agent-view.usecase.ts
@@ -86,7 +86,7 @@ export class AgentViewUsecase {
   > = {
     [AgentType.WebVisitIdentifier]: AgentListenerEvent.NewWebSession,
     [AgentType.IcpQualifier]: CapabilityType.IcpQualify,
-    [AgentType.SupportSpotter]: AgentListenerEvent.CompanyIdentified,
+    [AgentType.SupportSpotter]: AgentListenerEvent.NewMeetingRecording,
     [AgentType.MeetingKeeper]: AgentListenerEvent.NewMeetingRecording,
     [AgentType.CashflowGuardian]: CapabilityType.GenerateInvoice,
     [AgentType.CampaignManager]: CapabilityType.ManageCampaignExecution,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default listener for `AgentType.SupportSpotter` to `AgentListenerEvent.NewMeetingRecording` in `AgentViewUsecase`.
> 
>   - **Behavior**:
>     - Change default listener for `AgentType.SupportSpotter` from `AgentListenerEvent.CompanyIdentified` to `AgentListenerEvent.NewMeetingRecording` in `AgentViewUsecase`.
>   - **Files Affected**:
>     - `agent-view.usecase.ts`: Update in `defaultConfigMap` for `AgentType.SupportSpotter`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 37752b1b21af18fce2c184221f5a98d3ff141e2f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->