### PR TITLE
fix sku id

### DIFF
--- a/packages/server/customer-os-postgres-repository/repository/sku_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/sku_repository.go
@@ -39,7 +39,7 @@ func (repo *skuRepository) Get(ctx context.Context, tenant, skuId string) (*post
 	}
 
 	var existing *postgresentity.SkuEntity
-	err := repo.db.First(&existing, "tenant = ? and skuId = ?", tenant, skuId).Error
+	err := repo.db.First(&existing, "tenant = ? and id = ?", tenant, skuId).Error
 	if err != nil {
 		span.LogFields(tracingLog.Bool("result.found", false))
 		if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes query in `Get()` method of `skuRepository` to use `id` instead of `skuId` for SKU retrieval.
> 
>   - **Behavior**:
>     - Fixes query in `Get()` method of `skuRepository` in `sku_repository.go` to use `id` instead of `skuId` for retrieving SKU by ID.
>   - **Error Handling**:
>     - No changes to error handling; existing logic remains intact.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b52b5e33d31a55113a37e0f340454bd3b0bfc1a2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->