### PR TITLE
fix meeting keeper

### DIFF
--- a/packages/server/customer-os-api/rest/integrations/fathom.go
+++ b/packages/server/customer-os-api/rest/integrations/fathom.go
@@ -2,6 +2,9 @@ package integrations
 
 import (
 	"context"
+	"net/http"
+	"strings"
+
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/dto"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
@@ -11,9 +14,8 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/mailsherpa/mailvalidate"
 	"github.com/gin-gonic/gin"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
-	"net/http"
-	"strings"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
 )
@@ -50,7 +52,7 @@ func (h *IntegrationHandler) FathomZapier(c *gin.Context, tenant string) {
 }
 
 func (h *IntegrationHandler) handleFathomAISummaryZapier(c *gin.Context, ctx context.Context) {
-	span, _ := commontracing.StartTracerSpan(c.Request.Context(), "Flows.handleFathomAISummaryZapier")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Integrations.handleFathomAISummaryZapier")
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
 
@@ -69,7 +71,18 @@ func (h *IntegrationHandler) handleFathomAISummaryZapier(c *gin.Context, ctx con
 		h.responseHandler.HandleError(c, http.StatusNotFound, &message)
 		return
 	}
-	ctx = common.SetUserEmailInContext(ctx, email)
+	userId, err := h.GetCustomerOSUser(ctx, []string{email})
+	if err != nil {
+		message := "User not found"
+		h.responseHandler.HandleError(c, http.StatusNotFound, &message)
+		return
+	}
+	if userId == "" {
+		h.responseHandler.HandleError(c, http.StatusUnauthorized, nil)
+		return
+	}
+	span.LogKV("userId", userId)
+	ctx = common.SetUserIdInContext(ctx, userId)
 
 	aiSummaryData := &aiSummaryDataPayload
 	err = aiSummaryData.toCleanPayload()
@@ -96,7 +109,7 @@ func (h *IntegrationHandler) handleFathomAISummaryZapier(c *gin.Context, ctx con
 }
 
 func (h *IntegrationHandler) publishFathomMeetingSummaryCreatedEvent(c *gin.Context, ctx context.Context, aiSummaryData *FathomZapierPayload) error {
-	span, _ := commontracing.StartTracerSpan(c.Request.Context(), "Flows.publishFathomMeetingSummaryCreatedEvent")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Integrations.publishFathomMeetingSummaryCreatedEvent")
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
 

--- a/packages/server/customer-os-api/rest/integrations/grain.go
+++ b/packages/server/customer-os-api/rest/integrations/grain.go
@@ -15,13 +15,14 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/mailsherpa/mailvalidate"
 	"github.com/gin-gonic/gin"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
 )
 
 func (h *IntegrationHandler) GrainZapier(c *gin.Context, tenant string) {
-	ctx, span := commontracing.StartHttpServerTracerSpanWithHeader(c.Request.Context(), "Flows.Grain", c.Request.Header)
+	ctx, span := commontracing.StartHttpServerTracerSpanWithHeader(c.Request.Context(), "Integrations.Grain", c.Request.Header)
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
 	tracing.TagTenant(span, tenant)
@@ -49,7 +50,7 @@ func (h *IntegrationHandler) GrainZapier(c *gin.Context, tenant string) {
 }
 
 func (h *IntegrationHandler) handleGrainNewRecordingEventZapier(c *gin.Context, ctx context.Context) {
-	span, _ := commontracing.StartTracerSpan(c.Request.Context(), "Flows.handleGrainNewRecorderEventZapier")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Integrations.handleGrainNewRecorderEventZapier")
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
 
@@ -75,13 +76,20 @@ func (h *IntegrationHandler) handleGrainNewRecordingEventZapier(c *gin.Context, 
 		return
 	}
 
-	userEmail, err := h.getCustomerOSUser(ctx, grainData.RecordingData.Owners)
+	userID, err := h.GetCustomerOSUser(ctx, grainData.RecordingData.Owners)
 	if err != nil {
 		message := "User not found"
 		h.responseHandler.HandleError(c, http.StatusNotFound, &message)
 		return
 	}
-	ctx = common.SetUserEmailInContext(ctx, userEmail)
+	if userID == "" {
+		message := "User not found"
+		h.responseHandler.HandleError(c, http.StatusNotFound, &message)
+		return
+	}
+
+	span.LogKV("userId", userID)
+	ctx = common.SetUserIdInContext(ctx, userID)
 
 	h.responseHandler.HandleAccepted(c)
 
@@ -93,8 +101,8 @@ func (h *IntegrationHandler) handleGrainNewRecordingEventZapier(c *gin.Context, 
 	return
 }
 
-func (h *IntegrationHandler) getCustomerOSUser(ctx context.Context, meetingOwners []string) (string, error) {
-	span, _ := commontracing.StartTracerSpan(ctx, "Flows.getCustomerOSUser")
+func (h *IntegrationHandler) GetCustomerOSUser(ctx context.Context, meetingOwners []string) (string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Integrations.getCustomerOSUser")
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
 
@@ -110,14 +118,14 @@ func (h *IntegrationHandler) getCustomerOSUser(ctx context.Context, meetingOwner
 		}
 		user, _ := h.services.CommonServices.UserService.FindUserByEmail(ctx, email)
 		if user != nil && user.Id != "" {
-			return owner, nil
+			return user.Id, nil
 		}
 	}
 	return "", coserrors.ErrCannotIdentifyUser
 }
 
 func (h *IntegrationHandler) publishGrainMeetingSummaryCreatedEvent(c *gin.Context, ctx context.Context, grainData *GrainRecordingData) error {
-	span, _ := commontracing.StartTracerSpan(c.Request.Context(), "Flows.publishGrainMeetingSummaryEvent")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Integrations.publishGrainMeetingSummaryCreatedEvent")
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
 

--- a/packages/server/customer-os-api/rest/integrations/grain.go
+++ b/packages/server/customer-os-api/rest/integrations/grain.go
@@ -50,7 +50,7 @@ func (h *IntegrationHandler) GrainZapier(c *gin.Context, tenant string) {
 }
 
 func (h *IntegrationHandler) handleGrainNewRecordingEventZapier(c *gin.Context, ctx context.Context) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Integrations.handleGrainNewRecorderEventZapier")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Integrations.handleGrainNewRecordingEventZapier")
 	defer span.Finish()
 	commontracing.TagComponentRest(span)
 

--- a/packages/server/customer-os-api/rest/webhooks/admin.go
+++ b/packages/server/customer-os-api/rest/webhooks/admin.go
@@ -2,7 +2,6 @@ package webhooks
 
 import (
 	"fmt"
-	"github.com/opentracing/opentracing-go/log"
 	"net/http"
 	"strings"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/gin-gonic/gin"
-	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/rest/integrations"
 	"github.com/customeros/customeros/packages/server/customer-os-api/rest/response"
@@ -272,51 +270,6 @@ func (h *WebhookHandler) DeactivateWebhook(baseURL, apiPath string) gin.HandlerF
 		h.responseHandler.HandleSuccess(c, NoActiveWebhooks{
 			Message: "Webhook successfully deactivated",
 		})
-	}
-}
-
-func (h *WebhookHandler) HandleWebhook(flowsPath string) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		ctx, span := tracing.StartHttpServerTracerSpanWithHeader(c.Request.Context(), "Webhooks", c.Request.Header)
-		defer span.Finish()
-		tracing.TagComponentRest(span)
-
-		span.LogFields(log.String("param.tenantHash", c.Param("tenantHash")))
-
-		tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenantByHashId(ctx, c.Param("tenantHash"))
-		if err != nil {
-			err := errors.Wrap(err, "Unable to identify tenant")
-			tracing.TraceErr(span, err)
-			h.responseHandler.HandleError(c, http.StatusUnauthorized, nil)
-			return
-		}
-
-		webhookPath := strings.TrimPrefix(c.Request.URL.Path, flowsPath)
-		integration, err := h.services.CommonServices.WebhookService.GetIntegrationFromWebhookPath(ctx, tenant, webhookPath)
-		if err != nil {
-			message := "Webhook not found"
-			h.responseHandler.HandleError(c, http.StatusNotFound, &message)
-			return
-		}
-		span.LogKV("result.integration", integration.String())
-
-		switch integration {
-		case commonEnum.SourceCalCom:
-			h.integrationsHandler.CalDotCom(c, tenant)
-		// todo
-		case commonEnum.SourceFathom:
-			h.integrationsHandler.FathomZapier(c, tenant)
-		case commonEnum.SourceGrain:
-			h.integrationsHandler.GrainZapier(c, tenant)
-		case commonEnum.SourcePostmark:
-			h.integrationsHandler.PostmarkInboundEmail(c)
-		// todo
-		default:
-			err := errors.New("Unsupported integration")
-			tracing.TraceErr(span, err)
-			h.responseHandler.HandleError(c, http.StatusNotFound, nil)
-			return
-		}
 	}
 }
 

