### PR TITLE
propagate skuId on new version, and validate sku id

### DIFF
--- a/packages/server/customer-os-common-module/data_fields/service_line_item_fields.go
+++ b/packages/server/customer-os-common-module/data_fields/service_line_item_fields.go
@@ -22,3 +22,7 @@ type SLIFields struct {
 	ParentId   *string               `json:"parentId,omitempty"`
 	NewVersion *bool                 `json:"newVersion,omitempty"`
 }
+
+func (s *SLIFields) IsNewVersion() bool {
+	return s.NewVersion != nil && *s.NewVersion
+}

--- a/packages/server/customer-os-common-module/services/init.go
+++ b/packages/server/customer-os-common-module/services/init.go
@@ -237,7 +237,7 @@ func InitCommonServices(
 	orgImpl := organization.NewOrganizationService(log, postgresRepositories, neo4jRepositories, eventsImpl, domainImpl, industryImpl, socialImpl, userImpl, currencyImpl)
 	contractImpl := contract.NewContractService(log, neo4jRepositories, eventsImpl, nil, orgImpl)
 	opportunityImpl := opportunity.NewOpportunityService(log, neo4jRepositories, eventsImpl, contractImpl, orgImpl, tenantSettingsImpl)
-	sliImpl := sli.NewServiceLineItemService(log, eventsImpl, neo4jRepositories, contractImpl)
+	sliImpl := sli.NewServiceLineItemService(log, eventsImpl, neo4jRepositories, postgresRepositories, contractImpl)
 	invoiceImpl := invoice.NewInvoiceService(log, neo4jRepositories, postgresRepositories, &cfg.External, &cfg.Internal, eventsImpl, contractImpl, sliImpl, tenantSettingsImpl, postmarkImpl, fileImpl, externalSystemImpl)
 	logEntry := logentry.NewLogEntryService(log, neo4jRepositories, eventsImpl, orgImpl)
 	mailboxImpl := mailbox.NewMailboxService(log, postgresRepositories, neo4jRepositories, emailImpl)

--- a/packages/server/customer-os-common-module/services/service_line_item/service.go
+++ b/packages/server/customer-os-common-module/services/service_line_item/service.go
@@ -3,6 +3,7 @@ package sli
 import (
 	"context"
 	"fmt"
+	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 	"strconv"
 	"time"
 
@@ -44,14 +45,16 @@ type serviceLineItemService struct {
 	log      logger.Logger
 	events   *events.EventsService
 	neo4j    *neo4j_repository.Repositories
+	postgres *postgres_repository.Repositories
 	contract interfaces.ContractService
 }
 
-func NewServiceLineItemService(log logger.Logger, events *events.EventsService, neo4j *neo4j_repository.Repositories, contract interfaces.ContractService) interfaces.ServiceLineItemService {
+func NewServiceLineItemService(log logger.Logger, events *events.EventsService, neo4j *neo4j_repository.Repositories, postgres *postgres_repository.Repositories, contract interfaces.ContractService) interfaces.ServiceLineItemService {
 	return &serviceLineItemService{
 		log:      log,
 		events:   events,
 		neo4j:    neo4j,
+		postgres: postgres,
 		contract: contract,
 	}
 }
@@ -87,24 +90,6 @@ func (s *serviceLineItemService) Save(ctx context.Context, txWithPostCommit *uti
 		createFlow = true
 		span.LogKV("flow", "create")
 
-		// prepare missing fields
-		if dataFields.CreatedAt == nil || dataFields.CreatedAt.IsZero() {
-			dataFields.CreatedAt = utils.NowPtr()
-		}
-		if dataFields.StartedAt == nil || dataFields.StartedAt.IsZero() {
-			dataFields.StartedAt = utils.NowPtr()
-		}
-		if utils.IfNotNilString(dataFields.Source) == "" {
-			dataFields.Source = utils.StringPtr(neo4jentity.DataSourceOpenline.String())
-		}
-		if utils.IfNotNilString(dataFields.AppSource) == "" {
-			dataFields.AppSource = utils.StringPtr(common.GetAppSourceFromContext(ctx))
-		}
-		if utils.IfNotNilFloat64(dataFields.TaxRate) < 0 {
-			dataFields.TaxRate = utils.Float64Ptr(0)
-		}
-		dataFields.TaxRate = utils.Float64Ptr(utils.TruncateFloat64(utils.IfNotNilFloat64(dataFields.TaxRate), 2))
-
 		// validate data
 		if utils.IfNotNilInt64(dataFields.Quantity) < 0 {
 			err = errors.New("quantity cannot be negative")
@@ -128,6 +113,64 @@ func (s *serviceLineItemService) Save(ctx context.Context, txWithPostCommit *uti
 			exists, err := s.neo4j.CommonReadRepository.ExistsById(ctx, tenant, *dataFields.ContractId, model.NodeLabelContract)
 			if err != nil || !exists {
 				err = errors.New("contract not found")
+				tracing.TraceErr(span, err)
+				return "", err
+			}
+		}
+
+		if dataFields.IsNewVersion() && utils.IfNotNilString(dataFields.ParentId) == "" {
+			err = errors.New("parentId is required for new version")
+			tracing.TraceErr(span, err)
+			return "", err
+		}
+
+		// prepare missing fields
+		if dataFields.CreatedAt == nil || dataFields.CreatedAt.IsZero() {
+			dataFields.CreatedAt = utils.NowPtr()
+		}
+		if dataFields.StartedAt == nil || dataFields.StartedAt.IsZero() {
+			dataFields.StartedAt = utils.NowPtr()
+		}
+		if utils.IfNotNilString(dataFields.Source) == "" {
+			dataFields.Source = utils.StringPtr(neo4jentity.DataSourceOpenline.String())
+		}
+		if utils.IfNotNilString(dataFields.AppSource) == "" {
+			dataFields.AppSource = utils.StringPtr(common.GetAppSourceFromContext(ctx))
+		}
+		if utils.IfNotNilFloat64(dataFields.TaxRate) < 0 {
+			dataFields.TaxRate = utils.Float64Ptr(0)
+		}
+		dataFields.TaxRate = utils.Float64Ptr(utils.TruncateFloat64(utils.IfNotNilFloat64(dataFields.TaxRate), 2))
+
+		// set sku id from previous version
+		if dataFields.IsNewVersion() {
+			parentEntities, err := s.GetServiceLineItemsByParentId(ctx, *dataFields.ParentId)
+			if err != nil {
+				tracing.TraceErr(span, err)
+				return "", err
+			}
+			for _, parentEntity := range *parentEntities {
+				if parentEntity.SkuId != "" {
+					dataFields.SkuId = utils.StringPtr(parentEntity.SkuId)
+					break
+				}
+			}
+		}
+
+		// validate sku id exists
+		if utils.IfNotNilString(dataFields.SkuId) != "" {
+			sku, err := s.postgres.SkuRepository.Get(ctx, tenant, *dataFields.SkuId)
+			if err != nil {
+				tracing.TraceErr(span, err)
+				return "", err
+			}
+			if sku == nil {
+				err = errors.New("sku not found")
+				tracing.TraceErr(span, err)
+				return "", err
+			}
+			if sku.Archived && !dataFields.IsNewVersion() {
+				err = errors.New("sku is archived")
 				tracing.TraceErr(span, err)
 				return "", err
 			}
@@ -262,7 +305,7 @@ func (s *serviceLineItemService) Save(ctx context.Context, txWithPostCommit *uti
 					}
 					if dataFields.BilledType.IsRecurrent() {
 						message := userName
-						if dataFields.NewVersion != nil && *dataFields.NewVersion {
+						if dataFields.IsNewVersion() {
 							message += " updated recurring service for "
 						} else {
 							message += " added a recurring service to "


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `ServiceLineItemService` to validate and propagate `skuId` for new versions, ensuring correct handling and validation of SKU IDs.
> 
>   - **Behavior**:
>     - In `service.go`, `Save()` now validates `skuId` existence and checks if it's archived when not a new version.
>     - Propagates `skuId` from parent for new versions in `Save()`.
>     - Requires `parentId` for new versions in `Save()`.
>   - **Services**:
>     - `NewServiceLineItemService()` in `service.go` now includes `postgres` repository for SKU validation.
>     - `InitCommonServices()` in `init.go` updated to pass `postgresRepositories` to `NewServiceLineItemService()`.
>   - **Models**:
>     - Adds `IsNewVersion()` method to `SLIFields` in `service_line_item_fields.go` to check if a service line item is a new version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 60ff49d9d3e51cad9434aa11bac5cb8eb6ada224. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->