### PR TITLE
[COS-6865] tests for contacts with no org

### DIFF
--- a/packages/apps/frontera/src/store/Contacts/__tests__/Contacts.integration.ts
+++ b/packages/apps/frontera/src/store/Contacts/__tests__/Contacts.integration.ts
@@ -1,8 +1,13 @@
 import { it, expect, describe } from 'vitest';
-import { VitestHelper } from '@store/vitest-helper.ts';
+import { VitestHelper, generateEmail } from '@store/vitest-helper.ts';
 import { OrganizationRepository } from '@infra/repositories/organization/organization.repository.ts';
 
-import { EmailLabel, EntityType, PhoneNumberLabel } from '@graphql/types';
+import {
+  EmailLabel,
+  EntityType,
+  PhoneNumberLabel,
+  SortingDirection,
+} from '@graphql/types';
 
 import { ContactService } from '../../Contacts/__service__/Contacts.service';
 import { JobRolesService } from '../../JobRoles/__service__/JobRoles.service.ts';
@@ -128,7 +133,7 @@ describe('ContactsService - Integration Tests', () => {
     expect(contact?.linkedInUrl).toBeNull();
   });
 
-  it('update contact', async () => {
+  it('update contact created in an organization', async () => {
     const { organizationId } = await VitestHelper.createOrganizationForTest(
       organizationsRepository,
     );
@@ -819,5 +824,130 @@ describe('ContactsService - Integration Tests', () => {
 
     expect(contactRemovedFirstTag?.tags?.length).toBe(1);
     expect(contactRemovedFirstTag?.tags?.[0]?.name).toBe(secondTagName);
+  });
+
+  it('creates a contact by LinkedinIn, with no organization', async () => {
+    const linkedIn_urls = [
+      'https://www.linkedin.com/in/Vitest-' + crypto.randomUUID(),
+    ];
+
+    // const contactId =
+    await VitestHelper.createContactBulkByLinkedInForTest(
+      contactService,
+      linkedIn_urls,
+    );
+
+    const { ui_contacts_search } = await contactService.searchContacts({
+      where: {
+        AND: [], // Empty AND array for no specific filters
+      },
+      sort: {
+        by: 'CONTACTS_UPDATED_AT',
+        direction: SortingDirection.Desc,
+      },
+    });
+
+    const createContacts = (
+      await contactService.getContactsByIds({ ids: ui_contacts_search.ids })
+    ).ui_contacts.filter(
+      (contact) =>
+        contact.linkedInUrl !== null &&
+        contact.linkedInUrl !== undefined &&
+        linkedIn_urls.includes(contact.linkedInUrl),
+    );
+
+    expect(createContacts).toHaveLength(linkedIn_urls.length);
+  });
+
+  it('creates multiple contacts by LinkedinIn, with no organization', async () => {
+    const linkedIn_urls = [
+      'https://www.linkedin.com/in/Vitest-' + crypto.randomUUID(),
+      'https://www.linkedin.com/in/Vitest-' + crypto.randomUUID(),
+    ];
+
+    // const contactId =
+    await VitestHelper.createContactBulkByLinkedInForTest(
+      contactService,
+      linkedIn_urls,
+    );
+
+    const { ui_contacts_search } = await contactService.searchContacts({
+      where: {
+        AND: [], // Empty AND array for no specific filters
+      },
+      sort: {
+        by: 'CONTACTS_UPDATED_AT',
+        direction: SortingDirection.Desc,
+      },
+    });
+
+    const createContacts = (
+      await contactService.getContactsByIds({ ids: ui_contacts_search.ids })
+    ).ui_contacts.filter(
+      (contact) =>
+        contact.linkedInUrl !== null &&
+        contact.linkedInUrl !== undefined &&
+        linkedIn_urls.includes(contact.linkedInUrl),
+    );
+
+    expect(createContacts).toHaveLength(linkedIn_urls.length);
+  });
+
+  it('creates a contact by Email, with no organization', async () => {
+    const emails = [generateEmail()];
+
+    await VitestHelper.createContactBulkByEmailForTest(contactService, emails);
+
+    const { ui_contacts_search } = await contactService.searchContacts({
+      where: {
+        AND: [],
+      },
+      sort: {
+        by: 'CONTACTS_UPDATED_AT',
+        direction: SortingDirection.Desc,
+      },
+    });
+
+    const createContacts = (
+      await contactService.getContactsByIds({ ids: ui_contacts_search.ids })
+    ).ui_contacts.filter((contact) =>
+      contact.emails.some(
+        (emailObj) =>
+          emailObj.email !== null &&
+          emailObj.email !== undefined &&
+          emails.includes(emailObj.email),
+      ),
+    );
+
+    expect(createContacts).toHaveLength(emails.length);
+  });
+
+  it('creates multiple contacts by Email, with no organization', async () => {
+    const emails = [generateEmail(), generateEmail()];
+
+    await VitestHelper.createContactBulkByEmailForTest(contactService, emails);
+
+    const { ui_contacts_search } = await contactService.searchContacts({
+      where: {
+        AND: [],
+      },
+      sort: {
+        by: 'CONTACTS_UPDATED_AT',
+        direction: SortingDirection.Desc,
+      },
+    });
+
+    const createContacts = (
+      await contactService.getContactsByIds({ ids: ui_contacts_search.ids })
+    ).ui_contacts.filter((contact) =>
+      contact.emails.some(
+        (emailObj) =>
+          emailObj.email !== null &&
+          emailObj.email !== undefined &&
+          emails.includes(emailObj.email),
+      ),
+    );
+
+    expect(createContacts).toHaveLength(emails.length);
   });
 });

--- a/packages/apps/frontera/src/store/vitest-helper.ts
+++ b/packages/apps/frontera/src/store/vitest-helper.ts
@@ -4,6 +4,8 @@ import { ContactService } from '@store/Contacts/__service__/Contacts.service.ts'
 import { contactsTestState } from '@store/Contacts/__tests__/contactsTestState.ts';
 import { organizationsTestState } from '@store/Organizations/__tests__/organizationsTestState.ts';
 
+import { SortingDirection } from '@graphql/types';
+
 interface ContactCreateInput {
   name?: string;
   socialUrl?: string;
@@ -119,22 +121,32 @@ export class VitestHelper {
 
   static async createContactBulkByLinkedInForTest(
     contactService: ContactService,
-    count: number = 1,
-    flowId?: string,
+    linkedInUrls: string[],
   ) {
-    const linkedInUrls = Array.from(
-      { length: count },
-      () => `https://www.linkedin.com/in/Vitest-${crypto.randomUUID()}`,
-    );
-
     const { contact_CreateBulkByLinkedIn: contactIds } =
       await contactService.createContactBulkByLinkedIn({
         linkedInUrls,
-        flowId,
       });
 
-    // Track all created contacts
-    contactIds.forEach((id) => trackContact(id));
+    const { ui_contacts_search } = await contactService.searchContacts({
+      where: {
+        AND: [], // Empty AND array for no specific filters
+      },
+      sort: {
+        by: 'CONTACTS_UPDATED_AT',
+        direction: SortingDirection.Desc,
+      },
+    });
+    const createContacts = (
+      await contactService.getContactsByIds({ ids: ui_contacts_search.ids })
+    ).ui_contacts.filter(
+      (contact) =>
+        contact.linkedInUrl !== null &&
+        contact.linkedInUrl !== undefined &&
+        linkedInUrls.includes(contact.linkedInUrl),
+    );
+
+    createContacts.forEach((createContacts) => trackContact(createContacts.id));
 
     return {
       contactIds,
@@ -144,22 +156,35 @@ export class VitestHelper {
 
   static async createContactBulkByEmailForTest(
     contactService: ContactService,
-    count: number = 1,
-    flowId?: string,
+    emails: string[],
   ) {
-    const emails = Array.from(
-      { length: count },
-      () => `vitest-${crypto.randomUUID()}@${crypto.randomUUID()}.com`,
-    );
-
     const { contact_CreateBulkByEmail: contactIds } =
       await contactService.createContactBulkByEmail({
         emails,
-        flowId,
       });
 
-    // Track all created contacts
-    contactIds.forEach((id) => trackContact(id));
+    const { ui_contacts_search } = await contactService.searchContacts({
+      where: {
+        AND: [],
+      },
+      sort: {
+        by: 'CONTACTS_UPDATED_AT',
+        direction: SortingDirection.Desc,
+      },
+    });
+
+    const createContacts = (
+      await contactService.getContactsByIds({ ids: ui_contacts_search.ids })
+    ).ui_contacts.filter((contact) =>
+      contact.emails.some(
+        (emailObj) =>
+          emailObj.email !== null &&
+          emailObj.email !== undefined &&
+          emails.includes(emailObj.email),
+      ),
+    );
+
+    createContacts.forEach((createContacts) => trackContact(createContacts.id));
 
     return {
       contactIds,
@@ -174,4 +199,16 @@ export const trackOrganization = (organizationId: string) => {
 
 export const trackContact = (contactId: string) => {
   contactsTestState.createdContactsIds.add(contactId);
+};
+
+export const generateEmail = (): string => {
+  const letters = 'abcdefghijklmnopqrstuvwxyz';
+  const firstPart = Array.from({ length: 5 }, () =>
+    letters.charAt(Math.floor(Math.random() * letters.length)),
+  ).join('');
+  const secondPart = Array.from({ length: 4 }, () =>
+    letters.charAt(Math.floor(Math.random() * letters.length)),
+  ).join('');
+
+  return `${firstPart}.${secondPart}@msn.com`;
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add tests for creating contacts without an organization using LinkedIn URLs and emails, and update helper functions to support these tests.
> 
>   - **Tests**:
>     - Add tests in `Contacts.integration.ts` for creating contacts without an organization using LinkedIn URLs and emails.
>     - Test cases include single and multiple contacts creation.
>   - **Helper Functions**:
>     - Update `createContactBulkByLinkedInForTest` and `createContactBulkByEmailForTest` in `vitest-helper.ts` to support new test cases.
>     - Add `generateEmail` function in `vitest-helper.ts` for generating random emails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 97e8c16090d24dab8395e1ab908866c956a98e73. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->