### PR TITLE
Email keeper work

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/cron/cron.go
+++ b/packages/runner/customer-os-data-upkeeper/cron/cron.go
@@ -163,9 +163,9 @@ func registerJobs(c *cron.Cron, cont *container.Container) {
 	addJob(cont.Cfg.App.Cron.CronScheduleCleanEmails, GroupEmail, cleanEmails, "cleanEmails")
 	addJob(cont.Cfg.App.Cron.CronScheduleSendEmails, GroupSendEmails, sendEmails, "sendEmails")
 	addJob(cont.Cfg.App.Cron.CronScheduleProcessSentEmails, GroupProcessEmails, processSentEmails, "processSentEmails")
-	// addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsFromProvidersRealtime, ingestEmailsFromProvidersRealtime, "ingestEmailsFromProvidersRealtime")
-	// addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsFromProvidersHistory, ingestEmailsFromProvidersHistory, "ingestEmailsFromProvidersHistory")
-	//addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsSendToAgents, ingestEmailsSendToAgents, "ingestEmailsSendToAgents")
+	addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsFromProvidersRealtime, ingestEmailsFromProvidersRealtime, "ingestEmailsFromProvidersRealtime")
+	addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsFromProvidersHistory, ingestEmailsFromProvidersHistory, "ingestEmailsFromProvidersHistory")
+	addJob(cont.Cfg.App.Cron.CronScheduleIngestEmailsFromProviders, GroupIngestEmailsSendToAgents, ingestEmailsSendToAgents, "ingestEmailsSendToAgents")
 
 	// Flow Jobs
 	addJob(cont.Cfg.App.Cron.CronScheduleFlowExecution, GroupFlow, flowExecution, "flowExecution")

--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -1087,6 +1087,7 @@ type ComplexityRoot struct {
 		AdminAddWorkspaceAccess                    func(childComplexity int, authenticatedUserEmail string, tenant string) int
 		AdminRemoveWorkspaceAccess                 func(childComplexity int, authenticatedUserEmail string, tenant string) int
 		AdminSwitchCurrentWorkspace                func(childComplexity int, switchToTenant string) int
+		AdminTenantAddDomainAsWorkspace            func(childComplexity int, domain string) int
 		AdminTenantHardDelete                      func(childComplexity int, tenant string, confirmTenant string) int
 		AgentDelete                                func(childComplexity int, id string) int
 		AgentSave                                  func(childComplexity int, input model.AgentSaveInput) int
@@ -1997,6 +1998,7 @@ type MutationResolver interface {
 	AdminAddWorkspaceAccess(ctx context.Context, authenticatedUserEmail string, tenant string) (bool, error)
 	AdminRemoveWorkspaceAccess(ctx context.Context, authenticatedUserEmail string, tenant string) (bool, error)
 	AdminSwitchCurrentWorkspace(ctx context.Context, switchToTenant string) (bool, error)
+	AdminTenantAddDomainAsWorkspace(ctx context.Context, domain string) (bool, error)
 	AdminTenantHardDelete(ctx context.Context, tenant string, confirmTenant string) (bool, error)
 	AgentSave(ctx context.Context, input model.AgentSaveInput) (*model.Agent, error)
 	AgentDelete(ctx context.Context, id string) (bool, error)
@@ -7515,6 +7517,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.AdminSwitchCurrentWorkspace(childComplexity, args["switchToTenant"].(string)), true
+
+	case "Mutation.admin_tenant_AddDomainAsWorkspace":
+		if e.complexity.Mutation.AdminTenantAddDomainAsWorkspace == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_admin_tenant_AddDomainAsWorkspace_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.AdminTenantAddDomainAsWorkspace(childComplexity, args["domain"].(string)), true
 
 	case "Mutation.admin_tenant_hardDelete":
 		if e.complexity.Mutation.AdminTenantHardDelete == nil {
@@ -13483,6 +13497,8 @@ extend type Mutation {
 
     admin_switchCurrentWorkspace(switchToTenant: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER]) @hasTenant
 
+    admin_tenant_AddDomainAsWorkspace(domain: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER]) @hasTenant
+
     admin_tenant_hardDelete(tenant: String!, confirmTenant: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER]) @hasTenant
 }
 
