### PR TITLE
delete quickbooks

### DIFF
--- a/packages/server/customer-os-api/rest/private/quickbooks.go
+++ b/packages/server/customer-os-api/rest/private/quickbooks.go
@@ -92,7 +92,6 @@ func CallbackQuickbooks(s *cosapi_services.Services) gin.HandlerFunc {
 
 func RevokeQuickbooks(s *cosapi_services.Services) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Start a tracer span for the revoke callback endpoint.
 		ctx, span := tracing.StartHttpServerTracerSpanWithHeader(c, "/internal/v1/settings/quickbooks/revoke", c.Request.Header)
 		defer span.Finish()
 		tracing.TagComponentRest(span)

--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -180,20 +180,21 @@ func (s *quickbooksService) RevokeAccess(ctx context.Context) error {
 		return fmt.Errorf("failed to read revoke response: %w", err)
 	}
 
-	span.LogFields(log.String("revokeResponse", string(bodyBytes)))
+	span.LogFields(log.String("quickbooks.response", string(bodyBytes)))
 
 	// Check for a successful response
 	if resp.StatusCode != http.StatusOK {
 		errMsg := fmt.Sprintf("revoke quickbooks request returned status %d", resp.StatusCode)
 		tracing.TraceErr(span, fmt.Errorf(errMsg))
-		span.LogFields(log.String("quickbooks.response", string(bodyBytes)))
-		return fmt.Errorf(errMsg)
 	}
 
-	err = s.postgres.QuickbooksSettingsRepository.Delete(ctx, tenant)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return err
+	// http.StatusBadRequest is returned when revoking access from already removed app
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusBadRequest {
+		err = s.postgres.QuickbooksSettingsRepository.Delete(ctx, tenant)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves `RevokeAccess` in `quickbooksService` to handle `http.StatusBadRequest` and updates logging.
> 
>   - **Behavior**:
>     - `RevokeAccess` in `quickbooksService` now deletes QuickBooks settings if the response status is `http.StatusOK` or `http.StatusBadRequest`.
>     - Adjusted logging in `RevokeAccess` to use `quickbooks.response` instead of `revokeResponse`.
>   - **Misc**:
>     - Removed a comment in `RevokeQuickbooks` in `quickbooks.go` about starting a tracer span.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 64e015a8ff3e6b8234653a1f27ca6b269f071463. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->