### PR TITLE
fix qb

### DIFF
--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -294,6 +294,11 @@ func (s *quickbooksService) SaveProduct(ctx context.Context, id, productName str
 		qbProduct.Item.UnitPrice = price
 		qbProduct.Item.Active = !archived
 
+		// nullify PurchaseCost if ExpenseAccountRef is not set
+		if qbProduct.Item.ExpenseAccountRef == nil {
+			qbProduct.Item.PurchaseCost = nil
+		}
+
 		jsonBytes, _ := json.Marshal(qbProduct.Item)
 		err = json.Unmarshal(jsonBytes, &qbSaveProductRequest)
 		if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `SaveProduct` in `quickbooksService` to nullify `PurchaseCost` if `ExpenseAccountRef` is not set.
> 
>   - **Behavior**:
>     - In `quickbooksService.SaveProduct`, nullifies `PurchaseCost` if `ExpenseAccountRef` is not set, ensuring correct product data handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 24ce520d65ee92babf571febe0d7fae583cfb6b2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->