### PR TITLE
Add ability to crawl a company website

### DIFF
--- a/packages/server/customer-os-api/config/config.go
+++ b/packages/server/customer-os-api/config/config.go
@@ -49,6 +49,7 @@ type CommonConfig struct {
 	PdfConverter      commonconf.PdfConverterConfig
 	GoogleOAuthConfig commonconf.GoogleOAuthConfig
 	AzureOAuthConfig  commonconf.AzureOAuthConfig
+	Jina              commonconf.JinaConfig
 }
 
 type AppConfig struct {
@@ -132,6 +133,7 @@ func InitConfig() (*Config, error) {
 			NovuConfig:           cmnCfg.Novu,
 			TemporalConfig:       cmnCfg.Temporal,
 			BrandfetchConfig:     cmnCfg.Brandfetch,
+			JinaConfig:           cmnCfg.Jina,
 		},
 		Internal: commonconf.InternalServicesConfig{
 			CustomerOsApi:       cmnCfg.CosApi,

--- a/packages/server/customer-os-api/rest/init_handlers.go
+++ b/packages/server/customer-os-api/rest/init_handlers.go
@@ -22,6 +22,7 @@ type RestHandlers struct {
 
 	AskAI                *private.AskAIHandler
 	Billing              *billing.BillingHandler
+	BrowserExtension     *public.BrowserExtensionHandler
 	Contact              *customerbase.ContactHandler
 	Enrich               *enrich.EnrichHandler
 	Files                *files.FileHandler
@@ -33,9 +34,9 @@ type RestHandlers struct {
 	PrivateIntegrations  *private.PrivateIntegrationHandler
 	Verify               *verify.VerifyHandler
 	Webhooks             *webhooks.WebhookHandler
+	Webscrape            *private.WebscrapeHandler
 	WebTracker           *reveal.WebTrackerHandler
 	WebsiteTrackerEvents *public.WebsiteTrackerEventsHandler
-	BrowserExtension     *public.BrowserExtensionHandler
 }
 
 func InitRestHandlers(services *cosapi_services.Services) *RestHandlers {
@@ -45,6 +46,7 @@ func InitRestHandlers(services *cosapi_services.Services) *RestHandlers {
 	handlers := RestHandlers{
 		AskAI:                private.NewAskAIHandler(services, responseHandler),
 		Billing:              billing.NewBillingHandler(services, responseHandler),
+		BrowserExtension:     public.NewBrowserExtensionHandler(services, responseHandler),
 		Contact:              customerbase.NewContactHandler(services, responseHandler),
 		Enrich:               enrich.NewEnrichHandler(services, responseHandler),
 		Files:                files.NewFileHandler(services, responseHandler),
@@ -56,9 +58,9 @@ func InitRestHandlers(services *cosapi_services.Services) *RestHandlers {
 		PrivateIntegrations:  private.NewPrivateIntegrationHandler(services, responseHandler),
 		Verify:               verify.NewVerifyHandler(services, responseHandler),
 		Webhooks:             webhooks.NewWebhookHandler(services, responseHandler, integrationsHandler),
+		Webscrape:            private.NewWebscrapeHandler(services, responseHandler),
 		WebTracker:           reveal.NewWebTrackerHandler(services, responseHandler),
 		WebsiteTrackerEvents: public.NewWebsiteTrackerEventsHandler(services, responseHandler),
-		BrowserExtension:     public.NewBrowserExtensionHandler(services, responseHandler),
 	}
 
 	return &handlers

--- a/packages/server/customer-os-api/rest/private/scrape.go
+++ b/packages/server/customer-os-api/rest/private/scrape.go
@@ -1,0 +1,82 @@
+package private
+
+import (
+	"net/http"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/constants"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/gin-gonic/gin"
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/customeros/customeros/packages/server/customer-os-api/rest/response"
+	cosapi_services "github.com/customeros/customeros/packages/server/customer-os-api/services"
+)
+
+type WebscrapeHandler struct {
+	services        *cosapi_services.Services
+	responseHandler *response.Response
+}
+
+func NewWebscrapeHandler(services *cosapi_services.Services, responseHandler *response.Response) *WebscrapeHandler {
+	return &WebscrapeHandler{
+		services:        services,
+		responseHandler: responseHandler,
+	}
+}
+
+type WebscrapeRequest struct {
+	Url string `json:"url"`
+}
+
+type WebscrapeResponse struct {
+	ScrapedUrls []string `json:"scrapedUrls"`
+}
+
+func (h *WebscrapeHandler) Crawl() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := common.WithCustomContextFromGinRequest(c, constants.AppSourceCustomerOsApi)
+
+		ctx, span := tracing.StartHttpServerTracerSpanWithHeader(ctx, "/crawl", c.Request.Header)
+		defer span.Finish()
+		tracing.SetDefaultServiceSpanTags(ctx, span)
+
+		// parse request
+		request, err := h.parseRequest(c)
+		if err != nil {
+			message := "Unable to parse request"
+			h.responseHandler.HandleError(c, http.StatusBadRequest, &message)
+			return
+		}
+
+		crawled, err := h.services.CommonServices.WebscraperService.Crawl(ctx, request.Url)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			message := "Unable to crawl website"
+			h.responseHandler.HandleError(c, http.StatusInternalServerError, &message)
+			return
+		}
+
+		h.responseHandler.HandleSuccess(c, WebscrapeResponse{
+			ScrapedUrls: crawled,
+		})
+
+		return
+	}
+}
+
+func (h *WebscrapeHandler) parseRequest(c *gin.Context) (*WebscrapeRequest, error) {
+	span, _ := opentracing.StartSpanFromContext(c.Request.Context(), "parseRequest")
+	defer span.Finish()
+	tracing.TagComponentRest(span)
+
+	var request WebscrapeRequest
+	err := c.BindJSON(&request)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+	tracing.LogObjectAsJson(span, "request", request)
+
+	return &request, nil
+}

--- a/packages/server/customer-os-api/server/internal_routes.go
+++ b/packages/server/customer-os-api/server/internal_routes.go
@@ -189,4 +189,12 @@ func registerInternalRoutes(ctx context.Context, r *gin.Engine, s *cosapi_servic
 		routeType: RouteInternal,
 		services:  s,
 	})
+
+	registerRoute(ctx, r, RouteConfig{
+		method:    "POST",
+		path:      fmt.Sprintf("%s/crawl", InternalPath),
+		handler:   h.Webscrape.Crawl(),
+		routeType: RouteInternal,
+		services:  s,
+	})
 }

--- a/packages/server/customer-os-common-module/interfaces/company_research.go
+++ b/packages/server/customer-os-common-module/interfaces/company_research.go
@@ -3,5 +3,6 @@ package interfaces
 import "context"
 
 type CompanyResearch interface {
-	GetIdealCustomerProfile(ctx context.Context) (string, error)
+	GenerateIdealCustomerProfile(ctx context.Context, tenantDomain string, trainingWebsites []string) (string, error)
+	GenerateCompanyBrief(ctx context.Context, domains []string) (string, error)
 }

--- a/packages/server/customer-os-common-module/interfaces/company_research.go
+++ b/packages/server/customer-os-common-module/interfaces/company_research.go
@@ -1,0 +1,7 @@
+package interfaces
+
+import "context"
+
+type CompanyResearch interface {
+	GetIdealCustomerProfile(ctx context.Context) (string, error)
+}

--- a/packages/server/customer-os-common-module/interfaces/webscraper.go
+++ b/packages/server/customer-os-common-module/interfaces/webscraper.go
@@ -3,5 +3,6 @@ package interfaces
 import "context"
 
 type WebscraperService interface {
+	Crawl(ctx context.Context, startUrl string) ([]string, error)
 	Scrape(ctx context.Context, url string) (string, error)
 }

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
@@ -19,20 +18,20 @@ import (
 const MinICPCompanyExamples = 5
 
 type EvaluateICPFitCapability struct {
-	aiService interfaces.AIService
+	aiService         interfaces.AIService
+	webscraperService interfaces.WebscraperService
 }
 
 type EvaluateICPFitInput struct {
-	OrganizationID      string              `json:"organizationId"`
-	CompanyName         string              `json:"companyName"`
-	PrimaryDomain       string              `json:"primaryDomain"`
-	CompanyDescriptions CompanyDescriptions `json:"companyDescriptions"`
-	IndustryNAICSName   string              `json:"industryName"`
-	YearCompanyFounded  string              `json:"yearCompanyFounded"`
-	EmployeeCount       int64               `json:"employeeCount"`
-	CompanyCity         string              `json:"companyCity"`
-	CompanyRegion       string              `json:"companyRegion"`
-	CompanyCountryA2    string              `json:"companyCountry"`
+	OrganizationID     string `json:"organizationId"`
+	CompanyName        string `json:"companyName"`
+	PrimaryDomain      string `json:"primaryDomain"`
+	IndustryNAICSName  string `json:"industryName"`
+	YearCompanyFounded string `json:"yearCompanyFounded"`
+	EmployeeCount      int64  `json:"employeeCount"`
+	CompanyCity        string `json:"companyCity"`
+	CompanyRegion      string `json:"companyRegion"`
+	CompanyCountryA2   string `json:"companyCountry"`
 }
 
 type EvaluateICPFitOutput struct {
@@ -49,12 +48,6 @@ type EvaluateICPFitConfig struct {
 func (c *EvaluateICPFitConfig) Validate() bool {
 	isValid := true
 
-	if c.QualificationCriteria.Value == "" {
-		c.QualificationCriteria.Error = "Please provide a qualification criteria"
-		isValid = false
-	} else {
-		c.QualificationCriteria.Error = ""
-	}
 	if len(c.ICPCompanyExamples.Value) < MinICPCompanyExamples {
 		c.ICPCompanyExamples.Error = "Add at least 5 websites"
 		isValid = false
@@ -65,9 +58,10 @@ func (c *EvaluateICPFitConfig) Validate() bool {
 	return isValid
 }
 
-func NewEvaluateICPFitCapability(aiService interfaces.AIService) *EvaluateICPFitCapability {
+func NewEvaluateICPFitCapability(aiService interfaces.AIService, webscraperService interfaces.WebscraperService) *EvaluateICPFitCapability {
 	return &EvaluateICPFitCapability{
-		aiService: aiService,
+		aiService:         aiService,
+		webscraperService: webscraperService,
 	}
 }
 
@@ -113,8 +107,6 @@ func (c *EvaluateICPFitCapability) ValidateInput(input EvaluateICPFitInput) erro
 		return errors.New("missing required input: PrimaryDomain")
 	case input.CompanyName == "":
 		return errors.New("missing required input: CompanyName")
-	case input.CompanyDescriptions.Description == "":
-		return errors.New("missing required input: CompanyDescription")
 	case input.IndustryNAICSName == "":
 		return errors.New("missing required input: IndustryNAICSName")
 	case input.EmployeeCount == 0:
@@ -151,8 +143,14 @@ func (c *EvaluateICPFitCapability) Execute(ctx context.Context, executionContain
 		return enum.CapabilityExecutionError, result, err
 	}
 
+	// get ICP profile
+
 	// build prompt
-	systemPrompt, content := c.buildPrompts(executionContainer)
+	systemPrompt, content, err := c.buildPrompts(ctx, executionContainer)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return enum.CapabilityExecutionError, result, err
+	}
 
 	// askAI
 	answer, err := c.aiService.AskAI(ctx, enum.AIModelAnthropicHaiku, systemPrompt, content)
@@ -184,8 +182,18 @@ func (c *EvaluateICPFitCapability) Execute(ctx context.Context, executionContain
 	return enum.CapabilityExecutionCompleted, result, nil
 }
 
-func (c *EvaluateICPFitCapability) buildPrompts(executionContainer interfaces.TypedExecutionContainer[EvaluateICPFitInput, EvaluateICPFitConfig]) (string, string) {
+func (c *EvaluateICPFitCapability) buildPrompts(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[EvaluateICPFitInput, EvaluateICPFitConfig]) (string, string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "EvaluateICPFitCapability.buildPrompts")
+	defer span.Finish()
+	tracing.TagComponentService(span)
+
 	company := executionContainer.InputData
+
+	homepage, err := c.webscraperService.Scrape(ctx, company.PrimaryDomain)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", "", err
+	}
 
 	systemPrompt := `You are a world class company analyst. Your objective is to determine whether the company I provide you fits our ideal customer profile or not. I will provide you with three datasets: 1. a description of our ideal customer, 2. criteria that automatically disqualifies companies, and 3. all the context I have about the company, including their name, location, and several descriptions taken from their website and linkedin pages.
 
@@ -205,15 +213,6 @@ Important:
 - Follow the JSON format exactly.
 - Pay special attention to location criteria in your decision making.`
 
-	var descLines []string
-	descriptions := []string{company.CompanyDescriptions.Description2, company.CompanyDescriptions.Description3, company.CompanyDescriptions.Description4, company.CompanyDescriptions.Description5}
-	for i, d := range descriptions {
-		if strings.TrimSpace(d) != "" {
-			descLines = append(descLines, fmt.Sprintf("Description Line %d: %s", i+1, d))
-		}
-	}
-	additionalCompanyDescriptions := strings.Join(descLines, ";")
-
 	content := fmt.Sprintf(`
         ICP Qualificaton Criteria: %s
         ICP Disqualification Criteria: %s
@@ -223,14 +222,13 @@ Important:
         Employee Count: %d
         Location: %s, %s, %s
         Industry Name: %s
-		Company Description: %s
-		Additional Company Descriptions: %s
+		Company Homepage: %s
         `, executionContainer.ConfigData.QualificationCriteria.Value, executionContainer.ConfigData.DisqualificationCriteria.Value,
 		company.CompanyName, company.PrimaryDomain, company.YearCompanyFounded, company.EmployeeCount,
 		company.CompanyCity, company.CompanyRegion, company.CompanyCountryA2,
-		company.IndustryNAICSName, company.CompanyDescriptions.Description, additionalCompanyDescriptions)
+		company.IndustryNAICSName, homepage)
 
-	return systemPrompt, content
+	return systemPrompt, content, nil
 }
 
 func (c *EvaluateICPFitCapability) parseAnswer(ctx context.Context, answer string) (*ICPAnswer, error) {

--- a/packages/server/customer-os-common-module/services/agent_capability/init.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/init.go
@@ -2,8 +2,8 @@ package agent_capability
 
 import (
 	"fmt"
-	neo4j_repository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
 
+	neo4j_repository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
@@ -33,6 +33,7 @@ func InitCapabilities(
 	tagService interfaces.TagService,
 	workspaceService interfaces.WorkspaceService,
 	quickbooksService interfaces.QuickbooksService,
+	webscraperService interfaces.WebscraperService,
 ) *AgentCapabilities {
 	var capabilities []interfaces.AgentCapabilityUntyped
 	capabilities = append(capabilities, NewAddMeetingNotesToCompanyCapability(organizationService, markdownService))
@@ -43,7 +44,7 @@ func InitCapabilities(
 	capabilities = append(capabilities, NewCreateMarkdownTimelineEventCapability(markdownService))
 	capabilities = append(capabilities, NewDetectSupportWebVisitCapability(events))
 	capabilities = append(capabilities, NewEnrichEmailAddressCapability())
-	capabilities = append(capabilities, NewEvaluateICPFitCapability(aiService))
+	capabilities = append(capabilities, NewEvaluateICPFitCapability(aiService, webscraperService))
 	capabilities = append(capabilities, NewExtractMeetingHighlightsCapability(aiService))
 	capabilities = append(capabilities, NewExtractSupportSignalsFromMeetingCapability(aiService))
 	capabilities = append(capabilities, NewForwardEmailReplyCapability())

--- a/packages/server/customer-os-common-module/services/company_research/service.go
+++ b/packages/server/customer-os-common-module/services/company_research/service.go
@@ -29,10 +29,14 @@ func (s *companyResearchService) GenerateIdealCustomerProfile(ctx context.Contex
 	span, ctx := opentracing.StartSpanFromContext(ctx, "icpService.GenerateIdealCustomerProfile")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	return "", nil
 }
 
 func (s *companyResearchService) GenerateCompanyBrief(ctx context.Context, domains []string) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "companyResearchService.GenerateCompanyBrief")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	return "", nil
 }

--- a/packages/server/customer-os-common-module/services/company_research/service.go
+++ b/packages/server/customer-os-common-module/services/company_research/service.go
@@ -1,0 +1,38 @@
+package company_research
+
+import (
+	"context"
+
+	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+)
+
+type companyResearchService struct {
+	postgresRepositories *postgres_repository.Repositories
+	aiService            interfaces.AIService
+}
+
+func NewCompanyResearchService(
+	postgresRepositories *postgres_repository.Repositories,
+	aiService interfaces.AIService,
+) interfaces.CompanyResearch {
+	return &companyResearchService{
+		postgresRepositories: postgresRepositories,
+		aiService:            aiService,
+	}
+}
+
+func (s *companyResearchService) GenerateIdealCustomerProfile(ctx context.Context, tenantDomain string, trainingWebsites []string) (string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "icpService.GenerateIdealCustomerProfile")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+}
+
+func (s *companyResearchService) GenerateCompanyBrief(ctx context.Context, domains []string) (string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "companyResearchService.GenerateCompanyBrief")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+}

--- a/packages/server/customer-os-common-module/services/init.go
+++ b/packages/server/customer-os-common-module/services/init.go
@@ -291,6 +291,7 @@ func InitCommonServices(
 		tagImpl,
 		workspaceImpl,
 		quickbooksImpl,
+		webscrapeImpl,
 	)
 
 	// initialize agents

--- a/packages/server/customer-os-common-module/services/webscraper/crawl.go
+++ b/packages/server/customer-os-common-module/services/webscraper/crawl.go
@@ -1,0 +1,194 @@
+package webscraper
+
+import (
+	"bufio"
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/customeros/mailsherpa/domaincheck"
+	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+)
+
+const (
+	MaxCrawlDepth   = 5
+	MaxPagesToCrawl = 100
+)
+
+func (s *webscraperService) Crawl(ctx context.Context, startUrl string) ([]string, error) {
+	// timeout
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, "webscraperService.Crawl")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	_, primaryDomain := domaincheck.PrimaryDomainCheck(utils.ExtractDomain(startUrl))
+	if primaryDomain == "" {
+		err := errors.New("Not a valid domain")
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+
+	workspaceDomains := []string{primaryDomain}
+	results := make(chan string, MaxPagesToCrawl)
+	errChan := make(chan error, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Start recursive crawl
+	go s.crawlRecursive(ctx, startUrl, workspaceDomains, 0, &wg, results, errChan)
+
+	// Wait for completion in separate goroutine
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// Collect results
+	var allUrls []string
+	for url := range results {
+		allUrls = append(allUrls, url)
+	}
+
+	// Check for errors
+	select {
+	case err := <-errChan:
+		tracing.TraceErr(span, err)
+		return nil, err
+	default:
+		return allUrls, nil
+	}
+}
+
+func (s *webscraperService) crawlRecursive(
+	ctx context.Context,
+	url string,
+	workspaceDomains []string,
+	depth int,
+	wg *sync.WaitGroup,
+	results chan<- string,
+	errChan chan<- error,
+) {
+	defer wg.Done()
+
+	// Check for already visited URLs
+	if _, visited := s.visitedURLs.LoadOrStore(url, true); visited {
+		return
+	}
+
+	// Check context and depth
+	select {
+	case <-ctx.Done():
+		return
+	default:
+		if depth >= MaxCrawlDepth {
+			return
+		}
+	}
+
+	// Create span for this URL
+	span, ctx := opentracing.StartSpanFromContext(ctx, "crawlRecursive")
+	defer span.Finish()
+	span.SetTag("url", url)
+	span.SetTag("depth", depth)
+
+	// Scrape current URL
+	content, err := s.Scrape(ctx, url)
+	if err != nil {
+		select {
+		case errChan <- errors.Wrapf(err, "failed to scrape %s", url):
+		default:
+		}
+		return
+	}
+
+	// Send URL to results
+	results <- url
+
+	// Get new links
+	links := s.linksToCrawl(content, workspaceDomains)
+
+	// Rate limiting channel
+	limiter := make(chan struct{}, 5)
+
+	// Crawl new links
+	for _, link := range links {
+		select {
+		case <-ctx.Done():
+			return
+		case limiter <- struct{}{}:
+			wg.Add(1)
+			go func(link string) {
+				defer func() { <-limiter }()
+				s.crawlRecursive(ctx, link, workspaceDomains, depth+1, wg, results, errChan)
+			}(link)
+		}
+	}
+}
+
+func (s *webscraperService) extractLinks(content string) []string {
+	var urls []string
+
+	// Find the Links/Buttons section
+	sections := strings.Split(content, "Links/Buttons:")
+	if len(sections) < 2 {
+		return urls
+	}
+
+	// Process the Links/Buttons section
+	linksSection := sections[1]
+	scanner := bufio.NewScanner(strings.NewReader(linksSection))
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Skip empty lines
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// Extract URL from markdown link format [text](url)
+		if strings.Contains(line, "](") {
+			start := strings.Index(line, "](") + 2
+			end := strings.Index(line[start:], ")")
+			if end != -1 {
+				url := line[start : start+end]
+				// Skip empty URLs and fragment-only URLs
+				if url != "" && url != "#" {
+					urls = append(urls, url)
+				}
+			}
+		}
+	}
+
+	return urls
+}
+
+func (s *webscraperService) linksToCrawl(content string, workspaceDomains []string) []string {
+	var urls []string
+	links := s.extractLinks(content)
+	for _, link := range links {
+		if s.shouldCrawl(link, workspaceDomains) {
+			urls = append(urls, link)
+		}
+	}
+	return urls
+}
+
+func (s *webscraperService) shouldCrawl(url string, workspaceDomains []string) bool {
+	urlDomain := utils.ExtractDomain(url)
+	for _, domain := range workspaceDomains {
+		if strings.Contains(urlDomain, domain) {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/server/customer-os-common-module/services/webscraper/crawl.go
+++ b/packages/server/customer-os-common-module/services/webscraper/crawl.go
@@ -58,14 +58,7 @@ func (s *webscraperService) Crawl(ctx context.Context, startUrl string) ([]strin
 		allUrls = append(allUrls, url)
 	}
 
-	// Check for errors
-	select {
-	case err := <-errChan:
-		tracing.TraceErr(span, err)
-		return nil, err
-	default:
-		return allUrls, nil
-	}
+	return allUrls, nil
 }
 
 func (s *webscraperService) crawlRecursive(
@@ -176,6 +169,7 @@ func (s *webscraperService) linksToCrawl(content string, workspaceDomains []stri
 	var urls []string
 	links := s.extractLinks(content)
 	for _, link := range links {
+		link = strings.TrimSuffix(link, "#")
 		if s.shouldCrawl(link, workspaceDomains) {
 			urls = append(urls, link)
 		}
@@ -184,9 +178,35 @@ func (s *webscraperService) linksToCrawl(content string, workspaceDomains []stri
 }
 
 func (s *webscraperService) shouldCrawl(url string, workspaceDomains []string) bool {
+	if shouldSkipURL(url) {
+		return false
+	}
+
 	urlDomain := utils.ExtractDomain(url)
 	for _, domain := range workspaceDomains {
 		if strings.Contains(urlDomain, domain) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldSkipURL(url string) bool {
+	skipKeywords := []string{
+		"login", "logout", "signin", "signout", "register", "signup",
+		"account", "profile", "dashboard", "settings", "preferences",
+		"cart", "checkout", "order", "payment", "billing",
+		"mailto", "tel", "api", "webhook", "feed", "rss",
+		"staging", "stage", "dev", "test", "beta", "sandbox",
+		"session", "token", "search", "filter", "sort", "page",
+		"share", "support", "help", "faq", "ticket", "contact",
+		"calendar", "date", "archive", "tag", "admin", "manage",
+		"status", "password",
+	}
+
+	lowercaseURL := strings.ToLower(url)
+	for _, keyword := range skipKeywords {
+		if strings.Contains(lowercaseURL, keyword) {
 			return true
 		}
 	}

--- a/packages/server/customer-os-common-module/services/webscraper/service.go
+++ b/packages/server/customer-os-common-module/services/webscraper/service.go
@@ -66,6 +66,12 @@ func (s *webscraperService) Scrape(ctx context.Context, url string) (string, err
 	return contents, nil
 }
 
+func (s *webscraperService) Crawl(ctx context.Context, startUrl string) ([]string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "webscraperService.Crawl")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+}
+
 func (s *webscraperService) fetchPage(ctx context.Context, url string) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "WebscraperService.fetchPage")
 	defer span.Finish()

--- a/packages/server/customer-os-common-module/services/webscraper/service.go
+++ b/packages/server/customer-os-common-module/services/webscraper/service.go
@@ -52,6 +52,12 @@ func (s *webscraperService) Scrape(ctx context.Context, url string) (string, err
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 	span.LogFields(log.String("url", url))
 
+	url = strings.TrimSuffix(url, "/")
+	url = strings.TrimSuffix(url, "#")
+	if !strings.HasPrefix(url, "http") {
+		url = "https://" + url
+	}
+
 	// check cache
 	cachedData, err := s.checkCache(ctx, url, WebpageScrapeTTLInDays)
 	if err != nil {
@@ -84,6 +90,10 @@ func (s *webscraperService) Scrape(ctx context.Context, url string) (string, err
 		return "", ErrUnprocessable
 	}
 
+	if strings.Contains(contents, "Robot Challenge") {
+		return "", ErrUnprocessable
+	}
+
 	if contents == "" {
 		return "", nil
 	}
@@ -107,6 +117,10 @@ func (s *webscraperService) fetchPage(ctx context.Context, url string) (string, 
 	span, ctx := opentracing.StartSpanFromContext(ctx, "WebscraperService.fetchPage")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	if s.config.ApiKey == "" {
+		return "", errors.New("Jina API key not set")
+	}
 
 	requestUrl := s.config.Url + url
 	span.LogKV("requestUrl", requestUrl)

--- a/packages/server/customer-os-common-module/services/webscraper/service.go
+++ b/packages/server/customer-os-common-module/services/webscraper/service.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -24,16 +25,21 @@ import (
 type webscraperService struct {
 	config               *config.JinaConfig
 	postgresRepositories *postgres_repository.Repositories
+	visitedURLs          sync.Map
+	limiter              chan struct{}
 }
 
 func NewWebscraperService(config *config.JinaConfig, postgres *postgres_repository.Repositories) interfaces.WebscraperService {
 	return &webscraperService{
 		config:               config,
 		postgresRepositories: postgres,
+		limiter:              make(chan struct{}, 5),
 	}
 }
 
-const WebpageScrapeTTLInDays = 180
+const (
+	WebpageScrapeTTLInDays = 180
+)
 
 var (
 	ErrPaymentRequired = errors.New("Jina balance requires topup")
@@ -45,6 +51,16 @@ func (s *webscraperService) Scrape(ctx context.Context, url string) (string, err
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 	span.LogFields(log.String("url", url))
+
+	// check cache
+	cachedData, err := s.checkCache(ctx, url, WebpageScrapeTTLInDays)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", err
+	}
+	if cachedData != "" {
+		return cachedData, nil
+	}
 
 	// fetch page contents
 	contents, err := s.fetchPage(ctx, url)
@@ -87,25 +103,10 @@ func (s *webscraperService) Scrape(ctx context.Context, url string) (string, err
 	return contents, nil
 }
 
-func (s *webscraperService) Crawl(ctx context.Context, startUrl string) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "webscraperService.Crawl")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-}
-
 func (s *webscraperService) fetchPage(ctx context.Context, url string) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "WebscraperService.fetchPage")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
-
-	cachedData, err := s.checkCache(ctx, url, WebpageScrapeTTLInDays)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return "", err
-	}
-	if cachedData != "" {
-		return cachedData, nil
-	}
 
 	requestUrl := s.config.Url + url
 	span.LogKV("requestUrl", requestUrl)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds web scraping capability to crawl company websites, including a new `/crawl` endpoint and integration with existing services.
> 
>   - **Behavior**:
>     - Adds `WebscrapeHandler` in `scrape.go` to handle web scraping requests via a new `/crawl` endpoint.
>     - Implements `Crawl()` method in `webscraperService` to recursively scrape URLs up to a depth of 5 and a maximum of 100 pages.
>     - Updates `internal_routes.go` to register the new `/crawl` route.
>   - **Configuration**:
>     - Adds `JinaConfig` to `config.go` for web scraping configuration.
>   - **Interfaces**:
>     - Adds `Crawl()` method to `WebscraperService` interface in `webscraper.go`.
>   - **Capabilities**:
>     - Updates `EvaluateICPFitCapability` in `capability_evaluate_icp_fit.go` to use the new `webscraperService` for scraping company homepages.
>   - **Services**:
>     - Initializes `webscraperService` in `init.go` with `JinaConfig` and integrates it into `CommonServices`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a2a3cf7cf4f6607e67b551412dd4deb2949832c2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->