### PR TITLE
Fix userId on oauth callback

### DIFF
--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -539,8 +539,7 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 		currentTenant = signInRequest.Tenant
 		defaultTenant = signInRequest.Tenant
 
-		//TODO set user id
-		//services.CommonServices.UserService.FindUserByEmail()
+		userId = common.GetUserIdFromContext(ctx)
 	}
 
 	// handle email token


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `userId` retrieval in `signIn()` in `registration.go` by using `common.GetUserIdFromContext(ctx)`.
> 
>   - **Behavior**:
>     - Fixes setting of `userId` in `signIn()` in `registration.go` by using `common.GetUserIdFromContext(ctx)`.
>     - Ensures `userId` is correctly retrieved from context during sign-in process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 1b515d2435202df0f0ce6493d3aad3a9d861e228. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->