### PR TITLE
get debtor acc id

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/quickbooks.go
+++ b/packages/server/customer-os-common-module/interfaces/quickbooks.go
@@ -13,6 +13,7 @@ type QuickbooksService interface {
 	RevokeAccess(ctx context.Context) error
 	SaveProduct(ctx context.Context, id, productName string, archived bool, price float64) (*QuickbooksSaveProductResponse, error)
 	GetProduct(ctx context.Context, id string) (*QuickbooksGetProductResponse, error)
+	GetAccountIdByName(ctx context.Context, accountName string) (string, error)
 	SaveCustomer(ctx context.Context, id, customerName string) (*QuickbooksSaveCustomerResponse, error)
 	SaveInvoice(ctx context.Context, customerId, invoiceNumber string, invoiceDate time.Time, lines []QuickbooksInvoiceLine) (*QuickbooksSaveInvoiceResponse, error)
 	PayInvoice(ctx context.Context, customerId, invoiceId string, totalAmount float64) (*QuickbooksSavePaymentResponse, error)

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -373,6 +373,12 @@ func (c *SyncInvoiceToAccountingCapability) syncInvoiceToQuickbooksJournalEntry(
 	debitJournalLineItem.JournalEntryLineDetail.PostingType = "Debit"
 	debitJournalLineItem.JournalEntryLineDetail.Entity.EntityRef.Value = contractEntity.QuickbooksCustomerId
 	debitJournalLineItem.JournalEntryLineDetail.AccountRef.Name = "Debtors"
+	debtorsAccountId, err := c.quickbooksService.GetAccountIdByName(ctx, "Debtors")
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return err
+	}
+	debitJournalLineItem.JournalEntryLineDetail.AccountRef.Value = debtorsAccountId
 	journalLineItems = append(journalLineItems, debitJournalLineItem)
 
 	// prepare credit journal line items

--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -221,23 +221,14 @@ func (s *quickbooksService) SaveProduct(ctx context.Context, id, productName str
 	}
 
 	if quickbooksSettingsEntity.SalesAccountId == "" {
-		//search for the sales account
-		searchSalesAccountUrl := s.qbConfig.Url + fmt.Sprintf("/v3/company/%s/query?query=select+Id+from+Account+where+Name='CustomerOS+Sales'", quickbooksSettingsEntity.RealmId)
-		searchSalesAccountResponse, err := s.performRequest(ctx, quickbooksSettingsEntity, searchSalesAccountUrl, "POST", nil, true)
+		salesAccountId, err := s.GetAccountIdByName(ctx, "CustomerOS Sales")
 		if err != nil {
 			tracing.TraceErr(span, err)
 			return nil, err
 		}
 
-		var searchSalesAccount interfaces.QuickbooksSearchAccountResponse
-		err = json.Unmarshal(searchSalesAccountResponse, &searchSalesAccount)
-		if err != nil {
-			tracing.TraceErr(span, err)
-			return nil, err
-		}
-
-		if len(searchSalesAccount.QueryResponse.Account) > 0 {
-			quickbooksSettingsEntity.SalesAccountId = searchSalesAccount.QueryResponse.Account[0].Id
+		if salesAccountId != "" {
+			quickbooksSettingsEntity.SalesAccountId = salesAccountId
 			_, err = s.postgres.QuickbooksSettingsRepository.Save(ctx, *quickbooksSettingsEntity)
 			if err != nil {
 				tracing.TraceErr(span, err)
@@ -807,4 +798,45 @@ func (s *quickbooksService) ZeroJournalEntry(ctx context.Context, journalEntryId
 	}
 
 	return nil
+}
+
+func (s *quickbooksService) GetAccountIdByName(ctx context.Context, accountName string) (string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "QuickbooksService.GetAccountIdByName")
+	defer span.Finish()
+	tenant := common.GetTenantFromContext(ctx)
+	tracing.TagTenant(span, tenant)
+	span.LogFields(log.String("accountName", accountName))
+
+	// Retrieve QuickBooks settings for the tenant.
+	qbSettings, err := s.postgres.QuickbooksSettingsRepository.Get(ctx, tenant)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", fmt.Errorf("failed to retrieve QuickBooks settings for tenant %s: %w", tenant, err)
+	}
+	if qbSettings == nil {
+		err = errors.New("QuickBooks settings not found")
+		tracing.TraceErr(span, err)
+		return "", err
+	}
+
+	// Construct the URL for querying the account by name.
+	queryURL := fmt.Sprintf("%s/v3/company/%s/query?query=select+Id+from+Account+where+Name='%s'", s.qbConfig.Url, qbSettings.RealmId, accountName)
+	// Perform the request.
+	resp, err := s.performRequest(ctx, qbSettings, queryURL, "POST", nil, true)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", fmt.Errorf("failed to query account: %w", err)
+	}
+
+	var searchAccountResp interfaces.QuickbooksSearchAccountResponse
+	err = json.Unmarshal(resp, &searchAccountResp)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return "", fmt.Errorf("failed to unmarshal account response: %w", err)
+	}
+
+	if len(searchAccountResp.QueryResponse.Account) > 0 {
+		return searchAccountResp.QueryResponse.Account[0].Id, nil
+	}
+	return "", nil
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `GetAccountIdByName` to `QuickbooksService` for retrieving account IDs by name, and integrate it into journal entry synchronization and product saving.
> 
>   - **New Functionality**:
>     - Add `GetAccountIdByName(ctx, accountName)` to `QuickbooksService` interface in `interfaces/quickbooks.go`.
>     - Implement `GetAccountIdByName` in `quickbooksService` in `quickbooks.go` to query account ID by name from QuickBooks.
>   - **Integration**:
>     - Use `GetAccountIdByName` in `syncInvoiceToQuickbooksJournalEntry` in `capability_invoice_sync_to_accounting.go` to set `AccountRef.Value` for debit journal line items.
>     - Refactor `SaveProduct` in `quickbooks.go` to use `GetAccountIdByName` for retrieving `SalesAccountId`.
>   - **Misc**:
>     - Remove redundant code in `SaveProduct` related to sales account retrieval in `quickbooks.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7a508b58738b5fc76d6017dbb5ed52e6eb9863a1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->