### PR TITLE
slack notifications

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/slack.go
+++ b/packages/server/customer-os-common-module/interfaces/slack.go
@@ -12,7 +12,7 @@ type SlackService interface {
 	GetSlackChannels(ctx context.Context, tenant string) ([]*postgres_entity.SlackChannel, error)
 	GetPaginatedSlackChannels(ctx context.Context, tenant string, page, limit int) (*utils.Pagination, error)
 	StoreSlackChannel(ctx context.Context, tenant, source, channelId, channelName string, organizationId *string) error
-	SendMessageFromBot(ctx context.Context, channel, blocks string) error
+	SendMessageFromBot(ctx context.Context, channel, blocks string, autoJoinSlackChannel bool) error
 	GetSlackSettings(ctx context.Context, tenant string) (*SlackSettingsResponse, error)
 	ListSlackChannelsWithBot(ctx context.Context) ([]SlackChannelResponse, error)
 	JoinSlackChannelsWithBot(ctx context.Context, channelId string) error

--- a/packages/server/customer-os-common-module/services/notification/service.go
+++ b/packages/server/customer-os-common-module/services/notification/service.go
@@ -30,7 +30,7 @@ func (s *notificationService) NotifySlackChannel(ctx context.Context, channelID 
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 
-	err := s.slackService.SendMessageFromBot(ctx, channelID, message)
+	err := s.slackService.SendMessageFromBot(ctx, channelID, message, true)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err

--- a/packages/server/customer-os-common-module/services/slack/service.go
+++ b/packages/server/customer-os-common-module/services/slack/service.go
@@ -35,6 +35,11 @@ func NewSlackService(log logger.Logger, postgres *postgres_repository.Repositori
 	}
 }
 
+type slackResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error"`
+}
+
 func (s *slackService) GetSlackChannels(ctx context.Context, tenant string) ([]*postgresEntity.SlackChannel, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SlackService.GetSlackChannels")
 	defer span.Finish()
@@ -110,10 +115,11 @@ func (s *slackService) StoreSlackChannel(ctx context.Context, tenant, source, ch
 	return nil
 }
 
-func (s *slackService) SendMessageFromBot(ctx context.Context, channel, blocks string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "NotificationService.sendSlackMessage")
+func (s *slackService) SendMessageFromBot(ctx context.Context, channel, blocks string, autoJoinSlackChannel bool) error {
+	span, _ := opentracing.StartSpanFromContext(ctx, "NotificationService.SendMessageFromBot")
 	defer span.Finish()
 	span.LogFields(log.String("channel", channel))
+	span.LogFields(log.Bool("autoJoinSlackChannel", autoJoinSlackChannel))
 
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {
@@ -189,6 +195,28 @@ func (s *slackService) SendMessageFromBot(ctx context.Context, channel, blocks s
 	}
 
 	span.LogFields(log.String("response.body", string(responseBody)))
+
+	var slackResp slackResponse
+	if err := json.Unmarshal(responseBody, &slackResp); err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	// Handle errors from Slack API
+	if !slackResp.OK {
+		if autoJoinSlackChannel && slackResp.Error == "not_in_channel" {
+			err = s.JoinSlackChannelsWithBot(ctx, channel)
+			if err != nil {
+				tracing.TraceErr(span, err)
+				return err
+			}
+			return s.SendMessageFromBot(ctx, channel, blocks, false)
+		} else {
+			err := fmt.Errorf("slack API error: %s", slackResp.Error)
+			tracing.TraceErr(span, err)
+			return err
+		}
+	}
 
 	return nil
 }
@@ -347,18 +375,15 @@ func (s *slackService) JoinSlackChannelsWithBot(ctx context.Context, channelId s
 		return err
 	}
 
-	var result struct {
-		OK    bool   `json:"ok"`
-		Error string `json:"error"`
-	}
-	if err := json.Unmarshal(body, &result); err != nil {
+	var slackResp slackResponse
+	if err := json.Unmarshal(body, &slackResp); err != nil {
 		tracing.TraceErr(span, err)
 		return err
 	}
 
 	// Handle errors from Slack API
-	if !result.OK {
-		err := fmt.Errorf("slack API error: %s", result.Error)
+	if !slackResp.OK {
+		err := fmt.Errorf("slack API error: %s", slackResp.Error)
 		tracing.TraceErr(span, err)
 		return err
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add auto-join feature to `SendMessageFromBot` in `slack.go` and refactor Slack API response handling.
> 
>   - **Behavior**:
>     - `SendMessageFromBot` in `slack.go` now accepts `autoJoinSlackChannel` to auto-join channels if not a member.
>     - If `not_in_channel` error occurs and `autoJoinSlackChannel` is true, attempts to join channel and resend message.
>   - **Refactoring**:
>     - Introduced `slackResponse` struct in `slack.go` for handling Slack API responses.
>     - Replaced inline response handling with `slackResponse` in `SendMessageFromBot` and `JoinSlackChannelsWithBot`.
>   - **Misc**:
>     - Updated `NotifySlackChannel` in `notification/service.go` to pass `true` for `autoJoinSlackChannel`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for ce24aae2ebe7de41bc92e83b1ff4248cbe55368d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->