### PR TITLE
feat(COS-6882): Open agent rename modal on agent name click

### DIFF
--- a/packages/apps/frontera/src/routes/agent/components/Header/Header.tsx
+++ b/packages/apps/frontera/src/routes/agent/components/Header/Header.tsx
@@ -8,6 +8,7 @@ import { Switch } from '@ui/form/Switch';
 import { Icon, IconName } from '@ui/media/Icon';
 import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
+import { Button } from '@ui/form/Button/Button.tsx';
 import { Menu, MenuItem, MenuList, MenuButton } from '@ui/overlay/Menu/Menu';
 import { Popover, PopoverContent, PopoverTrigger } from '@ui/overlay/Popover';
 
@@ -99,14 +100,14 @@ export const Header = observer(
             </Popover>
 
             <div className='flex items-center gap-1'>
-              <p
-                tabIndex={0}
-                role={'button'}
-                className='text-md font-medium cursor-pointer'
+              <Button
+                size='xxs'
+                variant='ghost'
                 onClick={() => handleOpenCommandMenu('RenameAgent')}
+                className='text-md font-medium hover:bg-transparent focus:bg-transparent'
               >
                 {agentName}
-              </p>
+              </Button>
               <Menu open={menuOpen} onOpenChange={setMenuOpen}>
                 <MenuButton asChild>
                   <IconButton

--- a/packages/apps/frontera/src/routes/agent/components/Header/Header.tsx
+++ b/packages/apps/frontera/src/routes/agent/components/Header/Header.tsx
@@ -55,6 +55,15 @@ export const Header = observer(
     }, []);
     const [_ring, bg, iconColor] = colorMap;
 
+    const handleOpenCommandMenu = (type: 'RenameAgent' | 'ArchiveAgent') => {
+      store.ui.commandMenu.setType(type);
+      store.ui.commandMenu.setContext({
+        ...store.ui.commandMenu.context,
+        ids: [id],
+      });
+      store.ui.commandMenu.setOpen(true);
+    };
+
     return (
       <div className='w-full border-b border-b-gray-200 px-3 py-[11px] flex justify-between items-center'>
         <div className='flex items-center gap-1'>
@@ -90,7 +99,14 @@ export const Header = observer(
             </Popover>
 
             <div className='flex items-center gap-1'>
-              <p className='text-md font-medium'>{agentName}</p>
+              <p
+                tabIndex={0}
+                role={'button'}
+                className='text-md font-medium cursor-pointer'
+                onClick={() => handleOpenCommandMenu('RenameAgent')}
+              >
+                {agentName}
+              </p>
               <Menu open={menuOpen} onOpenChange={setMenuOpen}>
                 <MenuButton asChild>
                   <IconButton
@@ -103,14 +119,7 @@ export const Header = observer(
                 <MenuList side='bottom' align='start'>
                   <MenuItem
                     className='group'
-                    onClick={() => {
-                      store.ui.commandMenu.setType('RenameAgent');
-                      store.ui.commandMenu.setContext({
-                        ...store.ui.commandMenu.context,
-                        ids: [id],
-                      });
-                      store.ui.commandMenu.setOpen(true);
-                    }}
+                    onClick={() => handleOpenCommandMenu('RenameAgent')}
                   >
                     <Icon
                       name='edit-03'
@@ -146,14 +155,7 @@ export const Header = observer(
                   {/*</MenuItem>*/}
                   <MenuItem
                     className='group'
-                    onClick={() => {
-                      store.ui.commandMenu.setContext({
-                        ...store.ui.commandMenu.context,
-                        ids: [id],
-                      });
-                      store.ui.commandMenu.setType('ArchiveAgent');
-                      store.ui.commandMenu.setOpen(true);
-                    }}
+                    onClick={() => handleOpenCommandMenu('ArchiveAgent')}
                   >
                     <Icon
                       name='archive'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Clicking the agent name in `Header.tsx` now opens the rename modal using a `Button`, with refactored command menu logic.
> 
>   - **Behavior**:
>     - Clicking the agent name in `Header.tsx` now opens the rename modal using a `Button` component.
>     - Refactors command menu logic into `handleOpenCommandMenu()` for 'RenameAgent' and 'ArchiveAgent'.
>   - **UI Components**:
>     - Adds `Button` component for agent name in `Header.tsx`.
>     - Updates `MenuItem` click handlers to use `handleOpenCommandMenu()`.
>   - **Misc**:
>     - Removes redundant command menu logic from `MenuItem` click handlers in `Header.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a1cb36bed94a7b76f0e93f3c69913c615abaf3e4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->