### PR TITLE
fxi qb format date

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/execution_service.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/execution_service.go
@@ -375,11 +375,14 @@ func executeCapability[I, O, C any](
 	case enum.CapabilityExecutionStop:
 		return enum.CapabilityExecutionStop, nil, nil
 
+	case enum.CapabilityExecutionRetry:
+		return enum.CapabilityExecutionRetry, nil, err
+
 	case enum.CapabilityExecutionPending:
 		// todo  -- need to implement poll until done
 		return enum.CapabilityExecutionPending, nil, nil
 
 	default:
-		return enum.CapabilityExecutionError, nil, errors.New("Unexpected capability execution status")
+		return enum.CapabilityExecutionError, nil, errors.New("executeCapability: Unexpected capability execution status")
 	}
 }

--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -690,10 +690,12 @@ func (s *quickbooksService) QuickbooksConnected(ctx context.Context) (bool, erro
 func (s *quickbooksService) SaveJournalEntry(ctx context.Context, txnDate time.Time, journalLineItems []interfaces.QuickbooksJournalEntryLine) (*interfaces.QuickbooksJournalEntryResponse, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "QuickbooksService.SaveJournalEntry")
 	defer span.Finish()
-
 	tenant := common.GetTenantFromContext(ctx)
 	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("txnDate", txnDate.Format("2006-01-02")))
+	tracing.LogObjectAsJson(span, "journalLineItems", journalLineItems)
+
+	txnDateStr := txnDate.Format("2006/01/02")
+	span.LogFields(log.String("txnDate", txnDateStr))
 
 	// Retrieve QuickBooks settings for the tenant.
 	qbSettingsEntity, err := s.postgres.QuickbooksSettingsRepository.Get(ctx, tenant)
@@ -708,7 +710,7 @@ func (s *quickbooksService) SaveJournalEntry(ctx context.Context, txnDate time.T
 
 	// Build the request payload.
 	request := map[string]interface{}{
-		"TxnDate": txnDate.Format("2006-01-02"),
+		"TxnDate": txnDateStr,
 		"Line":    journalLineItems,
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change date format in `SaveJournalEntry` in `quickbooks.go` from `YYYY-MM-DD` to `YYYY/MM/DD`.
> 
>   - **Behavior**:
>     - Change date format in `SaveJournalEntry` in `quickbooks.go` from `YYYY-MM-DD` to `YYYY/MM/DD`.
>     - Affects logging and request payload for `TxnDate`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2e02ee7188d5e72b47c090fedda3371e3078f88f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->