### PR TITLE
Fix browser extension visibility for bulk contact and single contact …

### DIFF
--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/AddContactsBulk.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/AddContactsBulk.tsx
@@ -1,4 +1,4 @@
-import React, { useState, KeyboardEvent } from 'react';
+import React, { useMemo, useState, KeyboardEvent } from 'react';
 
 import { useKey } from 'rooks';
 import { observer } from 'mobx-react-lite';
@@ -26,6 +26,7 @@ export const AddContactsBulk = observer(() => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [loadingError, setLoadingError] = useState<string>('');
   const [showEmptyError, setShowEmptyError] = useState<boolean>(false);
+  const _usecase = useMemo(() => new AddContactsBulkUsecase(), []);
 
   const handleClose = (e: KeyboardEvent) => {
     e.stopPropagation();
@@ -193,7 +194,7 @@ export const AddContactsBulk = observer(() => {
             `Add one ${type === 'email' ? 'email' : 'LinkedIn URL'} per line`}
         </div>
 
-        {AddContactsBulkUsecase.isBrowserExtensionEnabled &&
+        {!AddContactsBulkUsecase.isBrowserExtensionEnabled &&
           type === 'linkedin' && (
             <div className='flex justify-between bg-success-50 rounded-md px-2 py-1 my-4'>
               <div className='flex items-center gap-2 text-success-700 text-sm'>
@@ -201,7 +202,8 @@ export const AddContactsBulk = observer(() => {
                 <span>
                   <span>Prospect faster.</span>{' '}
                   <a
-                    target='_blank' rel='noopener noreferrer'
+                    target='_blank'
+                    rel='noopener noreferrer'
                     className='underline hover:text-success-900'
                     href='https://chromewebstore.google.com/detail/customeros/khmdccjeodppdldkgifcnkndemjpfoml'
                   >

--- a/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/AddSingleContact.tsx
+++ b/packages/apps/frontera/src/routes/src/components/CommandMenu/commands/contacts/AddSingleContact.tsx
@@ -141,7 +141,7 @@ export const AddSingleContact = observer(() => {
             }}
           />
 
-          {CreateContactUsecase.isBrowserExtensionEnabled &&
+          {!CreateContactUsecase.isBrowserExtensionEnabled &&
             usecase.type === 'linkedin' && (
               <div className='flex justify-between bg-success-50 rounded-md px-2 py-1 mb-4'>
                 <div className='flex items-center gap-2 text-success-700 text-sm'>


### PR DESCRIPTION
…creation
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes browser extension prompt visibility in `AddContactsBulk.tsx` and `AddSingleContact.tsx` for LinkedIn contact type.
> 
>   - **Behavior**:
>     - Fixes visibility of browser extension prompt in `AddContactsBulk.tsx` and `AddSingleContact.tsx`.
>     - Prompts are now shown only when `isBrowserExtensionEnabled` is `false` and the contact type is `linkedin`.
>   - **Code Changes**:
>     - In `AddContactsBulk.tsx`, changed condition to `!AddContactsBulkUsecase.isBrowserExtensionEnabled` for showing the extension prompt.
>     - In `AddSingleContact.tsx`, changed condition to `!CreateContactUsecase.isBrowserExtensionEnabled` for showing the extension prompt.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 85fa53694536f372d71b03a70e52a8d0e14b0a67. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->