### PR TITLE
retry for quickbooks

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -128,7 +128,7 @@ func (c *SyncInvoiceToAccountingCapability) Execute(ctx context.Context, executi
 		err = c.syncInvoiceToQuickbooks(ctx, *invoice)
 		if err != nil {
 			tracing.TraceErr(span, err)
-			return enum.CapabilityExecutionCompleted, result, err
+			return enum.CapabilityExecutionRetry, result, err
 		}
 	}
 
@@ -136,13 +136,13 @@ func (c *SyncInvoiceToAccountingCapability) Execute(ctx context.Context, executi
 		err = c.syncPaidInvoiceToQuickbooks(ctx, *invoice)
 		if err != nil {
 			tracing.TraceErr(span, err)
-			return enum.CapabilityExecutionCompleted, result, err
+			return enum.CapabilityExecutionRetry, result, err
 		}
 	} else if invoice.Status == neo4jenum.InvoiceStatusVoid {
 		err = c.syncVoidInvoiceToQuickbooks(ctx, *invoice)
 		if err != nil {
 			tracing.TraceErr(span, err)
-			return enum.CapabilityExecutionCompleted, result, err
+			return enum.CapabilityExecutionRetry, result, err
 		}
 	}
 
@@ -196,8 +196,9 @@ func (c *SyncInvoiceToAccountingCapability) syncInvoiceToQuickbooks(ctx context.
 		}
 
 		if sku.QuickbooksId == "" {
-			span.LogFields(log.String("skip", fmt.Sprintf("QuickbooksId not found for sku %s", sku.ID)))
-			return nil
+			err = errors.New(fmt.Sprintf("QuickbooksId not found for sku %s", sku.ID))
+			tracing.TraceErr(span, err)
+			return err
 		}
 	}
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -132,6 +132,13 @@ func (c *SyncInvoiceToAccountingCapability) Execute(ctx context.Context, executi
 		}
 	}
 
+	// refetch invoice to get updated quickbooks invoice id
+	invoice, err = c.invoiceService.GetById(ctx, nil, executionContainer.InputData.InvoiceID)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return enum.CapabilityExecutionCompleted, result, err
+	}
+
 	if invoice.Status == neo4jenum.InvoiceStatusPaid {
 		err = c.syncPaidInvoiceToQuickbooks(ctx, *invoice)
 		if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change error handling in `SyncInvoiceToAccountingCapability` to retry on errors and improve SKU Quickbooks ID error logging.
> 
>   - **Behavior**:
>     - Change return status from `CapabilityExecutionCompleted` to `CapabilityExecutionRetry` in `Execute()` for errors in `syncInvoiceToQuickbooks()`, `syncPaidInvoiceToQuickbooks()`, and `syncVoidInvoiceToQuickbooks()`.
>     - Refetch invoice after syncing to Quickbooks to update Quickbooks invoice ID.
>   - **Error Handling**:
>     - In `syncInvoiceToQuickbooks()`, log and return an error if `QuickbooksId` is missing for SKU instead of skipping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7e344ebaa260825a6d2b643903431a2b6c1bca45. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->