### PR TITLE
omit empties

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/quickbooks.go
+++ b/packages/server/customer-os-common-module/interfaces/quickbooks.go
@@ -179,19 +179,19 @@ type QuickbooksJournalEntryLine struct {
 }
 
 type QuickbooksEntityRef struct {
-	Value string `json:"value"`
-	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
+	Name  string `json:"name,omitempty"`
 }
 
 type QuickbooksEntity struct {
-	Type      string              `json:"type"`
+	Type      string              `json:"type,omitempty"`
 	EntityRef QuickbooksEntityRef `json:"EntityRef"`
 }
 
 // JournalEntryLineDetail contains information such as posting type and account reference.
 type QuickbooksJournalEntryLineDetail struct {
 	// PostingType indicates whether the line is a "Debit" or "Credit".
-	PostingType string `json:"PostingType"`
+	PostingType string `json:"PostingType,omitempty"`
 	// AccountRef references the account impacted.
 	AccountRef QuickbooksAccountRef `json:"AccountRef"`
 	Entity     QuickbooksEntity     `json:"Entity"`
@@ -200,7 +200,7 @@ type QuickbooksJournalEntryLineDetail struct {
 // AccountRef represents a reference to an account in QuickBooks.
 type QuickbooksAccountRef struct {
 	// Value is the unique identifier of the account.
-	Value string `json:"value"`
+	Value string `json:"value,omitempty"`
 	// Name is an optional friendly name for the account.
 	Name string `json:"name,omitempty"`
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `omitempty` to several fields in Quickbooks-related structs to omit empty fields from JSON serialization.
> 
>   - **Behavior**:
>     - Add `omitempty` to `Value` and `Name` in `QuickbooksEntityRef`.
>     - Add `omitempty` to `Type` in `QuickbooksEntity`.
>     - Add `omitempty` to `PostingType` in `QuickbooksJournalEntryLineDetail`.
>     - Add `omitempty` to `Value` in `QuickbooksAccountRef`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c9993865bc71ebc69a7f806ed90f5b3bba1e3ebf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->