### PR TITLE
stats in api

### DIFF
--- a/packages/server/customer-os-api/graphql/resolver/agent.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/agent.resolvers.go
@@ -8,14 +8,15 @@ import (
 	"context"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
-	"github.com/customeros/customeros/packages/server/customer-os-api/mapper"
-	enummapper "github.com/customeros/customeros/packages/server/customer-os-api/mapper/enum"
-	"github.com/customeros/customeros/packages/server/customer-os-api/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
+
+	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
+	"github.com/customeros/customeros/packages/server/customer-os-api/mapper"
+	enummapper "github.com/customeros/customeros/packages/server/customer-os-api/mapper/enum"
+	"github.com/customeros/customeros/packages/server/customer-os-api/tracing"
 )
 
 // AgentSave is the resolver for the agent_Save field.
@@ -161,6 +162,12 @@ func (r *queryResolver) Agents(ctx context.Context) ([]*model.Agent, error) {
 		agent := mapper.MapAgentToModel(agentEntity)
 		agent.Goal = (*agentInfo)[agentEntity.Type].Goal
 		agent.Description = (*agentInfo)[agentEntity.Type].Description
+		metric, err := r.Services.CommonServices.AgentService.GetNorthStarMetricById(ctx, agent.ID, agentEntity.Type)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return nil, err
+		}
+		agent.Metric = metric
 		agents = append(agents, agent)
 	}
 	return agents, nil
@@ -173,13 +180,29 @@ func (r *queryResolver) Agent(ctx context.Context, id string) (*model.Agent, err
 	tracing.SetDefaultResolverSpanTags(ctx, span)
 	span.LogKV("id", id)
 
+	agentInfo, err := r.Services.CommonServices.AgentService.GetAgentInfo(ctx)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+
 	agentEntity, err := r.Services.CommonServices.AgentService.GetAgentById(ctx, id)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		graphql.AddErrorf(ctx, "Failed to get agent")
 		return nil, nil
 	}
-	return mapper.MapAgentToModel(agentEntity), nil
+	agent := mapper.MapAgentToModel(agentEntity)
+	agent.Goal = (*agentInfo)[agentEntity.Type].Goal
+	agent.Description = (*agentInfo)[agentEntity.Type].Description
+	metric, err := r.Services.CommonServices.AgentService.GetNorthStarMetricById(ctx, agent.ID, agentEntity.Type)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+	agent.Metric = metric
+
+	return agent, nil
 }
 
 // SlackChannelsWithBot is the resolver for the slackChannelsWithBot field.

--- a/packages/server/customer-os-common-module/interfaces/agent.go
+++ b/packages/server/customer-os-common-module/interfaces/agent.go
@@ -20,6 +20,7 @@ type AgentService interface {
 
 	CreateAgentExecutionRecord(ctx context.Context, agent postgres_entity.Agent, triggerEvent, traceId string) (string, error)
 	GetAgentInfo(ctx context.Context) (*map[enum.AgentType]AgentInfo, error)
+	GetNorthStarMetricById(ctx context.Context, agentID string, agentType enum.AgentType) (string, error)
 }
 
 type AgentRegistry interface {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add North Star metric retrieval to `Agents` and `Agent` resolvers in GraphQL API, with support in `AgentService` interface.
> 
>   - **GraphQL Resolvers**:
>     - Update `Agents` and `Agent` resolvers in `agent.resolvers.go` to fetch and include North Star metric for each agent.
>   - **Interfaces**:
>     - Add `GetNorthStarMetricById` method to `AgentService` interface in `agent.go` to retrieve North Star metric by agent ID and type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f3baf7d29da948e0ef87777d8ac1014213b89590. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->