### PR TITLE
fix: shift+e crash the app

### DIFF
--- a/packages/apps/frontera/src/routes/finder/src/components/Actions/ContactActions.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Actions/ContactActions.tsx
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react-lite';
 import { useKeys, useKeyBindings } from 'rooks';
 import { Contact } from '@store/Contacts/Contact.dto';
 import { CommandMenuType } from '@store/UI/CommandMenu.store.ts';
+import { EditEmailCase } from '@domain/usecases/command-menu/edit-email.usecase';
 
 import { useStore } from '@shared/hooks/useStore';
 import { useModKey } from '@shared/hooks/useModKey';
@@ -18,6 +19,7 @@ interface TableActionsProps {
   table: TableInstance<Contact>;
   enableKeyboardShortcuts?: boolean;
 }
+const editEmailUseCase = EditEmailCase.getInstance();
 
 export const ContactTableActions = observer(
   ({
@@ -109,6 +111,11 @@ export const ContactTableActions = observer(
       (e) => {
         e.stopPropagation();
         e.preventDefault();
+        editEmailUseCase.setEmail(
+          table
+            .getRow(focusedId || '')
+            .original.value.emails?.find((e) => e.primary)?.email || '',
+        );
         handleOpen('EditEmail', 'email');
       },
       { when: enableKeyboardShortcuts && (selectCount === 1 || !!focusedId) },

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/email/EmailCell.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/Cells/email/EmailCell.tsx
@@ -12,7 +12,6 @@ import { useStore } from '@shared/hooks/useStore';
 import { Archive } from '@ui/media/icons/Archive';
 import { TextInput } from '@ui/media/icons/TextInput';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
-import { EmailValidationDetails } from '@graphql/types';
 import { PlusCircle } from '@ui/media/icons/PlusCircle';
 import { DotsVertical } from '@ui/media/icons/DotsVertical';
 import { useCopyToClipboard } from '@shared/hooks/useCopyToClipboard';
@@ -21,242 +20,242 @@ import { EmailValidationMessage } from '@shared/components/ContactDetails/compon
 
 interface EmailCellProps {
   contactId: string;
-  validationDetails: EmailValidationDetails | undefined;
 }
-export const EmailCell = observer(
-  ({ validationDetails, contactId }: EmailCellProps) => {
-    const store = useStore();
 
-    const [isHovered, setIsHovered] = useState(false);
-    const [isOpened, setIsOpened] = useState(false);
-    const [_, copyToClipboard] = useCopyToClipboard();
+const editEmailUseCase = EditEmailCase.getInstance();
 
-    const contactStore = store.contacts.value.get(contactId);
+export const EmailCell = observer(({ contactId }: EmailCellProps) => {
+  const store = useStore();
 
-    if (!contactStore) return;
+  const [isHovered, setIsHovered] = useState(false);
+  const [isOpened, setIsOpened] = useState(false);
+  const [_, copyToClipboard] = useCopyToClipboard();
 
-    const isEnrichingContact = contactStore?.isEnriching;
+  const contactStore = store.contacts.value.get(contactId);
 
-    const ref = useRef(null);
+  if (!contactStore) return;
 
-    const activeOrgId = contactStore?.value.primaryOrganizationId;
-    const domains =
-      activeOrgId && store.organizations.value.get(activeOrgId)?.value?.domains;
-    const orgActive = contactStore?.value.primaryOrganizationName;
+  const isEnrichingContact = contactStore?.isEnriching;
 
-    const email = contactStore.value.emails.find((e) => e.primary)?.email;
+  const ref = useRef(null);
 
-    const isEnrichingEmail = contactStore?.emailEnriching;
-    const enrichedEmailNotFound =
-      !contactStore.value.enrichedEmailFound &&
-      !email &&
-      contactStore.value.enrichedEmailEnrichedAt;
+  const activeOrgId = contactStore?.value.primaryOrganizationId;
+  const domains =
+    activeOrgId && store.organizations.value.get(activeOrgId)?.value?.domains;
+  const orgActive = contactStore?.value.primaryOrganizationName;
 
-    const enrichingStatus = isEnrichingContact
-      ? 'Enriching...'
-      : isEnrichingEmail
-      ? 'Finding email...'
-      : enrichedEmailNotFound
-      ? 'Not found'
-      : 'Not set';
+  const email = contactStore.value.emails.find((e) => e.primary)?.email;
 
-    return (
-      <div
-        ref={ref}
-        className='flex cursor-pointer'
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
-        <Menu
-          onOpenChange={(newStatus) => {
-            setIsOpened(newStatus);
-          }}
+  const isEnrichingEmail = contactStore?.emailEnriching;
+  const enrichedEmailNotFound =
+    !contactStore.value.enrichedEmailFound &&
+    !email &&
+    contactStore.value.enrichedEmailEnrichedAt;
+
+  const enrichingStatus = isEnrichingContact
+    ? 'Enriching...'
+    : isEnrichingEmail
+    ? 'Finding email...'
+    : enrichedEmailNotFound
+    ? 'Not found'
+    : 'Not set';
+
+  const validationDetails = contactStore?.value.emails.find(
+    (e) => e.primary === true,
+  )?.emailValidationDetails;
+
+  return (
+    <div
+      ref={ref}
+      className='flex cursor-pointer'
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <Menu onOpenChange={(newStatus) => setIsOpened(newStatus)}>
+        <MenuButton
+          asChild
+          className='text-ellipsis overflow-hidden whitespace-nowrap'
         >
-          <MenuButton
-            asChild
-            className='text-ellipsis overflow-hidden whitespace-nowrap'
-          >
-            <div className='flex items-center gap-2'>
-              {!email && <p className='text-gray-400 '>{enrichingStatus}</p>}
-              {email && (
-                <EmailValidationMessage
-                  email={email}
-                  validationDetails={validationDetails}
-                />
+          <div className='flex items-center gap-2'>
+            {!email && <p className='text-gray-400 '>{enrichingStatus}</p>}
+            {email && (
+              <EmailValidationMessage
+                email={email}
+                validationDetails={validationDetails}
+              />
+            )}
+            <div className='inline-flex gap-2'>
+              {email}
+              {isEnrichingEmail && (
+                <Tooltip label={`Finding email at ${orgActive}`}>
+                  <div>
+                    <Spinner
+                      size='sm'
+                      label='finding email'
+                      className='text-gray-400 fill-gray-700 ml-2'
+                    />
+                  </div>
+                </Tooltip>
               )}
-              <div className='inline-flex gap-2'>
-                {email}
-                {isEnrichingEmail && (
-                  <Tooltip label={`Finding email at ${orgActive}`}>
-                    <div>
-                      <Spinner
-                        size='sm'
-                        label='finding email'
-                        className='text-gray-400 fill-gray-700 ml-2'
-                      />
-                    </div>
-                  </Tooltip>
-                )}
-              </div>
             </div>
-          </MenuButton>
-          <MenuList align='start' className='max-w-[600px] w-[250px]'>
-            {orgActive && !!domains?.length && (
-              <MenuItem onClick={() => {}}>
-                <div className=' flex overflow-hidden items-center text-ellipsis w-[200px]'>
-                  {isEnrichingEmail ? (
-                    <Tooltip label={`Finding email at ${orgActive}`}>
-                      <Spinner
-                        size='sm'
-                        label='finding email'
-                        className='text-gray-400 fill-gray-700 mr-2'
-                      />
-                    </Tooltip>
-                  ) : (
-                    <Star06 className='mr-2 text-gray-500 size-4' />
+          </div>
+        </MenuButton>
+        <MenuList align='start' className='max-w-[600px] w-[250px]'>
+          {orgActive && !!domains?.length && (
+            <MenuItem>
+              <div className=' flex overflow-hidden items-center text-ellipsis w-[200px]'>
+                {isEnrichingEmail ? (
+                  <Tooltip label={`Finding email at ${orgActive}`}>
+                    <Spinner
+                      size='sm'
+                      label='finding email'
+                      className='text-gray-400 fill-gray-700 mr-2'
+                    />
+                  </Tooltip>
+                ) : (
+                  <Star06 className='mr-2 text-gray-500 size-4' />
+                )}
+                <p className='w-[190px] truncate'>
+                  {isEnrichingEmail
+                    ? `Finding email at ${orgActive}`
+                    : `Find email at ${orgActive}`}
+                </p>
+              </div>
+            </MenuItem>
+          )}
+
+          <MenuItem
+            onClick={() => {
+              store.ui.commandMenu.setContext({
+                ids: [contactStore?.id || ''],
+                entity: 'Contact',
+                property: 'email',
+              });
+              store.ui.commandMenu.setType('AddEmail');
+              store.ui.commandMenu.setOpen(true);
+            }}
+          >
+            <div className='overflow-hidden text-ellipsis'>
+              <PlusCircle className='mr-2 text-gray-500' />
+              Add new email
+            </div>
+          </MenuItem>
+          {contactStore?.value.emails
+            .filter((e) => e.email !== '')
+            .map((email) => (
+              <MenuItem
+                key={email.email}
+                onClick={() => {
+                  contactStore.value.emails.forEach((e) => {
+                    e.primary = false;
+                  });
+                  contactStore?.draft();
+
+                  const findIdx = contactStore?.value.emails.findIndex(
+                    (e) => e.email === email.email,
+                  );
+
+                  contactStore.value.emails[findIdx].primary = true;
+                  contactStore?.commit();
+                }}
+              >
+                <div className='flex items-center overflow-hidden text-ellipsis justify-between w-full [&_svg]:size-4'>
+                  <div className='flex items-center gap-2 max-w-[200px]'>
+                    <EmailValidationMessage
+                      email={email.email || ''}
+                      validationDetails={email.emailValidationDetails}
+                    />
+                    <p className='truncate'>{email.email}</p>
+                  </div>
+                  {email?.primary === true && (
+                    <Check className='text-primary-600' />
                   )}
-                  <p className='w-[190px] truncate'>
-                    {isEnrichingEmail
-                      ? `Finding email at ${orgActive}`
-                      : `Find email at ${orgActive}`}
-                  </p>
                 </div>
               </MenuItem>
-            )}
-
-            <MenuItem
+            ))}
+        </MenuList>
+      </Menu>
+      {(isHovered || isOpened) &&
+        orgActive &&
+        !isEnrichingEmail &&
+        !!domains?.length && (
+          <Tooltip asChild label={`Find email at ${orgActive}`}>
+            <IconButton
+              size='xxs'
+              variant='ghost'
+              className='ml-2'
+              icon={<Star06 />}
+              aria-label='Find work email'
               onClick={() => {
-                store.ui.commandMenu.setContext({
-                  ids: [contactStore?.id || ''],
-                  entity: 'Contact',
-                  property: 'email',
-                });
-                store.ui.commandMenu.setType('AddEmail');
+                contactStore.findEmail();
+              }}
+            />
+          </Tooltip>
+        )}
+      {(email ?? '').length > 0 && (
+        <Menu onOpenChange={(newStatus) => setIsOpened(newStatus)}>
+          <MenuButton asChild>
+            {(isHovered || isOpened) && (
+              <IconButton
+                size='xxs'
+                variant='ghost'
+                aria-label='edit'
+                className='rounded-[5px] ml-[2px] '
+                icon={<DotsVertical className='text-gray-500' />}
+              />
+            )}
+          </MenuButton>
+
+          <MenuList align='start' side='bottom'>
+            <MenuItem
+              className='group/edit-email'
+              onClick={() => {
+                editEmailUseCase.setEmail(email!);
+                store.ui.commandMenu.setType('EditEmail');
                 store.ui.commandMenu.setOpen(true);
               }}
             >
               <div className='overflow-hidden text-ellipsis'>
-                <PlusCircle className='mr-2 text-gray-500' />
-                Add new email
+                <TextInput className='mr-2 group-hover/edit-email:text-gray-700 text-gray-500 ' />
+                Edit email
               </div>
             </MenuItem>
-            {contactStore?.value.emails
-              .filter((e) => e.email !== '')
-              .map((email) => (
-                <MenuItem
-                  key={email.email}
-                  onClick={() => {
-                    contactStore.value.emails.forEach((e) => {
-                      e.primary = false;
-                    });
-                    contactStore?.draft();
 
-                    const findIdx = contactStore?.value.emails.findIndex(
-                      (e) => e.email === email.email,
-                    );
+            <MenuItem
+              className='group/archive-email'
+              onClick={() => {
+                const idx = contactStore?.value.emails.findIndex(
+                  (e) => e.email === email,
+                );
 
-                    contactStore.value.emails[findIdx].primary = true;
-                    contactStore?.commit();
-                  }}
-                >
-                  <div className='flex items-center overflow-hidden text-ellipsis justify-between w-full [&_svg]:size-4'>
-                    <div className='flex items-center gap-2 max-w-[200px]'>
-                      <EmailValidationMessage
-                        email={email.email || ''}
-                        validationDetails={email.emailValidationDetails}
-                      />
-                      <p className='truncate'>{email.email}</p>
-                    </div>
-                    {email?.primary === true && (
-                      <Check className='text-primary-600' />
-                    )}
-                  </div>
-                </MenuItem>
-              ))}
+                if (idx !== -1) {
+                  contactStore?.draft();
+                  contactStore?.value.emails.splice(idx, 1);
+                  contactStore?.commit();
+                }
+              }}
+            >
+              <div className='overflow-hidden text-ellipsis'>
+                <Archive className='mr-2 group-hover/archive-email:text-gray-700 text-gray-500' />
+                Archive email
+              </div>
+            </MenuItem>
+            {email && (
+              <MenuItem
+                className='group/copy-email'
+                onClick={() => {
+                  copyToClipboard(email, 'Email copied');
+                }}
+              >
+                <div className='overflow-hidden text-ellipsis'>
+                  <Copy01 className='group-hover/copy-email:text-gray-700 text-gray-500 mr-2' />
+                  Copy email
+                </div>
+              </MenuItem>
+            )}
           </MenuList>
         </Menu>
-        {(isHovered || isOpened) &&
-          orgActive &&
-          !isEnrichingEmail &&
-          !!domains?.length && (
-            <Tooltip asChild label={`Find email at ${orgActive}`}>
-              <IconButton
-                size='xxs'
-                variant='ghost'
-                icon={<Star06 />}
-                className={'ml-2'}
-                aria-label='Find work email'
-                onClick={() => {
-                  contactStore.findEmail();
-                }}
-              />
-            </Tooltip>
-          )}
-        {(email ?? '').length > 0 && (
-          <Menu onOpenChange={(newStatus) => setIsOpened(newStatus)}>
-            <MenuButton asChild>
-              {(isHovered || isOpened) && (
-                <IconButton
-                  size='xxs'
-                  variant='ghost'
-                  aria-label='edit'
-                  className='rounded-[5px] ml-[2px] '
-                  icon={<DotsVertical className='text-gray-500' />}
-                />
-              )}
-            </MenuButton>
-
-            <MenuList align='start' side='bottom'>
-              <MenuItem
-                className='group/edit-email'
-                onClick={() => {
-                  EditEmailCase.prototype.setEmail(email!);
-                  store.ui.commandMenu.setType('EditEmail');
-                  store.ui.commandMenu.setOpen(true);
-                }}
-              >
-                <div className='overflow-hidden text-ellipsis'>
-                  <TextInput className='mr-2 group-hover/edit-email:text-gray-700 text-gray-500 ' />
-                  Edit email
-                </div>
-              </MenuItem>
-
-              <MenuItem
-                className='group/archive-email'
-                onClick={() => {
-                  const idx = contactStore?.value.emails.findIndex(
-                    (e) => e.email === email,
-                  );
-
-                  if (idx !== -1) {
-                    contactStore?.draft();
-                    contactStore?.value.emails.splice(idx, 1);
-                    contactStore?.commit();
-                  }
-                }}
-              >
-                <div className='overflow-hidden text-ellipsis'>
-                  <Archive className='mr-2 group-hover/archive-email:text-gray-700 text-gray-500' />
-                  Archive email
-                </div>
-              </MenuItem>
-              {email && (
-                <MenuItem
-                  className='group/copy-email'
-                  onClick={() => {
-                    copyToClipboard(email, 'Email copied');
-                  }}
-                >
-                  <div className='overflow-hidden text-ellipsis'>
-                    <Copy01 className='group-hover/copy-email:text-gray-700 text-gray-500 mr-2' />
-                    Copy email
-                  </div>
-                </MenuItem>
-              )}
-            </MenuList>
-          </Menu>
-        )}
-      </div>
-    );
-  },
-);
+      )}
+    </div>
+  );
+});

--- a/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/columns.tsx
+++ b/packages/apps/frontera/src/routes/finder/src/components/Columns/contacts/columns.tsx
@@ -117,16 +117,7 @@ const columns: Record<string, Column> = {
       enableColumnFilter: false,
       enableSorting: false,
       cell: (props) => {
-        const validationDetails = props.row.original.value.emails.find(
-          (e) => e.primary === true,
-        )?.emailValidationDetails;
-
-        return (
-          <EmailCell
-            contactId={props.row.id}
-            validationDetails={validationDetails}
-          />
-        );
+        return <EmailCell contactId={props.row.id} />;
       },
       header: (props) => (
         <THead<HTMLInputElement>

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/EditEmail.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/EditEmail.tsx
@@ -7,6 +7,8 @@ import { Edit03 } from '@ui/media/icons/Edit03';
 import { useStore } from '@shared/hooks/useStore';
 import { Command, CommandItem, CommandInput } from '@ui/overlay/CommandMenu';
 
+const editEmailUseCase = EditEmailCase.getInstance();
+
 export const EditEmail = observer(() => {
   const store = useStore();
   const context = store.ui.commandMenu.context;
@@ -17,10 +19,7 @@ export const EditEmail = observer(() => {
 
   useEffect(() => {
     if (contact) {
-      EditEmailCase.prototype.setEntity(contact);
-      EditEmailCase.prototype.setEmail(
-        contact.value.emails.filter((e) => e.primary)[0]?.email || '',
-      );
+      editEmailUseCase.setEntity(contact);
     }
   }, [contact?.id]);
 
@@ -28,7 +27,7 @@ export const EditEmail = observer(() => {
 
   useEffect(() => {
     if (contact.id) {
-      EditEmailCase.prototype.setOldEmail(EditEmailCase.prototype.email);
+      editEmailUseCase.setOldEmail(editEmailUseCase.email);
     }
   }, [contact?.id]);
 
@@ -37,9 +36,9 @@ export const EditEmail = observer(() => {
       <CommandInput
         label={label}
         placeholder={'Edit email'}
-        value={EditEmailCase.prototype.email}
+        value={editEmailUseCase.email}
         onValueChange={(newValue) => {
-          EditEmailCase.prototype.setEmail(newValue);
+          editEmailUseCase.setEmail(newValue);
         }}
         onKeyDownCapture={(e) => {
           if (e.key === ' ') {
@@ -52,12 +51,12 @@ export const EditEmail = observer(() => {
         <CommandItem
           leftAccessory={<Edit03 />}
           onSelect={() => {
-            EditEmailCase.prototype.submit();
+            editEmailUseCase.submit();
             store.ui.commandMenu.setOpen(false);
             store.ui.commandMenu.setType('ContactCommands');
           }}
         >
-          {`Rename email to "${EditEmailCase.prototype.email}"`}
+          {`Rename email to "${editEmailUseCase.email}"`}
         </CommandItem>
       </Command.List>
     </Command>

--- a/packages/apps/frontera/src/routes/src/components/ContactDetails/components/EmailsSection/EmailMenuActions.tsx
+++ b/packages/apps/frontera/src/routes/src/components/ContactDetails/components/EmailsSection/EmailMenuActions.tsx
@@ -24,6 +24,8 @@ import {
 
 import { emailStatuses } from './EmailValidationMessage';
 
+const editEmailUseCase = EditEmailCase.getInstance();
+
 interface EmailMenuActionsProps {
   id: string;
   idx: number;
@@ -64,7 +66,7 @@ export const EmailMenuActions = observer(
           <MenuItem
             className='group/edit-email'
             onClick={() => {
-              EditEmailCase.prototype.setEmail(email);
+              editEmailUseCase.setEmail(email);
               store.ui.commandMenu.setType('EditEmail');
               store.ui.commandMenu.setContext({
                 ids: [contactStore?.value.id ?? ''],

--- a/packages/apps/frontera/src/routes/src/components/EmailMultiCreatableSelect/MultiValueWithActionMenu.tsx
+++ b/packages/apps/frontera/src/routes/src/components/EmailMultiCreatableSelect/MultiValueWithActionMenu.tsx
@@ -24,6 +24,8 @@ interface MultiValueWithActionMenuProps extends MultiValueProps<SelectOption> {
   removeOption: (value: string) => void;
 }
 
+const editEmailUseCase = EditEmailCase.getInstance();
+
 export const MultiValueWithActionMenu: FC<MultiValueWithActionMenuProps> =
   observer(({ name, navigateAfterAddingToPeople, removeOption, ...rest }) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -108,7 +110,7 @@ export const MultiValueWithActionMenu: FC<MultiValueWithActionMenuProps> =
                 onPointerDown={(e) => {
                   e.stopPropagation();
                   e.preventDefault();
-                  EditEmailCase.prototype.setEmail(rest.data.value);
+                  editEmailUseCase.setEmail(rest.data.value);
                   store.ui.commandMenu.setType('EditEmail');
 
                   store.ui.commandMenu.setContext({

--- a/packages/apps/frontera/src/ui/presentation/Table/Table.tsx
+++ b/packages/apps/frontera/src/ui/presentation/Table/Table.tsx
@@ -520,14 +520,7 @@ const TableBody = <T extends object>({
   );
 
   return (
-    <TBody
-      className='w-full'
-      data-test={dataTest}
-      style={{
-        transform: 'translate3d(0, 0, 0)',
-        willChange: 'transform',
-      }}
-    >
+    <TBody className='w-full' data-test={dataTest}>
       {!virtualRows.length && !isLoading && <NoResults tableId={tableId} />}
       {virtualRows.map((virtualRow) => {
         const row = rows[virtualRow.index];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix crash on Shift+E by setting email before opening edit menu and refactor to use singleton `EditEmailCase` instance.
> 
>   - **Behavior**:
>     - Fix crash on Shift+E by setting email in `ContactTableActions` before opening edit menu.
>     - Use singleton `EditEmailCase` instance in `ContactActions.tsx`, `EmailCell.tsx`, `EditEmail.tsx`, `EmailMenuActions.tsx`, and `MultiValueWithActionMenu.tsx`.
>   - **Refactoring**:
>     - Remove `validationDetails` prop from `EmailCell` in `columns.tsx`.
>     - Simplify `TableBody` in `Table.tsx` by removing unnecessary styles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 47000df3fa297bdd07647237d6888dee737827f2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->