### PR TITLE
Fix auth

### DIFF
--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -287,6 +287,10 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 				authUserId = common_utils.GetStringPropOrEmpty(authUserProps, "id")
 				defaultTenant = common_utils.GetStringPropOrEmpty(authUserProps, "defaultTenant")
 				currentTenant = common_utils.GetStringPropOrEmpty(authUserProps, "currentTenant")
+
+				ctx = common.WithCustomContext(ctx, &common.CustomContext{
+					Tenant: currentTenant,
+				})
 			} else {
 				//auth with different provider found. link back to the same user and add new auth
 				authNodes, err := services.CommonServices.Neo4jRepositories.AuthenticationReadRepository.GetByAuthId(ctx, signInRequest.LoggedInEmail)
@@ -307,6 +311,10 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 					authUserId = common_utils.GetStringPropOrEmpty(authUserProps, "id")
 					defaultTenant = common_utils.GetStringPropOrEmpty(authUserProps, "defaultTenant")
 					currentTenant = common_utils.GetStringPropOrEmpty(authUserProps, "currentTenant")
+
+					ctx = common.WithCustomContext(ctx, &common.CustomContext{
+						Tenant: currentTenant,
+					})
 
 					authId, err = services.Repositories.Neo4jRepositories.AuthenticationWriteRepository.CreateAuthentication(ctx, *txWithPostCommit.Tx, neoEntity.AuthenticationEntity{
 						AuthId:     signInRequest.LoggedInEmail,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add tenant information to context during sign-in in `registration.go` to support multi-tenant authentication.
> 
>   - **Behavior**:
>     - Add tenant information to context in `signIn()` in `registration.go` when authentication is successful.
>     - Handles both cases: when auth with the same provider is found and when auth with a different provider is found.
>   - **Context Management**:
>     - Uses `common.WithCustomContext()` to set `Tenant` in the context.
>     - Ensures `currentTenant` is set in the context for subsequent operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f97ab389edaf0111e9a23c1153ff162efcbc4ccb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->