### PR TITLE
Sli invoice status

### DIFF
--- a/packages/server/customer-os-api/dataloader/dataloader.go
+++ b/packages/server/customer-os-api/dataloader/dataloader.go
@@ -114,6 +114,7 @@ type Loaders struct {
 	InvoiceLinesForInvoice                      *dataloader.Loader
 	OrdersForOrganization                       *dataloader.Loader
 	InvoicesForContract                         *dataloader.Loader
+	InvoicesForServiceLineItem                  *dataloader.Loader
 	FlowParticipantsForFlow                     *dataloader.Loader
 	FlowActionsForFlow                          *dataloader.Loader
 	FlowSendersForFlow                          *dataloader.Loader
@@ -424,6 +425,7 @@ func NewDataLoader(services *cosapi_services.Services) *Loaders {
 		OpportunitiesForOrganization:                dataloader.NewBatchedLoader(opportunityBatcher.getOpportunitiesForOrganizations, dataloader.WithClearCacheOnBatch(), dataloader.WithWait(defaultDataloaderWaitTime)),
 		InvoiceLinesForInvoice:                      dataloader.NewBatchedLoader(invoiceBatcher.getInvoiceLinesForInvoice, dataloader.WithClearCacheOnBatch(), dataloader.WithWait(defaultDataloaderWaitTime)),
 		InvoicesForContract:                         dataloader.NewBatchedLoader(invoiceBatcher.getInvoicesForContract, dataloader.WithClearCacheOnBatch(), dataloader.WithWait(defaultDataloaderWaitTime)),
+		InvoicesForServiceLineItem:                  dataloader.NewBatchedLoader(invoiceBatcher.getInvoicesForServiceLineItem, dataloader.WithClearCacheOnBatch(), dataloader.WithWait(defaultDataloaderWaitTime)),
 		FlowParticipantsForFlow:                     dataloader.NewBatchedLoader(flowBatcher.getFlowParticipantsForFlow, dataloader.WithClearCacheOnBatch(), dataloader.WithWait(defaultDataloaderWaitTime)),
 		FlowActionsForFlow:                          dataloader.NewBatchedLoader(flowBatcher.getFlowActionsForFlow, dataloader.WithClearCacheOnBatch(), dataloader.WithWait(defaultDataloaderWaitTime)),
 		FlowSendersForFlow:                          dataloader.NewBatchedLoader(flowBatcher.getFlowSendersForFlow, dataloader.WithClearCacheOnBatch(), dataloader.WithWait(defaultDataloaderWaitTime)),

--- a/packages/server/customer-os-api/dataloader/invoice_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/invoice_dataloader.go
@@ -2,10 +2,10 @@ package dataloader
 
 import (
 	"context"
-	"github.com/graph-gophers/dataloader"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
+	"github.com/graph-gophers/dataloader"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
@@ -24,6 +24,16 @@ func (i *Loaders) GetInvoiceLinesForInvoice(ctx context.Context, invoiceId strin
 
 func (i *Loaders) GetInvoicesForContract(ctx context.Context, contractId string) (*neo4jentity.InvoiceEntities, error) {
 	thunk := i.InvoicesForContract.Load(ctx, dataloader.StringKey(contractId))
+	result, err := thunk()
+	if err != nil {
+		return nil, err
+	}
+	resultObj := result.(neo4jentity.InvoiceEntities)
+	return &resultObj, nil
+}
+
+func (i *Loaders) GetInvoicesForServiceLineItem(ctx context.Context, sliId string) (*neo4jentity.InvoiceEntities, error) {
+	thunk := i.InvoicesForContract.Load(ctx, dataloader.StringKey(sliId))
 	result, err := thunk()
 	if err != nil {
 		return nil, err
@@ -117,6 +127,58 @@ func (b *invoiceBatcher) getInvoicesForContract(ctx context.Context, keys datalo
 	// construct an output array of dataloader results
 	results := make([]*dataloader.Result, len(keys))
 	for invoiceId, record := range invoicesByContractId {
+		if ix, ok := keyOrder[invoiceId]; ok {
+			results[ix] = &dataloader.Result{Data: record, Error: nil}
+			delete(keyOrder, invoiceId)
+		}
+	}
+	for _, ix := range keyOrder {
+		results[ix] = &dataloader.Result{Data: neo4jentity.InvoiceEntities{}, Error: nil}
+	}
+
+	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.InvoiceEntities{})); err != nil {
+		tracing.TraceErr(span, err)
+		return []*dataloader.Result{{nil, err}}
+	}
+
+	span.LogFields(log.Int("result.length", len(results)))
+
+	return results
+}
+
+func (b *invoiceBatcher) getInvoicesForServiceLineItem(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceDataLoader.getInvoicesForServiceLineItem")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+
+	ids, keyOrder := sortKeys(keys)
+
+	ctx, cancel := utils.GetLongLivedContext(ctx)
+	defer cancel()
+
+	invoiceEntitiesPtr, err := b.invoiceService.GetInvoicesForServiceLineItems(ctx, ids)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		// check if context deadline exceeded error occurred
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get invoices for service line items")}}
+		}
+		return []*dataloader.Result{{Data: nil, Error: err}}
+	}
+
+	invoicesBySliId := make(map[string]neo4jentity.InvoiceEntities)
+	for _, val := range *invoiceEntitiesPtr {
+		if list, ok := invoicesBySliId[val.DataloaderKey]; ok {
+			invoicesBySliId[val.DataloaderKey] = append(list, val)
+		} else {
+			invoicesBySliId[val.DataloaderKey] = neo4jentity.InvoiceEntities{val}
+		}
+	}
+
+	// construct an output array of dataloader results
+	results := make([]*dataloader.Result, len(keys))
+	for invoiceId, record := range invoicesBySliId {
 		if ix, ok := keyOrder[invoiceId]; ok {
 			results[ix] = &dataloader.Result{Data: record, Error: nil}
 			delete(keyOrder, invoiceId)

--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -1633,22 +1633,23 @@ type ComplexityRoot struct {
 	}
 
 	ServiceLineItem struct {
-		BillingCycle   func(childComplexity int) int
-		Closed         func(childComplexity int) int
-		Comments       func(childComplexity int) int
-		CreatedBy      func(childComplexity int) int
-		Description    func(childComplexity int) int
-		ExternalLinks  func(childComplexity int) int
-		Metadata       func(childComplexity int) int
-		ParentID       func(childComplexity int) int
-		Paused         func(childComplexity int) int
-		Price          func(childComplexity int) int
-		Quantity       func(childComplexity int) int
-		ServiceEnded   func(childComplexity int) int
-		ServiceStarted func(childComplexity int) int
-		Sku            func(childComplexity int) int
-		SkuID          func(childComplexity int) int
-		Tax            func(childComplexity int) int
+		BillingCycle    func(childComplexity int) int
+		Closed          func(childComplexity int) int
+		Comments        func(childComplexity int) int
+		CreatedBy       func(childComplexity int) int
+		Description     func(childComplexity int) int
+		ExternalLinks   func(childComplexity int) int
+		InvoicingStatus func(childComplexity int) int
+		Metadata        func(childComplexity int) int
+		ParentID        func(childComplexity int) int
+		Paused          func(childComplexity int) int
+		Price           func(childComplexity int) int
+		Quantity        func(childComplexity int) int
+		ServiceEnded    func(childComplexity int) int
+		ServiceStarted  func(childComplexity int) int
+		Sku             func(childComplexity int) int
+		SkuID           func(childComplexity int) int
+		Tax             func(childComplexity int) int
 	}
 
 	Sku struct {
@@ -2301,6 +2302,8 @@ type ServiceLineItemResolver interface {
 
 	CreatedBy(ctx context.Context, obj *model.ServiceLineItem) (*model.User, error)
 	ExternalLinks(ctx context.Context, obj *model.ServiceLineItem) ([]*model.ExternalSystem, error)
+
+	InvoicingStatus(ctx context.Context, obj *model.ServiceLineItem) (*model.ServiceInvoicingStatus, error)
 }
 type SlackChannelResolver interface {
 	Organization(ctx context.Context, obj *model.SlackChannel) (*model.Organization, error)
@@ -12075,6 +12078,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ServiceLineItem.ExternalLinks(childComplexity), true
 
+	case "ServiceLineItem.invoicing_status":
+		if e.complexity.ServiceLineItem.InvoicingStatus == nil {
+			break
+		}
+
+		return e.complexity.ServiceLineItem.InvoicingStatus(childComplexity), true
+
 	case "ServiceLineItem.metadata":
 		if e.complexity.ServiceLineItem.Metadata == nil {
 			break
@@ -17062,6 +17072,7 @@ type ServiceLineItem implements MetadataInterface {
     externalLinks:      [ExternalSystem!]! @goField(forceResolver: true)
     closed:             Boolean!
     paused:             Boolean!
+    invoicing_status:   ServiceInvoicingStatus @goField(forceResolver: true)
 }
 
 input ServiceLineItemInput {
@@ -17148,6 +17159,12 @@ enum BilledType {
     Deprecated
     """
     USAGE @deprecated(reason: "Not supported yet.")
+}
+
+enum ServiceInvoicingStatus {
+    READY
+    INVOICED
+    VOID
 }
 
 input TaxInput {
@@ -37111,6 +37128,8 @@ func (ec *executionContext) fieldContext_Contract_contractLineItems(_ context.Co
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
+			case "invoicing_status":
+				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -39188,6 +39207,8 @@ func (ec *executionContext) fieldContext_Contract_serviceLineItems(_ context.Con
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
+			case "invoicing_status":
+				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -54716,6 +54737,8 @@ func (ec *executionContext) fieldContext_InvoiceLine_contractLineItem(_ context.
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
+			case "invoicing_status":
+				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -78869,6 +78892,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Create(ctx co
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
+			case "invoicing_status":
+				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -78992,6 +79017,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_NewVersion(ct
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
+			case "invoicing_status":
+				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -79115,6 +79142,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Update(ctx co
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
+			case "invoicing_status":
+				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -100300,6 +100329,8 @@ func (ec *executionContext) fieldContext_Query_serviceLineItem(ctx context.Conte
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
+			case "invoicing_status":
+				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -103701,6 +103732,47 @@ func (ec *executionContext) fieldContext_ServiceLineItem_paused(_ context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceLineItem_invoicing_status(ctx context.Context, field graphql.CollectedField, obj *model.ServiceLineItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ServiceLineItem().InvoicingStatus(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.ServiceInvoicingStatus)
+	fc.Result = res
+	return ec.marshalOServiceInvoicingStatus2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐServiceInvoicingStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceLineItem_invoicing_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceLineItem",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ServiceInvoicingStatus does not have child fields")
 		},
 	}
 	return fc, nil
@@ -134242,6 +134314,39 @@ func (ec *executionContext) _ServiceLineItem(ctx context.Context, sel ast.Select
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "invoicing_status":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ServiceLineItem_invoicing_status(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -143149,6 +143254,22 @@ func (ec *executionContext) marshalOResult2ᚖgithubᚗcomᚋcustomerosᚋcustom
 		return graphql.Null
 	}
 	return ec._Result(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOServiceInvoicingStatus2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐServiceInvoicingStatus(ctx context.Context, v any) (*model.ServiceInvoicingStatus, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(model.ServiceInvoicingStatus)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOServiceInvoicingStatus2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐServiceInvoicingStatus(ctx context.Context, sel ast.SelectionSet, v *model.ServiceInvoicingStatus) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) marshalOServiceLineItem2ᚕᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐServiceLineItemᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.ServiceLineItem) graphql.Marshaler {

--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -12078,7 +12078,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ServiceLineItem.ExternalLinks(childComplexity), true
 
-	case "ServiceLineItem.invoicing_status":
+	case "ServiceLineItem.invoicingStatus":
 		if e.complexity.ServiceLineItem.InvoicingStatus == nil {
 			break
 		}
@@ -17072,7 +17072,7 @@ type ServiceLineItem implements MetadataInterface {
     externalLinks:      [ExternalSystem!]! @goField(forceResolver: true)
     closed:             Boolean!
     paused:             Boolean!
-    invoicing_status:   ServiceInvoicingStatus @goField(forceResolver: true)
+    invoicingStatus:   ServiceInvoicingStatus @goField(forceResolver: true)
 }
 
 input ServiceLineItemInput {
@@ -37128,8 +37128,8 @@ func (ec *executionContext) fieldContext_Contract_contractLineItems(_ context.Co
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
-			case "invoicing_status":
-				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
+			case "invoicingStatus":
+				return ec.fieldContext_ServiceLineItem_invoicingStatus(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -39207,8 +39207,8 @@ func (ec *executionContext) fieldContext_Contract_serviceLineItems(_ context.Con
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
-			case "invoicing_status":
-				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
+			case "invoicingStatus":
+				return ec.fieldContext_ServiceLineItem_invoicingStatus(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -54737,8 +54737,8 @@ func (ec *executionContext) fieldContext_InvoiceLine_contractLineItem(_ context.
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
-			case "invoicing_status":
-				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
+			case "invoicingStatus":
+				return ec.fieldContext_ServiceLineItem_invoicingStatus(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -78892,8 +78892,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Create(ctx co
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
-			case "invoicing_status":
-				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
+			case "invoicingStatus":
+				return ec.fieldContext_ServiceLineItem_invoicingStatus(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -79017,8 +79017,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_NewVersion(ct
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
-			case "invoicing_status":
-				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
+			case "invoicingStatus":
+				return ec.fieldContext_ServiceLineItem_invoicingStatus(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -79142,8 +79142,8 @@ func (ec *executionContext) fieldContext_Mutation_contractLineItem_Update(ctx co
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
-			case "invoicing_status":
-				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
+			case "invoicingStatus":
+				return ec.fieldContext_ServiceLineItem_invoicingStatus(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -100329,8 +100329,8 @@ func (ec *executionContext) fieldContext_Query_serviceLineItem(ctx context.Conte
 				return ec.fieldContext_ServiceLineItem_closed(ctx, field)
 			case "paused":
 				return ec.fieldContext_ServiceLineItem_paused(ctx, field)
-			case "invoicing_status":
-				return ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
+			case "invoicingStatus":
+				return ec.fieldContext_ServiceLineItem_invoicingStatus(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceLineItem", field.Name)
 		},
@@ -103737,8 +103737,8 @@ func (ec *executionContext) fieldContext_ServiceLineItem_paused(_ context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _ServiceLineItem_invoicing_status(ctx context.Context, field graphql.CollectedField, obj *model.ServiceLineItem) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ServiceLineItem_invoicing_status(ctx, field)
+func (ec *executionContext) _ServiceLineItem_invoicingStatus(ctx context.Context, field graphql.CollectedField, obj *model.ServiceLineItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceLineItem_invoicingStatus(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -103765,7 +103765,7 @@ func (ec *executionContext) _ServiceLineItem_invoicing_status(ctx context.Contex
 	return ec.marshalOServiceInvoicingStatus2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐServiceInvoicingStatus(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_ServiceLineItem_invoicing_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_ServiceLineItem_invoicingStatus(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ServiceLineItem",
 		Field:      field,
@@ -134314,7 +134314,7 @@ func (ec *executionContext) _ServiceLineItem(ctx context.Context, sel ast.Select
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "invoicing_status":
+		case "invoicingStatus":
 			field := field
 
 			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
@@ -134323,7 +134323,7 @@ func (ec *executionContext) _ServiceLineItem(ctx context.Context, sel ast.Select
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._ServiceLineItem_invoicing_status(ctx, field, obj)
+				res = ec._ServiceLineItem_invoicingStatus(ctx, field, obj)
 				return res
 			}
 

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -2559,22 +2559,23 @@ type Result struct {
 }
 
 type ServiceLineItem struct {
-	Metadata       *Metadata         `json:"metadata"`
-	BillingCycle   BilledType        `json:"billingCycle"`
-	Comments       string            `json:"comments"`
-	SkuID          *string           `json:"skuId,omitempty"`
-	Sku            *Sku              `json:"sku,omitempty"`
-	Description    string            `json:"description"`
-	ParentID       string            `json:"parentId"`
-	Price          float64           `json:"price"`
-	Quantity       int64             `json:"quantity"`
-	ServiceEnded   *time.Time        `json:"serviceEnded,omitempty"`
-	ServiceStarted time.Time         `json:"serviceStarted"`
-	Tax            *Tax              `json:"tax"`
-	CreatedBy      *User             `json:"createdBy,omitempty"`
-	ExternalLinks  []*ExternalSystem `json:"externalLinks"`
-	Closed         bool              `json:"closed"`
-	Paused         bool              `json:"paused"`
+	Metadata        *Metadata               `json:"metadata"`
+	BillingCycle    BilledType              `json:"billingCycle"`
+	Comments        string                  `json:"comments"`
+	SkuID           *string                 `json:"skuId,omitempty"`
+	Sku             *Sku                    `json:"sku,omitempty"`
+	Description     string                  `json:"description"`
+	ParentID        string                  `json:"parentId"`
+	Price           float64                 `json:"price"`
+	Quantity        int64                   `json:"quantity"`
+	ServiceEnded    *time.Time              `json:"serviceEnded,omitempty"`
+	ServiceStarted  time.Time               `json:"serviceStarted"`
+	Tax             *Tax                    `json:"tax"`
+	CreatedBy       *User                   `json:"createdBy,omitempty"`
+	ExternalLinks   []*ExternalSystem       `json:"externalLinks"`
+	Closed          bool                    `json:"closed"`
+	Paused          bool                    `json:"paused"`
+	InvoicingStatus *ServiceInvoicingStatus `json:"invoicing_status,omitempty"`
 }
 
 func (ServiceLineItem) IsMetadataInterface()        {}
@@ -5139,6 +5140,49 @@ func (e *Role) UnmarshalGQL(v any) error {
 }
 
 func (e Role) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type ServiceInvoicingStatus string
+
+const (
+	ServiceInvoicingStatusReady    ServiceInvoicingStatus = "READY"
+	ServiceInvoicingStatusInvoiced ServiceInvoicingStatus = "INVOICED"
+	ServiceInvoicingStatusVoid     ServiceInvoicingStatus = "VOID"
+)
+
+var AllServiceInvoicingStatus = []ServiceInvoicingStatus{
+	ServiceInvoicingStatusReady,
+	ServiceInvoicingStatusInvoiced,
+	ServiceInvoicingStatusVoid,
+}
+
+func (e ServiceInvoicingStatus) IsValid() bool {
+	switch e {
+	case ServiceInvoicingStatusReady, ServiceInvoicingStatusInvoiced, ServiceInvoicingStatusVoid:
+		return true
+	}
+	return false
+}
+
+func (e ServiceInvoicingStatus) String() string {
+	return string(e)
+}
+
+func (e *ServiceInvoicingStatus) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ServiceInvoicingStatus(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ServiceInvoicingStatus", str)
+	}
+	return nil
+}
+
+func (e ServiceInvoicingStatus) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -2575,7 +2575,7 @@ type ServiceLineItem struct {
 	ExternalLinks   []*ExternalSystem       `json:"externalLinks"`
 	Closed          bool                    `json:"closed"`
 	Paused          bool                    `json:"paused"`
-	InvoicingStatus *ServiceInvoicingStatus `json:"invoicing_status,omitempty"`
+	InvoicingStatus *ServiceInvoicingStatus `json:"invoicingStatus,omitempty"`
 }
 
 func (ServiceLineItem) IsMetadataInterface()        {}

--- a/packages/server/customer-os-api/graphql/resolver/service_line_item.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/service_line_item.resolvers.go
@@ -7,6 +7,7 @@ package resolver
 import (
 	"context"
 	"errors"
+
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/dataloader"
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/generated"

--- a/packages/server/customer-os-api/graphql/resolver/service_line_item.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/service_line_item.resolvers.go
@@ -7,7 +7,6 @@ package resolver
 import (
 	"context"
 	"errors"
-
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/dataloader"
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/generated"
@@ -354,6 +353,39 @@ func (r *serviceLineItemResolver) ExternalLinks(ctx context.Context, obj *model.
 		return nil, nil
 	}
 	return mapper.MapEntitiesToExternalSystems(entities), nil
+}
+
+// InvoicingStatus is the resolver for the invoicing_status field.
+func (r *serviceLineItemResolver) InvoicingStatus(ctx context.Context, obj *model.ServiceLineItem) (*model.ServiceInvoicingStatus, error) {
+	ctx = tracing.EnrichCtxWithSpanCtxForGraphQL(ctx, graphql.GetOperationContext(ctx))
+
+	if obj.BillingCycle != model.BilledTypeOnce {
+		return utils.ToPtr(model.ServiceInvoicingStatusReady), nil
+	}
+	invoices, err := dataloader.For(ctx).GetInvoicesForServiceLineItem(ctx, obj.Metadata.ID)
+	if err != nil {
+		tracing.TraceErr(opentracing.SpanFromContext(ctx), err)
+		r.log.Errorf("Failed to get invoices for service line item %s: %s", obj.Metadata.ID, err.Error())
+		graphql.AddErrorf(ctx, "Failed to get invoices for service line item %s", obj.Metadata.ID)
+		return nil, nil
+	}
+	if invoices == nil {
+		return utils.ToPtr(model.ServiceInvoicingStatusReady), nil
+	}
+	status := model.ServiceInvoicingStatusReady
+	for _, invoice := range *invoices {
+		if invoice.DryRun {
+			continue
+		}
+		if invoice.Status == neo4jenum.InvoiceStatusVoid {
+			status = model.ServiceInvoicingStatusVoid
+			break
+		} else if invoice.Status != neo4jenum.InvoiceStatusInitialized {
+			status = model.ServiceInvoicingStatusInvoiced
+			break
+		}
+	}
+	return &status, nil
 }
 
 // ServiceLineItem returns generated.ServiceLineItemResolver implementation.

--- a/packages/server/customer-os-api/graphql/schemas/service_line_item.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/service_line_item.graphqls
@@ -30,6 +30,7 @@ type ServiceLineItem implements MetadataInterface {
     externalLinks:      [ExternalSystem!]! @goField(forceResolver: true)
     closed:             Boolean!
     paused:             Boolean!
+    invoicing_status:   ServiceInvoicingStatus @goField(forceResolver: true)
 }
 
 input ServiceLineItemInput {
@@ -116,6 +117,12 @@ enum BilledType {
     Deprecated
     """
     USAGE @deprecated(reason: "Not supported yet.")
+}
+
+enum ServiceInvoicingStatus {
+    READY
+    INVOICED
+    VOID
 }
 
 input TaxInput {

--- a/packages/server/customer-os-api/graphql/schemas/service_line_item.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/service_line_item.graphqls
@@ -30,7 +30,7 @@ type ServiceLineItem implements MetadataInterface {
     externalLinks:      [ExternalSystem!]! @goField(forceResolver: true)
     closed:             Boolean!
     paused:             Boolean!
-    invoicing_status:   ServiceInvoicingStatus @goField(forceResolver: true)
+    invoicingStatus:   ServiceInvoicingStatus @goField(forceResolver: true)
 }
 
 input ServiceLineItemInput {

--- a/packages/server/customer-os-api/rest/private/user_settings.go
+++ b/packages/server/customer-os-api/rest/private/user_settings.go
@@ -29,7 +29,7 @@ func GetOAuthSettings(s *cosapi_services.Services) gin.HandlerFunc {
 func GetSlackSettings(s *cosapi_services.Services) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tenant, _ := c.Get(security.KEY_TENANT_NAME)
-		userSettings, err := s.CommonServices.SlackService.GetSlackSettings(c, tenant.(string))
+		userSettings, err := s.CommonServices.SlackService.GetSlackSettings(c.Request.Context(), tenant.(string))
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return

--- a/packages/server/customer-os-common-module/interfaces/invoice.go
+++ b/packages/server/customer-os-common-module/interfaces/invoice.go
@@ -24,6 +24,7 @@ type InvoiceService interface {
 	GetByNumber(ctx context.Context, number string) (*neo4jentity.InvoiceEntity, error)
 	GetInvoiceLinesForInvoices(ctx context.Context, invoiceIds []string) (*neo4jentity.InvoiceLineEntities, error)
 	GetInvoicesForContracts(ctx context.Context, contractIds []string) (*neo4jentity.InvoiceEntities, error)
+	GetInvoicesForServiceLineItems(ctx context.Context, sliIds []string) (*neo4jentity.InvoiceEntities, error)
 	GetNonDryRunInvoicesForOrganization(ctx context.Context, tenant, organizationId string) (*neo4jentity.InvoiceEntities, error)
 	SimulateInvoice(ctx context.Context, invoiceData *SimulateInvoiceRequestData) ([]*SimulateInvoiceResponseData, error)
 	NextInvoiceDryRun(ctx context.Context, contractId string) (string, error)

--- a/packages/server/customer-os-common-module/services/invoice/service.go
+++ b/packages/server/customer-os-common-module/services/invoice/service.go
@@ -736,6 +736,26 @@ func (s *invoiceService) GetInvoicesForContracts(ctx context.Context, contractId
 	return &invoiceEntities, nil
 }
 
+func (s *invoiceService) GetInvoicesForServiceLineItems(ctx context.Context, sliIds []string) (*neo4jentity.InvoiceEntities, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceService.GetInvoicesForServiceLineItems")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+	span.LogFields(log.Object("sliIds", sliIds))
+
+	invoices, err := s.neo4j.InvoiceReadRepository.GetAllForServiceLineItems(ctx, common.GetTenantFromContext(ctx), sliIds)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+	invoiceEntities := make(neo4jentity.InvoiceEntities, 0, len(invoices))
+	for _, v := range invoices {
+		invoiceEntity := neo4jmapper.MapDbNodeToInvoiceEntity(v.Node)
+		invoiceEntity.DataloaderKey = v.LinkedNodeId
+		invoiceEntities = append(invoiceEntities, *invoiceEntity)
+	}
+	return &invoiceEntities, nil
+}
+
 type SimulateInvoices struct {
 	ContractId         string
 	IssueDate          time.Time
@@ -1270,17 +1290,27 @@ func (s *invoiceService) fillCycleInvoice(ctx context.Context, invoiceEntity *ne
 		invoiceLineCalculationsReady := false
 		// process one time SLIs
 		if sliEntity.Billed == neo4jenum.BilledTypeOnce {
-			// Check any version of SLI not invoiced
-			result, err := s.neo4j.InvoiceLineReadRepository.GetLatestInvoiceLineWithInvoiceIdByServiceLineItemParentId(ctx, common.GetTenantFromContext(ctx), sliEntity.ParentID)
+			// Get all invoices for one time
+			invoices, err := s.GetInvoicesForServiceLineItems(ctx, []string{sliEntity.ID})
 			if err != nil {
 				tracing.TraceErr(span, err)
-				s.log.Errorf("Error getting latest invoice line for sli parent id {%s}: {%s}", sliEntity.ParentID, err.Error())
+				return nil, nil, err
 			}
-			if result != nil {
-				// SLI already invoiced
-				reasonForSliExcludedFromInvoicing[sliEntity.ID] = "SLI already invoiced"
-				continue
+			if invoices != nil && len(*invoices) > 0 {
+				alreadyInvoiced := false
+				for _, invoice := range *invoices {
+					if !invoice.DryRun && invoice.Status != neo4jenum.InvoiceStatusInitialized {
+						alreadyInvoiced = true
+						break
+					}
+				}
+				if alreadyInvoiced {
+					// SLI already invoiced
+					reasonForSliExcludedFromInvoicing[sliEntity.ID] = "SLI already invoiced"
+					continue
+				}
 			}
+
 			quantity := sliEntity.Quantity
 			calculatedSLIAmount = utils.RoundHalfUpFloat64(float64(quantity)*sliEntity.Price, 2)
 			calculatedSLIVat = utils.RoundHalfUpFloat64(calculatedSLIAmount*sliEntity.VatRate/100, 2)

--- a/packages/server/customer-os-neo4j-repository/repository/invoice_line_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/invoice_line_read_repository.go
@@ -112,7 +112,7 @@ func (r *invoiceLineReadRepository) GetLatestInvoiceLineWithInvoiceIdByServiceLi
 	params := map[string]any{
 		"tenant":       tenant,
 		"parentId":     sliParentId,
-		"skipStatuses": []string{neo4jenum.InvoiceStatusInitialized.String(), neo4jenum.InvoiceStatusVoid.String()},
+		"skipStatuses": []string{neo4jenum.InvoiceStatusInitialized.String()},
 	}
 	span.LogFields(log.String("cypher", cypher))
 	tracing.LogObjectAsJson(span, "params", params)

--- a/packages/server/customer-os-neo4j-repository/repository/invoice_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/invoice_read_repository.go
@@ -29,6 +29,7 @@ type InvoiceReadRepository interface {
 	GetFirstPreviewFilledInvoice(ctx context.Context, tenant, contractId string) (*dbtype.Node, error)
 	GetExpiredDryRunInvoices(ctx context.Context) ([]*utils.DbNodeAndTenant, error)
 	GetAllForContracts(ctx context.Context, tenant string, ids []string) ([]*utils.DbNodeAndId, error)
+	GetAllForServiceLineItems(ctx context.Context, tenant string, ids []string) ([]*utils.DbNodeAndId, error)
 	GetInvoicesForOverdue(ctx context.Context) ([]*utils.DbNodeAndTenant, error)
 	GetInvoicesForOnHold(ctx context.Context) ([]*utils.DbNodeAndTenant, error)
 	GetInvoicesForScheduled(ctx context.Context) ([]*utils.DbNodeAndTenant, error)
@@ -570,9 +571,44 @@ func (r *invoiceReadRepository) GetAllForContracts(ctx context.Context, tenant s
 	tracing.TagTenant(span, tenant)
 	span.LogFields(log.Object("contractIds", ids))
 
-	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)<-[:HAS_INVOICE]->(c:Contract) 
+	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)<-[:HAS_INVOICE]-(c:Contract) 
 			WHERE c.id IN $ids
 			RETURN i, c.id`
+	params := map[string]any{
+		"tenant": tenant,
+		"ids":    ids,
+	}
+	span.LogFields(log.String("query", cypher))
+	tracing.LogObjectAsJson(span, "params", params)
+
+	session := r.prepareReadSession(ctx)
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
+			return nil, err
+		} else {
+			return utils.ExtractAllRecordsAsDbNodeAndId(ctx, queryResult, err)
+		}
+	})
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	return result.([]*utils.DbNodeAndId), err
+}
+
+func (r *invoiceReadRepository) GetAllForServiceLineItems(ctx context.Context, tenant string, ids []string) ([]*utils.DbNodeAndId, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetAllForServiceLineItems")
+	defer span.Finish()
+	tracing.TagComponentNeo4jRepository(span)
+	tracing.TagTenant(span, tenant)
+	span.LogFields(log.Object("sliIds", ids))
+
+	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)<-[:HAS_INVOICE]-(:Contract)-[:HAS_SERVICE]->(sli:ServiceLineItem)
+			WHERE sli.id IN $ids
+			RETURN i, sli.id`
 	params := map[string]any{
 		"tenant": tenant,
 		"ids":    ids,

--- a/packages/server/customer-os-neo4j-repository/repository/invoice_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/invoice_read_repository.go
@@ -606,7 +606,7 @@ func (r *invoiceReadRepository) GetAllForServiceLineItems(ctx context.Context, t
 	tracing.TagTenant(span, tenant)
 	span.LogFields(log.Object("sliIds", ids))
 
-	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)<-[:HAS_INVOICE]-(:Contract)-[:HAS_SERVICE]->(sli:ServiceLineItem)
+	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)-[:HAS_INVOICE_LINE]->(:InvoiceLine)-[:INVOICED]->(sli:ServiceLineItem)
 			WHERE sli.id IN $ids
 			RETURN i, sli.id`
 	params := map[string]any{


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `invoicingStatus` field to `ServiceLineItem` in GraphQL schema and implement related data fetching and resolver logic.
> 
>   - **GraphQL Schema and Resolvers**:
>     - Add `invoicingStatus` field to `ServiceLineItem` in `service_line_item.graphqls`.
>     - Implement `InvoicingStatus` resolver in `service_line_item.resolvers.go` to determine status based on invoices.
>   - **Data Loaders**:
>     - Add `InvoicesForServiceLineItem` loader in `dataloader.go` and `invoice_dataloader.go`.
>     - Implement `getInvoicesForServiceLineItem` in `invoice_dataloader.go` to fetch invoices for service line items.
>   - **Invoice Service**:
>     - Add `GetInvoicesForServiceLineItems` method in `invoice.go` and `service.go` to retrieve invoices for service line items.
>     - Update `fillCycleInvoice` in `service.go` to check if service line items are already invoiced.
>   - **Miscellaneous**:
>     - Fix context usage in `GetSlackSettings` in `user_settings.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c02d6d892cc3d9ce3052723710d12f71ade31732. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->