@@ -18369,6 +18385,34 @@ func (ec *executionContext) field_Mutation_admin_switchCurrentWorkspace_argsSwit
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("switchToTenant"))
 	if tmp, ok := rawArgs["switchToTenant"]; ok {
+		return ec.unmarshalNString2string(ctx, tmp)
+	}
+
+	var zeroVal string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_admin_tenant_AddDomainAsWorkspace_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_admin_tenant_AddDomainAsWorkspace_argsDomain(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["domain"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_admin_tenant_AddDomainAsWorkspace_argsDomain(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (string, error) {
+	if _, ok := rawArgs["domain"]; !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("domain"))
+	if tmp, ok := rawArgs["domain"]; ok {
 		return ec.unmarshalNString2string(ctx, tmp)
 	}
 
@@ -63155,6 +63199,95 @@ func (ec *executionContext) fieldContext_Mutation_admin_switchCurrentWorkspace(c
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_admin_switchCurrentWorkspace_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_admin_tenant_AddDomainAsWorkspace(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_admin_tenant_AddDomainAsWorkspace(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		directive0 := func(rctx context.Context) (any, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().AdminTenantAddDomainAsWorkspace(rctx, fc.Args["domain"].(string))
+		}
+
+		directive1 := func(ctx context.Context) (any, error) {
+			roles, err := ec.unmarshalNRole2ᚕgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐRoleᚄ(ctx, []any{"PLATFORM_OWNER"})
+			if err != nil {
+				var zeroVal bool
+				return zeroVal, err
+			}
+			if ec.directives.HasRole == nil {
+				var zeroVal bool
+				return zeroVal, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, roles)
+		}
+		directive2 := func(ctx context.Context) (any, error) {
+			if ec.directives.HasTenant == nil {
+				var zeroVal bool
+				return zeroVal, errors.New("directive hasTenant is not implemented")
+			}
+			return ec.directives.HasTenant(ctx, nil, directive1)
+		}
+
+		tmp, err := directive2(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(bool); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be bool`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_admin_tenant_AddDomainAsWorkspace(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_admin_tenant_AddDomainAsWorkspace_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -128856,6 +128989,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "admin_switchCurrentWorkspace":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_admin_switchCurrentWorkspace(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "admin_tenant_AddDomainAsWorkspace":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_admin_tenant_AddDomainAsWorkspace(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/packages/server/customer-os-api/graphql/resolver/admin.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/admin.resolvers.go
@@ -92,6 +92,23 @@ func (r *mutationResolver) AdminSwitchCurrentWorkspace(ctx context.Context, swit
 	return true, nil
 }
 
+// AdminTenantAddDomainAsWorkspace is the resolver for the admin_tenant_AddDomainAsWorkspace field.
+func (r *mutationResolver) AdminTenantAddDomainAsWorkspace(ctx context.Context, domain string) (bool, error) {
+	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "MutationResolver.AdminTenantAddDomainAsWorkspace", graphql.GetOperationContext(ctx))
+	defer span.Finish()
+	tracing.SetDefaultResolverSpanTags(ctx, span)
+
+	span.LogKV("domain", domain)
+
+	err := r.Services.CommonServices.WorkspaceService.AddDomainAsWorkspace(ctx, domain)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return false, err
+	}
+
+	return true, nil
+}
+
 // AdminTenantHardDelete is the resolver for the admin_tenant_hardDelete field.
 func (r *mutationResolver) AdminTenantHardDelete(ctx context.Context, tenant string, confirmTenant string) (bool, error) {
 	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "MutationResolver.TenantHardDelete", graphql.GetOperationContext(ctx))

--- a/packages/server/customer-os-api/graphql/resolver/user.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/user.resolvers.go
@@ -248,15 +248,3 @@ func (r *userResolver) Calendars(ctx context.Context, obj *model.User) ([]*model
 func (r *Resolver) User() generated.UserResolver { return &userResolver{r} }
 
 type userResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//    it when you're done.
-//  - You have helper methods in this file. Move them out to keep these resolver files clean.
-/*
-	func (r *userResolver) MailboxesV3(ctx context.Context, obj *model.User) ([]*model.MailboxV2, error) {
-	panic(fmt.Errorf("not implemented: MailboxesV3 - mailboxesV3"))
-}
-*/

--- a/packages/server/customer-os-api/graphql/schemas/admin.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/admin.graphqls
@@ -8,6 +8,8 @@ extend type Mutation {
 
     admin_switchCurrentWorkspace(switchToTenant: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER]) @hasTenant
 
+    admin_tenant_AddDomainAsWorkspace(domain: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER]) @hasTenant
+
     admin_tenant_hardDelete(tenant: String!, confirmTenant: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER]) @hasTenant
 }
 

--- a/packages/server/customer-os-api/rest/private/slack.go
+++ b/packages/server/customer-os-api/rest/private/slack.go
@@ -244,7 +244,7 @@ func RevokeSlack(s *cosapi_services.Services) gin.HandlerFunc {
 				}
 				c.JSON(http.StatusOK, gin.H{})
 			} else {
-				tracing.TraceErr(span, err)
+				tracing.TraceErr(span, errors.Wrap(errors.New("slack response not ok"), *slackResponse.Error))
 				c.JSON(http.StatusInternalServerError, gin.H{"error": slackResponse.Error})
 			}
 		}

--- a/packages/server/customer-os-common-module/services/google/service.go
+++ b/packages/server/customer-os-common-module/services/google/service.go
@@ -401,7 +401,7 @@ func (s *googleService) ReadEmails(ctx context.Context, batchSize int64, importS
 	var results []*postgresEntity.EmailRawData
 
 	gmailService, err := s.GetGmailService(ctx, importState.Username, importState.Tenant)
-	if err != nil {
+	if err != nil || gmailService == nil {
 		logrus.Errorf("failed to create gmail service: %v", err)
 		return nil, "", fmt.Errorf("failed to create gmail service: %v", err)
 	}

--- a/packages/server/customer-os-common-module/services/init.go
+++ b/packages/server/customer-os-common-module/services/init.go
@@ -261,7 +261,7 @@ func InitCommonServices(
 	mailboxImpl := mailbox.NewMailboxService(log, postgresRepositories, neo4jRepositories, emailImpl)
 	interactionEventImpl := interaction_event.NewInteractionEventService(neo4jRepositories, emailImpl)
 	mailstackImpl := mailstack.NewMailstackService(&cfg.External.StripeConfig, eventsImpl, postgresRepositories, cloudfareImpl, namecheapImpl, mailboxImpl, openSRSImpl)
-	mailImpl := mail.NewMailService(cacheImpl, postgresRepositories, neo4jRepositories, azureImpl, contactImpl, emailImpl, googleImpl, interactionEventImpl, interactionSessionImpl, openSRSImpl, orgImpl)
+	mailImpl := mail.NewMailService(cacheImpl, postgresRepositories, neo4jRepositories, azureImpl, contactImpl, emailImpl, googleImpl, interactionEventImpl, interactionSessionImpl, openSRSImpl, orgImpl, workspaceImpl)
 	flowExecutionImpl := flow_execution.NewFlowExecutionService(neo4jRepositories, postgresRepositories, eventsImpl, emailImpl, nil, orgImpl, socialImpl)
 	flowImpl := flow.NewFlowService(neo4jRepositories, postgresRepositories, eventsImpl, flowExecutionImpl)
 	locationImpl := location.NewLocationService(log, neo4jRepositories, postgresRepositories, eventsImpl, &cfg.External.AnthropicConfig.Prompts, aiImpl, contactImpl, orgImpl)

--- a/packages/server/customer-os-common-module/services/mail/processor.go
+++ b/packages/server/customer-os-common-module/services/mail/processor.go
@@ -614,6 +614,17 @@ func (s *mailService) GetOrganizationIdForEmail(ctx context.Context, txWithPostC
 			err = errors.New("unable to extract domain from email: " + email)
 			return "", err
 		}
+
+		tenantWorkspaces, err := s.workspace.GetWorkspaceDomainsForTenant(ctx)
+		if err != nil {
+			err = errors.Wrap(err, "failed to get workspace domains for tenant")
+			return "", err
+		}
+
+		if utils.Contains(tenantWorkspaces, domain) {
+			return "", nil
+		}
+
 		if utils.Contains(s.cache.GetPersonalEmailProviders(), domain) ||
 			emailSyntax.IsSystemGenerated ||
 			emailSyntax.IsRoleAccount {

--- a/packages/server/customer-os-common-module/services/mail/service.go
+++ b/packages/server/customer-os-common-module/services/mail/service.go
@@ -25,9 +25,10 @@ type mailService struct {
 	email              interfaces.EmailService
 	interactionEvent   interfaces.InteractionEventService
 	org                interfaces.OrganizationService
+	workspace          interfaces.WorkspaceService
 }
 
-func NewMailService(cache *caches.Cache, postgres *postgres_repository.Repositories, neo4j *neo4j_repository.Repositories, azure interfaces.AzureService, contact interfaces.ContactService, email interfaces.EmailService, google interfaces.GoogleService, interactionEvent interfaces.InteractionEventService, interactionSession interfaces.InteractionSessionService, opensrs interfaces.OpenSrsService, org interfaces.OrganizationService) interfaces.MailService {
+func NewMailService(cache *caches.Cache, postgres *postgres_repository.Repositories, neo4j *neo4j_repository.Repositories, azure interfaces.AzureService, contact interfaces.ContactService, email interfaces.EmailService, google interfaces.GoogleService, interactionEvent interfaces.InteractionEventService, interactionSession interfaces.InteractionSessionService, opensrs interfaces.OpenSrsService, org interfaces.OrganizationService, workspace interfaces.WorkspaceService) interfaces.MailService {
 	return &mailService{
 		cache:              cache,
 		postgres:           postgres,
@@ -40,6 +41,7 @@ func NewMailService(cache *caches.Cache, postgres *postgres_repository.Repositor
 		email:              email,
 		interactionEvent:   interactionEvent,
 		org:                org,
+		workspace:          workspace,
 	}
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable email ingestion jobs, add domain management mutation, and improve error handling and service initialization.
> 
>   - **Cron Jobs**:
>     - Enabled email ingestion jobs in `cron.go` by uncommenting `addJob` calls for `ingestEmailsFromProvidersRealtime`, `ingestEmailsFromProvidersHistory`, and `ingestEmailsSendToAgents`.
>   - **GraphQL**:
>     - Added `AdminTenantAddDomainAsWorkspace` mutation in `admin.graphqls` and implemented resolver in `admin.resolvers.go`.
>   - **Error Handling**:
>     - Improved error wrapping in `slack.go` for Slack response errors.
>     - Added nil check for `gmailService` in `service.go` to handle service creation failures.
>   - **Service Initialization**:
>     - Updated `NewMailService` in `service.go` to include `workspace` service.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 52dffc56e5646587d06f113c755e71cf4ca00df7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->