### PR TITLE
sli update with no changes

### DIFF
--- a/packages/server/customer-os-api/services/service_line_item/service_line_item_service.go
+++ b/packages/server/customer-os-api/services/service_line_item/service_line_item_service.go
@@ -296,7 +296,7 @@ func (s *serviceLineItemService) Update(ctx context.Context, serviceLineItemDeta
 		baseServiceLineItemEntity.Billed != serviceLineItemDetails.SliBilledType
 
 	// If no changes recorded, return
-	if !anyFieldChanged && (utils.ToDate(baseServiceLineItemEntity.StartedAt).Equal(startedAt) || sliIsInvoiced) {
+	if !anyFieldChanged && (utils.ToDate(baseServiceLineItemEntity.StartedAt).Equal(startedAt) || utils.CloseToNow(startedAt) || sliIsInvoiced) {
 		span.LogFields(log.String("result", "No changes recorded"))
 		return nil
 	}

--- a/packages/server/customer-os-common-module/utils/time_utils.go
+++ b/packages/server/customer-os-common-module/utils/time_utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -266,4 +267,8 @@ func ConvertToUTC(datetimeStr string) (time.Time, error) {
 	}
 
 	return parsedTime.UTC(), nil
+}
+
+func CloseToNow(t time.Time) bool {
+	return math.Abs(time.Now().Sub(t).Seconds()) < time.Minute.Seconds()
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `CloseToNow` utility and update `Update` logic in `service_line_item_service.go` to check if start date is close to now.
> 
>   - **Behavior**:
>     - Update condition in `Update()` in `service_line_item_service.go` to include `utils.CloseToNow(startedAt)` for determining if no changes are recorded.
>   - **Utils**:
>     - Add `CloseToNow(t time.Time) bool` in `time_utils.go` to check if a time is within one minute of the current time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 5952ae993e3127314979f2a677d78e455c48bbe4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->