### PR TITLE
fix agent routing

### DIFF
--- a/packages/server/customer-os-api/rest/integrations/fathom.go
+++ b/packages/server/customer-os-api/rest/integrations/fathom.go
@@ -128,7 +128,9 @@ func (h *IntegrationHandler) publishFathomMeetingSummaryCreatedEvent(c *gin.Cont
 		ParticipantEmails:   participants,
 		MeetingRecordingUrl: aiSummaryData.Recording.ShareURL,
 	}
-	if !contains(event.ParticipantEmails, aiSummaryData.FathomUser.Email) { event.ParticipantEmails = append(event.ParticipantEmails, aiSummaryData.FathomUser.Email) }
+	if !utils.IsStringInSlice(aiSummaryData.FathomUser.Email, event.ParticipantEmails) {
+		event.ParticipantEmails = append(event.ParticipantEmails, aiSummaryData.FathomUser.Email)
+	}
 
 	if aiSummaryData.Meeting.ScheduledStartTime.IsZero() {
 		event.Timestamp = utils.Now()

--- a/packages/server/customer-os-api/rest/integrations/grain.go
+++ b/packages/server/customer-os-api/rest/integrations/grain.go
@@ -118,7 +118,13 @@ func (h *IntegrationHandler) GetCustomerOSUser(ctx context.Context, meetingOwner
 		}
 		user, _ := h.services.CommonServices.UserService.FindUserByEmail(ctx, email)
 		if user != nil && user.Id != "" {
-			return user.Id, nil
+			agent, err := h.services.Repositories.PostgresRepositories.AgentRepository.GetActiveConfiguredAgentsByUserAndType(ctx, []enum.AgentType{enum.AgentMeetingKeeper})
+			if agent != nil {
+				return user.Id, nil
+			}
+			if err != nil {
+				tracing.TraceErr(span, err)
+			}
 		}
 	}
 	return "", coserrors.ErrCannotIdentifyUser


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve agent routing by checking for active agents in `GetCustomerOSUser` and enhance email checking in `fathom.go`.
> 
>   - **Behavior**:
>     - In `fathom.go`, replace `contains` with `utils.IsStringInSlice` to check if `FathomUser.Email` is in `ParticipantEmails`.
>     - In `grain.go`, modify `GetCustomerOSUser` to check for active configured agents before returning `user.Id`.
>   - **Error Handling**:
>     - In `grain.go`, log errors with `tracing.TraceErr` if agent retrieval fails in `GetCustomerOSUser`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 01a13c8779a578155dbd6d89c39de6b886cdcc33. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->