### PR TITLE
Fathom agent fixes

### DIFF
--- a/packages/server/customer-os-api/rest/integrations/fathom.go
+++ b/packages/server/customer-os-api/rest/integrations/fathom.go
@@ -2,9 +2,6 @@ package integrations
 
 import (
 	"context"
-	"net/http"
-	"strings"
-
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/dto"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
@@ -15,6 +12,8 @@ import (
 	"github.com/customeros/mailsherpa/mailvalidate"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	"net/http"
+	"strings"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
 )
@@ -24,9 +23,6 @@ func (h *IntegrationHandler) FathomZapier(c *gin.Context, tenant string) {
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
 	tracing.TagTenant(span, tenant)
-
-	// trace all params
-	span.LogKV("param.tenantId", c.Param("tenant"))
 
 	// update context with tenant, pass this where tenant is needed
 	ctx = common.WithCustomContext(ctx, &common.CustomContext{
@@ -115,15 +111,15 @@ func (h *IntegrationHandler) publishFathomMeetingSummaryCreatedEvent(c *gin.Cont
 	event := dto.NewMeetingRecording{
 		MeetingTitle:        aiSummaryData.Meeting.Title,
 		Source:              enum.SourceFathom,
-		Content:             &content,
-		ParticipantEmails:   &participants,
+		Content:             content,
+		ParticipantEmails:   participants,
 		MeetingRecordingUrl: aiSummaryData.Recording.ShareURL,
 	}
 
 	if aiSummaryData.Meeting.ScheduledStartTime.IsZero() {
-		event.Timestamp = utils.NowPtr()
+		event.Timestamp = utils.Now()
 	} else {
-		event.Timestamp = utils.TimePtr(aiSummaryData.Meeting.ScheduledStartTime.UTC())
+		event.Timestamp = aiSummaryData.Meeting.ScheduledStartTime.UTC()
 	}
 
 	pubErr := h.services.CommonServices.Events.Publisher.PublishFanoutEvent(ctx, meetingID, model.MEETING, event)

--- a/packages/server/customer-os-api/rest/integrations/grain.go
+++ b/packages/server/customer-os-api/rest/integrations/grain.go
@@ -128,15 +128,15 @@ func (h *IntegrationHandler) publishGrainMeetingSummaryCreatedEvent(c *gin.Conte
 	event := dto.NewMeetingRecording{
 		MeetingTitle:        grainData.RecordingData.Title,
 		Source:              enum.SourceGrain,
-		Content:             &content,
-		ParticipantEmails:   &participants,
+		Content:             content,
+		ParticipantEmails:   participants,
 		MeetingRecordingUrl: grainData.RecordingData.PublicURL,
 	}
 
 	if grainData.RecordingData.StartDatetime.IsZero() {
-		event.Timestamp = utils.NowPtr()
+		event.Timestamp = utils.Now()
 	} else {
-		event.Timestamp = utils.TimePtr(grainData.RecordingData.StartDatetime.UTC())
+		event.Timestamp = grainData.RecordingData.StartDatetime.UTC()
 	}
 
 	pubErr := h.services.CommonServices.Events.Publisher.PublishFanoutEvent(ctx, meetingID, model.MEETING, event)

--- a/packages/server/customer-os-common-module/dto/new_meeting_recording.go
+++ b/packages/server/customer-os-common-module/dto/new_meeting_recording.go
@@ -2,16 +2,15 @@ package dto
 
 import (
 	"encoding/json"
-	"time"
-
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
+	"time"
 )
 
 type NewMeetingRecording struct {
 	MeetingTitle        string      `json:"meetingTitle,omitempty"`
-	ParticipantEmails   *[]string   `json:"meetingParticipantEmails,omitempty"`
-	Content             *string     `json:"meetingContent,omitempty"`
-	Timestamp           *time.Time  `json:"meetingTimestamp,omitempty"`
+	ParticipantEmails   []string    `json:"meetingParticipantEmails,omitempty" `
+	Content             string      `json:"meetingContent,omitempty"`
+	Timestamp           time.Time   `json:"meetingTimestamp,omitempty"`
 	Source              enum.Source `json:"meetingSource,omitempty"`
 	MeetingRecordingUrl string      `json:"meetingRecordingUrl"`
 }

--- a/packages/server/customer-os-common-module/services/agent_listeners/listener_new_meeting_recording.go
+++ b/packages/server/customer-os-common-module/services/agent_listeners/listener_new_meeting_recording.go
@@ -2,7 +2,6 @@ package agent_listeners
 
 import (
 	"context"
-
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 	"github.com/opentracing/opentracing-go"

--- a/packages/server/customer-os-common-module/services/agent_listeners/listener_new_meeting_recording.go
+++ b/packages/server/customer-os-common-module/services/agent_listeners/listener_new_meeting_recording.go
@@ -121,7 +121,7 @@ func (l *NewMeetingRecordingListener) Handle(ctx context.Context, baseEvent any)
 		return err
 	}
 
-	if data.Content == nil {
+	if data.Content == "" {
 		err := errors.New("No meeting content")
 		tracing.TraceErr(span, err)
 		return err

--- a/packages/server/customer-os-common-module/services/events/listener.go
+++ b/packages/server/customer-os-common-module/services/events/listener.go
@@ -2,9 +2,9 @@ package events
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 
-	"github.com/mitchellh/mapstructure"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
@@ -98,9 +98,24 @@ func DecodeEventData[T any](ctx context.Context, event *dto.Event) (T, error) {
 	tracing.SetDefaultListenerSpanTags(ctx, span)
 
 	var decoded T
-	if err := mapstructure.Decode(event.Event.Data, &decoded); err != nil {
-		err = errors.Wrap(err, "failed to decode event data")
-		tracing.LogObjectAsJson(span, "event", event)
+
+	bytes, ok := event.Event.Data.(map[string]interface{})
+	if !ok {
+		err := errors.New("failed to cast event data to map[string]interface{}")
+		tracing.TraceErr(span, err)
+		return decoded, err
+	}
+
+	// Convert map[string]interface{} to JSON bytes
+	jsonBytes, err := json.Marshal(bytes)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return decoded, err
+	}
+
+	// Now unmarshal the JSON bytes into the target struct or map
+	err = json.Unmarshal(jsonBytes, &decoded)
+	if err != nil {
 		tracing.TraceErr(span, err)
 		return decoded, err
 	}

--- a/packages/server/events-subscribers/events_subscribers_main.go
+++ b/packages/server/events-subscribers/events_subscribers_main.go
@@ -256,6 +256,13 @@ func (a *App) initializeListeners() error {
 		a.deps.CommonServices.AgentRunnerService,
 	))
 
+	// fathom and grain listeners
+	a.events.Subscriber.RegisterListener(common_agent_listeners.NewNewMeetingRecordingListener(
+		a.logger,
+		a.deps.PostgresRepositories,
+		a.deps.CommonServices.AgentRunnerService,
+	))
+
 	return nil
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve Fathom and Grain meeting recording event handling by updating data processing, validation, and listener registration.
> 
>   - **Behavior**:
>     - In `fathom.go` and `grain.go`, remove pointer usage for `Content` and `ParticipantEmails` in `publishFathomMeetingSummaryCreatedEvent()` and `publishGrainMeetingSummaryCreatedEvent()`.
>     - Replace `utils.NowPtr()` with `utils.Now()` for `Timestamp` in both functions.
>     - Add `NewNewMeetingRecordingListener` registration in `events_subscribers_main.go`.
>   - **Models**:
>     - In `new_meeting_recording.go`, change `ParticipantEmails` and `Content` from pointers to values in `NewMeetingRecording`.
>   - **Listeners**:
>     - In `listener_new_meeting_recording.go`, update `Handle()` to check for empty `Content` and `ParticipantEmails`.
>     - In `listener.go`, replace `mapstructure.Decode` with JSON marshaling/unmarshaling in `DecodeEventData()`.
>   - **Misc**:
>     - Remove unused imports in `fathom.go` and `grain.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f4658e379492f90a87ec2257f10f9e4560f31389. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->