### PR TITLE
fix content-type on logos

### DIFF
--- a/packages/server/customer-os-common-module/clients/aws_client/s3.go
+++ b/packages/server/customer-os-common-module/clients/aws_client/s3.go
@@ -2,7 +2,6 @@ package aws_client
 
 import (
 	"context"
-	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -14,7 +13,7 @@ import (
 )
 
 type S3Client interface {
-	Upload(ctx context.Context, bucket, key string, content io.Reader) error
+	Upload(ctx context.Context, uploadContainer s3manager.UploadInput) error
 	Download(ctx context.Context, bucket, key string) (string, error)
 	ListFiles(ctx context.Context, bucket string) ([]string, error)
 	ChangeRegion(ctx context.Context, region string)
@@ -37,16 +36,12 @@ func NewS3Client(config *aws.Config) S3Client {
 	}
 }
 
-func (s *s3Client) Upload(ctx context.Context, bucket, key string, content io.Reader) error {
+func (s *s3Client) Upload(ctx context.Context, uploadContainer s3manager.UploadInput) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "s3Client.Upload")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 
-	_, err := s.Uploader.Upload(&s3manager.UploadInput{
-		Bucket: &bucket,
-		Key:    &key,
-		Body:   content,
-	})
+	_, err := s.Uploader.Upload(&uploadContainer)
 	return err
 }
 

--- a/packages/server/customer-os-common-module/services/media/service.go
+++ b/packages/server/customer-os-common-module/services/media/service.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"net/http"
 	"path/filepath"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 	"github.com/opentracing/opentracing-go"
 	tracingLog "github.com/opentracing/opentracing-go/log"
@@ -105,8 +107,29 @@ func (s *mediaService) DownloadImageToS3(ctx context.Context, imageURL, bucketNa
 		}
 	}
 
+	if contentType == "" {
+		ext := strings.ToLower(filepath.Ext(s3FilePath))
+		switch ext {
+		case ".jpg", ".jpeg":
+			contentType = "image/jpeg"
+		case ".png":
+			contentType = "image/png"
+		case ".gif":
+			contentType = "image/gif"
+		case ".webp":
+			contentType = "image/webp"
+		default:
+			contentType = "image/jpeg" // fallback
+		}
+	}
+
 	// Upload directly to S3 using the provided S3Client
-	err = s.s3client.Upload(ctx, bucketName, s3FilePath, resp.Body)
+	err = s.s3client.Upload(ctx, s3manager.UploadInput{
+		Bucket:      aws.String(bucketName),
+		Key:         aws.String(s3FilePath),
+		Body:        resp.Body,
+		ContentType: aws.String(contentType),
+	})
 	if err != nil {
 		span.LogFields(tracingLog.Error(err))
 		return "", err


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `Upload` function to accept `s3manager.UploadInput` and ensure correct content type in S3 uploads.
> 
>   - **Behavior**:
>     - Modify `Upload` function in `s3.go` to accept `s3manager.UploadInput` instead of individual parameters.
>     - In `service.go`, determine content type based on file extension or default to `image/jpeg` if not provided.
>     - Ensure correct content type is set when uploading images to S3 in `DownloadImageToS3()`.
>   - **Misc**:
>     - Remove unused import `io` from `s3.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 92c9de0882c40c10db131114de693ef7745dd633. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->