### PR TITLE
Fix:tag selection for Apply tag to company agent

### DIFF
--- a/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-tag-to-company.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-tag-to-company.usecase.ts
@@ -53,6 +53,7 @@ export class AddTagToCompanyUsecase {
         onSuccess: (id) => {
           this.select(id);
           this.newTag.add(name);
+          this.execute();
           this.setSearchTerm('');
         },
       },

--- a/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-tag-to-company.usecase.ts
+++ b/packages/apps/frontera/src/domain/usecases/agents/capabilities/add-tag-to-company.usecase.ts
@@ -10,7 +10,7 @@ import { EntityType } from '@shared/types/__generated__/graphql.types';
 
 export class AddTagToCompanyUsecase {
   @observable public accessor searchTerm = '';
-  @observable public accessor newTags = new Set();
+  @observable public accessor newTag = new Set();
   @observable public accessor initialTags: { label: string; value: string }[] =
     [];
 
@@ -52,7 +52,7 @@ export class AddTagToCompanyUsecase {
       {
         onSuccess: (id) => {
           this.select(id);
-          this.newTags.add(name);
+          this.newTag.add(name);
           this.setSearchTerm('');
         },
       },
@@ -125,11 +125,11 @@ export class AddTagToCompanyUsecase {
       return;
     }
 
-    this.newTags.clear();
-    this.newTags.add(id);
+    this.newTag.clear();
+    this.newTag.add(id);
 
     span.end({
-      ids: Array.from(this.newTags),
+      ids: Array.from(this.newTag),
     });
   }
 
@@ -145,18 +145,23 @@ export class AddTagToCompanyUsecase {
   }
 
   @computed
-  get selectedTags() {
-    return this.tagList.filter(
-      (tag) =>
-        this.newTags.has(tag.value) ||
-        this.initialTags.some((t) => t.value === tag.value),
+  get selectedTag() {
+    const newTag = this.tagList.find((tag) => this.newTag.has(tag.value));
+
+    if (newTag) {
+      return [newTag];
+    }
+    const initialTag = this.tagList.find((tag) =>
+      this.initialTags.some((t) => t.value === tag.value),
     );
+
+    return initialTag ? [initialTag] : [];
   }
 
   @action
   public reset() {
     this.searchTerm = '';
-    this.newTags.clear();
+    this.newTag.clear();
     this.initialTags = [];
   }
 
@@ -174,7 +179,7 @@ export class AddTagToCompanyUsecase {
       return;
     }
 
-    const tagName = this.selectedTags.map((tag) => tag.label).join(', ');
+    const tagName = this.selectedTag.map((tag) => tag.label).join(', ');
 
     agent?.setCapabilityConfig(
       CapabilityType.ApplyTagToCompany,

--- a/packages/apps/frontera/src/routes/agent/components/Capabilities/ApplyTag/ApplyTag.tsx
+++ b/packages/apps/frontera/src/routes/agent/components/Capabilities/ApplyTag/ApplyTag.tsx
@@ -28,22 +28,17 @@ export const ApplyTag = observer(() => {
           Choose or create one tag to identify companies that need support
         </p>
         <Tags
+          isMulti={false}
           className='mt-1'
           options={usecase.tagList}
           placeholder='Company tags'
-          value={usecase.selectedTags}
+          value={usecase.selectedTag}
           inputValue={usecase.searchTerm}
           onCreate={() => usecase.create()}
           setInputValue={usecase.setSearchTerm}
           leftAccessory={<Icon name='tag-01' className='mr-3 text-gray-500' />}
           onChange={(selection) => {
-            if (Array.isArray(selection) && selection.length > 1) return;
-
-            if (Array.isArray(selection) && selection.length > 0) {
-              usecase.select(selection[0]?.value);
-            } else {
-              usecase.reset();
-            }
+            usecase.select(selection.value);
             usecase.execute();
           }}
         />

--- a/packages/apps/frontera/src/routes/src/components/Tags/Tags.tsx
+++ b/packages/apps/frontera/src/routes/src/components/Tags/Tags.tsx
@@ -67,6 +67,10 @@ export const Tags = observer(
       }
     };
 
+    const foundOption = options.some((o) =>
+      o.label.toLowerCase().includes(inputValue.toLowerCase()),
+    );
+
     return (
       <Popover>
         <Tooltip align='start' label='Company tags'>
@@ -118,7 +122,7 @@ export const Tags = observer(
             onInputChange={setInputValue}
             placeholder={inputPlaceholder}
             onKeyDown={(e) => {
-              if (e.key === 'Enter' && !options.length) {
+              if (e.key === 'Enter' && !foundOption) {
                 onCreate?.(inputValue);
                 setInputValue('');
               }

--- a/packages/apps/frontera/src/store/Agents/Agent.dto.ts
+++ b/packages/apps/frontera/src/store/Agents/Agent.dto.ts
@@ -183,7 +183,7 @@ export class Agent extends Entity<AgentDatum> {
 
   public toPayload(): Omit<
     AgentDatum,
-    'createdAt' | 'updatedAt' | 'isConfigured' | 'scope'
+    'createdAt' | 'updatedAt' | 'isConfigured' | 'scope' | 'goal'
   > {
     return omit(this.value, [
       'createdAt',
@@ -191,6 +191,7 @@ export class Agent extends Entity<AgentDatum> {
       'error',
       'isConfigured',
       'scope',
+      'goal',
     ]);
   }
 
@@ -198,7 +199,7 @@ export class Agent extends Entity<AgentDatum> {
     name: string,
   ): Omit<
     AgentDatum,
-    'createdAt' | 'updatedAt' | 'isConfigured' | 'id' | 'scope'
+    'createdAt' | 'updatedAt' | 'isConfigured' | 'id' | 'scope' | 'goal'
   > {
     return omit({ ...this.value, name }, [
       'createdAt',
@@ -206,6 +207,7 @@ export class Agent extends Entity<AgentDatum> {
       'error',
       'isConfigured',
       'scope',
+      'goal',
       'id',
     ]);
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor tag selection to handle a single tag for applying tags to company agents, with adjustments in logic and payload handling.
> 
>   - **Behavior**:
>     - Change from handling multiple tags to a single tag in `AddTagToCompanyUsecase`.
>     - `newTags` renamed to `newTag` in `add-tag-to-company.usecase.ts`.
>     - `selectedTags` renamed to `selectedTag` in `add-tag-to-company.usecase.ts`.
>     - `isMulti` set to `false` in `ApplyTag.tsx` and `Tags.tsx` to reflect single tag selection.
>   - **Logic Adjustments**:
>     - Adjust `create()` and `select()` methods in `AddTagToCompanyUsecase` to handle single tag logic.
>     - Modify `onChange` logic in `ApplyTag.tsx` to handle single tag selection.
>     - Update `onKeyDown` logic in `Tags.tsx` to check for existing options before creating a new tag.
>   - **Misc**:
>     - Exclude `goal` from payload in `Agent.dto.ts` in `toPayload()` and `toDuplicatePayload()` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for ad7bd6d94449f6a13b0fed888a43cf51cb138827. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->