### PR TITLE
fix(COS-6870): Clean up deprecated agent properties from GraphQL query

### DIFF
--- a/packages/apps/frontera/src/infra/repositories/agent/mutations/saveAgent.generated.ts
+++ b/packages/apps/frontera/src/infra/repositories/agent/mutations/saveAgent.generated.ts
@@ -12,9 +12,7 @@ export type SaveAgentMutation = {
     type: Types.AgentType;
     name: string;
     goal: string;
-    goalType: string;
     isActive: boolean;
-    flowId?: string | null;
     visible: boolean;
     createdAt: any;
     updatedAt: any;

--- a/packages/apps/frontera/src/infra/repositories/agent/mutations/saveAgent.graphql
+++ b/packages/apps/frontera/src/infra/repositories/agent/mutations/saveAgent.graphql
@@ -20,9 +20,7 @@ mutation saveAgent($input: AgentSaveInput!) {
       errors
     }
     goal
-    goalType
     isActive
-    flowId
     visible
     createdAt
     updatedAt

--- a/packages/apps/frontera/src/infra/repositories/agent/queries/agent.generated.ts
+++ b/packages/apps/frontera/src/infra/repositories/agent/queries/agent.generated.ts
@@ -13,9 +13,7 @@ export type AgentQuery = {
     name: string;
     scope: Types.AgentScope;
     goal: string;
-    goalType: string;
     isActive: boolean;
-    flowId?: string | null;
     visible: boolean;
     createdAt: any;
     updatedAt: any;

--- a/packages/apps/frontera/src/infra/repositories/agent/queries/agent.graphql
+++ b/packages/apps/frontera/src/infra/repositories/agent/queries/agent.graphql
@@ -21,9 +21,7 @@ query agent($id: ID!) {
       errors
     }
     goal
-    goalType
     isActive
-    flowId
     visible
     createdAt
     updatedAt

--- a/packages/apps/frontera/src/infra/repositories/agent/queries/agents.generated.ts
+++ b/packages/apps/frontera/src/infra/repositories/agent/queries/agents.generated.ts
@@ -10,10 +10,8 @@ export type AgentsQuery = {
     type: Types.AgentType;
     name: string;
     goal: string;
-    goalType: string;
     isActive: boolean;
     scope: Types.AgentScope;
-    flowId?: string | null;
     visible: boolean;
     createdAt: any;
     updatedAt: any;

--- a/packages/apps/frontera/src/infra/repositories/agent/queries/agents.graphql
+++ b/packages/apps/frontera/src/infra/repositories/agent/queries/agents.graphql
@@ -20,10 +20,8 @@ query agents {
       errors
     }
     goal
-    goalType
     isActive
     scope
-    flowId
     visible
     createdAt
     updatedAt

--- a/packages/apps/frontera/src/store/Agents/Agent.dto.ts
+++ b/packages/apps/frontera/src/store/Agents/Agent.dto.ts
@@ -183,14 +183,13 @@ export class Agent extends Entity<AgentDatum> {
 
   public toPayload(): Omit<
     AgentDatum,
-    'createdAt' | 'updatedAt' | 'isConfigured' | 'goalType' | 'scope'
+    'createdAt' | 'updatedAt' | 'isConfigured' | 'scope'
   > {
     return omit(this.value, [
       'createdAt',
       'updatedAt',
       'error',
       'isConfigured',
-      'goalType',
       'scope',
     ]);
   }
@@ -199,14 +198,13 @@ export class Agent extends Entity<AgentDatum> {
     name: string,
   ): Omit<
     AgentDatum,
-    'createdAt' | 'updatedAt' | 'isConfigured' | 'goalType' | 'id' | 'scope'
+    'createdAt' | 'updatedAt' | 'isConfigured' | 'id' | 'scope'
   > {
     return omit({ ...this.value, name }, [
       'createdAt',
       'updatedAt',
       'error',
       'isConfigured',
-      'goalType',
       'scope',
       'id',
     ]);
@@ -309,13 +307,11 @@ export class Agent extends Entity<AgentDatum> {
         listeners: [],
         capabilities: [],
         goal: '',
-        goalType: '',
         type: AgentType.WebVisitIdentifier,
         icon: '',
         color: '',
         visible: true,
         isActive: true,
-        flowId: '',
         error: null,
         isConfigured: false,
         scope: AgentScope.Workspace,


### PR DESCRIPTION
- Remove unused goalType field
- Remove unused flowId field
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove deprecated `goalType` and `flowId` fields from agent GraphQL queries and TypeScript types.
> 
>   - **GraphQL Queries and Mutations**:
>     - Removed `goalType` and `flowId` from `saveAgent.graphql`, `agent.graphql`, and `agents.graphql`.
>   - **TypeScript Types**:
>     - Removed `goalType` and `flowId` from `SaveAgentMutation` in `saveAgent.generated.ts`.
>     - Removed `goalType` and `flowId` from `AgentQuery` in `agent.generated.ts`.
>     - Removed `goalType` and `flowId` from `AgentsQuery` in `agents.generated.ts`.
>   - **DTO Changes**:
>     - Removed `goalType` from `toPayload()` and `toDuplicatePayload()` in `Agent.dto.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 13fb5fdebb047db05896dd93fd7d9dd29f8a59df. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->