### PR TITLE
fix(COS-6872): Prevent existing channel name from being cleared when entering a non-existent channel

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-slack-channel.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-slack-channel.usecase.ts
@@ -4,7 +4,6 @@ import { Agent } from '@store/Agents/Agent.dto';
 import { action, computed, observable } from 'mobx';
 import { AgentService } from '@domain/services/agent/agent.service';
 
-import { SelectOption } from '@ui/utils/types';
 import { CapabilityType } from '@graphql/types';
 
 export const cooldownPeriods = [1, 4, 8, 12, 24, 999999];
@@ -45,20 +44,19 @@ export class AddSlackChannelUsecase {
   get allOptions() {
     return this.root.common.slackChannelsArray.map((val) => {
       return { value: val.channelId, label: val.name };
-    }, [] as SelectOption[]);
+    });
   }
 
   @computed
   get options() {
-    return this.allOptions.reduce((acc, curr) => {
-      if (!curr) return acc;
-
-      if (!curr.label.toLowerCase().includes(this.inputValue.toLowerCase())) {
-        return acc;
-      }
-
-      return [...acc, { value: curr.value, label: curr.label }];
-    }, [] as SelectOption[]);
+    return this.allOptions
+      .filter((option) =>
+        option?.label.toLowerCase().includes(this.inputValue.toLowerCase()),
+      )
+      .map((option) => ({
+        value: option.value,
+        label: option.label,
+      }));
   }
 
   @computed

--- a/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-slack-channel.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-slack-channel.usecase.ts
@@ -42,21 +42,30 @@ export class AddSlackChannelUsecase {
   }
 
   @computed
+  get allOptions() {
+    return this.root.common.slackChannelsArray.map((val) => {
+      return { value: val.channelId, label: val.name };
+    }, [] as SelectOption[]);
+  }
+
+  @computed
   get options() {
-    return this.root.common.slackChannelsArray.reduce((acc, curr) => {
+    return this.allOptions.reduce((acc, curr) => {
       if (!curr) return acc;
 
-      if (!curr.name.toLowerCase().includes(this.inputValue.toLowerCase())) {
+      if (!curr.label.toLowerCase().includes(this.inputValue.toLowerCase())) {
         return acc;
       }
 
-      return [...acc, { value: curr.channelId, label: curr.name }];
+      return [...acc, { value: curr.value, label: curr.label }];
     }, [] as SelectOption[]);
   }
 
   @computed
   get selectedOption() {
-    return this.options.find((option) => option.value === this.selectedChannel);
+    return this.allOptions.find(
+      (option) => option.value === this.selectedChannel,
+    );
   }
 
   @computed

--- a/packages/apps/frontera/src/store/Agents/Agent.dto.ts
+++ b/packages/apps/frontera/src/store/Agents/Agent.dto.ts
@@ -183,7 +183,7 @@ export class Agent extends Entity<AgentDatum> {
 
   public toPayload(): Omit<
     AgentDatum,
-    'createdAt' | 'updatedAt' | 'isConfigured' | 'scope'
+    'createdAt' | 'updatedAt' | 'isConfigured' | 'scope' | 'goal'
   > {
     return omit(this.value, [
       'createdAt',
@@ -191,6 +191,7 @@ export class Agent extends Entity<AgentDatum> {
       'error',
       'isConfigured',
       'scope',
+      'goal',
     ]);
   }
 
@@ -198,7 +199,7 @@ export class Agent extends Entity<AgentDatum> {
     name: string,
   ): Omit<
     AgentDatum,
-    'createdAt' | 'updatedAt' | 'isConfigured' | 'id' | 'scope'
+    'createdAt' | 'updatedAt' | 'isConfigured' | 'id' | 'scope' | 'goal'
   > {
     return omit({ ...this.value, name }, [
       'createdAt',
@@ -207,6 +208,7 @@ export class Agent extends Entity<AgentDatum> {
       'isConfigured',
       'scope',
       'id',
+      'goal',
     ]);
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prevents clearing of existing channel name in `AddSlackChannelUsecase` and updates `Agent` class to omit `goal` field in payloads.
> 
>   - **Behavior**:
>     - Prevents clearing of existing channel name in `AddSlackChannelUsecase` when entering a non-existent channel by using `allOptions` for `selectedOption`.
>   - **Models**:
>     - Updates `Agent` class in `Agent.dto.ts` to omit `goal` field in `toPayload()` and `toDuplicatePayload()` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d89cdfec8ab9e51a1a4f28ca306088af4539fc32. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->