### PR TITLE
unique agents

### DIFF
--- a/packages/server/customer-os-common-module/services/agent/agent_registry_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_registry_service.go
@@ -37,6 +37,7 @@ type AgentMetadata struct {
 	Type        string `toml:"type"`
 	Scope       string `toml:"scope"`
 	Icon        string `toml:"icon"`
+	Unique      bool   `toml:"unique"`
 }
 
 type GoalConfig struct {
@@ -142,6 +143,7 @@ func (r *agentRegistryService) processAgentConfigFile(ctx context.Context, filen
 		Version:          agentConfig.Agent.Version,
 		Filename:         filename,
 		Icon:             agentConfig.Agent.Icon,
+		IsUnique:         agentConfig.Agent.Unique,
 		IsActive:         true,
 	}
 

--- a/packages/server/customer-os-common-module/services/agent/agent_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_service.go
@@ -116,6 +116,20 @@ func (a *agentService) CreateAgent(ctx context.Context, agentType enum.AgentType
 		return nil, err
 	}
 
+	// if agent registry is unique, check no other instances of agent exist before creation
+	if agentRegistry.IsUnique {
+		agents, err := a.postgresRepositories.AgentRepository.GetAllAgentsByTypes(ctx, []enum.AgentType{agentType})
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return nil, err
+		}
+		if len(agents) > 0 {
+			err := errors.New("agent already exists")
+			tracing.TraceErr(span, err)
+			return nil, err
+		}
+	}
+
 	// build new agent
 	agent := postgresentity.Agent{
 		Type:        agentType,

--- a/packages/server/customer-os-postgres-repository/entity/agent_registry.go
+++ b/packages/server/customer-os-postgres-repository/entity/agent_registry.go
@@ -23,6 +23,7 @@ type AgentRegistry struct {
 	Goal             string          `gorm:"column:goal;type:varchar(255)" json:"goal"`
 	Metric           string          `gorm:"column:metric;type:varchar(255)" json:"metric"`
 	IsActive         bool            `gorm:"column:is_active;type:boolean;default:true" json:"isActive"`
+	IsUnique         bool            `gorm:"column:unique;type:boolean;default:false" json:"unique"`
 	Icon             string          `gorm:"column:icon;type:text" json:"icon"`
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add uniqueness constraint to agents, preventing multiple instances of unique agent types.
> 
>   - **Behavior**:
>     - Adds `Unique` field to `AgentMetadata` in `agent_registry_service.go` to mark agents as unique.
>     - In `CreateAgent` in `agent_service.go`, checks if an agent type is unique and prevents creation if an instance already exists.
>   - **Models**:
>     - Adds `IsUnique` field to `AgentRegistry` in `agent_registry.go` to store uniqueness information in the database.
>   - **Misc**:
>     - Updates `processAgentConfigFile` in `agent_registry_service.go` to handle the new `Unique` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a3d1b6b714333b091b9c2162a3f98d216f4aa32e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->