### PR TITLE
update quickbooks revoke url

### DIFF
--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -148,7 +148,7 @@ func (s *quickbooksService) RevokeAccess(ctx context.Context) error {
 	}
 
 	// Prepare the revoke request
-	revokeURL := "https://oauth.platform.intuit.com/oauth2/v1/revoke"
+	revokeURL := "https://developer.api.intuit.com/v2/oauth2/tokens/revoke"
 	formData := url.Values{}
 	formData.Set("token", token)
 	requestBody := formData.Encode()
@@ -184,8 +184,9 @@ func (s *quickbooksService) RevokeAccess(ctx context.Context) error {
 
 	// Check for a successful response
 	if resp.StatusCode != http.StatusOK {
-		errMsg := fmt.Sprintf("revoke token request returned status %d, response: %s", resp.StatusCode, string(bodyBytes))
+		errMsg := fmt.Sprintf("revoke quickbooks request returned status %d", resp.StatusCode)
 		tracing.TraceErr(span, fmt.Errorf(errMsg))
+		span.LogFields(log.String("quickbooks.response", string(bodyBytes)))
 		return fmt.Errorf(errMsg)
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update QuickBooks revoke URL and enhance logging in `RevokeAccess` function in `quickbooks.go`.
> 
>   - **Behavior**:
>     - Update `revokeURL` in `RevokeAccess` function in `quickbooks.go` to `https://developer.api.intuit.com/v2/oauth2/tokens/revoke`.
>     - Add logging of QuickBooks response body in `RevokeAccess` function for non-OK HTTP status codes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3ca176dace360d8bbcaac2327e723dfcd7271cde. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->