--- a/packages/server/customer-os-api/rest/webhooks/handle.go
+++ b/packages/server/customer-os-api/rest/webhooks/handle.go
@@ -1,0 +1,57 @@
+package webhooks
+
+import (
+	"net/http"
+	"strings"
+
+	commonEnum "github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/gin-gonic/gin"
+	"github.com/opentracing/opentracing-go/log"
+	"github.com/pkg/errors"
+)
+
+func (h *WebhookHandler) HandleWebhook(flowsPath string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartHttpServerTracerSpanWithHeader(c.Request.Context(), "Webhooks", c.Request.Header)
+		defer span.Finish()
+		tracing.TagComponentRest(span)
+
+		span.LogFields(log.String("param.tenantHash", c.Param("tenantHash")))
+
+		tenant, err := h.services.Repositories.PostgresRepositories.TenantRepository.GetTenantByHashId(ctx, c.Param("tenantHash"))
+		if err != nil {
+			err := errors.Wrap(err, "Unable to identify tenant")
+			tracing.TraceErr(span, err)
+			h.responseHandler.HandleError(c, http.StatusUnauthorized, nil)
+			return
+		}
+
+		webhookPath := strings.TrimPrefix(c.Request.URL.Path, flowsPath)
+		integration, err := h.services.CommonServices.WebhookService.GetIntegrationFromWebhookPath(ctx, tenant, webhookPath)
+		if err != nil {
+			message := "Webhook not found"
+			h.responseHandler.HandleError(c, http.StatusNotFound, &message)
+			return
+		}
+		span.LogKV("result.integration", integration.String())
+
+		switch integration {
+		case commonEnum.SourceCalCom:
+			h.integrationsHandler.CalDotCom(c, tenant)
+		// todo
+		case commonEnum.SourceFathom:
+			h.integrationsHandler.FathomZapier(c, tenant)
+		case commonEnum.SourceGrain:
+			h.integrationsHandler.GrainZapier(c, tenant)
+		case commonEnum.SourcePostmark:
+			h.integrationsHandler.PostmarkInboundEmail(c)
+		// todo
+		default:
+			err := errors.New("Unsupported integration")
+			tracing.TraceErr(span, err)
+			h.responseHandler.HandleError(c, http.StatusNotFound, nil)
+			return
+		}
+	}
+}

