### PR TITLE
Remove 'goal' from Agent payload methods

### DIFF
--- a/packages/apps/frontera/src/store/Agents/Agent.dto.ts
+++ b/packages/apps/frontera/src/store/Agents/Agent.dto.ts
@@ -183,7 +183,7 @@ export class Agent extends Entity<AgentDatum> {
 
   public toPayload(): Omit<
     AgentDatum,
-    'createdAt' | 'updatedAt' | 'isConfigured' | 'scope'
+    'createdAt' | 'updatedAt' | 'isConfigured' | 'scope' | 'goal'
   > {
     return omit(this.value, [
       'createdAt',
@@ -191,6 +191,7 @@ export class Agent extends Entity<AgentDatum> {
       'error',
       'isConfigured',
       'scope',
+      'goal',
     ]);
   }
 
@@ -198,7 +199,7 @@ export class Agent extends Entity<AgentDatum> {
     name: string,
   ): Omit<
     AgentDatum,
-    'createdAt' | 'updatedAt' | 'isConfigured' | 'id' | 'scope'
+    'createdAt' | 'updatedAt' | 'isConfigured' | 'id' | 'scope' | 'goal'
   > {
     return omit({ ...this.value, name }, [
       'createdAt',
@@ -207,6 +208,7 @@ export class Agent extends Entity<AgentDatum> {
       'isConfigured',
       'scope',
       'id',
+      'goal',
     ]);
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove 'goal' from payload methods in `Agent` class, affecting payload construction.
> 
>   - **Behavior**:
>     - Remove 'goal' from `toPayload()` and `toDuplicatePayload()` in `Agent` class.
>     - Affects payload construction by omitting 'goal' field.
>   - **Misc**:
>     - No changes to other methods or functionalities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 6d11fd85279c30901580592dca8c86b49710fe5d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->