### PR TITLE
Stop workspace visit early

### DIFF
--- a/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
@@ -306,7 +306,7 @@ func (a *agentRunnerService) handleExecutionResult(ctx context.Context, params c
 		checkpointData := map[string]any{
 			"status":       status.String(),
 			"output":       output,
-			"completed_at": time.Now().UTC(),
+			"completed_at": utils.Now(),
 		}
 		if err := a.postgresRepositories.AgentExecutionRepository.CompleteStep(ctx, params.executionID, params.capabilityTypeStr, checkpointData); err != nil {
 			tracing.TraceErr(span, err)
@@ -317,7 +317,7 @@ func (a *agentRunnerService) handleExecutionResult(ctx context.Context, params c
 		checkpointData := map[string]any{
 			"status":     status.String(),
 			"output":     output,
-			"stopped_at": time.Now().UTC(),
+			"stopped_at": utils.Now(),
 		}
 		if err := a.postgresRepositories.AgentExecutionRepository.CompleteStep(ctx, params.executionID, params.capabilityTypeStr, checkpointData); err != nil {
 			tracing.TraceErr(span, err)

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
@@ -78,7 +78,7 @@ func (c *AnalyzeWebSessionCapability) ValidateInput(data AnalyzeWebSessionInput)
 	return nil
 }
 
-func (c *AnalyzeWebSessionCapability) ValidateConfig(config postgres_entity.NoConfig) error {
+func (c *AnalyzeWebSessionCapability) ValidateConfig(postgres_entity.NoConfig) error {
 	return nil
 }
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
@@ -154,7 +154,7 @@ func (c *IdentifyWebsiteVisitorCapability) Execute(ctx context.Context, executio
 		if err != nil {
 			tracing.TraceErr(span, err)
 		}
-		return enum.CapabilityExecutionCompleted, result, nil
+		return enum.CapabilityExecutionStop, result, nil
 	}
 
 	err = c.publishWebVisitorIdentifiedEvent(ctx, executionContainer.AgentExecutionID)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `analyzeWebSessionForSupport` functionality and related cron jobs, DTOs, and enums, while refactoring invoicing-related files.
> 
>   - **Cron Jobs**:
>     - Removed `CronScheduleAnalyzeWebSessionsForSupport` from `config.go` and `cron.go`.
>     - Deleted `analyzeWebSessionForSupport()` function in `cron.go`.
>   - **DTOs**:
>     - Removed `NewSupportVisit` struct and its usage in `new_support_visit.go`.
>     - Added `Name()` method to `InvoicePaid`, `PastDueInvoice`, and `InvoiceVoided` in their respective files.
>   - **Enums**:
>     - Removed `EventNewSupportVisit` from `agent_listeners.go`.
>   - **Agent Capabilities**:
>     - Removed event publishing in `capability_analyze_web_session.go` and `capability_apply_tag_to_company.go`.
>     - Changed return status to `CapabilityExecutionStop` in `capability_identify_web_visitor.go` for workspace domains.
>   - **Miscellaneous**:
>     - Renamed `invoicing_start.go` to `invoicing_run.go` and `invoicing_start_with_autopayment.go` to `invoicing_run_with_autopayment.go`.
>     - Updated `handleExecutionResult()` in `agent_runner_service.go` to use `utils.Now()` instead of `time.Now().UTC()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 5ca00a4eb26f84d24ad6132c07ac1e9d7628eb70. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->