### PR TITLE
QB work

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/quickbooks.go
+++ b/packages/server/customer-os-common-module/interfaces/quickbooks.go
@@ -68,48 +68,49 @@ type QuickbooksGetInvoiceResponse struct {
 
 type QuickbooksGetProductResponse struct {
 	Item struct {
-		Name        string `json:"Name"`
-		Sku         string `json:"Sku"`
-		Description string `json:"Description"`
-		Active      bool   `json:"Active"`
-		SubItem     bool   `json:"SubItem"`
-		ParentRef   struct {
-			Value string `json:"value"`
-			Name  string `json:"name"`
-		} `json:"ParentRef"`
-		Level              int     `json:"Level"`
-		FullyQualifiedName string  `json:"FullyQualifiedName"`
-		Taxable            bool    `json:"Taxable"`
-		UnitPrice          float64 `json:"UnitPrice"`
-		Type               string  `json:"Type"`
-		IncomeAccountRef   struct {
+		Type             string  `json:"Type"`
+		Name             string  `json:"Name"`
+		Active           bool    `json:"Active"`
+		UnitPrice        float64 `json:"UnitPrice"`
+		Sku              *string `json:"Sku"`
+		IncomeAccountRef struct {
 			Value string `json:"value"`
 			Name  string `json:"name"`
 		} `json:"IncomeAccountRef"`
-		PurchaseDesc      string  `json:"PurchaseDesc"`
-		PurchaseCost      float64 `json:"PurchaseCost"`
-		ExpenseAccountRef struct {
-			Value string `json:"value"`
-			Name  string `json:"name"`
-		} `json:"ExpenseAccountRef"`
-		PrefVendorRef struct {
-			Value string `json:"value"`
-			Name  string `json:"name"`
-		} `json:"PrefVendorRef"`
-		TrackQtyOnHand       bool `json:"TrackQtyOnHand"`
-		TaxClassificationRef struct {
-			Value string `json:"value"`
-			Name  string `json:"name"`
-		} `json:"TaxClassificationRef"`
-		DeferredRevenue bool   `json:"DeferredRevenue"`
-		Domain          string `json:"domain"`
-		Sparse          bool   `json:"sparse"`
-		Id              string `json:"Id"`
-		SyncToken       string `json:"SyncToken"`
-		MetaData        struct {
+		Sparse    bool   `json:"sparse"`
+		Id        string `json:"Id"`
+		SyncToken string `json:"SyncToken"`
+		MetaData  struct {
 			CreateTime      time.Time `json:"CreateTime"`
 			LastUpdatedTime time.Time `json:"LastUpdatedTime"`
 		} `json:"MetaData"`
+
+		Description *string `json:"Description"`
+		SubItem     *bool   `json:"SubItem"`
+		ParentRef   *struct {
+			Value string `json:"value"`
+			Name  string `json:"name"`
+		} `json:"ParentRef"`
+		Level              *int     `json:"Level"`
+		FullyQualifiedName *string  `json:"FullyQualifiedName"`
+		Taxable            *bool    `json:"Taxable"`
+		PurchaseDesc       *string  `json:"PurchaseDesc"`
+		PurchaseCost       *float64 `json:"PurchaseCost"`
+		ExpenseAccountRef  *struct {
+			Value string `json:"value"`
+			Name  string `json:"name"`
+		} `json:"ExpenseAccountRef"`
+		PrefVendorRef *struct {
+			Value string `json:"value"`
+			Name  string `json:"name"`
+		} `json:"PrefVendorRef"`
+		TrackQtyOnHand       *bool `json:"TrackQtyOnHand"`
+		TaxClassificationRef *struct {
+			Value string `json:"value"`
+			Name  string `json:"name"`
+		} `json:"TaxClassificationRef"`
+		DeferredRevenue *bool   `json:"DeferredRevenue"`
+		Domain          *string `json:"domain"`
 	} `json:"Item"`
 	Time time.Time `json:"time"`
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make fields in `QuickbooksGetProductResponse` optional by using pointers, allowing for missing field handling in Quickbooks responses.
> 
>   - **Struct Changes**:
>     - In `QuickbooksGetProductResponse` struct, fields `Sku`, `Description`, `SubItem`, `ParentRef`, `Level`, `FullyQualifiedName`, `Taxable`, `PurchaseDesc`, `PurchaseCost`, `ExpenseAccountRef`, `PrefVendorRef`, `TrackQtyOnHand`, `TaxClassificationRef`, `DeferredRevenue`, and `Domain` are now pointers, making them optional.
>     - Added `Type`, `UnitPrice`, `IncomeAccountRef`, `Sparse`, `Id`, `SyncToken`, and `MetaData` fields to `QuickbooksGetProductResponse` struct.
>   - **Behavior**:
>     - Allows handling of missing fields in Quickbooks product responses by using pointers for optional fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 742f0b0f6ec70630e3dd258d8f6c7ed7bb9463f9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->