### PR TITLE
Scrape global orgs

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/.gitignore
+++ b/packages/runner/customer-os-data-upkeeper/.gitignore
@@ -1,2 +1,3 @@
 bin
 customer-os-data-upkeeper
+.envrc

--- a/packages/runner/customer-os-data-upkeeper/config/config.go
+++ b/packages/runner/customer-os-data-upkeeper/config/config.go
@@ -99,6 +99,7 @@ func Load() *Config {
 			BetterContactConfig: cmnCfg.BetterContact,
 			SlackConfig:         cmnCfg.SlackConfig,
 			NovuConfig:          cmnCfg.NovuConfig,
+			JinaConfig:          cmnCfg.JinaConfig,
 		},
 		Internal: commonconf.InternalServicesConfig{
 			CustomerOsApi:       cmnCfg.CustomerOsApi,

--- a/packages/runner/customer-os-data-upkeeper/config/config.go
+++ b/packages/runner/customer-os-data-upkeeper/config/config.go
@@ -1,13 +1,15 @@
 package config
 
 import (
+	"log"
+
 	"github.com/caarlos0/env/v6"
-	cronconf "github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/cron/config"
 	commonconf "github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/joho/godotenv"
-	"log"
+
+	cronconf "github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/cron/config"
 )
 
 type CommonConfig struct {
@@ -29,6 +31,7 @@ type CommonConfig struct {
 	GoogleOAuthConfig commonconf.GoogleOAuthConfig
 	AzureOAuthConfig  commonconf.AzureOAuthConfig
 	NovuConfig        commonconf.NovuConfig
+	JinaConfig        commonconf.JinaConfig
 }
 
 type AppConfig struct {

--- a/packages/runner/customer-os-data-upkeeper/cron/config/config.go
+++ b/packages/runner/customer-os-data-upkeeper/cron/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	CronScheduleSyncDataToGlobalOrgs           string `env:"CRON_SCHEDULE_SYNC_DATA_TO_GLOBAL_ORGS" envDefault:"15 */1 * * * *"`
 	CronScheduleEnrichGlobalOrg                string `env:"CRON_SCHEDULE_ENRICH_GLOBAL_ORG" envDefault:"30 */1 * * * *"`
 	CronScheduleSyncFromGlobalOrgsToTenantOrgs string `env:"CRON_SCHEDULE_SYNC_FROM_GLOBAL_ORGS_TO_TENANT_ORGS" envDefault:"45 */1 * * * *"`
+	CronScheduleGlobalOrgScrape                string `env:"CRON_SCHEDULE_GLOBAL_ORG_SCRAPE" envDefault:"20 */5 * * * *"`
 
 	// Contacts
 	CronScheduleUpkeepContacts                            string `env:"CRON_SCHEDULE_UPKEEP_CONTACTS" envDefault:"0 */15 * * * *"`

--- a/packages/runner/customer-os-data-upkeeper/cron/cron.go
+++ b/packages/runner/customer-os-data-upkeeper/cron/cron.go
@@ -128,7 +128,7 @@ func registerJobs(c *cron.Cron, cont *container.Container) {
 	addJob(cont.Cfg.App.Cron.CronScheduleProcessWebsiteForGlobalOrgs, GroupGlobalOrg, processWebsiteForGlobalOrgs, "processWebsiteForGlobalOrgs")
 	addJob(cont.Cfg.App.Cron.CronScheduleEnrichGlobalOrg, GroupGlobalOrg, enrichGlobalOrganization, "enrichGlobalOrganization")
 	addJob(cont.Cfg.App.Cron.CronScheduleSyncFromGlobalOrgsToTenantOrgs, GroupGlobalOrg, syncGlobalOrgsToTenantOrganizations, "syncGlobalOrgsToTenantOrganizations")
-	addJob(cont.Cfg.App.Cron.CronScheduleGlobalOrgScrape, GroupGlobalOrg, scapeGlobalOrganizations, "scrapeGlobalOrganizations")
+	addJob(cont.Cfg.App.Cron.CronScheduleGlobalOrgScrape, GroupGlobalOrg, scrapeGlobalOrganizations, "scrapeGlobalOrganizations")
 
 	// Contract Jobs
 	addJob(cont.Cfg.App.Cron.CronScheduleUpdateContract, GroupContract, updateContractsStatusAndRenewal, "updateContractsStatusAndRenewal")
@@ -373,7 +373,7 @@ func syncGlobalOrgsToTenantOrganizations(cont *container.Container) {
 	service.NewGlobalOrganizationService(cont.Cfg, cont.Log, cont.CommonServices).SyncGlobalOrgsToTenantOrganizations()
 }
 
-func scapeGlobalOrganizations(cont *container.Container) {
+func scrapeGlobalOrganizations(cont *container.Container) {
 	service.NewGlobalOrganizationService(cont.Cfg, cont.Log, cont.CommonServices).ScrapeGlobalOrgs()
 }
 

--- a/packages/runner/customer-os-data-upkeeper/cron/cron.go
+++ b/packages/runner/customer-os-data-upkeeper/cron/cron.go
@@ -1,10 +1,10 @@
 package cron
 
 import (
-	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"sync"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/robfig/cron"
 
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/container"
@@ -128,6 +128,7 @@ func registerJobs(c *cron.Cron, cont *container.Container) {
 	addJob(cont.Cfg.App.Cron.CronScheduleProcessWebsiteForGlobalOrgs, GroupGlobalOrg, processWebsiteForGlobalOrgs, "processWebsiteForGlobalOrgs")
 	addJob(cont.Cfg.App.Cron.CronScheduleEnrichGlobalOrg, GroupGlobalOrg, enrichGlobalOrganization, "enrichGlobalOrganization")
 	addJob(cont.Cfg.App.Cron.CronScheduleSyncFromGlobalOrgsToTenantOrgs, GroupGlobalOrg, syncGlobalOrgsToTenantOrganizations, "syncGlobalOrgsToTenantOrganizations")
+	addJob(cont.Cfg.App.Cron.CronScheduleGlobalOrgScrape, GroupGlobalOrg, scapeGlobalOrganizations, "scrapeGlobalOrganizations")
 
 	// Contract Jobs
 	addJob(cont.Cfg.App.Cron.CronScheduleUpdateContract, GroupContract, updateContractsStatusAndRenewal, "updateContractsStatusAndRenewal")
@@ -151,7 +152,7 @@ func registerJobs(c *cron.Cron, cont *container.Container) {
 	addJob(cont.Cfg.App.Cron.CronScheduleEnrichContacts, GroupContactEnrich, enrichContacts, "enrichContacts")
 	addJob(cont.Cfg.App.Cron.CronScheduleLinkOrphanContactsToOrganizationBaseOnLinkedinScrapIn, GroupOrphanContacts, linkOrphanContactsToOrganizationBaseOnLinkedinScrapIn, "linkOrphanContacts")
 
-	//Email Jobs
+	// Email Jobs
 	addJob(cont.Cfg.App.Cron.CronScheduleValidateEmails, GroupEmail, validateEmails, "validateEmails")
 	addJob(cont.Cfg.App.Cron.CronScheduleValidateEmailsFromBulkRequests, GroupEmailBulk, validateEmailsFromBulkRequests, "validateEmailsFromBulkRequests")
 	addJob(cont.Cfg.App.Cron.CronScheduleCheckScrubbyResult, GroupEmail, checkScrubbyResult, "checkScrubbyResult")
@@ -159,9 +160,9 @@ func registerJobs(c *cron.Cron, cont *container.Container) {
 	addJob(cont.Cfg.App.Cron.CronScheduleCleanEmails, GroupEmail, cleanEmails, "cleanEmails")
 	addJob(cont.Cfg.App.Cron.CronScheduleSendEmails, GroupSendEmails, sendEmails, "sendEmails")
 	addJob(cont.Cfg.App.Cron.CronScheduleProcessSentEmails, GroupProcessEmails, processSentEmails, "processSentEmails")
-	//addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsFromProvidersRealtime, ingestEmailsFromProvidersRealtime, "ingestEmailsFromProvidersRealtime")
-	//addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsFromProvidersHistory, ingestEmailsFromProvidersHistory, "ingestEmailsFromProvidersHistory")
-	//addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsSendToAgents, ingestEmailsSendToAgents, "ingestEmailsSendToAgents")
+	// addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsFromProvidersRealtime, ingestEmailsFromProvidersRealtime, "ingestEmailsFromProvidersRealtime")
+	// addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsFromProvidersHistory, ingestEmailsFromProvidersHistory, "ingestEmailsFromProvidersHistory")
+	// addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsSendToAgents, ingestEmailsSendToAgents, "ingestEmailsSendToAgents")
 
 	// Flow Jobs
 	addJob(cont.Cfg.App.Cron.CronScheduleFlowExecution, GroupFlow, flowExecution, "flowExecution")
@@ -225,7 +226,7 @@ func generateCycleInvoices(cont *container.Container) {
 }
 
 func generateOffCycleInvoices(cont *container.Container) {
-	//service.NewInvoiceService(cont.Cfg, cont.Log, cont.CommonServices, cont.Repositories).GenerateOffCycleInvoices()
+	// service.NewInvoiceService(cont.Cfg, cont.Log, cont.CommonServices, cont.Repositories).GenerateOffCycleInvoices()
 }
 
 func generateNextPreviewInvoices(cont *container.Container) {
@@ -370,6 +371,10 @@ func processWebSessions(cont *container.Container) {
 
 func syncGlobalOrgsToTenantOrganizations(cont *container.Container) {
 	service.NewGlobalOrganizationService(cont.Cfg, cont.Log, cont.CommonServices).SyncGlobalOrgsToTenantOrganizations()
+}
+
+func scapeGlobalOrganizations(cont *container.Container) {
+	service.NewGlobalOrganizationService(cont.Cfg, cont.Log, cont.CommonServices).ScrapeGlobalOrgs()
 }
 
 func checkTenantOnboarding(cont *container.Container) {

--- a/packages/runner/customer-os-data-upkeeper/cron/cron_test.go
+++ b/packages/runner/customer-os-data-upkeeper/cron/cron_test.go
@@ -69,6 +69,7 @@ func TestStartCron(t *testing.T) {
 				CronScheduleCheckTenantOnboarding:                                 "0 0 */1 * * *",
 				CronScheduleIcpCheck:                                              "0 0 */1 * * *",
 				CronScheduleRerunAgent:                                            "0 0 */1 * * *",
+				CronScheduleGlobalOrgScrape:                                       "0 0 */1 * * *",
 			},
 		},
 	}

--- a/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
@@ -91,9 +91,16 @@ func (s *globalOrganizationService) ScrapeGlobalOrgs() {
 	}
 
 	for _, org := range orgs {
-		err := s.commonServices.WebscraperService.Scrape(ctx, org.PrimaryDomain, org.PrimaryDomain)
+		page := "https://" + org.PrimaryDomain
+		err := s.commonServices.WebscraperService.Scrape(ctx, page, org.PrimaryDomain)
 		if err != nil {
 			tracing.TraceErr(span, errors.Wrap(err, "error scraping global org primary domain"))
+			continue
+		}
+
+		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.MarkScraped(ctx, org.ID)
+		if err != nil {
+			tracing.TraceErr(span, errors.Wrap(err, "error updating global org scraped status"))
 			continue
 		}
 	}

--- a/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
@@ -42,6 +42,7 @@ type GlobalOrganizationService interface {
 	ScrapinCompanyByWebsite()
 	EnrichGlobalOrganization()
 	SyncGlobalOrgsToTenantOrganizations()
+	ScrapeGlobalOrgs()
 }
 
 type globalOrganizationService struct {
@@ -67,6 +68,35 @@ func (s *globalOrganizationService) EnrichGlobalOrganization() {
 	s.enrichName()
 	s.enrichIndustry()
 	s.enrichDescription()
+}
+
+func (s *globalOrganizationService) ScrapeGlobalOrgs() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // Cancel context on exit
+
+	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.ScrapeGlobalOrgs")
+	defer span.Finish()
+	tracing.TagComponentCronJob(span)
+
+	limit := 10
+
+	orgs, err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetOrganizationsToScrape(ctx, limit)
+	if err != nil {
+		tracing.TraceErr(span, errors.Wrap(err, "error getting records to scrape"))
+		return
+	}
+
+	if len(orgs) == 0 {
+		return
+	}
+
+	for _, org := range orgs {
+		err := s.commonServices.WebscraperService.Scrape(ctx, org.PrimaryDomain, org.PrimaryDomain)
+		if err != nil {
+			tracing.TraceErr(span, errors.Wrap(err, "error scraping global org primary domain"))
+			continue
+		}
+	}
 }
 
 func (s *globalOrganizationService) syncScrapinToGlobalOrganization() {

--- a/packages/server/customer-os-common-module/config/common_config.go
+++ b/packages/server/customer-os-common-module/config/common_config.go
@@ -41,6 +41,7 @@ type ExternalServicesConfig struct {
 	EnrowConfig          EnrowConfig
 	IntegrationAppConfig IntegrationAppConfig
 	IpDataConfig         IpDataConfig
+	JinaConfig           JinaConfig
 	NamecheapConfig      NamecheapConfig
 	NovuConfig           NovuConfig
 	OpenSRSConfig        OpenSRSConfig

--- a/packages/server/customer-os-common-module/config/external_servces_config.go
+++ b/packages/server/customer-os-common-module/config/external_servces_config.go
@@ -46,3 +46,8 @@ type QuickbooksConfig struct {
 	ClientSecret string `env:"QUICKBOOKS_CLIENT_SECRET"`
 	RedirectUrl  string `env:"QUICKBOOKS_REDIRECT_URL"`
 }
+
+type JinaConfig struct {
+	Url    string `env:"JINA_URL" envDefault:"https://r.jina.ai"`
+	ApiKey string `env:"JINA_API_KEY" envDefault:"N/A"`
+}

--- a/packages/server/customer-os-common-module/config/external_servces_config.go
+++ b/packages/server/customer-os-common-module/config/external_servces_config.go
@@ -48,6 +48,6 @@ type QuickbooksConfig struct {
 }
 
 type JinaConfig struct {
-	Url    string `env:"JINA_URL" envDefault:"https://r.jina.ai"`
+	Url    string `env:"JINA_URL" envDefault:"https://r.jina.ai/"`
 	ApiKey string `env:"JINA_API_KEY" envDefault:"N/A"`
 }

--- a/packages/server/customer-os-common-module/interfaces/webscraper.go
+++ b/packages/server/customer-os-common-module/interfaces/webscraper.go
@@ -1,0 +1,7 @@
+package interfaces
+
+import "context"
+
+type WebscraperService interface {
+	Scrape(ctx context.Context, url, primaryDomain string) error
+}

--- a/packages/server/customer-os-common-module/services/init.go
+++ b/packages/server/customer-os-common-module/services/init.go
@@ -69,6 +69,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/user"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/verify"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/webhook"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/webscraper"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/workflow"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/workspace"
 )
@@ -136,6 +137,7 @@ type CommonServices struct {
 	VerifyService              interfaces.VerifyService
 	QuickbooksService          interfaces.QuickbooksService
 	WebhookService             interfaces.WebhookService
+	WebscraperService          interfaces.WebscraperService
 	WorkflowService            interfaces.WorkflowService
 	WorkspaceService           interfaces.WorkspaceService
 
@@ -219,6 +221,7 @@ func InitCommonServices(
 	userImpl := user.NewUserService(neo4jRepositories, postgresRepositories, eventsImpl)
 	quickbooksImpl := quickbooks.NewQuickbooksService(&cfg.External.QuickbooksConfig, postgresRepositories)
 	webhookImpl := webhook.NewWebhookService(log, postgresRepositories)
+	webscrapeImpl := webscraper.NewWebscraperService(&cfg.External.JinaConfig, postgresRepositories)
 	workflowImpl := workflow.NewWorkflowService(postgresRepositories)
 	workspaceImpl := workspace.NewWorkspaceService(neo4jRepositories)
 
@@ -362,6 +365,7 @@ func InitCommonServices(
 		VerifyService:              verifyImpl,
 		QuickbooksService:          quickbooksImpl,
 		WebhookService:             webhookImpl,
+		WebscraperService:          webscrapeImpl,
 		WorkflowService:            workflowImpl,
 		WorkspaceService:           workspaceImpl,
 

--- a/packages/server/customer-os-common-module/services/webscraper/service.go
+++ b/packages/server/customer-os-common-module/services/webscraper/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
@@ -60,6 +61,7 @@ func (s *webscraperService) fetchPage(ctx context.Context, url string) (string, 
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 
 	requestUrl := s.config.Url + url
+	span.LogKV("requestUrl", requestUrl)
 
 	req, err := http.NewRequest("GET", requestUrl, nil)
 	if err != nil {
@@ -67,10 +69,17 @@ func (s *webscraperService) fetchPage(ctx context.Context, url string) (string, 
 		return "", err
 	}
 
+	// Align headers with working curl command
 	req.Header.Set("Authorization", "Bearer "+s.config.ApiKey)
-	req.Header.Set("X-Return-Format", "markdown")
+	req.Header.Set("X-Return-Format", "markdown")  // Get markdown output
+	req.Header.Set("X-Retain-Images", "none")      // Don't retain images
+	req.Header.Set("X-With-Links-Summary", "true") // Include links summary
 
-	client := &http.Client{}
+	// Add a timeout
+	client := &http.Client{
+		Timeout: 60 * time.Second,
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		tracing.TraceErr(span, err)
@@ -79,12 +88,16 @@ func (s *webscraperService) fetchPage(ctx context.Context, url string) (string, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("error code: %d", resp.StatusCode)
+		err = fmt.Errorf("error code: %d", resp.StatusCode)
+		tracing.TraceErr(span, err)
+		return "", err
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("error reading response body: %v", err)
+		err = fmt.Errorf("error reading response body: %v", err)
+		tracing.TraceErr(span, err)
+		return "", err
 	}
 
 	return string(body), nil

--- a/packages/server/customer-os-common-module/services/webscraper/service.go
+++ b/packages/server/customer-os-common-module/services/webscraper/service.go
@@ -1,0 +1,91 @@
+package webscraper
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
+	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/config"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+)
+
+type webscraperService struct {
+	config               *config.JinaConfig
+	postgresRepositories *postgres_repository.Repositories
+}
+
+func NewWebscraperService(config *config.JinaConfig, postgres *postgres_repository.Repositories) interfaces.WebscraperService {
+	return &webscraperService{
+		config:               config,
+		postgresRepositories: postgres,
+	}
+}
+
+func (s *webscraperService) Scrape(ctx context.Context, url, primaryDomain string) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebscraperService.Scrape")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	// fetch page contents
+	contents, err := s.fetchPage(ctx, url)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	_, err = s.postgresRepositories.GlobalOrganizationWebpageRepository.Save(ctx, postgres_entity.GlobalOrganizationWebpages{
+		Url:           url,
+		PrimaryDomain: primaryDomain,
+		Content:       contents,
+	})
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	// todo parse page urls and scrape them
+
+	return nil
+}
+
+func (s *webscraperService) fetchPage(ctx context.Context, url string) (string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebscraperService.fetchPage")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	requestUrl := s.config.Url + url
+
+	req, err := http.NewRequest("GET", requestUrl, nil)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+s.config.ApiKey)
+	req.Header.Set("X-Return-Format", "markdown")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("error code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response body: %v", err)
+	}
+
+	return string(body), nil
+}

--- a/packages/server/customer-os-postgres-repository/entity/global_organization.go
+++ b/packages/server/customer-os-postgres-repository/entity/global_organization.go
@@ -39,6 +39,7 @@ type GlobalOrganization struct {
 	SourceDescription4      string     `gorm:"column:source_description_4;type:text" json:"sourceDescription4"`
 	SourceDescription5      string     `gorm:"column:source_description_5;type:text" json:"sourceDescription5"`
 	SyncedToNeoAt           *time.Time `gorm:"column:synced_to_neo_at;type:timestamp" json:"syncedToNeoAt"`
+	Scraped                 bool       `gorm:"column:scraped;type:boolean" json:"scraped"`
 }
 
 // TableName sets the name of the table for GORM
@@ -46,7 +47,7 @@ func (GlobalOrganization) TableName() string {
 	return "global_organization"
 }
 
-//CREATE EXTENSION IF NOT EXISTS pg_trgm;
-//CREATE INDEX idx_global_organization_name_trgm ON global_organization USING gin (name gin_trgm_ops);
-//CREATE INDEX idx_global_organization_primary_domain_trgm ON global_organization USING gin (primary_domain gin_trgm_ops);
-//CREATE INDEX idx_global_organization_other_domains_trgm ON global_organization USING gin (other_domains gin_trgm_ops);
+// CREATE EXTENSION IF NOT EXISTS pg_trgm;
+// CREATE INDEX idx_global_organization_name_trgm ON global_organization USING gin (name gin_trgm_ops);
+// CREATE INDEX idx_global_organization_primary_domain_trgm ON global_organization USING gin (primary_domain gin_trgm_ops);
+// CREATE INDEX idx_global_organization_other_domains_trgm ON global_organization USING gin (other_domains gin_trgm_ops);

--- a/packages/server/customer-os-postgres-repository/entity/global_organization_webpages.go
+++ b/packages/server/customer-os-postgres-repository/entity/global_organization_webpages.go
@@ -1,0 +1,16 @@
+package postgres_entity
+
+import "time"
+
+type GlobalOrganizationWebpages struct {
+	ID            uint64    `gorm:"primary_key;autoIncrement" json:"id"`
+	PrimaryDomain string    `gorm:"column:primary_domain;type:varchar(255);NOT NULL;index:idx_global_organization_primary_domain,unique" json:"primaryDomain"`
+	Url           string    `gorm:"column:url;type:text" json:"url"`
+	Content       string    `gorm:"column:content;type:text" json:"content"`
+	CreatedAt     time.Time `gorm:"column:created_at;type:timestamp;DEFAULT:current_timestamp" json:"createdAt"`
+	UpdatedAt     time.Time `gorm:"column:updated_at;type:timestamp;DEFAULT:current_timestamp" json:"updatedAt"`
+}
+
+func (GlobalOrganizationWebpages) TableName() string {
+	return "global_organization_webpages"
+}

--- a/packages/server/customer-os-postgres-repository/repository/global_organization_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/global_organization_repository.go
@@ -28,6 +28,7 @@ type GlobalOrganizationRepository interface {
 	MarkIndustryEnrichRequested(ctx context.Context, id uint64) error
 	MarkDescriptionEnrichRequested(ctx context.Context, id uint64) error
 	MarkNameEnrichRequested(ctx context.Context, id uint64) error
+	MarkScraped(ctx context.Context, id uint64) error
 	SetIndustry(ctx context.Context, id uint64, industryNaicsCode, industryNaicsName string) error
 	SetDescription(ctx context.Context, id uint64, description string) error
 	SetName(ctx context.Context, id uint64, name string) error
@@ -179,7 +180,7 @@ func (r *globalOrganizationRepository) GetOrganizationsToScrape(ctx context.Cont
 
 	organizations := make([]*postgres_entity.GlobalOrganization, 0)
 	result := r.db.WithContext(ctx).
-		Where("scraped = ?", false).
+		Where("scraped = ? OR scraped IS NULL", false).
 		Order("created_at DESC").
 		Limit(limit).
 		Find(&organizations)
@@ -388,5 +389,28 @@ func (r *globalOrganizationRepository) markEnrichRequested(ctx context.Context, 
 	if result.Error != nil {
 		return result.Error
 	}
+	return nil
+}
+
+func (r *globalOrganizationRepository) MarkScraped(ctx context.Context, id uint64) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.MarkScraped")
+	defer span.Finish()
+	tracing.TagComponentPostgresRepository(span)
+
+	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalOrganization{}).
+		Where("id = ?", id).
+		UpdateColumn("scraped", true)
+
+	if result.Error != nil {
+		tracing.TraceErr(span, result.Error)
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		err := errors.New("no organization found with provided ID")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
 	return nil
 }

--- a/packages/server/customer-os-postgres-repository/repository/global_organization_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/global_organization_repository.go
@@ -3,13 +3,15 @@ package postgres_repository
 import (
 	"context"
 	"errors"
+	"time"
+
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/opentracing/opentracing-go"
 	tracingLog "github.com/opentracing/opentracing-go/log"
 	"gorm.io/gorm"
-	"time"
+
+	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 )
 
 type GlobalOrganizationRepository interface {
@@ -22,6 +24,7 @@ type GlobalOrganizationRepository interface {
 	GetOrganizationsToEnrichIndustry(ctx context.Context, hoursFromPreviousAttempt, maxAttempts, limit int) ([]*postgres_entity.GlobalOrganization, error)
 	GetOrganizationsToEnrichDescription(ctx context.Context, hoursFromPreviousAttempt, maxAttempts, limit int) ([]*postgres_entity.GlobalOrganization, error)
 	GetOrganizationsToEnrichName(ctx context.Context, hoursFromPreviousAttempt, maxAttempts, limit int) ([]*postgres_entity.GlobalOrganization, error)
+	GetOrganizationsToScrape(ctx context.Context, limit int) ([]*postgres_entity.GlobalOrganization, error)
 	MarkIndustryEnrichRequested(ctx context.Context, id uint64) error
 	MarkDescriptionEnrichRequested(ctx context.Context, id uint64) error
 	MarkNameEnrichRequested(ctx context.Context, id uint64) error
@@ -159,6 +162,25 @@ func (r *globalOrganizationRepository) GetOrganizationsToEnrichIndustry(ctx cont
 		Order("CASE WHEN industry_requested_at IS NULL THEN 0 ELSE 1 END ASC").
 		Order("CASE WHEN industry_requested_at IS NULL THEN created_at END DESC").
 		Order("industry_requested_at ASC").
+		Limit(limit).
+		Find(&organizations)
+	if result.Error != nil {
+		tracing.TraceErr(span, result.Error)
+		return nil, result.Error
+	}
+	span.LogFields(tracingLog.Int("found", len(organizations)))
+	return organizations, nil
+}
+
+func (r *globalOrganizationRepository) GetOrganizationsToScrape(ctx context.Context, limit int) ([]*postgres_entity.GlobalOrganization, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetOrganizationsToScrape")
+	defer span.Finish()
+	tracing.TagComponentPostgresRepository(span)
+
+	organizations := make([]*postgres_entity.GlobalOrganization, 0)
+	result := r.db.WithContext(ctx).
+		Where("scraped = ?", false).
+		Order("created_at DESC").
 		Limit(limit).
 		Find(&organizations)
 	if result.Error != nil {

--- a/packages/server/customer-os-postgres-repository/repository/global_organization_webpages.go
+++ b/packages/server/customer-os-postgres-repository/repository/global_organization_webpages.go
@@ -1,0 +1,64 @@
+package postgres_repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/opentracing/opentracing-go"
+	"gorm.io/gorm"
+
+	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
+)
+
+type GlobalOrganizationWebpageRepository interface {
+	Save(ctx context.Context, webpageData postgres_entity.GlobalOrganizationWebpages) (*postgres_entity.GlobalOrganizationWebpages, error)
+}
+
+type globalOrganizationWebpageRepository struct {
+	gormDb *gorm.DB
+}
+
+func NewGlobalOrganizationWebpageRepository(gormDb *gorm.DB) GlobalOrganizationWebpageRepository {
+	return &globalOrganizationWebpageRepository{gormDb: gormDb}
+}
+
+func (r *globalOrganizationWebpageRepository) Save(ctx context.Context, webpageData postgres_entity.GlobalOrganizationWebpages) (*postgres_entity.GlobalOrganizationWebpages, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "globalOrganizationWebpageRepository.Save")
+	defer span.Finish()
+	tracing.TagComponentPostgresRepository(span)
+
+	// Check if a record with this URL already exists
+	var existingRecord postgres_entity.GlobalOrganizationWebpages
+	result := r.gormDb.Where("url = ?", webpageData.Url).First(&existingRecord)
+
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			// URL doesn't exist, create a new record
+			webpageData.CreatedAt = time.Now()
+			webpageData.UpdatedAt = time.Now()
+			if err := r.gormDb.Create(&webpageData).Error; err != nil {
+				return nil, err
+			}
+			return &webpageData, nil
+		}
+		// Some other database error occurred
+		return nil, result.Error
+	}
+
+	// URL exists, update the content and updated_at timestamp
+	existingRecord.Content = webpageData.Content
+	existingRecord.UpdatedAt = time.Now()
+
+	// If primary domain is provided, update it too
+	if webpageData.PrimaryDomain != "" {
+		existingRecord.PrimaryDomain = webpageData.PrimaryDomain
+	}
+
+	if err := r.gormDb.Save(&existingRecord).Error; err != nil {
+		return nil, err
+	}
+
+	return &existingRecord, nil
+}

--- a/packages/server/customer-os-postgres-repository/repository/repositories.go
+++ b/packages/server/customer-os-postgres-repository/repository/repositories.go
@@ -2,8 +2,9 @@ package postgres_repository
 
 import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/config"
-	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"gorm.io/gorm"
+
+	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 )
 
 type Repositories struct {
@@ -50,6 +51,7 @@ type Repositories struct {
 	FlowNodeRepository                           FlowNodeRepository
 	FlowTransitionsRegistryRepository            FlowTransitionsRegistryRepository
 	GlobalOrganizationRepository                 GlobalOrganizationRepository
+	GlobalOrganizationWebpageRepository          GlobalOrganizationWebpageRepository
 	GlobalOrganizationWebsiteToProcessRepository GlobalOrganizationWebsiteToProcessRepository
 	GoogleServiceAccountKeyRepository            GoogleServiceAccountKeyRepository
 	InvoiceRepository                            InvoiceRepository
@@ -134,6 +136,7 @@ func InitRepositories(postgresDB *config.PostgresDB) *Repositories {
 		FlowNodeRepository:                           NewFlowNodeRepository(postgresDB.GormDB),
 		FlowTransitionsRegistryRepository:            NewFlowTransitionsRegistryRepository(postgresDB.GormDB),
 		GlobalOrganizationRepository:                 NewGlobalOrganizationRepository(postgresDB.GormDB),
+		GlobalOrganizationWebpageRepository:          NewGlobalOrganizationWebpageRepository(postgresDB.GormDB),
 		GlobalOrganizationWebsiteToProcessRepository: NewGlobalOrganizationWebsiteToProcessRepository(postgresDB.GormDB),
 		InvoiceRepository:                            NewInvoiceRepository(postgresDB.GormDB),
 		IngestEmailMessageRepository:                 NewIngestEmailMessageRepository(postgresDB.GormDB),
@@ -208,6 +211,7 @@ func (r *Repositories) Migration(postgresDB *config.PostgresDB) {
 		&postgres_entity.FlowNode{},
 		&postgres_entity.FlowTransitionsRegistry{},
 		&postgres_entity.GlobalOrganization{},
+		&postgres_entity.GlobalOrganizationWebpages{},
 		&postgres_entity.GlobalOrganizationWebsiteToProcess{},
 		&postgres_entity.IngestEmailMessage{},
 		&postgres_entity.InvoiceNumberEntity{},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a cron job and services to scrape global organizations' websites and store data in Postgres.
> 
>   - **Behavior**:
>     - Adds `scrapeGlobalOrganizations` cron job in `cron.go` to scrape global organizations' websites every 5 minutes.
>     - Implements `ScrapeGlobalOrgs()` in `global_organization_service.go` to fetch organizations and call the web scraper.
>     - Introduces `WebscraperService` interface in `webscraper.go` to handle web scraping logic.
>   - **Configurations**:
>     - Adds `CronScheduleGlobalOrgScrape` to `cron/config.go` for scheduling the new cron job.
>     - Updates `config.go` and `common_config.go` to include `JinaConfig` for web scraping service configuration.
>   - **Models and Repositories**:
>     - Adds `GlobalOrganizationWebpages` model in `global_organization_webpages.go` to store scraped webpage data.
>     - Implements `GlobalOrganizationWebpageRepository` in `global_organization_webpages.go` to handle database operations for webpage data.
>     - Updates `global_organization.go` to include `scraped` field for tracking scraping status.
>     - Adds methods `GetOrganizationsToScrape` and `MarkScraped` in `global_organization_repository.go` to manage scraping tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 9dfd31582bddb20636b025370bb84637c5e8efd2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->