### PR TITLE
correct some tracing

### DIFF
--- a/packages/server/customer-os-neo4j-repository/repository/action_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/action_read_repository.go
@@ -3,12 +3,13 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
+
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 )
@@ -31,32 +32,33 @@ func NewActionReadRepository(driver *neo4j.DriverWithContext, database string) A
 }
 
 func (r *actionReadRepository) GetFor(ctx context.Context, tenant string, entityType model.EntityType, entityIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AttachmentRepository.GetAttachmentsForXX")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionReadRepository.GetFor")
 	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-
+	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
 	span.LogFields(log.String("entityType", entityType.String()), log.String("entityIds", fmt.Sprintf("%v", entityIds)))
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
-	var query = "MATCH (n:%s_%s)<-[:ACTION_ON]-(a:Action_%s)"
-	query += " WHERE n.id IN $entityIds "
-	query += " RETURN a, n.id"
+
+	cypher := fmt.Sprintf("MATCH (n:%s_%s)<-[:ACTION_ON]-(a:Action_%s) WHERE n.id IN $entityIds RETURN a, n.id",
+		entityType.Neo4jLabel(), tenant, tenant)
+
+	params := map[string]any{
+		"tenant":    tenant,
+		"entityIds": entityIds,
+	}
+	span.LogFields(log.String("cypher", cypher))
+	tracing.LogObjectAsJson(span, "params", params)
 
 	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
-		if queryResult, err := tx.Run(ctx, fmt.Sprintf(query, entityType.Neo4jLabel(), tenant, tenant),
-			map[string]any{
-				"tenant":    tenant,
-				"entityIds": entityIds,
-			}); err != nil {
+		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
 			return nil, err
 		} else {
 			return utils.ExtractAllRecordsAsDbNodeAndId(ctx, queryResult, err)
 		}
 	})
-	span.LogFields(log.String("query", query))
 	if err != nil {
+		tracing.TraceErr(span, err)
 		return nil, err
 	}
 	return result.([]*utils.DbNodeAndId), err
