### PR TITLE
add shortcuts to welcome page + agents

### DIFF
--- a/packages/apps/frontera/src/routes/agents/page.tsx
+++ b/packages/apps/frontera/src/routes/agents/page.tsx
@@ -1,9 +1,11 @@
 import { useEffect } from 'react';
 
 import { observer } from 'mobx-react-lite';
-import { useLocalStorage } from 'usehooks-ts';
+import { useUnmount, useLocalStorage } from 'usehooks-ts';
 
 import { useStore } from '@shared/hooks/useStore';
+import { PreviewCard } from '@shared/components/PreviewCard';
+import { ShortcutsPanel } from '@shared/components/PreviewCard/components/ShortcutsPanel';
 import {
   ScrollAreaRoot,
   ScrollAreaThumb,
@@ -45,35 +47,55 @@ export const AgentsPage = observer(() => {
     store.ui.commandMenu.setType('AgentsCommands');
   }, []);
 
+  useUnmount(() => {
+    store.ui.setShortcutsPanel(false);
+  });
+
   return (
-    <div className='relative h-full'>
+    <div>
       <Header />
-      <ScrollAreaRoot className='h-full'>
-        <ScrollAreaViewport>
-          <div className='flex flex-wrap p-4 gap-4'>
-            {agents
-              .filter((agent) => agent.value.visible)
-              .map((agent) => (
-                <AgentCard
-                  id={agent.id}
-                  key={agent.id}
-                  icon={agent.value.icon}
-                  name={agent.value.name}
-                  colorMap={agent.colorMap}
-                  defaultName={agent.defaultName}
-                  status={agent.value.isActive ? 'ON' : 'OFF'}
-                  hasError={!!agent.value.error || !agent.value.isConfigured}
-                />
-              ))}
-            <div className='min-w-[372px] flex-1 p-3'></div>
-            <div className='min-w-[372px] flex-1 p-3'></div>
-            <div className='min-w-[372px] flex-1 p-3'></div>
+      <div className='flex h-full'>
+        <div className='relative h-full w-full'>
+          <div className='h-full'>
+            <ScrollAreaRoot className='h-full'>
+              <ScrollAreaViewport>
+                <div className='flex flex-wrap p-4 gap-4'>
+                  {agents
+                    .filter((agent) => agent.value.visible)
+                    .map((agent) => (
+                      <AgentCard
+                        id={agent.id}
+                        key={agent.id}
+                        icon={agent.value.icon}
+                        name={agent.value.name}
+                        colorMap={agent.colorMap}
+                        defaultName={agent.defaultName}
+                        status={agent.value.isActive ? 'ON' : 'OFF'}
+                        hasError={
+                          !!agent.value.error || !agent.value.isConfigured
+                        }
+                      />
+                    ))}
+                  <div className='min-w-[372px] flex-1 p-3'></div>
+                  <div className='min-w-[372px] flex-1 p-3'></div>
+                  <div className='min-w-[372px] flex-1 p-3'></div>
+                </div>
+              </ScrollAreaViewport>
+              <ScrollAreaScrollbar orientation='vertical'>
+                <ScrollAreaThumb />
+              </ScrollAreaScrollbar>
+            </ScrollAreaRoot>
           </div>
-        </ScrollAreaViewport>
-        <ScrollAreaScrollbar orientation='vertical'>
-          <ScrollAreaThumb />
-        </ScrollAreaScrollbar>
-      </ScrollAreaRoot>
+        </div>
+
+        <div className='h-full'>
+          {store.ui.showShortcutsPanel && (
+            <PreviewCard>
+              <ShortcutsPanel />
+            </PreviewCard>
+          )}
+        </div>
+      </div>
     </div>
   );
 });

--- a/packages/apps/frontera/src/routes/onboarding/page.tsx
+++ b/packages/apps/frontera/src/routes/onboarding/page.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { match } from 'ts-pattern';
+import { useUnmount } from 'usehooks-ts';
 import { observer } from 'mobx-react-lite';
 
 import { Send03 } from '@ui/media/icons/Send03';
