### PR TITLE
feat(COS-6862): Show single agent command menu when hovering over agent card + enable shortcuts when agent card is hovered/focused

### DIFF
--- a/packages/apps/frontera/src/routes/agents/components/AgentCard/AgentCard.tsx
+++ b/packages/apps/frontera/src/routes/agents/components/AgentCard/AgentCard.tsx
@@ -1,7 +1,14 @@
+import { useMemo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+import { useKeys } from 'rooks';
+import { observer } from 'mobx-react-lite';
+import { AgentViewUsecase } from '@domain/usecases/agents/agent-view.usecase';
 
 import { cn } from '@ui/utils/cn';
 import { Icon, IconName } from '@ui/media/Icon';
+import { useStore } from '@shared/hooks/useStore';
+import { useModKey } from '@shared/hooks/useModKey';
 import { Tag, TagLabel } from '@ui/presentation/Tag';
 
 interface AgentCardProps {
@@ -14,75 +21,148 @@ interface AgentCardProps {
   colorMap: [ring: string, bg: string, iconColor: string];
 }
 
-export const AgentCard = ({
-  id,
-  name,
-  icon,
-  status,
-  hasError,
-  defaultName,
-  colorMap,
-}: AgentCardProps) => {
-  const navigate = useNavigate();
-  const tagColor =
-    hasError && status === 'ON'
-      ? 'warning'
-      : status === 'OFF'
-      ? 'grayModern'
-      : 'success';
+export const AgentCard = observer(
+  ({
+    id,
+    name,
+    icon,
+    status,
+    hasError,
+    defaultName,
+    colorMap,
+  }: AgentCardProps) => {
+    const store = useStore();
 
-  const [ring, bg, iconColor] = colorMap;
+    const navigate = useNavigate();
+    const tagColor =
+      hasError && status === 'ON'
+        ? 'warning'
+        : status === 'OFF'
+        ? 'grayModern'
+        : 'success';
 
-  return (
-    <div
-      onClick={() => navigate(`/agents/${id}`)}
-      className={cn(
-        'p-3 min-w-[372px] flex-1 rounded-lg flex items-center gap-2 ring-0 border cursor-pointer group hover:bg-white hover:shadow-lg transition-all ring-grayModern-200 hover:ring-1',
-        ring,
-      )}
-    >
+    const [ring, bg, iconColor] = colorMap;
+
+    const handleStateChange = (isActive: boolean) => {
+      if (store.ui.commandMenu.isOpen) return;
+
+      if (isActive) {
+        store.ui.commandMenu.setContext({
+          ...store.ui.commandMenu.context,
+          ids: [id],
+        });
+        store.ui.commandMenu.setType('AgentCommands');
+      } else {
+        store.ui.commandMenu.clearContext();
+        store.ui.commandMenu.setType('AgentsCommands');
+      }
+    };
+
+    useEffect(() => {
+      return () => {
+        store.ui.commandMenu.clearContext();
+        store.ui.commandMenu.setType('AgentsCommands');
+      };
+    }, [store.ui.commandMenu]);
+
+    const usecase = useMemo(() => new AgentViewUsecase(id), [id]);
+
+    useKeys(
+      ['Shift', 'S'],
+      (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        usecase.toggleActive();
+      },
+      {
+        when: store.ui.commandMenu.context.ids?.[0] === id,
+      },
+    );
+
+    useKeys(
+      ['Shift', 'R'],
+      (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        store.ui.commandMenu.setType('RenameAgent');
+        store.ui.commandMenu.setOpen(true);
+      },
+      {
+        when: store.ui.commandMenu.context.ids?.[0] === id,
+      },
+    );
+
+    useModKey(
+      'Backspace',
+      () => {
+        store.ui.commandMenu.setType('ArchiveAgent');
+        store.ui.commandMenu.setOpen(true);
+      },
+      {
+        when: store.ui.commandMenu.context.ids?.[0] === id,
+      },
+    );
+
+    return (
       <div
-        className={cn('p-2 flex items-center rounded-lg bg-grayModern-50', bg)}
+        tabIndex={0}
+        role={'button'}
+        onFocus={() => handleStateChange(true)}
+        onBlur={() => handleStateChange(false)}
+        onClick={() => navigate(`/agents/${id}`)}
+        onMouseEnter={() => handleStateChange(true)}
+        onMouseLeave={() => handleStateChange(false)}
+        className={cn(
+          'p-3 min-w-[372px] flex-1 rounded-lg flex items-center gap-2 ring-0 border cursor-pointer group hover:bg-white hover:shadow-lg transition-all ring-grayModern-200 hover:ring-1',
+          ring,
+        )}
       >
-        <Icon
-          name={(icon as IconName) ?? 'radar'}
-          className={cn('size-6 text-grayModern-500', iconColor)}
-        />
-      </div>
-
-      <div className='flex justify-between w-full'>
-        <div className='flex flex-col justify-center'>
-          {name.toLowerCase() !== defaultName.toLowerCase() && (
-            <p className='line-clamp-1 text-xs text-grayModern-500'>
-              {defaultName}
-            </p>
+        <div
+          className={cn(
+            'p-2 flex items-center rounded-lg bg-grayModern-50',
+            bg,
           )}
-          <p className='line-clamp-2 text-sm font-medium'>
-            {name || defaultName}
-          </p>
+        >
+          <Icon
+            name={(icon as IconName) ?? 'radar'}
+            className={cn('size-6 text-grayModern-500', iconColor)}
+          />
         </div>
-        <div className='flex items-center'>
-          <Tag colorScheme={tagColor}>
-            <TagLabel className='flex items-center gap-1'>
-              <Icon
-                stroke={hasError && status === 'ON' ? 'currentColor' : 'none'}
-                className={cn('size-3', {
-                  'text-warning-500': hasError && status === 'ON',
-                  'text-gray-500': status === 'OFF',
-                })}
-                name={
-                  hasError && status === 'ON'
-                    ? 'alert-triangle'
-                    : status === 'OFF'
-                    ? 'dot-single'
-                    : 'dot-live-success'
-                }
-              />
-              {status}
-            </TagLabel>
-          </Tag>
+
+        <div className='flex justify-between w-full'>
+          <div className='flex flex-col justify-center'>
+            {name.toLowerCase() !== defaultName.toLowerCase() && (
+              <p className='line-clamp-1 text-xs text-grayModern-500'>
+                {defaultName}
+              </p>
+            )}
+            <p className='line-clamp-2 text-sm font-medium'>
+              {name || defaultName}
+            </p>
+          </div>
+          <div className='flex items-center'>
+            <Tag colorScheme={tagColor}>
+              <TagLabel className='flex items-center gap-1'>
+                <Icon
+                  stroke={hasError && status === 'ON' ? 'currentColor' : 'none'}
+                  className={cn('size-3', {
+                    'text-warning-500': hasError && status === 'ON',
+                    'text-gray-500': status === 'OFF',
+                  })}
+                  name={
+                    hasError && status === 'ON'
+                      ? 'alert-triangle'
+                      : status === 'OFF'
+                      ? 'dot-single'
+                      : 'dot-live-success'
+                  }
+                />
+                {status}
+              </TagLabel>
+            </Tag>
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  },
+);

--- a/packages/apps/frontera/src/routes/agents/components/AgentCard/AgentCard.tsx
+++ b/packages/apps/frontera/src/routes/agents/components/AgentCard/AgentCard.tsx
@@ -63,7 +63,7 @@ export const AgentCard = observer(
         store.ui.commandMenu.clearContext();
         store.ui.commandMenu.setType('AgentsCommands');
       };
-    }, [store.ui.commandMenu]);
+    }, []);
 
     const usecase = useMemo(() => new AgentViewUsecase(id), [id]);
 

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/CommandMenu.tsx
@@ -201,6 +201,7 @@ export const CommandMenu = observer(() => {
           store.ui.commandMenu.setOpen(false);
         } else {
           store.ui.commandMenu.setType('AgentsCommands');
+          store.ui.commandMenu.setOpen(false);
         }
       })
       .otherwise(() => {

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/AgentCommands.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/AgentCommands.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { observer } from 'mobx-react-lite';
-import { AgentViewUsecase } from '@domain/usecases/agents/agent-view.usecase.ts';
+import { AgentViewUsecase } from '@domain/usecases/agents/agent-view.usecase';
 
 import { Icon } from '@ui/media/Icon';
 import { useStore } from '@shared/hooks/useStore';


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances `AgentCard` with command menu on hover and keyboard shortcuts for agent actions, updating `CommandMenu` and `AgentCommands` accordingly.
> 
>   - **AgentCard.tsx**:
>     - Adds `useKeys` and `useModKey` hooks to handle keyboard shortcuts for toggling agent status, renaming, and archiving.
>     - Implements `handleStateChange` to show command menu on hover/focus.
>     - Uses `useEffect` to clear command menu context on unmount.
>   - **CommandMenu.tsx**:
>     - Ensures command menu closes when switching to 'AgentsCommands' type.
>   - **AgentCommands.tsx**:
>     - Updates `AgentCommands` to include new command items for renaming, changing status, and archiving agents with keyboard shortcuts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 51059109879425370ea5e969dbc6159e25be6c08. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->