### PR TITLE
fix invoice generation

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_generate_invoice.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_generate_invoice.go
@@ -108,6 +108,8 @@ func (c *GenerateInvoiceCapability) NewConfig() GenerateInvoiceConfig {
 
 func (c *GenerateInvoiceCapability) DefaultConfig() any {
 	config := c.NewConfig()
+	config.CcEmails.Value = []string{}
+	config.BccEmails.Value = []string{}
 	return &config
 }
 

--- a/packages/server/customer-os-common-module/services/invoice/service.go
+++ b/packages/server/customer-os-common-module/services/invoice/service.go
@@ -2369,7 +2369,7 @@ func (s *invoiceService) generateInvoicePDF(ctx context.Context,
 	fileDTO, err := s.fileService.UploadSingleFileBytesDirect(ctx, basePath, invoiceEntity.Id, "Invoice - "+invoiceEntity.Number+".pdf", pdfBytes, true)
 	if err != nil {
 		tracing.TraceErr(span, errors.Wrap(err, "UploadSingleFileBytes"))
-		return "", errors.Wrap(err, "UploadSingleFileBytes")
+		return "", err
 	}
 
 	if fileDTO.ID == "" {

--- a/packages/server/events-subscribers/.env
+++ b/packages/server/events-subscribers/.env
@@ -45,3 +45,6 @@ NOVU_API_KEY:
 MAILSHERPA_API_KEY:
 
 RABBITMQ_URL: amqp://guest:guest@localhost:5672
+
+AWS_S3_REGION: eu-west-2
+AWS_S3_BUCKET: openline-dev-fs-bucket


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix invoice generation by initializing email fields and improving error handling in PDF generation.
> 
>   - **Behavior**:
>     - Initialize `CcEmails` and `BccEmails` to empty slices in `DefaultConfig()` in `capability_generate_invoice.go`.
>     - Remove redundant error wrapping in `generateInvoicePDF()` in `service.go`.
>   - **Misc**:
>     - Minor error handling improvement in `generateInvoicePDF()` in `service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for e1a26b2967788c48a7f2200f67aa6290edeb4bbe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->