### PR TITLE
add metric to save agent

### DIFF
--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -13497,6 +13497,7 @@ type Agent {
 input AgentSaveInput {
   id: ID
   type: AgentType @deprecated ## field is not update-able
+  metric: String! @deprecated ## field is not updata-able
   name: String
   capabilities: [CapabilitySaveInput!]
   listeners: [AgentListenerSaveInput!]
@@ -112810,7 +112811,7 @@ func (ec *executionContext) unmarshalInputAgentSaveInput(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "type", "name", "capabilities", "listeners", "isActive", "visible", "color", "icon"}
+	fieldsInOrder := [...]string{"id", "type", "metric", "name", "capabilities", "listeners", "isActive", "visible", "color", "icon"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -112831,6 +112832,13 @@ func (ec *executionContext) unmarshalInputAgentSaveInput(ctx context.Context, ob
 				return it, err
 			}
 			it.Type = data
+		case "metric":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("metric"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Metric = data
 		case "name":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -143,6 +143,7 @@ type AgentListenerSaveInput struct {
 type AgentSaveInput struct {
 	ID           *string                   `json:"id,omitempty"`
 	Type         *AgentType                `json:"type,omitempty"`
+	Metric       string                    `json:"metric"`
 	Name         *string                   `json:"name,omitempty"`
 	Capabilities []*CapabilitySaveInput    `json:"capabilities,omitempty"`
 	Listeners    []*AgentListenerSaveInput `json:"listeners,omitempty"`

--- a/packages/server/customer-os-api/graphql/resolver/agent.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/agent.resolvers.go
@@ -8,14 +8,15 @@ import (
 	"context"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
-	"github.com/customeros/customeros/packages/server/customer-os-api/mapper"
-	enummapper "github.com/customeros/customeros/packages/server/customer-os-api/mapper/enum"
-	"github.com/customeros/customeros/packages/server/customer-os-api/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
+
+	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
+	"github.com/customeros/customeros/packages/server/customer-os-api/mapper"
+	enummapper "github.com/customeros/customeros/packages/server/customer-os-api/mapper/enum"
+	"github.com/customeros/customeros/packages/server/customer-os-api/tracing"
 )
 
 // AgentSave is the resolver for the agent_Save field.
@@ -121,7 +122,9 @@ func (r *mutationResolver) AgentSave(ctx context.Context, input model.AgentSaveI
 		return nil, nil
 	}
 
-	return mapper.MapAgentToModel(updatedAgentEntity), nil
+	updatedAgent := mapper.MapAgentToModel(updatedAgentEntity)
+	updatedAgent.Metric = input.Metric
+	return updatedAgent, nil
 }
 
 // AgentDelete is the resolver for the agent_Delete field.

--- a/packages/server/customer-os-api/graphql/schemas/agent.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/agent.graphqls
@@ -56,6 +56,7 @@ type Agent {
 input AgentSaveInput {
   id: ID
   type: AgentType @deprecated ## field is not update-able
+  metric: String! @deprecated ## field is not updata-able
   name: String
   capabilities: [CapabilitySaveInput!]
   listeners: [AgentListenerSaveInput!]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `metric` field to `Agent` and `AgentSaveInput`, marked as deprecated and not updateable, and update `AgentSave` resolver to handle it.
> 
>   - **GraphQL Schema**:
>     - Add `metric` field to `AgentSaveInput` and `Agent` in `agent.graphqls`, marked as deprecated and not updateable.
>   - **Models**:
>     - Add `metric` field to `Agent` and `AgentSaveInput` in `models_gen.go`.
>   - **Resolvers**:
>     - Update `AgentSave` in `agent.resolvers.go` to handle `metric` field when saving an agent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 86ec4057baabb6cf988ae12e77494e3149a62119. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->