### PR TITLE
add invoice number to qb

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/quickbooks.go
+++ b/packages/server/customer-os-common-module/interfaces/quickbooks.go
@@ -13,7 +13,7 @@ type QuickbooksService interface {
 	RevokeAccess(ctx context.Context) error
 	SaveProduct(ctx context.Context, id, productName string, archived bool, price float64) (*QuickbooksSaveProductResponse, error)
 	SaveCustomer(ctx context.Context, id, customerName string) (*QuickbooksSaveCustomerResponse, error)
-	SaveInvoice(ctx context.Context, customerId string, invoiceDate time.Time, lines []QuickbooksInvoiceLine) (*QuickbooksSaveInvoiceResponse, error)
+	SaveInvoice(ctx context.Context, customerId, invoiceNumber string, invoiceDate time.Time, lines []QuickbooksInvoiceLine) (*QuickbooksSaveInvoiceResponse, error)
 	PayInvoice(ctx context.Context, customerId, invoiceId string, totalAmount float64) (*QuickbooksSavePaymentResponse, error)
 	VoidInvoice(ctx context.Context, invoiceId string) (*QuickbooksSaveInvoiceResponse, error)
 }

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -130,19 +130,19 @@ func (c *SyncInvoiceToAccountingCapability) Execute(ctx context.Context, executi
 			tracing.TraceErr(span, err)
 			return enum.CapabilityExecutionCompleted, result, err
 		}
-	} else {
-		if invoice.Status == neo4jenum.InvoiceStatusPaid {
-			err = c.syncPaidInvoiceToQuickbooks(ctx, *invoice)
-			if err != nil {
-				tracing.TraceErr(span, err)
-				return enum.CapabilityExecutionCompleted, result, err
-			}
-		} else if invoice.Status == neo4jenum.InvoiceStatusVoid {
-			err = c.syncVoidInvoiceToQuickbooks(ctx, *invoice)
-			if err != nil {
-				tracing.TraceErr(span, err)
-				return enum.CapabilityExecutionCompleted, result, err
-			}
+	}
+
+	if invoice.Status == neo4jenum.InvoiceStatusPaid {
+		err = c.syncPaidInvoiceToQuickbooks(ctx, *invoice)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return enum.CapabilityExecutionCompleted, result, err
+		}
+	} else if invoice.Status == neo4jenum.InvoiceStatusVoid {
+		err = c.syncVoidInvoiceToQuickbooks(ctx, *invoice)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return enum.CapabilityExecutionCompleted, result, err
 		}
 	}
 
@@ -252,7 +252,7 @@ func (c *SyncInvoiceToAccountingCapability) syncInvoiceToQuickbooks(ctx context.
 		}
 	}
 
-	savedInvoiced, err := c.quickbooksService.SaveInvoice(ctx, organization.QuickbooksCustomerId, invoice.PeriodStartDate, quickbooksInvoiceLines)
+	savedInvoiced, err := c.quickbooksService.SaveInvoice(ctx, organization.QuickbooksCustomerId, invoice.Number, invoice.PeriodStartDate, quickbooksInvoiceLines)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err

--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -377,7 +377,7 @@ func (s *quickbooksService) SaveCustomer(ctx context.Context, id, customerName s
 	return &quickbooksResponse, nil
 }
 
-func (s *quickbooksService) SaveInvoice(ctx context.Context, customerId string, invoiceDate time.Time, lines []interfaces.QuickbooksInvoiceLine) (*interfaces.QuickbooksSaveInvoiceResponse, error) {
+func (s *quickbooksService) SaveInvoice(ctx context.Context, customerId, invoiceNumber string, invoiceDate time.Time, lines []interfaces.QuickbooksInvoiceLine) (*interfaces.QuickbooksSaveInvoiceResponse, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "QuickbooksService.SaveInvoice")
 	defer span.Finish()
 
@@ -399,8 +399,9 @@ func (s *quickbooksService) SaveInvoice(ctx context.Context, customerId string, 
 		"CustomerRef": map[string]interface{}{
 			"value": customerId,
 		},
-		"TxnDate": invoiceDate.Format("2006/01/25"),
-		"Line":    lines,
+		"TxnDate":   invoiceDate.Format("2006/01/25"),
+		"Line":      lines,
+		"DocNumber": invoiceNumber,
 	}
 
 	resp, err := s.performRequest(ctx, quickbooksSettingsEntity, s.qbConfig.Url+"/v3/company/"+quickbooksSettingsEntity.RealmId+"/invoice", "POST", request, true)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `invoiceNumber` parameter to `SaveInvoice` function in Quickbooks service to include document number in invoice requests.
> 
>   - **Behavior**:
>     - Add `invoiceNumber` parameter to `SaveInvoice` in `quickbooks.go`, `interfaces/quickbooks.go`, and `capability_invoice_sync_to_accounting.go`.
>     - Include `invoiceNumber` in Quickbooks invoice request payload in `quickbooks.go`.
>   - **Refactoring**:
>     - Remove unnecessary `else` block in `Execute()` in `capability_invoice_sync_to_accounting.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7c8cf9e1c77d470bbca753a2ca0d77700e0ab0cc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->