### PR TITLE
Fix slack redirect

### DIFF
--- a/packages/server/customer-os-api/rest/private/slack.go
+++ b/packages/server/customer-os-api/rest/private/slack.go
@@ -78,6 +78,7 @@ func RequestAccessSlack(s *cosapi_services.Services) gin.HandlerFunc {
 
 		if redirectUrl != "" {
 			slackRequestAccessUrl += "&redirect_url=" + url.QueryEscape(redirectUrl)
+			slackRequestAccessUrl += "&redirect_uri=" + url.QueryEscape(redirectUrl)
 		}
 
 		span.LogFields(log.Object("slackRequestAccessUrl", slackRequestAccessUrl))

--- a/packages/server/customer-os-api/rest/private/slack.go
+++ b/packages/server/customer-os-api/rest/private/slack.go
@@ -111,6 +111,7 @@ func CallbackSlack(s *cosapi_services.Services) gin.HandlerFunc {
 		requestData.Set("client_id", s.Cfg.Common.External.SlackConfig.ClientID)
 		requestData.Set("client_secret", s.Cfg.Common.External.SlackConfig.ClientSecret)
 		requestData.Set("redirect_url", url.QueryEscape(redirectUrl))
+		requestData.Set("redirect_uri", url.QueryEscape(redirectUrl))
 
 		// Encode the form data
 		requestBody := requestData.Encode()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes Slack redirect by adding `redirect_uri` parameter in `RequestAccessSlack` and `CallbackSlack` functions in `slack.go`.
> 
>   - **Behavior**:
>     - In `RequestAccessSlack` and `CallbackSlack` functions in `slack.go`, added `redirect_uri` parameter alongside `redirect_url` for Slack OAuth process.
>   - **Functions**:
>     - `RequestAccessSlack`: Appends `redirect_uri` to `slackRequestAccessUrl`.
>     - `CallbackSlack`: Sets `redirect_uri` in `requestData` for token exchange.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c435d620ffc4cd99cf54fa962e8f41b53c3ea9a6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->