@@ -11,14 +12,15 @@ import { Shuffle01 } from '@ui/media/icons/Shuffle01';
 import { Building07 } from '@ui/media/icons/Building07';
 import { Settings01 } from '@ui/media/icons/Settings01';
 import { WelcomePage } from '@ui/media/logos/WelcomePage';
+import { PreviewCard } from '@shared/components/PreviewCard';
 import { LinkedinOutline } from '@ui/media/icons/LinkedinOutline';
+import { ShortcutsPanel } from '@shared/components/PreviewCard/components/ShortcutsPanel';
 
-import { LongArrow } from './src/assets/LongArrow';
 import { OnboardingCard } from './src/components/OnboardingCard';
 import { DecorativePattern } from './src/assets/DecorativePattern';
 
 export const OnboardingPage = observer(() => {
-  const { globalCache, tableViewDefs, mailboxes } = useStore();
+  const { globalCache, tableViewDefs, mailboxes, ui } = useStore();
   const navigate = useNavigate();
 
   const onboarding = globalCache.value?.user?.onboarding;
@@ -72,69 +74,81 @@ export const OnboardingPage = observer(() => {
       .otherwise(() => null);
   };
 
+  useUnmount(() => {
+    ui.setShortcutsPanel(false);
+  });
+
   return (
-    <div className='flex h-full flex-col w-full relative'>
-      <div className='flex flex-col h-[323px] w-[500px] items-center self-center'>
-        <div className='relative flex-col'>
-          <WelcomePage className='w-[152px] h-[120px] absolute top-[20%] right-[34%]' />
-          <DecorativePattern width={500} height={480} className='-mt-[100px]' />
+    <>
+      <div className='flex h-full flex-col w-full relative'>
+        <div className='flex flex-col h-[323px] w-[500px] items-center self-center'>
+          <div className='relative flex-col'>
+            <WelcomePage className='w-[152px] h-[120px] absolute top-[20%] right-[34%]' />
+            <DecorativePattern
+              width={500}
+              height={480}
+              className='-mt-[100px]'
+            />
+          </div>
+          <article className='flex flex-col items-center top-[-180px] relative'>
+            <h1 className='font-bold text-xl'>Welcome!</h1>
+            <p className='mt-2'>Let’s get you started.</p>
+            <p className='mt-4'>Here are a few short paths to success:</p>
+          </article>
         </div>
-        <article className='flex flex-col items-center top-[-180px] relative'>
-          <h1 className='font-bold text-xl'>Welcome!</h1>
-          <p className='mt-2'>Let’s get you started.</p>
-          <p className='mt-4'>Here are a few short paths to success:</p>
-        </article>
-      </div>
 
-      <div className='flex gap-4 justify-center items-center '>
-        <div>
-          <OnboardingCard
-            title='Outbound'
-            timeInMinutes='2'
-            isFeatured={false}
-            contentTitle='Explore a sequence'
-            subtitle='Automated, surgical, reputable'
-            titleIcon={<Send03 className='text-inherit' />}
-            contentIcon={<Shuffle01 className='text-inherit' />}
-            onClick={() => handleOnboardingStepClick('outbound')}
-            isCompleted={onboarding?.onboardingOutboundStepCompleted}
-            description='Discover how to orchestrate a multichannel outbound campaign.'
-          />{' '}
-        </div>
-        <div>
-          <OnboardingCard
-            title='CRM'
-            isFeatured={true}
-            timeInMinutes='3'
-            contentTitle='Import a contact from LinkedIn'
-            subtitle='All the customer data, for everyone'
-            onClick={() => handleOnboardingStepClick('crm')}
-            isCompleted={onboarding?.onboardingCrmStepCompleted}
-            contentIcon={<LinkedinOutline className='size-5' />}
-            titleIcon={<Building07 className='size-6 text-inherit' />}
-            description='...then enrich their email and mobile number in one click'
-          />{' '}
-        </div>
-        <div>
-          <OnboardingCard
-            title='Mailstack'
-            timeInMinutes='5'
-            isFeatured={false}
-            titleIcon={<Inbox01 />}
-            contentIcon={<Settings01 />}
-            contentTitle='Setup my mailboxes'
-            subtitle='High-deliverability email infrastructure'
-            onClick={() => handleOnboardingStepClick('mailstack')}
-            isCompleted={onboarding?.onboardingMailstackStepCompleted}
-            description='Setup your high-reputation domains and senders, for pain-free outbound with optimal deliverability.'
-          />
+        <div className='flex gap-4 justify-center items-center '>
+          <div>
+            <OnboardingCard
+              title='Outbound'
+              timeInMinutes='2'
+              isFeatured={false}
+              contentTitle='Explore a sequence'
+              subtitle='Automated, surgical, reputable'
+              titleIcon={<Send03 className='text-inherit' />}
+              contentIcon={<Shuffle01 className='text-inherit' />}
+              onClick={() => handleOnboardingStepClick('outbound')}
+              isCompleted={onboarding?.onboardingOutboundStepCompleted}
+              description='Discover how to orchestrate a multichannel outbound campaign.'
+            />{' '}
+          </div>
+          <div>
+            <OnboardingCard
+              title='CRM'
+              isFeatured={true}
+              timeInMinutes='3'
+              contentTitle='Import a contact from LinkedIn'
+              subtitle='All the customer data, for everyone'
+              onClick={() => handleOnboardingStepClick('crm')}
+              isCompleted={onboarding?.onboardingCrmStepCompleted}
+              contentIcon={<LinkedinOutline className='size-5' />}
+              titleIcon={<Building07 className='size-6 text-inherit' />}
+              description='...then enrich their email and mobile number in one click'
+            />{' '}
+          </div>
+          <div>
+            <OnboardingCard
+              title='Mailstack'
+              timeInMinutes='5'
+              isFeatured={false}
+              titleIcon={<Inbox01 />}
+              contentIcon={<Settings01 />}
+              contentTitle='Setup my mailboxes'
+              subtitle='High-deliverability email infrastructure'
+              onClick={() => handleOnboardingStepClick('mailstack')}
+              isCompleted={onboarding?.onboardingMailstackStepCompleted}
+              description='Setup your high-reputation domains and senders, for pain-free outbound with optimal deliverability.'
+            />
+          </div>
         </div>
       </div>
-
-      <div className='flex absolute bottom-[80px] right-[80px]'>
-        <div className='text-sm -mt-2.5 mr-4'>Reach out for questions </div>
-        <LongArrow />
+      <div className='h-full'>
+        {ui.showShortcutsPanel && (
+          <PreviewCard>
+            <ShortcutsPanel />
+          </PreviewCard>
+        )}
       </div>
-    </div>
+    </>
   );
 });

--- a/packages/apps/frontera/src/routes/src/components/PreviewCard/PreviewCard.tsx
+++ b/packages/apps/frontera/src/routes/src/components/PreviewCard/PreviewCard.tsx
@@ -10,7 +10,7 @@ export const PreviewCard = ({ children }: PreviewCardProps) => {
   return (
     <div
       data-state={previewCard ? 'open' : 'closed'}
-      className='data-[state=open]:animate-slideLeftAndFade data-[state=closed]:animate-slideRightAndFade flex flex-col border border-r-0 border-t-0 border-gray-200 bg-white max-w-[400px] min-w-[400px]'
+      className='data-[state=open]:animate-slideLeftAndFade data-[state=closed]:animate-slideRightAndFade flex flex-col border border-r-0 border-t-0 border-b-0 border-gray-200  max-w-[400px] min-w-[400px] overflow-y-auto h-screen'
     >
       {children}
     </div>

--- a/packages/apps/frontera/src/routes/src/components/PreviewCard/components/ShortcutsPanel.tsx
+++ b/packages/apps/frontera/src/routes/src/components/PreviewCard/components/ShortcutsPanel.tsx
@@ -4,7 +4,6 @@ import Fuse from 'fuse.js';
 import { useKey } from 'rooks';
 import { observer } from 'mobx-react-lite';
 
-import { cn } from '@ui/utils/cn';
 import { Icon } from '@ui/media/Icon';
 import { Input } from '@ui/form/Input';
 import { IconButton } from '@ui/form/IconButton';
@@ -60,97 +59,89 @@ export const ShortcutsPanel = observer(() => {
   });
 
   return (
-    <div className={cn('border-transparent')}>
-      <div className='flex items-center justify-between pt-4 px-4'>
-        <p className='text-base font-medium'>Keyboard shortcuts</p>
-        <IconButton
-          size='xs'
-          variant='ghost'
-          icon={<Icon name='x-close' />}
-          aria-label='close-contact-overview'
-          onClick={() => store.ui.setShortcutsPanel(false)}
-        />
-      </div>
-      <div className='mt-2 flex items-center gap-x-2 px-4'>
-        <Icon name={'search-sm'} className='size-4 text-gray-500' />
-        <Input
-          autoFocus
-          size='sm'
-          type='text'
-          variant='unstyled'
-          value={searchTerm}
-          placeholder='Search shortcuts'
-          onChange={(e) => setSearchTerm(e.target.value)}
-        />
-      </div>
-      <div
-        style={{ height: `calc(100vh - 118px)` }}
-        className='w-full bg-white overflow-y-auto h-screen px-4 pb-6'
-      >
-        <div className='mt-2'>
-          {filteredSections.length > 0 ? (
-            filteredSections.map((section, idx) => (
-              <div key={idx} className='mb-5'>
-                <h3 className='text-sm font-medium text-gray-700 mb-2'>
-                  {section.title}
-                </h3>
-                <div className='space-y-2'>
-                  {section.shortcuts.map((shortcut, shortcutIdx) => (
-                    <div key={shortcutIdx} className='space-y-1'>
-                      <div className='flex items-center justify-between text-sm'>
-                        <span className='text-gray-700'>{shortcut.label}</span>
-                        <div className='flex items-center gap-1'>
-                          {shortcut?.sequence ? (
-                            <div className='flex items-center gap-1'>
-                              <kbd className='px-2 py-1 bg-gray-100 rounded text-xs'>
-                                {shortcut.sequence[0]}
-                              </kbd>
-                              <span className='text-xs text-gray-500'>
-                                then
-                              </span>
-                              <kbd className='px-2 py-1 bg-gray-100 rounded text-xs'>
-                                {shortcut.sequence[1]}
-                              </kbd>
-                            </div>
-                          ) : (
-                            <div className='flex items-center gap-1'>
-                              {shortcut?.modifierIcon && (
-                                <kbd className='px-2 py-1 bg-gray-100 rounded text-xs'>
-                                  <Icon
-                                    className='size-3'
-                                    name={shortcut.modifierIcon}
-                                  />
-                                </kbd>
-                              )}
-                              {shortcut?.key && (
-                                <kbd className='px-2 py-1 bg-gray-100 rounded text-xs'>
-                                  {shortcut.key}
-                                </kbd>
-                              )}
-
-                              {shortcut?.keyIcon && (
-                                <kbd className='px-2 py-1 bg-gray-100 rounded text-xs'>
-                                  <Icon
-                                    className='size-3'
-                                    name={shortcut.keyIcon}
-                                  />
-                                </kbd>
-                              )}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))
-          ) : (
-            <div className='text-center text-sm text-gray-500 mt-4'>
-              No shortcut found by that name…
-            </div>
-          )}
+    <div className='mb-10'>
+      <div className='sticky top-0 bg-white mb-2'>
+        <div className='flex items-center justify-between pt-4 px-4'>
+          <p className='text-base font-medium'>Keyboard shortcuts</p>
+          <IconButton
+            size='xs'
+            variant='ghost'
+            icon={<Icon name='x-close' />}
+            aria-label='close-contact-overview'
+            onClick={() => store.ui.setShortcutsPanel(false)}
+          />
         </div>
+        <div className='flex items-center gap-x-2 px-4'>
+          <Icon name={'search-sm'} className='size-4 text-gray-500' />
+          <Input
+            autoFocus
+            size='sm'
+            type='text'
+            variant='unstyled'
+            value={searchTerm}
+            placeholder='Search shortcuts'
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className='w-full px-4'>
+        {filteredSections.length > 0 ? (
+          filteredSections.map((section, idx) => (
+            <div key={idx} className='mb-5'>
+              <h3 className='text-sm font-medium text-gray-700 mb-2'>
+                {section.title}
+              </h3>
+              {section.shortcuts.map((shortcut, shortcutIdx) => (
+                <div
+                  key={shortcutIdx}
+                  className='mb-2 flex items-center justify-between text-sm'
+                >
+                  <p className='text-gray-700'>{shortcut.label}</p>
+                  <div className='flex items-center gap-1'>
+                    {shortcut?.sequence ? (
+                      <div className='flex items-center gap-1'>
+                        <kbd className='px-2 py-1 bg-gray-100 rounded text-xs'>
+                          {shortcut.sequence[0]}
+                        </kbd>
+                        <span className='text-xs text-gray-500'>then</span>
+                        <kbd className='px-2 py-1 bg-gray-100 rounded text-xs'>
+                          {shortcut.sequence[1]}
+                        </kbd>
+                      </div>
+                    ) : (
+                      <div className='flex items-center gap-1'>
+                        {shortcut?.modifierIcon && (
+                          <kbd className='px-2 py-1 bg-gray-100 rounded text-xs'>
+                            <Icon
+                              className='size-3'
+                              name={shortcut.modifierIcon}
+                            />
+                          </kbd>
+                        )}
+                        {shortcut?.key && (
+                          <kbd className='px-2 py-1 bg-gray-100 rounded text-xs'>
+                            {shortcut.key}
+                          </kbd>
+                        )}
+
+                        {shortcut?.keyIcon && (
+                          <kbd className='px-2 py-1 bg-gray-100 rounded text-xs'>
+                            <Icon className='size-3' name={shortcut.keyIcon} />
+                          </kbd>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))
+        ) : (
+          <div className='text-center text-sm text-gray-500 mt-4'>
+            No shortcut found by that name…
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/SettingsSection.tsx
+++ b/packages/apps/frontera/src/routes/src/components/RootSidenav/components/sections/SettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { observer } from 'mobx-react-lite';
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
@@ -22,8 +22,6 @@ export const SettingsSection = observer(() => {
   const debuggerFlag = useFeatureIsOn('debugger');
   const { open, onOpen, onClose, onToggle } = useDisclosure();
   const isDebuggerEnabled = import.meta.env.DEV || debuggerFlag;
-
-  const location = useLocation();
 
   const handleSignOutClick = () => {
     store.session.clearSession();
@@ -78,7 +76,6 @@ export const SettingsSection = observer(() => {
             <MenuItem
               className='group'
               data-test='help-item-settings'
-              disabled={location.pathname?.includes('agent')}
               onClick={() => store.ui.setShortcutsPanel(true)}
             >
               <div


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add shortcuts panel to welcome and agents pages, update `PreviewCard` and `ShortcutsPanel`, and include shortcuts menu item in settings.
> 
>   - **Shortcuts Panel**:
>     - Added `ShortcutsPanel` to `AgentsPage` and `OnboardingPage` to display keyboard shortcuts.
>     - `useUnmount` hook used to hide shortcuts panel on component unmount.
>   - **Components**:
>     - Updated `PreviewCard` to be scrollable and occupy full screen height.
>     - Modified `ShortcutsPanel` to include a search feature and display shortcuts grouped by section.
>   - **Settings**:
>     - Added menu item in `SettingsSection` to open shortcuts panel.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 294f67c547e3dcffa3e757ded10c76691e2f3816. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->