### PR TITLE
Fix slack redirect

### DIFF
--- a/packages/server/customer-os-api/rest/private/slack.go
+++ b/packages/server/customer-os-api/rest/private/slack.go
@@ -74,11 +74,10 @@ func RequestAccessSlack(s *cosapi_services.Services) gin.HandlerFunc {
 			slackRequestAccessUrl += "&state=" + state
 		}
 
-		redirectUrl := c.Query("redirect_url")
+		redirectUri := c.Query("redirect_uri")
 
-		if redirectUrl != "" {
-			slackRequestAccessUrl += "&redirect_url=" + url.QueryEscape(redirectUrl)
-			slackRequestAccessUrl += "&redirect_uri=" + url.QueryEscape(redirectUrl)
+		if redirectUri != "" {
+			slackRequestAccessUrl += "&redirect_uri=" + url.QueryEscape(redirectUri)
 		}
 
 		span.LogFields(log.Object("slackRequestAccessUrl", slackRequestAccessUrl))
@@ -102,16 +101,15 @@ func CallbackSlack(s *cosapi_services.Services) gin.HandlerFunc {
 		}
 
 		code := c.Request.URL.Query().Get("code")
-		redirectUrl := c.Request.URL.Query().Get("redirect_url")
+		redirectUri := c.Request.URL.Query().Get("redirect_uri")
 		span.LogKV("code", code)
-		span.LogKV("redirectUrl", url.QueryEscape(redirectUrl))
+		span.LogKV("redirectUri", url.QueryEscape(redirectUri))
 
 		requestData := url.Values{}
 		requestData.Set("code", code)
 		requestData.Set("client_id", s.Cfg.Common.External.SlackConfig.ClientID)
 		requestData.Set("client_secret", s.Cfg.Common.External.SlackConfig.ClientSecret)
-		requestData.Set("redirect_url", url.QueryEscape(redirectUrl))
-		requestData.Set("redirect_uri", url.QueryEscape(redirectUrl))
+		requestData.Set("redirect_uri", url.QueryEscape(redirectUri))
 
 		// Encode the form data
 		requestBody := requestData.Encode()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes parameter name from `redirect_url` to `redirect_uri` in Slack OAuth functions in `slack.go`.
> 
>   - **Behavior**:
>     - Corrects parameter name from `redirect_url` to `redirect_uri` in `RequestAccessSlack` and `CallbackSlack` functions in `slack.go`.
>     - Ensures `redirect_uri` is used consistently for Slack OAuth requests and logging.
>   - **Logging**:
>     - Updates log key from `redirectUrl` to `redirectUri` in `CallbackSlack`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 6bb61a9c1f353116808808eda68c62859bd6457e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->