### PR TITLE
fix context timeout

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/contact_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/contact_service.go
@@ -689,72 +689,74 @@ func (s *contactService) linkOrphanContactsToOrganizationBasedOnLinkedin(ctx con
 	span.LogFields(log.Int("orphanContactsCount", len(orphanContacts)))
 
 	for _, orphanContact := range orphanContacts {
-		func(record neo4jrepository.TenantAndContactIdAndParams) {
-			innerCtx := common.WithCustomContext(ctx, &common.CustomContext{
-				Tenant:    record.Tenant,
-				AppSource: constants.AppSourceDataUpkeeper,
-			})
-			innerSpan, innerCtx := tracing.StartTracerSpan(innerCtx, "ContactService.linkOrphanContactsToOrganizationBasedOnLinkedin.record")
-			defer innerSpan.Finish()
-			tracing.TagTenant(innerSpan, record.Tenant)
-			tracing.TagEntity(innerSpan, record.ContactId)
+		innerCtx := common.WithCustomContext(ctx, &common.CustomContext{
+			Tenant:    orphanContact.Tenant,
+			AppSource: constants.AppSourceDataUpkeeper,
+		})
+		s.processLinkOrphanContactToOrganizationBasedOnLinkedin(innerCtx, orphanContact)
+	}
+}
 
-			// Mark contact with link requested
-			err := s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(innerCtx, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyLinkWithOrgRequestedAt), utils.NowPtr())
-			if err != nil {
-				tracing.TraceErr(innerSpan, err)
-				return
-			}
+func (s *contactService) processLinkOrphanContactToOrganizationBasedOnLinkedin(ctx context.Context, record neo4jrepository.TenantAndContactIdAndParams) {
+	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.processLinkOrphanContactToOrganizationBasedOnLinkedin")
+	defer span.Finish()
+	tracing.TagTenant(span, record.Tenant)
+	tracing.TagEntity(span, record.ContactId)
 
-			scrapIn, err := s.commonServices.PostgresRepositories.EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow(innerCtx, record.FieldStr1, postgresentity.ScrapInFlowPersonProfile)
-			if err != nil {
-				tracing.TraceErr(innerSpan, errors.Wrap(err, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow"))
-				return
-			}
+	// Mark contact with link requested
+	err := s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(ctx, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyLinkWithOrgRequestedAt), utils.NowPtr())
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return
+	}
 
-			if scrapIn != nil && scrapIn.Success && scrapIn.CompanyFound {
+	scrapIn, err := s.commonServices.PostgresRepositories.EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow(ctx, record.FieldStr1, postgresentity.ScrapInFlowPersonProfile)
+	if err != nil {
+		tracing.TraceErr(span, errors.Wrap(err, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow"))
+		return
+	}
 
-				var scrapinContactResponse postgresentity.ScrapInResponseBody
-				err := json.Unmarshal([]byte(scrapIn.Data), &scrapinContactResponse)
-				if err != nil {
-					tracing.TraceErr(innerSpan, errors.Wrap(err, "json.Unmarshal"))
-					return
-				}
+	if scrapIn != nil && scrapIn.Success && scrapIn.CompanyFound {
 
-				domain := s.commonServices.DomainService.GetPrimaryDomainForOrganizationWebsite(innerCtx, scrapinContactResponse.Company.WebsiteUrl)
-				if domain == "" {
-					return
-				}
+		var scrapinContactResponse postgresentity.ScrapInResponseBody
+		err := json.Unmarshal([]byte(scrapIn.Data), &scrapinContactResponse)
+		if err != nil {
+			tracing.TraceErr(span, errors.Wrap(err, "json.Unmarshal"))
+			return
+		}
 
-				organizationByDomainNode, err := s.commonServices.Neo4jRepositories.OrganizationReadRepository.GetOrganizationByDomain(innerCtx, nil, record.Tenant, domain)
-				if err != nil {
-					// TODO uncomment when data is fixed in DB
-					// tracing.TraceErr(innerSpan, errors.Wrap(err, "OrganizationReadRepository.GetOrganizationByDomain"))
-					// return
-					return
-				}
+		domain := s.commonServices.DomainService.GetPrimaryDomainForOrganizationWebsite(ctx, scrapinContactResponse.Company.WebsiteUrl)
+		if domain == "" {
+			return
+		}
 
-				if organizationByDomainNode != nil {
-					organizationId := utils.GetStringPropOrEmpty(organizationByDomainNode.Props, "id")
+		organizationByDomainNode, err := s.commonServices.Neo4jRepositories.OrganizationReadRepository.GetOrganizationByDomain(ctx, nil, record.Tenant, domain)
+		if err != nil {
+			// TODO uncomment when data is fixed in DB
+			// tracing.TraceErr(innerSpan, errors.Wrap(err, "OrganizationReadRepository.GetOrganizationByDomain"))
+			// return
+			return
+		}
 
-					positionName := ""
-					if len(scrapinContactResponse.Person.Positions.PositionHistory) > 0 {
-						for _, position := range scrapinContactResponse.Person.Positions.PositionHistory {
-							if position.Title != "" && position.CompanyName != "" && position.CompanyName == scrapinContactResponse.Company.Name {
-								positionName = position.Title
-								break
-							}
-						}
-					}
+		if organizationByDomainNode != nil {
+			organizationId := utils.GetStringPropOrEmpty(organizationByDomainNode.Props, "id")
 
-					err = s.commonServices.ContactService.LinkContactWithOrganization(innerCtx, nil, record.ContactId, organizationId, positionName, "",
-						neo4jentity.DataSourceOpenline.String(), false, nil, nil)
-					if err != nil {
-						tracing.TraceErr(innerSpan, err)
+			positionName := ""
+			if len(scrapinContactResponse.Person.Positions.PositionHistory) > 0 {
+				for _, position := range scrapinContactResponse.Person.Positions.PositionHistory {
+					if position.Title != "" && position.CompanyName != "" && position.CompanyName == scrapinContactResponse.Company.Name {
+						positionName = position.Title
+						break
 					}
 				}
 			}
-		}(orphanContact)
+
+			err = s.commonServices.ContactService.LinkContactWithOrganization(ctx, nil, record.ContactId, organizationId, positionName, "",
+				neo4jentity.DataSourceOpenline.String(), false, nil, nil)
+			if err != nil {
+				tracing.TraceErr(span, err)
+			}
+		}
 	}
 }
 

--- a/packages/runner/customer-os-data-upkeeper/service/contact_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/contact_service.go
@@ -429,7 +429,7 @@ func (s *contactService) LinkOrphanContactsToOrganizationBaseOnLinkedinScrapIn()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s.linkOrphanContactsToOrganizationBaseOnLinkedinScrapIn(ctx)
+	s.linkOrphanContactsToOrganizationBasedOnLinkedin(ctx)
 }
 
 type BetterContactRequestBody struct {
@@ -672,13 +672,13 @@ func (s *contactService) processLinkedInUrl(ctx context.Context, tenant, linkedi
 	return nil
 }
 
-func (s *contactService) linkOrphanContactsToOrganizationBaseOnLinkedinScrapIn(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.linkOrphanContactsToOrganizationBaseOnLinkedinScrapIn")
+func (s *contactService) linkOrphanContactsToOrganizationBasedOnLinkedin(ctx context.Context) {
+	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.linkOrphanContactsToOrganizationBasedOnLinkedin")
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
 
 	limit := 200
-	delayFromPreviousAttemptDays := 7
+	delayFromPreviousAttemptDays := 14
 
 	orphanContacts, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsEnrichedNotLinkedToOrganization(ctx, delayFromPreviousAttemptDays, limit)
 	if err != nil {
@@ -694,7 +694,7 @@ func (s *contactService) linkOrphanContactsToOrganizationBaseOnLinkedinScrapIn(c
 				Tenant:    record.Tenant,
 				AppSource: constants.AppSourceDataUpkeeper,
 			})
-			innerSpan, innerCtx := tracing.StartTracerSpan(innerCtx, "ContactService.linkOrphanContactsToOrganizationBaseOnLinkedinScrapIn.record")
+			innerSpan, innerCtx := tracing.StartTracerSpan(innerCtx, "ContactService.linkOrphanContactsToOrganizationBasedOnLinkedin.record")
 			defer innerSpan.Finish()
 			tracing.TagTenant(innerSpan, record.Tenant)
 			tracing.TagEntity(innerSpan, record.ContactId)

--- a/packages/runner/customer-os-data-upkeeper/service/contact_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/contact_service.go
@@ -677,7 +677,10 @@ func (s *contactService) linkOrphanContactsToOrganizationBaseOnLinkedinScrapIn(c
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
 
-	orphanContacts, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsEnrichedNotLinkedToOrganization(ctx)
+	limit := 200
+	delayFromPreviousAttemptDays := 7
+
+	orphanContacts, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsEnrichedNotLinkedToOrganization(ctx, delayFromPreviousAttemptDays, limit)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return
@@ -685,70 +688,73 @@ func (s *contactService) linkOrphanContactsToOrganizationBaseOnLinkedinScrapIn(c
 
 	span.LogFields(log.Int("orphanContactsCount", len(orphanContacts)))
 
-	for _, orpanContact := range orphanContacts {
-		innerCtx := common.WithCustomContext(ctx, &common.CustomContext{
-			Tenant:    orpanContact.Tenant,
-			AppSource: constants.AppSourceDataUpkeeper,
-		})
+	for _, orphanContact := range orphanContacts {
+		func(record neo4jrepository.TenantAndContactIdAndParams) {
+			innerCtx := common.WithCustomContext(ctx, &common.CustomContext{
+				Tenant:    record.Tenant,
+				AppSource: constants.AppSourceDataUpkeeper,
+			})
+			innerSpan, innerCtx := tracing.StartTracerSpan(innerCtx, "ContactService.linkOrphanContactsToOrganizationBaseOnLinkedinScrapIn.record")
+			defer innerSpan.Finish()
+			tracing.TagTenant(innerSpan, record.Tenant)
+			tracing.TagEntity(innerSpan, record.ContactId)
 
-		tenant := orpanContact.Tenant
-
-		select {
-		case <-ctx.Done():
-			s.log.Infof("Context cancelled, stopping")
-			return
-		default:
-			// continue as normal
-		}
-
-		scrapIn, err := s.commonServices.PostgresRepositories.EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow(ctx, orpanContact.FieldStr1, postgresentity.ScrapInFlowPersonProfile)
-		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow"))
-			return
-		}
-
-		if scrapIn != nil && scrapIn.Success && scrapIn.CompanyFound {
-
-			var scrapinContactResponse postgresentity.ScrapInResponseBody
-			err := json.Unmarshal([]byte(scrapIn.Data), &scrapinContactResponse)
+			// Mark contact with link requested
+			err := s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(innerCtx, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyLinkWithOrgRequestedAt), utils.NowPtr())
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "json.Unmarshal"))
+				tracing.TraceErr(innerSpan, err)
 				return
 			}
 
-			domain := s.commonServices.DomainService.GetPrimaryDomainForOrganizationWebsite(ctx, scrapinContactResponse.Company.WebsiteUrl)
-			if domain == "" {
-				continue
-			}
-
-			organizationByDomainNode, err := s.commonServices.Neo4jRepositories.OrganizationReadRepository.GetOrganizationByDomain(ctx, nil, tenant, domain)
+			scrapIn, err := s.commonServices.PostgresRepositories.EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow(innerCtx, record.FieldStr1, postgresentity.ScrapInFlowPersonProfile)
 			if err != nil {
-				// TODO uncomment when data is fixed in DB
-				// tracing.TraceErr(span, errors.Wrap(err, "OrganizationReadRepository.GetOrganizationByDomain"))
-				// return
-				continue
+				tracing.TraceErr(innerSpan, errors.Wrap(err, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow"))
+				return
 			}
 
-			if organizationByDomainNode != nil {
-				organizationId := utils.GetStringPropOrEmpty(organizationByDomainNode.Props, "id")
+			if scrapIn != nil && scrapIn.Success && scrapIn.CompanyFound {
 
-				positionName := ""
-				if len(scrapinContactResponse.Person.Positions.PositionHistory) > 0 {
-					for _, position := range scrapinContactResponse.Person.Positions.PositionHistory {
-						if position.Title != "" && position.CompanyName != "" && position.CompanyName == scrapinContactResponse.Company.Name {
-							positionName = position.Title
-							break
+				var scrapinContactResponse postgresentity.ScrapInResponseBody
+				err := json.Unmarshal([]byte(scrapIn.Data), &scrapinContactResponse)
+				if err != nil {
+					tracing.TraceErr(innerSpan, errors.Wrap(err, "json.Unmarshal"))
+					return
+				}
+
+				domain := s.commonServices.DomainService.GetPrimaryDomainForOrganizationWebsite(innerCtx, scrapinContactResponse.Company.WebsiteUrl)
+				if domain == "" {
+					return
+				}
+
+				organizationByDomainNode, err := s.commonServices.Neo4jRepositories.OrganizationReadRepository.GetOrganizationByDomain(innerCtx, nil, record.Tenant, domain)
+				if err != nil {
+					// TODO uncomment when data is fixed in DB
+					// tracing.TraceErr(innerSpan, errors.Wrap(err, "OrganizationReadRepository.GetOrganizationByDomain"))
+					// return
+					return
+				}
+
+				if organizationByDomainNode != nil {
+					organizationId := utils.GetStringPropOrEmpty(organizationByDomainNode.Props, "id")
+
+					positionName := ""
+					if len(scrapinContactResponse.Person.Positions.PositionHistory) > 0 {
+						for _, position := range scrapinContactResponse.Person.Positions.PositionHistory {
+							if position.Title != "" && position.CompanyName != "" && position.CompanyName == scrapinContactResponse.Company.Name {
+								positionName = position.Title
+								break
+							}
 						}
 					}
-				}
 
-				err = s.commonServices.ContactService.LinkContactWithOrganization(innerCtx, nil, orpanContact.ContactId, organizationId, positionName, "",
-					neo4jentity.DataSourceOpenline.String(), false, nil, nil)
-				if err != nil {
-					tracing.TraceErr(span, err)
+					err = s.commonServices.ContactService.LinkContactWithOrganization(innerCtx, nil, record.ContactId, organizationId, positionName, "",
+						neo4jentity.DataSourceOpenline.String(), false, nil, nil)
+					if err != nil {
+						tracing.TraceErr(innerSpan, err)
+					}
 				}
 			}
-		}
+		}(orphanContact)
 	}
 }
 

--- a/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
@@ -106,7 +106,7 @@ func (s *globalOrganizationService) ScrapeGlobalOrgs() {
 
 		go func(org *postgres_entity.GlobalOrganization) {
 			// Create timeout context for this goroutine
-			childCtx, childCancel := context.WithTimeout(ctx, time.Minute)
+			childCtx, childCancel := context.WithTimeout(ctx, 90*time.Second)
 			defer childCancel()
 
 			childSpan, childCtx := tracing.StartTracerSpan(childCtx, "GlobalOrganizationService.ScrapeGlobalOrg")
@@ -117,7 +117,7 @@ func (s *globalOrganizationService) ScrapeGlobalOrgs() {
 			defer func() { <-semaphore }() // Release semaphore when done
 
 			page := "https://" + org.PrimaryDomain
-			contents, err := s.commonServices.WebscraperService.Scrape(childCtx, page, org.PrimaryDomain)
+			contents, err := s.commonServices.WebscraperService.Scrape(childCtx, page)
 			if err != nil {
 				switch {
 				case errors.Is(err, webscraper.ErrUnprocessable):

--- a/packages/runner/customer-os-data-upkeeper/service/media_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/media_service.go
@@ -67,7 +67,7 @@ func (s *mediaService) FetchAndStoreCompanyLogos() {
 }
 
 func (s *mediaService) downloadImage(ctx context.Context, orgId uint64, imageUrl, imagePath, imageType string) bool {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "mediaService.download")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "MediaService.downloadImage")
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
 

--- a/packages/server/customer-os-api/rest/private/quickbooks.go
+++ b/packages/server/customer-os-api/rest/private/quickbooks.go
@@ -41,6 +41,7 @@ func CallbackQuickbooks(s *cosapi_services.Services) gin.HandlerFunc {
 		ctx, span := tracing.StartHttpServerTracerSpanWithHeader(c, "/internal/v1/settings/quickbooks/oauth/callback", c.Request.Header)
 		defer span.Finish()
 
+		// TODO if realm not used, delete it
 		code := c.Request.URL.Query().Get("code")
 		realmId := c.Request.URL.Query().Get("realmId")
 		redirectUrl := c.Request.URL.Query().Get("redirect_url")
@@ -72,7 +73,16 @@ func CallbackQuickbooks(s *cosapi_services.Services) gin.HandlerFunc {
 
 func GetQuickbooksSettings(s *cosapi_services.Services) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		quickbooksConnected, err := s.CommonServices.QuickbooksService.QuickbooksConnected(c.Request.Context())
+		ctx, span := tracing.StartHttpServerTracerSpanWithHeader(c, "/internal/v1/settings/tenant/settings", c.Request.Header)
+		defer span.Finish()
+
+		tenant, _ := c.Get(security.KEY_TENANT_NAME)
+
+		ctx = common.WithCustomContext(ctx, &common.CustomContext{
+			Tenant: tenant.(string),
+		})
+
+		quickbooksConnected, err := s.CommonServices.QuickbooksService.QuickbooksConnected(ctx)
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return

--- a/packages/server/customer-os-api/rest/private/quickbooks.go
+++ b/packages/server/customer-os-api/rest/private/quickbooks.go
@@ -38,7 +38,7 @@ func RequestAccessQuickbooks(s *cosapi_services.Services) gin.HandlerFunc {
 
 func CallbackQuickbooks(s *cosapi_services.Services) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		ctx, span := tracing.StartHttpServerTracerSpanWithHeader(c, "/internal/v1/settings/slack/oauth/callback", c.Request.Header)
+		ctx, span := tracing.StartHttpServerTracerSpanWithHeader(c, "/internal/v1/settings/quickbooks/oauth/callback", c.Request.Header)
 		defer span.Finish()
 
 		code := c.Request.URL.Query().Get("code")

--- a/packages/server/customer-os-api/rest/private/quickbooks.go
+++ b/packages/server/customer-os-api/rest/private/quickbooks.go
@@ -28,8 +28,6 @@ func RequestAccessQuickbooks(s *cosapi_services.Services) gin.HandlerFunc {
 		state := c.Query("state")
 		if state != "" {
 			quickbooksRequestAccessUrl += "&state=" + state
-		} else {
-			quickbooksRequestAccessUrl += "&state=12345"
 		}
 
 		span.LogFields(log.Object("quickbooksRequestAccessUrl", quickbooksRequestAccessUrl))

--- a/packages/server/customer-os-api/rest/public/reveal_website_events.go
+++ b/packages/server/customer-os-api/rest/public/reveal_website_events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"net/http"
 	"strings"
 
@@ -57,6 +58,7 @@ func (h *WebsiteTrackerEventsHandler) Handle() gin.HandlerFunc {
 			return
 		}
 		span.SetTag(tracing.SpanTagTenant, tenant)
+		ctx = common.SetTenantInContext(ctx, tenant)
 
 		trackerData := h.buildTrackerDbData(c, tenant)
 		if trackerData == nil {
@@ -317,8 +319,10 @@ func (h *WebsiteTrackerEventsHandler) buildTrackerDbData(c *gin.Context, tenant 
 }
 
 func (h *WebsiteTrackerEventsHandler) isTrustedIP(ctx context.Context, ipAddress string) bool {
-	span, ctx := tracing.StartTracerSpan(ctx, "WebsiteTrackerEventsHandler.isTrustedIp")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebsiteTrackerEventsHandler.isTrustedIp")
 	defer span.Finish()
+	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	span.LogKV("ipAddress", ipAddress)
 
 	ipThreats, err := h.services.CommonServices.VerifyService.Threats(ctx, ipAddress)
 	if err != nil || ipThreats == nil {

--- a/packages/server/customer-os-api/server/route_registry.go
+++ b/packages/server/customer-os-api/server/route_registry.go
@@ -58,7 +58,7 @@ func registerRoute(ctx context.Context, r *gin.Engine, config RouteConfig) {
 				config.services.Repositories.PostgresRepositories.TenantWebhookApiKeyRepository,
 				config.services.Repositories.PostgresRepositories.AppKeyRepository,
 				security.PLATFORM_ADMIN_API,
-				security.WithCache(config.services.Cache),
+				security.WithCache(config.cache),
 			),
 			security.TenantUserContextEnhancer(
 				config.services.Repositories.Neo4jRepositories,

--- a/packages/server/customer-os-common-module/interfaces/webscraper.go
+++ b/packages/server/customer-os-common-module/interfaces/webscraper.go
@@ -3,5 +3,5 @@ package interfaces
 import "context"
 
 type WebscraperService interface {
-	Scrape(ctx context.Context, url, primaryDomain string) (string, error)
+	Scrape(ctx context.Context, url string) (string, error)
 }

--- a/packages/server/customer-os-common-module/services/mailstack/service.go
+++ b/packages/server/customer-os-common-module/services/mailstack/service.go
@@ -231,6 +231,7 @@ func (s *mailstackService) GetAllMailstackDomains(ctx context.Context) (map[stri
 		output[mailStackDomain.Domain] = mailStackDomain.Tenant
 	}
 
+	span.LogFields(tracingLog.Int("response.count", len(output)))
 	return output, nil
 }
 

--- a/packages/server/customer-os-common-module/services/verify/service.go
+++ b/packages/server/customer-os-common-module/services/verify/service.go
@@ -169,7 +169,7 @@ func (s *verifyService) IdentifyCompanyDomain(ctx context.Context, ipAddress str
 }
 
 func (s *verifyService) Threats(ctx context.Context, ipAddress string) (*interfaces.IpThreats, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "VerifyService.IsBot")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "VerifyService.Threats")
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 	defer span.Finish()
 	span.LogKV("ipAddress", ipAddress)

--- a/packages/server/customer-os-common-module/services/webscraper/service.go
+++ b/packages/server/customer-os-common-module/services/webscraper/service.go
@@ -35,11 +35,11 @@ var (
 	ErrUnprocessable   = errors.New("Jina cannot process webpage")
 )
 
-func (s *webscraperService) Scrape(ctx context.Context, url, primaryDomain string) (string, error) {
+func (s *webscraperService) Scrape(ctx context.Context, url string) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "WebscraperService.Scrape")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("url", url), log.String("primaryDomain", primaryDomain))
+	span.LogFields(log.String("url", url))
 
 	// fetch page contents
 	contents, err := s.fetchPage(ctx, url)

--- a/packages/server/customer-os-neo4j-repository/entity/contact.go
+++ b/packages/server/customer-os-neo4j-repository/entity/contact.go
@@ -24,6 +24,7 @@ const (
 	ContactPropertyFindMobilePhoneWithBetterContactCompletedAt ContactProperty = "techFindMobilePhoneWithBetterContactCompletedAt"
 	ContactPropertyFindMobilePhoneWithBetterContactFound       ContactProperty = "techFindMobilePhoneWithBetterContactFound"
 	ContactPropertyUpdateWithWorkEmailRequestedAt              ContactProperty = "techUpdateWithWorkEmailRequestedAt"
+	ContactPropertyLinkWithOrgRequestedAt                      ContactProperty = "techLinkWithOrgRequestedAt"
 	ContactPropertyCheckedAt                                   ContactProperty = "techCheckedAt"
 	ContactPropertyPrefix                                      ContactProperty = "prefix"
 	ContactPropertyFirstName                                   ContactProperty = "firstName"

--- a/packages/server/customer-os-neo4j-repository/repository/contact_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/contact_read_repository.go
@@ -24,7 +24,7 @@ type ContactsEnrichWorkEmail struct {
 	OrganizationDomain string
 }
 
-type TenantAndContactId struct {
+type TenantAndContactIdAndParams struct {
 	Tenant    string
 	ContactId string
 	FieldStr1 string
@@ -39,20 +39,20 @@ type ContactReadRepository interface {
 	CountByTenant(ctx context.Context, tenant string) (int64, error)
 	GetContact(ctx context.Context, tenant, contactId string) (*dbtype.Node, error)
 	GetContacts(ctx context.Context, tenant string, contactIds []string) ([]*dbtype.Node, error)
-	GetContactsEnrichedNotLinkedToOrganization(ctx context.Context) ([]TenantAndContactId, error)
+	GetContactsEnrichedNotLinkedToOrganization(ctx context.Context, delayFromPreviousAttemptDays, limit int) ([]TenantAndContactIdAndParams, error)
 	GetContactsWithSocialUrl(ctx context.Context, tenant, socialUrl string) ([]*dbtype.Node, error)
 	GetContactsWithEmail(ctx context.Context, tenant, email string) ([]*dbtype.Node, error)
 	GetContactInOrganizationByEmail(ctx context.Context, tenant, organizationId, email string) (*neo4j.Node, error)
 	GetActiveContactsForOrganizations(ctx context.Context, tenant string, organizationIds []string) ([]*utils.DbNodeAndId, error)
 	GetContactCountByOrganizations(ctx context.Context, tenant string, ids []string) (map[string]int64, error)
 	GetContactsToFindWorkEmailWithBetterContact(ctx context.Context, minutesFromLastContactUpdate, limit int) ([]ContactsEnrichWorkEmail, error)
-	GetContactsToEnrichWithEmailFromBetterContact(ctx context.Context, limit int) ([]TenantAndContactId, error)
-	GetContactsToEnrich(ctx context.Context, minutesFromLastContactUpdate, minutesFromLastEnrichAttempt, limit int) ([]TenantAndContactId, error)
-	GetContactsWithGroupOrSystemGeneratedEmail(ctx context.Context, limit int) ([]TenantAndContactId, error)
-	GetContactsWithEmailForNameUpdate(ctx context.Context, limit int) ([]TenantAndContactId, error)
+	GetContactsToEnrichWithEmailFromBetterContact(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error)
+	GetContactsToEnrich(ctx context.Context, minutesFromLastContactUpdate, minutesFromLastEnrichAttempt, limit int) ([]TenantAndContactIdAndParams, error)
+	GetContactsWithGroupOrSystemGeneratedEmail(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error)
+	GetContactsWithEmailForNameUpdate(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error)
 	GetContactsToCheck(ctx context.Context, minutesSinceLastUpdate, hoursSinceLastCheck, limit int) ([]TenantAndContact, error)
 	GetContactsByLinkedIn(ctx context.Context, tenant, url, alias, externalId string) ([]*dbtype.Node, error)
-	GetContactsToSetPrimaryJobRole(ctx context.Context, limit int) ([]TenantAndContactId, error)
+	GetContactsToSetPrimaryJobRole(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error)
 	GetDistinctContactRegions(ctx context.Context, tenant string) ([]string, error)
 	GetDistinctContactCities(ctx context.Context, tenant string) ([]string, error)
 }
@@ -69,20 +69,32 @@ func NewContactReadRepository(driver *neo4j.DriverWithContext, database string) 
 	}
 }
 
-func (r *contactReadRepository) GetContactsEnrichedNotLinkedToOrganization(ctx context.Context) ([]TenantAndContactId, error) {
+func (r *contactReadRepository) GetContactsEnrichedNotLinkedToOrganization(ctx context.Context, delayFromPreviousAttemptDays, limit int) ([]TenantAndContactIdAndParams, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsEnrichedNotLinkedToOrganization")
 	defer span.Finish()
 	tracing.TagComponentNeo4jRepository(span)
+	span.LogFields(log.Int("delayFromPreviousAttemptDays", delayFromPreviousAttemptDays), log.Int("limit", limit))
+
+	cypher := `MATCH (t:Tenant {active:true})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)-[:HAS]->(s:Social)
+			WHERE
+				(c.hide IS NULL OR c.hide = false) AND
+				(c.techLinkWithOrgRequestedAt IS NULL OR c.techLinkWithOrgRequestedAt < datetime() - duration({days: $delayDays})) AND
+				c.enrichedAt IS NOT NULL AND
+				s.url =~ '.*linkedin.com.*' AND 
+				NOT (c)--(:JobRole)
+			RETURN DISTINCT t.name, c.id, s.url limit $limit`
+	params := map[string]interface{}{
+		"limit":     limit,
+		"delayDays": delayFromPreviousAttemptDays,
+	}
+	span.LogFields(log.String("cypher", cypher))
+	tracing.LogObjectAsJson(span, "params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
 
 	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
-		if queryResult, err := tx.Run(ctx, `
-			MATCH (t:Tenant)<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)-[:HAS]->(s:Social) 
-			WHERE c.enrichedAt is not null and s.url =~ '.*linkedin.com.*' and not (c)--(:JobRole)
-			RETURN DISTINCT t.name, c.id, s.url`,
-			map[string]interface{}{}); err != nil {
+		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
 			return nil, err
 		} else {
 			return queryResult.Collect(ctx)
@@ -91,10 +103,10 @@ func (r *contactReadRepository) GetContactsEnrichedNotLinkedToOrganization(ctx c
 	if err != nil {
 		return nil, err
 	}
-	output := make([]TenantAndContactId, 0)
+	output := make([]TenantAndContactIdAndParams, 0)
 	for _, v := range result.([]*neo4j.Record) {
 		output = append(output,
-			TenantAndContactId{
+			TenantAndContactIdAndParams{
 				Tenant:    v.Values[0].(string),
 				ContactId: v.Values[1].(string),
 				FieldStr1: v.Values[2].(string),
@@ -437,7 +449,7 @@ func (r *contactReadRepository) GetContactsToFindWorkEmailWithBetterContact(ctx 
 	return output, nil
 }
 
-func (r *contactReadRepository) GetContactsToEnrichWithEmailFromBetterContact(ctx context.Context, limit int) ([]TenantAndContactId, error) {
+func (r *contactReadRepository) GetContactsToEnrichWithEmailFromBetterContact(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsToEnrichWithEmailFromBetterContact")
 	defer span.Finish()
 	tracing.TagComponentNeo4jRepository(span)
@@ -477,10 +489,10 @@ func (r *contactReadRepository) GetContactsToEnrichWithEmailFromBetterContact(ct
 	if err != nil {
 		return nil, err
 	}
-	output := make([]TenantAndContactId, 0)
+	output := make([]TenantAndContactIdAndParams, 0)
 	for _, v := range records.([]*neo4j.Record) {
 		output = append(output,
-			TenantAndContactId{
+			TenantAndContactIdAndParams{
 				Tenant:    v.Values[0].(string),
 				ContactId: v.Values[1].(string),
 				FieldStr1: v.Values[2].(string),
@@ -490,7 +502,7 @@ func (r *contactReadRepository) GetContactsToEnrichWithEmailFromBetterContact(ct
 	return output, nil
 }
 
-func (r *contactReadRepository) GetContactsToEnrich(ctx context.Context, minutesFromLastContactUpdate, minutesFromLastEnrichAttempt, limit int) ([]TenantAndContactId, error) {
+func (r *contactReadRepository) GetContactsToEnrich(ctx context.Context, minutesFromLastContactUpdate, minutesFromLastEnrichAttempt, limit int) ([]TenantAndContactIdAndParams, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsToEnrich")
 	defer span.Finish()
 	tracing.TagComponentNeo4jRepository(span)
@@ -541,10 +553,10 @@ func (r *contactReadRepository) GetContactsToEnrich(ctx context.Context, minutes
 	if err != nil {
 		return nil, err
 	}
-	output := make([]TenantAndContactId, 0)
+	output := make([]TenantAndContactIdAndParams, 0)
 	for _, v := range records.([]*neo4j.Record) {
 		output = append(output,
-			TenantAndContactId{
+			TenantAndContactIdAndParams{
 				Tenant:    v.Values[0].(string),
 				ContactId: v.Values[1].(string),
 			})
@@ -553,7 +565,7 @@ func (r *contactReadRepository) GetContactsToEnrich(ctx context.Context, minutes
 	return output, nil
 }
 
-func (r *contactReadRepository) GetContactsWithGroupOrSystemGeneratedEmail(ctx context.Context, limit int) ([]TenantAndContactId, error) {
+func (r *contactReadRepository) GetContactsWithGroupOrSystemGeneratedEmail(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsWithGroupOrSystemGeneratedEmail")
 	defer span.Finish()
 	tracing.TagComponentNeo4jRepository(span)
@@ -583,10 +595,10 @@ func (r *contactReadRepository) GetContactsWithGroupOrSystemGeneratedEmail(ctx c
 	if err != nil {
 		return nil, err
 	}
-	output := make([]TenantAndContactId, 0)
+	output := make([]TenantAndContactIdAndParams, 0)
 	for _, v := range records.([]*neo4j.Record) {
 		output = append(output,
-			TenantAndContactId{
+			TenantAndContactIdAndParams{
 				Tenant:    v.Values[0].(string),
 				ContactId: v.Values[1].(string),
 			})
@@ -595,7 +607,7 @@ func (r *contactReadRepository) GetContactsWithGroupOrSystemGeneratedEmail(ctx c
 	return output, nil
 }
 
-func (r *contactReadRepository) GetContactsWithEmailForNameUpdate(ctx context.Context, limit int) ([]TenantAndContactId, error) {
+func (r *contactReadRepository) GetContactsWithEmailForNameUpdate(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsWithEmailForNameUpdate")
 	defer span.Finish()
 	tracing.TagComponentNeo4jRepository(span)
@@ -629,10 +641,10 @@ func (r *contactReadRepository) GetContactsWithEmailForNameUpdate(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	output := make([]TenantAndContactId, 0)
+	output := make([]TenantAndContactIdAndParams, 0)
 	for _, v := range records.([]*neo4j.Record) {
 		output = append(output,
-			TenantAndContactId{
+			TenantAndContactIdAndParams{
 				Tenant:    v.Values[0].(string),
 				ContactId: v.Values[1].(string),
 				FieldStr1: v.Values[2].(string),
@@ -783,7 +795,7 @@ func (r *contactReadRepository) CountByTenant(ctx context.Context, tenant string
 	return organizationsCount, nil
 }
 
-func (r *contactReadRepository) GetContactsToSetPrimaryJobRole(ctx context.Context, limit int) ([]TenantAndContactId, error) {
+func (r *contactReadRepository) GetContactsToSetPrimaryJobRole(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsToSetPrimaryJobRole")
 	defer span.Finish()
 	tracing.TagComponentNeo4jRepository(span)
@@ -813,10 +825,10 @@ func (r *contactReadRepository) GetContactsToSetPrimaryJobRole(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	output := make([]TenantAndContactId, 0)
+	output := make([]TenantAndContactIdAndParams, 0)
 	for _, v := range records.([]*neo4j.Record) {
 		output = append(output,
-			TenantAndContactId{
+			TenantAndContactIdAndParams{
 				Tenant:    v.Values[0].(string),
 				ContactId: v.Values[1].(string),
 			})

--- a/packages/server/customer-os-postgres-repository/repository/global_organization_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/global_organization_repository.go
@@ -420,6 +420,7 @@ func (r *globalOrganizationRepository) SetScrapeStatus(ctx context.Context, id u
 	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.SetScrapeStatus")
 	defer span.Finish()
 	tracing.TagComponentPostgresRepository(span)
+	span.LogFields(tracingLog.Uint64("id", id), tracingLog.String("status", status.String()))
 
 	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalOrganization{}).
 		Where("id = ?", id).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix context timeout and improve orphan contacts linking in `contact_service.go` and `global_organization_service.go`, with refactoring and logging updates.
> 
>   - **Behavior**:
>     - Fix context timeout in `ScrapeGlobalOrgs()` in `global_organization_service.go` by increasing timeout to 90 seconds.
>     - Update `linkOrphanContactsToOrganizationBasedOnLinkedin()` in `contact_service.go` to handle orphan contacts with a delay and limit.
>     - Remove default state in `RequestAccessQuickbooks()` in `quickbooks.go`.
>   - **Refactoring**:
>     - Rename `linkOrphanContactsToOrganizationBaseOnLinkedinScrapIn()` to `linkOrphanContactsToOrganizationBasedOnLinkedin()` in `contact_service.go`.
>     - Rename `TenantAndContactId` to `TenantAndContactIdAndParams` in `contact_read_repository.go` and other related files.
>     - Remove `primaryDomain` parameter from `Scrape()` in `webscraper.go` and update related calls.
>   - **Misc**:
>     - Update logging and tracing in various functions across multiple files for better error handling and debugging.
>     - Minor updates to `route_registry.go` to use `config.cache` instead of `services.Cache`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 091179810279c23ccedce72400640bfe48934880. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->