### PR TITLE
add caching to webscraper

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
@@ -138,16 +138,6 @@ func (s *globalOrganizationService) ScrapeGlobalOrgs() {
 				return
 			}
 
-			_, err = s.commonServices.PostgresRepositories.GlobalOrganizationWebpageRepository.Save(childCtx, postgres_entity.GlobalOrganizationWebpages{
-				Url:           page,
-				PrimaryDomain: org.PrimaryDomain,
-				Content:       contents,
-			})
-			if err != nil {
-				tracing.TraceErr(childSpan, errors.Wrap(err, "error saving webpage content"))
-				return
-			}
-
 			err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetScrapeStatus(childCtx, org.ID, enum.ScrapeCompleted)
 			if err != nil {
 				tracing.TraceErr(childSpan, errors.Wrap(err, "error updating global org scraped status"))

--- a/packages/server/customer-os-common-module/services/webscraper/service.go
+++ b/packages/server/customer-os-common-module/services/webscraper/service.go
@@ -9,13 +9,16 @@ import (
 	"strings"
 	"time"
 
+	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
+	"github.com/customeros/mailsherpa/domaincheck"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 )
 
 type webscraperService struct {
@@ -29,6 +32,8 @@ func NewWebscraperService(config *config.JinaConfig, postgres *postgres_reposito
 		postgresRepositories: postgres,
 	}
 }
+
+const WebpageScrapeTTLInDays = 180
 
 var (
 	ErrPaymentRequired = errors.New("Jina balance requires topup")
@@ -63,6 +68,22 @@ func (s *webscraperService) Scrape(ctx context.Context, url string) (string, err
 		return "", ErrUnprocessable
 	}
 
+	if contents == "" {
+		return "", nil
+	}
+
+	_, primaryDomain := domaincheck.PrimaryDomainCheck(utils.ExtractDomain(url))
+
+	_, err = s.postgresRepositories.GlobalOrganizationWebpageRepository.Save(ctx, postgres_entity.GlobalOrganizationWebpages{
+		PrimaryDomain: primaryDomain,
+		Url:           url,
+		Content:       contents,
+	})
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", err
+	}
+
 	return contents, nil
 }
 
@@ -70,6 +91,15 @@ func (s *webscraperService) fetchPage(ctx context.Context, url string) (string, 
 	span, ctx := opentracing.StartSpanFromContext(ctx, "WebscraperService.fetchPage")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	cachedData, err := s.checkCache(ctx, url, WebpageScrapeTTLInDays)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", err
+	}
+	if cachedData != "" {
+		return cachedData, nil
+	}
 
 	requestUrl := s.config.Url + url
 	span.LogKV("requestUrl", requestUrl)
@@ -121,4 +151,21 @@ func (s *webscraperService) fetchPage(ctx context.Context, url string) (string, 
 	}
 
 	return string(body), nil
+}
+
+func (s *webscraperService) checkCache(ctx context.Context, url string, cacheTTL int) (string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "webscraperService.checkCache")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	record, err := s.postgresRepositories.GlobalOrganizationWebpageRepository.GetWebpage(ctx, url, cacheTTL)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", err
+	}
+	if record == nil || record.Content == "" {
+		return "", nil
+	}
+
+	return record.Content, nil
 }

--- a/packages/server/customer-os-postgres-repository/repository/global_organization_webpages.go
+++ b/packages/server/customer-os-postgres-repository/repository/global_organization_webpages.go
@@ -14,6 +14,7 @@ import (
 
 type GlobalOrganizationWebpageRepository interface {
 	Save(ctx context.Context, webpageData postgres_entity.GlobalOrganizationWebpages) (*postgres_entity.GlobalOrganizationWebpages, error)
+	GetWebpage(ctx context.Context, url string, lookbackInDays int) (*postgres_entity.GlobalOrganizationWebpages, error)
 }
 
 type globalOrganizationWebpageRepository struct {
@@ -61,4 +62,28 @@ func (r *globalOrganizationWebpageRepository) Save(ctx context.Context, webpageD
 	}
 
 	return &existingRecord, nil
+}
+
+func (r *globalOrganizationWebpageRepository) GetWebpage(ctx context.Context, url string, lookbackInDays int) (*postgres_entity.GlobalOrganizationWebpages, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "globalOrganizationWebpageRepository.GetWebpage")
+	defer span.Finish()
+	tracing.TagComponentPostgresRepository(span)
+
+	// Calculate the cutoff date
+	cutoffDate := time.Now().AddDate(0, 0, -lookbackInDays)
+
+	var record postgres_entity.GlobalOrganizationWebpages
+	err := r.gormDb.
+		Where("url = ?", url).
+		Where("updated_at > ?", cutoffDate).
+		First(&record).
+		Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return &record, nil
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add caching to the webscraper by checking and saving webpage content in the database, optimizing fetch operations.
> 
>   - **Caching Logic**:
>     - Added `checkCache()` in `webscraperService` to check for cached webpage content before fetching.
>     - `fetchPage()` in `webscraperService` now uses `checkCache()` to return cached data if available.
>     - `GetWebpage()` in `globalOrganizationWebpageRepository` retrieves cached content based on URL and TTL.
>   - **Database Operations**:
>     - Removed webpage content saving from `ScrapeGlobalOrgs()` in `global_organization_service.go`.
>     - `Scrape()` in `webscraperService` now saves webpage content to the database after fetching.
>   - **Constants**:
>     - Added `WebpageScrapeTTLInDays` constant in `webscraperService` for cache TTL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8f618e87aad35da782ca306893c5261d3a4468b7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->