@@ -69,8 +71,7 @@ func (r *actionReadRepository) prepareReadSession(ctx context.Context) neo4j.Ses
 func (r *actionReadRepository) GetLastAction(ctx context.Context, tenant, entityId string, entityType model.EntityType, actionType enum.ActionType) (*dbtype.Node, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionReadRepository.GetLastAction")
 	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
 	tracing.TagEntity(span, entityId)
 	span.LogFields(
 		log.String("entityType", entityType.String()),

--- a/packages/server/customer-os-neo4j-repository/repository/action_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/action_write_repository.go
@@ -3,8 +3,8 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
+	"time"
+
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
@@ -12,9 +12,10 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/constants"
 	neo4jmodel "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
-	"time"
 )
 
 type ActionWriteRepository interface {
@@ -43,10 +44,9 @@ func (r *actionWriteRepository) Create(ctx context.Context, tenant, entityId str
 }
 
 func (r *actionWriteRepository) CreateWithProperties(ctx context.Context, tenant, entityId string, entityType model.EntityType, actionType enum.ActionType, content, metadata string, createdAt time.Time, appSource string, extraProperties map[string]any) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionRepository.CreateWithProperties")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionWriteRepository.CreateWithProperties")
 	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
 	span.LogFields(log.String("entityId", entityId),
 		log.String("entityType", entityType.String()),
 		log.String("actionType", string(actionType)),
@@ -67,7 +67,7 @@ func (r *actionWriteRepository) CreateWithProperties(ctx context.Context, tenant
 								a:Action_%s, 
 								a:TimelineEvent, 
 								a:TimelineEvent_%s`, tenant, tenant)
-	if extraProperties != nil && len(extraProperties) > 0 {
+	if len(extraProperties) > 0 {
 		cypher += ` SET a += $extraProperties `
 	}
 	cypher += ` return a `
@@ -82,7 +82,7 @@ func (r *actionWriteRepository) CreateWithProperties(ctx context.Context, tenant
 		"appSource": appSource,
 		"createdAt": createdAt,
 	}
-	if extraProperties != nil && len(extraProperties) > 0 {
+	if len(extraProperties) > 0 {
 		params["extraProperties"] = extraProperties
 	}
 	span.LogFields(log.String("cypher", cypher))
@@ -106,10 +106,9 @@ func (r *actionWriteRepository) CreateWithProperties(ctx context.Context, tenant
 }
 
 func (r *actionWriteRepository) MergeByActionType(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, entityId string, entityType model.EntityType, actionType enum.ActionType, content, metadata string, createdAt time.Time, appSource string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionRepository.MergeByActionType")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionWriteRepository.MergeByActionType")
 	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
 	span.LogFields(log.String("entityId", entityId),
 		log.String("entityType", entityType.String()),
 		log.String("actionType", string(actionType)),
@@ -161,12 +160,15 @@ func (r *actionWriteRepository) MergeByActionType(ctx context.Context, tx *neo4j
 }
 
 func (r *actionWriteRepository) CreateV2(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, actionId, entityId string, entityType model.EntityType, data data_fields.ActionFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionRepository.CreateV2")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionWriteRepository.CreateV2")
 	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	span.LogFields(
+		log.String("tenant", tenant),
+		log.String("actionId", actionId),
+		log.String("entityId", entityId),
+		log.String("entityType", entityType.String()))
 	tracing.LogObjectAsJson(span, "data", data)
-	span.LogFields(log.String("entityId", entityId), log.String("entityType", entityType.String()))
 
 	cypher := fmt.Sprintf(`MATCH (n:%s_%s {id:$entityId}) `, entityType.Neo4jLabel(), tenant)
 	cypher += fmt.Sprintf(` MERGE (n)<-[:ACTION_ON]-(a:Action {id:$actionId}) 
@@ -180,7 +182,7 @@ func (r *actionWriteRepository) CreateV2(ctx context.Context, tx *neo4j.ManagedT
 								a:Action_%s, 
 								a:TimelineEvent, 
 								a:TimelineEvent_%s`, tenant, tenant)
-	if data.ExtraProperties != nil && len(data.ExtraProperties) > 0 {
+	if len(data.ExtraProperties) > 0 {
 		cypher += ` SET a += $extraProperties `
 	}
 
@@ -199,7 +201,7 @@ func (r *actionWriteRepository) CreateV2(ctx context.Context, tx *neo4j.ManagedT
 	} else {
 		params["type"] = ""
 	}
-	if data.ExtraProperties != nil && len(data.ExtraProperties) > 0 {
+	if len(data.ExtraProperties) > 0 {
 		params["extraProperties"] = data.ExtraProperties
 	}
 	span.LogFields(log.String("cypher", cypher))

--- a/packages/server/customer-os-neo4j-repository/repository/attachment_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/attachment_read_repository.go
@@ -3,11 +3,12 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
+
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 )
@@ -33,6 +34,7 @@ func (r *attachmentReadRepository) GetById(ctx context.Context, tenant, id strin
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AttachmentReadRepository.GetById")
 	defer span.Finish()
 	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	span.LogFields(log.String("id", id))
 
 	cypher := fmt.Sprintf("MATCH (a:Attachment_%s {id:$id}) RETURN a", tenant)
 	params := map[string]any{
@@ -63,8 +65,14 @@ func (r *attachmentReadRepository) GetById(ctx context.Context, tenant, id strin
 func (r *attachmentReadRepository) GetFor(ctx context.Context, tenant string, entityType neo4jenum.EntityType, entityRelation *neo4jenum.EntityRelation, ids []string) ([]*utils.DbNodeAndId, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AttachmentReadRepository.GetFor")
 	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	span.LogFields(
+		log.String("entityType", entityType.String()),
+		log.Int("ids.count", len(ids)))
+	if entityRelation != nil {
+		span.LogFields(log.String("entityRelation", entityRelation.String()))
+	}
+	tracing.LogObjectAsJson(span, "ids", ids)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s_%s)-`, entityType.Neo4jLabel(), tenant)
 
@@ -93,12 +101,12 @@ func (r *attachmentReadRepository) GetFor(ctx context.Context, tenant string, en
 	})
 
 	if err != nil {
+		tracing.TraceErr(span, err)
+		span.LogFields(log.Int("result.count", 0))
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
-	if result == nil {
-		return nil, nil
-	}
-	return result.([]*utils.DbNodeAndId), nil
+	resultArray := result.([]*utils.DbNodeAndId)
+	span.LogFields(log.Int("result.count", len(resultArray)))
+	return resultArray, nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/attachment_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/attachment_write_repository.go
@@ -3,14 +3,15 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
+	"time"
+
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
-	"time"
 )
 
 type AttachmentWriteRepository interface {
@@ -33,6 +34,11 @@ func (r *attachmentWriteRepository) Create(ctx context.Context, tx neo4j.Managed
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AttachmentWriteRepository.Create")
 	defer span.Finish()
 	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	span.LogFields(
+		log.String("id", id),
+		log.String("fileName", fileName),
+		log.String("mimeType", mimeType),
+		log.Int64("size", size))
 
 	id = utils.NewUUIDIfEmpty(id)
 
@@ -40,7 +46,7 @@ func (r *attachmentWriteRepository) Create(ctx context.Context, tx neo4j.Managed
 		createdAt = utils.NowPtr()
 	}
 
-	query := "MERGE (a:Attachment_%s {id:$id}) ON CREATE SET " +
+	cypher := "MERGE (a:Attachment_%s {id:$id}) ON CREATE SET " +
 		" a:Attachment, " +
 		" a.source=$source, " +
 		" a.createdAt=$createdAt, " +
@@ -53,24 +59,36 @@ func (r *attachmentWriteRepository) Create(ctx context.Context, tx neo4j.Managed
 		" a.appSource=$appSource " +
 		" RETURN a"
 
-	span.LogFields(log.String("query", query))
-
-	if queryResult, err := tx.Run(ctx, fmt.Sprintf(query, tenant),
-		map[string]interface{}{
-			"tenant":        tenant,
-			"source":        source,
-			"createdAt":     *createdAt,
-			"id":            id,
-			"cdnUrl":        cdnUrl,
-			"basePath":      basePath,
-			"fileName":      fileName,
-			"mimeType":      mimeType,
-			"size":          size,
-			"sourceOfTruth": sourceOfTruth,
-			"appSource":     appSource,
-		}); err != nil {
-		return nil, err
-	} else {
-		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
+	params := map[string]interface{}{
+		"tenant":        tenant,
+		"source":        source,
+		"createdAt":     *createdAt,
+		"id":            id,
+		"cdnUrl":        cdnUrl,
+		"basePath":      basePath,
+		"fileName":      fileName,
+		"mimeType":      mimeType,
+		"size":          size,
+		"sourceOfTruth": sourceOfTruth,
+		"appSource":     appSource,
 	}
+
+	span.LogFields(log.String("cypher", fmt.Sprintf(cypher, tenant)))
+	tracing.LogObjectAsJson(span, "params", params)
+
+	queryResult, err := tx.Run(ctx, fmt.Sprintf(cypher, tenant), params)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+
+	result, err := utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		span.LogFields(log.Bool("result.found", false))
+		return nil, err
+	}
+
+	span.LogFields(log.Bool("result.found", result != nil))
+	return result, nil
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved tracing and logging in Neo4j repository functions for better clarity and error tracking across action and attachment repositories.
> 
>   - **Tracing Improvements**:
>     - Updated span names in `GetFor`, `GetLastAction`, `CreateWithProperties`, `MergeByActionType`, and `CreateV2` functions in `action_read_repository.go` and `action_write_repository.go` for clarity.
>     - Replaced `tracing.TagComponentNeo4jRepository` and `tracing.TagTenant` with `tracing.SetDefaultNeo4jRepositorySpanTags` in `action_read_repository.go`, `action_write_repository.go`, `attachment_read_repository.go`, and `attachment_write_repository.go`.
>   - **Logging Enhancements**:
>     - Added detailed logging of parameters and cypher queries in `GetFor`, `GetById`, `Create`, and `MergeByActionType` functions across `action_read_repository.go`, `action_write_repository.go`, `attachment_read_repository.go`, and `attachment_write_repository.go`.
>     - Improved error logging with `tracing.TraceErr` in `GetFor`, `GetById`, `Create`, and `MergeByActionType` functions across the same files.
>   - **Miscellaneous**:
>     - Removed unnecessary nil checks for maps in `CreateWithProperties` and `CreateV2` functions in `action_write_repository.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 38df936fb444979da4b3a076585d5cdee552eba7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->