### PR TITLE
Check why slack was sent twice

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_listeners/listener_web_visitor_identified.go
+++ b/packages/server/customer-os-common-module/services/agent_listeners/listener_web_visitor_identified.go
@@ -71,7 +71,7 @@ func (l *WebVisitorIdentifiedListener) Handle(ctx context.Context, baseEvent any
 		return err
 	}
 
-	data, err := events.DecodeEventData[dto.WebVisitorNotIdentified](ctx, event)
+	data, err := events.DecodeEventData[dto.WebVisitorIdentified](ctx, event)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err

--- a/packages/server/customer-os-common-module/services/agent_listeners/listener_web_visitor_identified.go
+++ b/packages/server/customer-os-common-module/services/agent_listeners/listener_web_visitor_identified.go
@@ -2,6 +2,9 @@ package agent_listeners
 
 import (
 	"context"
+	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	"github.com/opentracing/opentracing-go/log"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
@@ -62,8 +65,50 @@ func (l *WebVisitorIdentifiedListener) Handle(ctx context.Context, baseEvent any
 	tracing.SetDefaultListenerSpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "baseEvent", baseEvent)
 
-	// TODO implement
-	return nil
+	event, err := l.ValidateBaseEvent(ctx, baseEvent)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
 
-	// return l.handleGoalAchieved(ctx, data.AgentExecutionId)
+	data, err := events.DecodeEventData[dto.WebVisitorNotIdentified](ctx, event)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	if data.AgentExecutionId != "" {
+		// TODO temporary disable goal achieved
+		//return l.handleGoalAchieved(ctx, data.AgentExecutionId)
+	}
+	return nil
+}
+
+func (l *WebVisitorIdentifiedListener) handleGoalAchieved(ctx context.Context, agentExecutionId string) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebVisitorIdentifiedListener.handleGoalAchieved")
+	defer span.Finish()
+	tracing.SetDefaultListenerSpanTags(ctx, span)
+	span.LogFields(log.String("agentExecutionId", agentExecutionId))
+
+	var agentExecution *postgres_entity.AgentExecution
+	var err error
+	agentExecution, err = l.postgresRepositories.AgentExecutionRepository.GetById(ctx, agentExecutionId)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+	if agentExecution == nil {
+		err = fmt.Errorf("agent execution not found")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	// update execution with goal achieved
+	_, err = l.postgresRepositories.AgentExecutionRepository.Completed(ctx, agentExecution.ID, utils.TruePtr())
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	return nil
 }

--- a/packages/server/customer-os-postgres-repository/repository/websession_events_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/websession_events_repository.go
@@ -157,18 +157,20 @@ func (r *webSessionEventsRepository) FindLastNotification(ctx context.Context, t
 	var result postgres_entity.WebSession
 	err := r.gormDb.
 		Model(&postgres_entity.WebSession{}).
-		Where("tenant = ? AND domain = ?", tenant, domain).
+		Where("tenant = ? AND domain = ? AND sent_slack_notification IS NOT NULL", tenant, domain).
 		Order("sent_slack_notification DESC").
 		First(&result).
 		Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
+			span.LogFields(log.String("result", "No record found"))
 			return nil, nil
 		}
 		tracing.TraceErr(span, err)
 		return nil, err
 	}
 
+	span.LogFields(log.String("result", "Record found: "+result.ID))
 	return &result, nil
 }
 

--- a/packages/server/events-subscribers/events_subscribers_main.go
+++ b/packages/server/events-subscribers/events_subscribers_main.go
@@ -213,9 +213,9 @@ func (a *App) initializeListeners() error {
 		a.deps.CommonServices.AgentRunnerService,
 	))
 
-	a.events.Subscriber.RegisterListener(common_agent_listeners.NewWebVisitorIdentifiedListener(a.logger, a.deps.PostgresRepositories)) // TODO check if still needed
-	a.events.Subscriber.RegisterListener(common_agent_listeners.NewCompanyIdentifiedListener(a.logger, a.deps.PostgresRepositories, a.deps.CommonServices.AgentRunnerService))
+	a.events.Subscriber.RegisterListener(common_agent_listeners.NewWebVisitorIdentifiedListener(a.logger, a.deps.PostgresRepositories))
 	a.events.Subscriber.RegisterListener(common_agent_listeners.NewWebVisitorNotIdentifiedListener(a.logger, a.deps.PostgresRepositories))
+	a.events.Subscriber.RegisterListener(common_agent_listeners.NewCompanyIdentifiedListener(a.logger, a.deps.PostgresRepositories, a.deps.CommonServices.AgentRunnerService))
 
 	// Cashflow guardian listeners
 	a.events.Subscriber.RegisterListener(common_agent_listeners.NewStartInvoiceRun(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Implement event handling in `WebVisitorIdentifiedListener` and adjust Slack notification logic in `websession_events_repository.go`.
> 
>   - **Behavior**:
>     - Implement `Handle()` in `WebVisitorIdentifiedListener` to validate and decode events, temporarily disabling `handleGoalAchieved()`.
>     - Modify `FindLastNotification()` in `websession_events_repository.go` to filter by `sent_slack_notification` and log results.
>   - **Listeners**:
>     - Adjust listener registration order in `events_subscribers_main.go` for `NewWebVisitorIdentifiedListener` and `NewCompanyIdentifiedListener`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for adfcbc77caec412cca1e55cac7186f32696b6ba8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->