### PR TITLE
meeting fixes

### DIFF
--- a/packages/server/customer-os-api/rest/integrations/common.go
+++ b/packages/server/customer-os-api/rest/integrations/common.go
@@ -32,11 +32,14 @@ func (h *IntegrationHandler) GetCustomerOSUser(ctx context.Context, emails []str
 		if email == "" {
 			continue
 		}
-		user, _ := h.services.CommonServices.UserService.FindUserByEmail(ctx, email)
+		user, err := h.services.CommonServices.UserService.FindUserByEmail(ctx, email)
+		if err != nil {
+			tracing.TraceErr(span, err)
+		}
 		if user != nil && user.Id != "" {
 			ctx = common.SetUserIdInContext(ctx, user.Id)
-			agent, err := h.services.Repositories.PostgresRepositories.AgentRepository.GetActiveConfiguredAgentsByUserAndType(ctx, []enum.AgentType{agent})
-			if agent != nil {
+			activeAgent, err := h.services.Repositories.PostgresRepositories.AgentRepository.GetActiveConfiguredAgentsByUserAndType(ctx, []enum.AgentType{agent})
+			if activeAgent != nil {
 				return user.Id, nil
 			}
 			if err != nil {

--- a/packages/server/customer-os-api/rest/integrations/common.go
+++ b/packages/server/customer-os-api/rest/integrations/common.go
@@ -1,13 +1,51 @@
 package integrations
 
 import (
-	"github.com/gin-gonic/gin"
-	cosapi_services "github.com/customeros/customeros/packages/server/customer-os-api/services"
+	"context"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	"github.com/customeros/mailsherpa/mailvalidate"
+	"github.com/gin-gonic/gin"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+
+	cosapi_services "github.com/customeros/customeros/packages/server/customer-os-api/services"
 )
+
+func (h *IntegrationHandler) GetCustomerOSUser(ctx context.Context, emails []string, agent enum.AgentType) (string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Integrations.getCustomerOSUser")
+	defer span.Finish()
+	tracing.TagComponentRest(span)
+
+	if len(emails) == 0 {
+		return "", coserrors.ErrCannotIdentifyUser
+	}
+
+	for _, owner := range emails {
+		validation := mailvalidate.ValidateEmailSyntax(owner)
+		email := validation.CleanEmail
+		if email == "" {
+			continue
+		}
+		user, _ := h.services.CommonServices.UserService.FindUserByEmail(ctx, email)
+		if user != nil && user.Id != "" {
+			ctx = common.SetUserIdInContext(ctx, user.Id)
+			agent, err := h.services.Repositories.PostgresRepositories.AgentRepository.GetActiveConfiguredAgentsByUserAndType(ctx, []enum.AgentType{agent})
+			if agent != nil {
+				return user.Id, nil
+			}
+			if err != nil {
+				tracing.TraceErr(span, err)
+			}
+		}
+	}
+	return "", coserrors.ErrCannotIdentifyUser
+}
 
 func getParticipantOrganizationIds(c *gin.Context, s *cosapi_services.Services, domains []string) ([]string, error) {
 	span, ctx := tracing.StartTracerSpan(c.Request.Context(), "flows.getParticipantOrganizationIds")

--- a/packages/server/customer-os-api/rest/integrations/fathom.go
+++ b/packages/server/customer-os-api/rest/integrations/fathom.go
@@ -71,7 +71,7 @@ func (h *IntegrationHandler) handleFathomAISummaryZapier(c *gin.Context, ctx con
 		h.responseHandler.HandleError(c, http.StatusNotFound, &message)
 		return
 	}
-	userId, err := h.GetCustomerOSUser(ctx, []string{email})
+	userId, err := h.GetCustomerOSUser(ctx, []string{email}, enum.AgentMeetingKeeper)
 	if err != nil {
 		message := "User not found"
 		h.responseHandler.HandleError(c, http.StatusNotFound, &message)

--- a/packages/server/customer-os-api/rest/integrations/grain.go
+++ b/packages/server/customer-os-api/rest/integrations/grain.go
@@ -6,14 +6,12 @@ import (
 	"strings"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/dto"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	commontracing "github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/customeros/mailsherpa/mailvalidate"
 	"github.com/gin-gonic/gin"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -76,7 +74,7 @@ func (h *IntegrationHandler) handleGrainNewRecordingEventZapier(c *gin.Context, 
 		return
 	}
 
-	userID, err := h.GetCustomerOSUser(ctx, grainData.RecordingData.Owners)
+	userID, err := h.GetCustomerOSUser(ctx, grainData.RecordingData.Owners, enum.AgentMeetingKeeper)
 	if err != nil {
 		message := "User not found"
 		h.responseHandler.HandleError(c, http.StatusNotFound, &message)
@@ -99,36 +97,6 @@ func (h *IntegrationHandler) handleGrainNewRecordingEventZapier(c *gin.Context, 
 		}
 	}()
 	return
-}
-
-func (h *IntegrationHandler) GetCustomerOSUser(ctx context.Context, meetingOwners []string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Integrations.getCustomerOSUser")
-	defer span.Finish()
-	commontracing.TagComponentRest(span)
-
-	if len(meetingOwners) == 0 {
-		return "", coserrors.ErrCannotIdentifyUser
-	}
-
-	for _, owner := range meetingOwners {
-		validation := mailvalidate.ValidateEmailSyntax(owner)
-		email := validation.CleanEmail
-		if email == "" {
-			continue
-		}
-		user, _ := h.services.CommonServices.UserService.FindUserByEmail(ctx, email)
-		if user != nil && user.Id != "" {
-			ctx = common.SetUserIdInContext(ctx, user.Id)
-			agent, err := h.services.Repositories.PostgresRepositories.AgentRepository.GetActiveConfiguredAgentsByUserAndType(ctx, []enum.AgentType{enum.AgentMeetingKeeper})
-			if agent != nil {
-				return user.Id, nil
-			}
-			if err != nil {
-				tracing.TraceErr(span, err)
-			}
-		}
-	}
-	return "", coserrors.ErrCannotIdentifyUser
 }
 
 func (h *IntegrationHandler) publishGrainMeetingSummaryCreatedEvent(c *gin.Context, ctx context.Context, grainData *GrainRecordingData) error {

--- a/packages/server/customer-os-api/rest/integrations/grain_model.go
+++ b/packages/server/customer-os-api/rest/integrations/grain_model.go
@@ -49,7 +49,7 @@ func (g *GrainRecording) participantEmails() []string {
 	emails := make([]string, len(g.Participants))
 
 	for v, participant := range g.Participants {
-		if participant.Email != nil {
+		if participant.Email != nil && *participant.Email != "" {
 			emails[v] = *participant.Email
 		}
 	}

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_extract_meeting_highlights.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_extract_meeting_highlights.go
@@ -68,8 +68,8 @@ type ExtractMeetingHighlightsInput struct {
 }
 
 type ExtractMeetingHighlightsOutput struct {
-	Summary     string   `json:"summary"`
-	ActionItems []string `json:"actionItems"`
+	MeetingSummary string   `json:"meetingSummary"`
+	ActionItems    []string `json:"actionItems"`
 }
 
 func (c *ExtractMeetingHighlightsCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[ExtractMeetingHighlightsInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, ExtractMeetingHighlightsOutput, error) {
@@ -95,7 +95,7 @@ func (c *ExtractMeetingHighlightsCapability) Execute(ctx context.Context, execut
 
 Please analyze the meeting and respond in this exact JSON format:
 {
-    "summary": "This is my clear and direct summary for the CEO.",
+    "meetingSummary": "This is my clear and direct summary for the CEO.",
     "actionItems": [
         "Name of owner: action item",
         "Name of owner: action item"
@@ -137,7 +137,7 @@ func (c *ExtractMeetingHighlightsCapability) parseAnswer(ctx context.Context, an
 		return ExtractMeetingHighlightsOutput{}, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
-	if result.Summary == "" {
+	if result.MeetingSummary == "" {
 		err := errors.New("Unable to produce meeting summary")
 		tracing.TraceErr(span, err)
 		return ExtractMeetingHighlightsOutput{}, err


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor user identification logic and rename struct fields for clarity and reuse in meeting integrations.
> 
>   - **Functionality**:
>     - Add `GetCustomerOSUser()` in `common.go` to identify users by email and agent type.
>     - Update `handleFathomAISummaryZapier()` and `handleGrainNewRecordingEventZapier()` to use `GetCustomerOSUser()`.
>   - **Refactoring**:
>     - Remove duplicate `GetCustomerOSUser()` from `grain.go`.
>   - **Struct Changes**:
>     - Rename `Summary` to `MeetingSummary` in `ExtractMeetingHighlightsOutput` in `capability_extract_meeting_highlights.go`.
>   - **Validation**:
>     - Add email validation in `participantEmails()` in `grain_model.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 682bb0d02a7f6268fb55bc340d058fcda121af4d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->