### PR TITLE
add query param to trace

### DIFF
--- a/packages/server/customer-os-api/rest/integrations/cal_com.go
+++ b/packages/server/customer-os-api/rest/integrations/cal_com.go
@@ -49,7 +49,7 @@ func (h *IntegrationHandler) CalDotCom(c *gin.Context) {
 	}
 
 	// determine tenant
-	tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenant(ctx, c.Param("tenantId"))
+	tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenantByHashId(ctx, c.Param("tenantId"))
 	if err != nil {
 		tracing.TraceErr(span, err)
 		h.responseHandler.HandleError(c, http.StatusInternalServerError, nil)

--- a/packages/server/customer-os-api/rest/integrations/fathom.go
+++ b/packages/server/customer-os-api/rest/integrations/fathom.go
@@ -24,7 +24,10 @@ func (h *IntegrationHandler) FathomZapier(c *gin.Context) {
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
 
-	tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenant(ctx, c.Param("tenantId"))
+	// trace all params
+	span.LogKV("param.tenantId", c.Param("tenantId"))
+
+	tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenantByHashId(ctx, c.Param("tenantId"))
 	if err != nil {
 		err := errors.Wrap(err, "Unable to identify tenant")
 		tracing.TraceErr(span, err)

--- a/packages/server/customer-os-api/rest/integrations/grain.go
+++ b/packages/server/customer-os-api/rest/integrations/grain.go
@@ -25,7 +25,7 @@ func (h *IntegrationHandler) GrainZapier(c *gin.Context) {
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
 
-	tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenant(ctx, c.Param("tenantId"))
+	tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenantByHashId(ctx, c.Param("tenantId"))
 	if err != nil {
 		err := errors.Wrap(err, "Unable to identify tenant")
 		tracing.TraceErr(span, err)

--- a/packages/server/customer-os-api/rest/webhooks/webhooks.go
+++ b/packages/server/customer-os-api/rest/webhooks/webhooks.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"fmt"
+	"github.com/opentracing/opentracing-go/log"
 	"net/http"
 	"strings"
 	"time"
@@ -280,7 +281,9 @@ func (h *WebhookHandler) HandleWebhook(flowsPath string) gin.HandlerFunc {
 		defer span.Finish()
 		tracing.TagComponentRest(span)
 
-		tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenant(ctx, c.Param("tenantHash"))
+		span.LogFields(log.String("param.tenantHash", c.Param("tenantHash")))
+
+		tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenantByHashId(ctx, c.Param("tenantHash"))
 		if err != nil {
 			err := errors.Wrap(err, "Unable to identify tenant")
 			tracing.TraceErr(span, err)

--- a/packages/server/customer-os-common-module/services/webhook/service.go
+++ b/packages/server/customer-os-common-module/services/webhook/service.go
@@ -46,7 +46,7 @@ func (w *webhookService) ValidateTenantId(ctx context.Context, tenant, tenantId 
 	span.LogFields(log.String("tenant", tenant))
 	span.LogFields(log.String("tenantId", tenantId))
 
-	tenantFromDb, err := w.postgresRepositories.TenantRepository.GetTenant(ctx, tenantId)
+	tenantFromDb, err := w.postgresRepositories.TenantRepository.GetTenantByHashId(ctx, tenantId)
 	if err != nil {
 		err = fmt.Errorf("Unable to lookup tenant hashId for %s: %v", tenant, err)
 		tracing.TraceErr(span, err)

--- a/packages/server/customer-os-postgres-repository/repository/tenant_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/tenant_repository.go
@@ -15,7 +15,7 @@ import (
 
 type TenantRepository interface {
 	Create(ctx context.Context, tenantEntity postgres_entity.Tenant) (*postgres_entity.Tenant, error)
-	GetTenant(ctx context.Context, hashID string) (string, error)
+	GetTenantByHashId(ctx context.Context, hashID string) (string, error)
 	GetHashID(ctx context.Context, tenant string) (string, error)
 	PermanentlyDelete(ctx context.Context, tenant string) error
 }
@@ -28,10 +28,11 @@ func NewTenantRepository(gormDb *gorm.DB) TenantRepository {
 	return &tenantRepository{gormDb: gormDb}
 }
 
-func (e *tenantRepository) GetTenant(ctx context.Context, hashID string) (string, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TenantRepository.GetTenant")
+func (e *tenantRepository) GetTenantByHashId(ctx context.Context, hashID string) (string, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TenantRepository.GetTenantByHashId")
 	defer span.Finish()
 	tracing.TagComponentPostgresRepository(span)
+	span.LogKV("hashID", hashID)
 
 	var tenant postgres_entity.Tenant
 	err := e.gormDb.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `GetTenant` with `GetTenantByHashId` for tenant retrieval by hash ID and enhances tracing in several integration handlers.
> 
>   - **Behavior**:
>     - Replaces `GetTenant` with `GetTenantByHashId` in `cal_com.go`, `fathom.go`, `grain.go`, `webhooks.go`, and `service.go` to retrieve tenant by hash ID.
>     - Logs query parameters for tracing in `fathom.go` and `webhooks.go`.
>   - **Repository**:
>     - Renames `GetTenant` to `GetTenantByHashId` in `tenant_repository.go` to reflect the method's purpose more accurately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2788410a7565a9010a12d40901fc4255415d68fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->