### PR TITLE
Add default_filters to table view definition update

### DIFF
--- a/packages/server/customer-os-postgres-repository/repository/table_view_definition_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/table_view_definition_repository.go
@@ -163,13 +163,14 @@ func (t tableViewDefinitionRepository) UpdateTableViewSharedDefinition(ctx conte
 	// Update the record
 	// Map the fields you want to allow updating, excluding UserId and TenantName
 	updateData := map[string]interface{}{
-		"table_name": viewDefinition.Name,
-		"position":   viewDefinition.Order,
-		"icon":       viewDefinition.Icon,
-		"filters":    viewDefinition.Filters,
-		"sorting":    viewDefinition.Sorting,
-		"columns":    viewDefinition.ColumnsJson,
-		"updated_at": utils.Now(),
+		"table_name":      viewDefinition.Name,
+		"position":        viewDefinition.Order,
+		"icon":            viewDefinition.Icon,
+		"filters":         viewDefinition.Filters,
+		"default_filters": viewDefinition.DefaultFilters,
+		"sorting":         viewDefinition.Sorting,
+		"columns":         viewDefinition.ColumnsJson,
+		"updated_at":      utils.Now(),
 	}
 
 	err = t.gormDb.Model(&existing).Updates(updateData).Error


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `default_filters` to the update data map in `UpdateTableViewSharedDefinition()` to allow updating shared table view definitions.
> 
>   - **Behavior**:
>     - Adds `default_filters` to the update data map in `UpdateTableViewSharedDefinition()` in `table_view_definition_repository.go`.
>     - Allows updating `default_filters` for shared table view definitions.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2fa8adbffc6673c7b1c40d9386923ae7c532e401. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->