### PR TITLE
fix fathom webhook

### DIFF
--- a/packages/server/customer-os-api/rest/integrations/cal_com.go
+++ b/packages/server/customer-os-api/rest/integrations/cal_com.go
@@ -20,10 +20,11 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
 )
 
-func (h *IntegrationHandler) CalDotCom(c *gin.Context) {
+func (h *IntegrationHandler) CalDotCom(c *gin.Context, tenant string) {
 	span, ctx := commontracing.StartTracerSpan(c.Request.Context(), "Flows.CalDotCom")
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
+	tracing.TagTenant(span, tenant)
 
 	if !strings.HasPrefix(c.ContentType(), "application/json") {
 		h.responseHandler.HandleError(c, http.StatusBadRequest, nil)
@@ -45,14 +46,6 @@ func (h *IntegrationHandler) CalDotCom(c *gin.Context) {
 	if signature == "" {
 		message := "Missing signature header"
 		h.responseHandler.HandleError(c, http.StatusBadRequest, &message)
-		return
-	}
-
-	// determine tenant
-	tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenantByHashId(ctx, c.Param("tenantId"))
-	if err != nil {
-		tracing.TraceErr(span, err)
-		h.responseHandler.HandleError(c, http.StatusInternalServerError, nil)
 		return
 	}
 

--- a/packages/server/customer-os-api/rest/integrations/fathom.go
+++ b/packages/server/customer-os-api/rest/integrations/fathom.go
@@ -19,22 +19,14 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
 )
 
-func (h *IntegrationHandler) FathomZapier(c *gin.Context) {
+func (h *IntegrationHandler) FathomZapier(c *gin.Context, tenant string) {
 	ctx, span := commontracing.StartHttpServerTracerSpanWithHeader(c.Request.Context(), "Flows.FathomZapier", c.Request.Header)
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
+	tracing.TagTenant(span, tenant)
 
 	// trace all params
-	span.LogKV("param.tenantId", c.Param("tenantId"))
-
-	tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenantByHashId(ctx, c.Param("tenantId"))
-	if err != nil {
-		err := errors.Wrap(err, "Unable to identify tenant")
-		tracing.TraceErr(span, err)
-
-		h.responseHandler.HandleError(c, http.StatusUnauthorized, nil)
-		return
-	}
+	span.LogKV("param.tenantId", c.Param("tenant"))
 
 	// update context with tenant, pass this where tenant is needed
 	ctx = common.WithCustomContext(ctx, &common.CustomContext{

--- a/packages/server/customer-os-api/rest/integrations/grain.go
+++ b/packages/server/customer-os-api/rest/integrations/grain.go
@@ -20,18 +20,11 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
 )
 
-func (h *IntegrationHandler) GrainZapier(c *gin.Context) {
+func (h *IntegrationHandler) GrainZapier(c *gin.Context, tenant string) {
 	ctx, span := commontracing.StartHttpServerTracerSpanWithHeader(c.Request.Context(), "Flows.Grain", c.Request.Header)
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
-
-	tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenantByHashId(ctx, c.Param("tenantId"))
-	if err != nil {
-		err := errors.Wrap(err, "Unable to identify tenant")
-		tracing.TraceErr(span, err)
-		h.responseHandler.HandleError(c, http.StatusUnauthorized, nil)
-		return
-	}
+	tracing.TagTenant(span, tenant)
 
 	// update context with tenant, pass this where tenant is needed
 	ctx = common.WithCustomContext(ctx, &common.CustomContext{

--- a/packages/server/customer-os-api/rest/webhooks/webhooks.go
+++ b/packages/server/customer-os-api/rest/webhooks/webhooks.go
@@ -298,15 +298,16 @@ func (h *WebhookHandler) HandleWebhook(flowsPath string) gin.HandlerFunc {
 			h.responseHandler.HandleError(c, http.StatusNotFound, &message)
 			return
 		}
+		span.LogKV("result.integration", integration.String())
 
 		switch integration {
 		case commonEnum.SourceCalCom:
-			h.integrationsHandler.CalDotCom(c)
+			h.integrationsHandler.CalDotCom(c, tenant)
 		// todo
 		case commonEnum.SourceFathom:
-			h.integrationsHandler.FathomZapier(c)
+			h.integrationsHandler.FathomZapier(c, tenant)
 		case commonEnum.SourceGrain:
-			h.integrationsHandler.GrainZapier(c)
+			h.integrationsHandler.GrainZapier(c, tenant)
 		case commonEnum.SourcePostmark:
 			h.integrationsHandler.PostmarkInboundEmail(c)
 		// todo


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor tenant handling in `CalDotCom`, `FathomZapier`, and `GrainZapier` functions to accept tenant as a parameter and update `HandleWebhook` to pass tenant.
> 
>   - **Behavior**:
>     - Refactor `CalDotCom`, `FathomZapier`, and `GrainZapier` functions to accept `tenant` as a parameter instead of determining it internally.
>     - Update `HandleWebhook` in `webhooks.go` to pass `tenant` to the above functions.
>   - **Tracing**:
>     - Add `tracing.TagTenant(span, tenant)` in `CalDotCom`, `FathomZapier`, and `GrainZapier` to log tenant information.
>   - **Error Handling**:
>     - Remove tenant determination logic and related error handling from `CalDotCom`, `FathomZapier`, and `GrainZapier`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for db73479f85ed3ae58e144116865945857638ecdc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->