### PR TITLE
fix tenant email parsing

### DIFF
--- a/packages/server/customer-os-api/rest/integrations/fathom.go
+++ b/packages/server/customer-os-api/rest/integrations/fathom.go
@@ -128,6 +128,7 @@ func (h *IntegrationHandler) publishFathomMeetingSummaryCreatedEvent(c *gin.Cont
 		ParticipantEmails:   participants,
 		MeetingRecordingUrl: aiSummaryData.Recording.ShareURL,
 	}
+	event.ParticipantEmails = append(event.ParticipantEmails, aiSummaryData.FathomUser.Email)
 
 	if aiSummaryData.Meeting.ScheduledStartTime.IsZero() {
 		event.Timestamp = utils.Now()

--- a/packages/server/customer-os-api/rest/integrations/fathom.go
+++ b/packages/server/customer-os-api/rest/integrations/fathom.go
@@ -128,7 +128,7 @@ func (h *IntegrationHandler) publishFathomMeetingSummaryCreatedEvent(c *gin.Cont
 		ParticipantEmails:   participants,
 		MeetingRecordingUrl: aiSummaryData.Recording.ShareURL,
 	}
-	event.ParticipantEmails = append(event.ParticipantEmails, aiSummaryData.FathomUser.Email)
+	if !contains(event.ParticipantEmails, aiSummaryData.FathomUser.Email) { event.ParticipantEmails = append(event.ParticipantEmails, aiSummaryData.FathomUser.Email) }
 
 	if aiSummaryData.Meeting.ScheduledStartTime.IsZero() {
 		event.Timestamp = utils.Now()

--- a/packages/server/customer-os-api/rest/integrations/grain_model.go
+++ b/packages/server/customer-os-api/rest/integrations/grain_model.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/customeros/mailsherpa/mailvalidate"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	"github.com/customeros/mailsherpa/mailvalidate"
 )
 
 // RecordingRes the top-level response structure
@@ -49,7 +49,9 @@ func (g *GrainRecording) participantEmails() []string {
 	emails := make([]string, len(g.Participants))
 
 	for v, participant := range g.Participants {
-		emails[v] = *participant.Email
+		if participant.Email != nil {
+			emails[v] = *participant.Email
+		}
 	}
 	return emails
 }

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_identify_meeting_participants.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_identify_meeting_participants.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
+	"github.com/customeros/mailsherpa/mailvalidate"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
@@ -95,7 +96,8 @@ func (c *IdentifyMeetingParticipantsCapability) Execute(ctx context.Context, exe
 	}
 
 	for _, email := range executionContainer.InputData.MeetingParticipantEmails {
-		if utils.IsStringInSlice(email, workspaceDomains) {
+		validation := mailvalidate.ValidateEmailSyntax(email)
+		if utils.IsStringInSlice(validation.Domain, workspaceDomains) {
 			result.MeetingParticipantEmailsTenant = append(result.MeetingParticipantEmailsTenant, email)
 		} else {
 			result.ContactEmails = append(result.ContactEmails, email)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance email parsing and validation in meeting participant handling across multiple components using `mailvalidate`.
> 
>   - **Email Parsing and Validation**:
>     - In `fathom.go`, append `aiSummaryData.FathomUser.Email` to `ParticipantEmails` in `publishFathomMeetingSummaryCreatedEvent()`.
>     - In `grain_model.go`, check for `nil` before accessing `participant.Email` in `participantEmails()`.
>     - In `capability_identify_meeting_participants.go`, use `mailvalidate.ValidateEmailSyntax()` to validate email domains in `Execute()`.
>   - **Imports**:
>     - Add `mailvalidate` import in `capability_identify_meeting_participants.go` and `grain_model.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 4c5a77d293219c679c7c93e2c15b46752ed8e13a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->