### PR TITLE
fix(COS-6881): Fix revoke slack access

### DIFF
--- a/packages/apps/frontera/src/store/Settings/Settings.store.ts
+++ b/packages/apps/frontera/src/store/Settings/Settings.store.ts
@@ -118,9 +118,11 @@ export class SettingsStore {
     try {
       this.isLoading = true;
 
-      const res = this.transport.http.post('/sa/slack/revoke', payload);
+      const res = await this.transport.http.post('/sa/slack/revoke', payload);
 
-      options?.onSuccess?.(res);
+      if (res) {
+        options?.onSuccess?.(res);
+      }
     } catch (err) {
       this.error = (err as Error)?.message;
       options?.onError?.(err as Error);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `revokeAccess` method in `Settings.store.ts` by adding `await` to HTTP POST request and ensuring `onSuccess` is called only if response is received.
> 
>   - **Behavior**:
>     - Fix `revokeAccess` method in `Settings.store.ts` by adding `await` to the HTTP POST request to `/sa/slack/revoke`.
>     - Ensure `onSuccess` callback is only called if a response is received.
>   - **Misc**:
>     - Set `isLoading` to `false` in `finally` block to ensure loading state is reset.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 9e69a596b5c2af9734584c0969c9da13066a1110. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->