--- a/packages/server/customer-os-common-module/common/context.go
+++ b/packages/server/customer-os-common-module/common/context.go
@@ -80,9 +80,9 @@ func SetAppSourceInContext(ctx context.Context, appSource string) context.Contex
 	return WithCustomContext(ctx, customContext)
 }
 
-func SetUserEmailInContext(ctx context.Context, userEmail string) context.Context {
+func SetUserIdInContext(ctx context.Context, userId string) context.Context {
 	customContext := GetContext(ctx)
-	customContext.UserEmail = userEmail
+	customContext.UserId = userId
 	return WithCustomContext(ctx, customContext)
 }
 

--- a/packages/server/customer-os-common-module/coserrors/errors.go
+++ b/packages/server/customer-os-common-module/coserrors/errors.go
@@ -6,8 +6,8 @@ import (
 
 var (
 	// context errors
-	ErrUserEmailNotSet = errors.New("User email not set")
-	ErrTenantNotSet    = errors.New("Tenant not set")
+	ErrUserIDNotSet = errors.New("UserID not set")
+	ErrTenantNotSet = errors.New("Tenant not set")
 
 	ErrAccessDenied        = errors.New("Access denied")
 	ErrInvalidEntityType   = errors.New("Invalid entity type")

--- a/packages/server/customer-os-common-module/services/agent_listeners/listener_new_meeting_recording.go
+++ b/packages/server/customer-os-common-module/services/agent_listeners/listener_new_meeting_recording.go
@@ -2,6 +2,7 @@ package agent_listeners
 
 import (
 	"context"
+
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 	"github.com/opentracing/opentracing-go"
@@ -103,8 +104,8 @@ func (l *NewMeetingRecordingListener) Handle(ctx context.Context, baseEvent any)
 		return err
 	}
 
-	if common.GetUserEmailFromContext(ctx) == "" {
-		err := coserrors.ErrUserEmailNotSet
+	if common.GetUserIdFromContext(ctx) == "" {
+		err := coserrors.ErrUserIDNotSet
 		tracing.TraceErr(span, err)
 		return err
 	}

--- a/packages/server/customer-os-postgres-repository/repository/agents_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agents_repository.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/opentracing/opentracing-go"
@@ -231,11 +232,14 @@ func (f *agentsRepository) GetActiveConfiguredAgentsByUserAndType(ctx context.Co
 	tracing.TagComponentPostgresRepository(span)
 
 	tenant := common.GetTenantFromContext(ctx)
+	if tenant == "" {
+		tracing.TraceErr(span, coserrors.ErrTenantNotSet)
+		return nil, coserrors.ErrTenantNotSet
+	}
 	user := common.GetUserIdFromContext(ctx)
-	if tenant == "" || user == "" {
-		err := errors.New("tenant or userEmail not set")
-		tracing.TraceErr(span, err)
-		return nil, err
+	if user == "" {
+		tracing.TraceErr(span, coserrors.ErrUserIDNotSet)
+		return nil, coserrors.ErrUserIDNotSet
 	}
 
 	var records []postgres_entity.Agent


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor user identification and webhook handling to use `userId` context, improve error handling, and enhance tracing in integrations and webhooks.
> 
>   - **Behavior**:
>     - Updated `handleFathomAISummaryZapier` and `handleGrainNewRecordingEventZapier` to use `userId` instead of `userEmail` for context in `fathom.go` and `grain.go`.
>     - Added error handling for missing `userId` in `listener_new_meeting_recording.go` and `agents_repository.go`.
>     - Improved webhook handling by moving `HandleWebhook` to `handle.go` and renaming `webhooks.go` to `admin.go`.
>   - **Context Management**:
>     - Replaced `SetUserEmailInContext` with `SetUserIdInContext` in `context.go`.
>     - Updated `GetCustomerOSUser` to return `userId` in `grain.go`.
>   - **Error Handling**:
>     - Introduced `ErrUserIDNotSet` in `errors.go`.
>     - Updated error messages to reflect `userId` usage in `agents_repository.go`.
>   - **Tracing**:
>     - Replaced `commontracing.StartTracerSpan` with `opentracing.StartSpanFromContext` in `fathom.go` and `grain.go` for better context propagation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 585dc4fe50423cec62fa248ba15340ce4ef012de. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->