### PR TITLE
link invoice to journal

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/quickbooks.go
+++ b/packages/server/customer-os-common-module/interfaces/quickbooks.go
@@ -20,6 +20,7 @@ type QuickbooksService interface {
 	VoidInvoice(ctx context.Context, invoiceId string) (*QuickbooksSaveInvoiceResponse, error)
 	SaveJournalEntry(ctx context.Context, txnDate time.Time, journalLineItems []QuickbooksJournalEntryLine) (*QuickbooksJournalEntryResponse, error)
 	ZeroJournalEntry(ctx context.Context, journalEntryId string) error
+	SavePaymentLinkingJournalEntryToInvoice(ctx context.Context, quickbooksCustomerId string, quickbooksInvoiceId string, quickbooksJournalEntryId string, txnDate time.Time, totalAmount float64) error
 }
 
 type QuickbooksInvoiceLine struct {

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -427,6 +427,12 @@ func (c *SyncInvoiceToAccountingCapability) syncInvoiceToQuickbooksJournalEntry(
 		return err
 	}
 
+	err = c.quickbooksService.SavePaymentLinkingJournalEntryToInvoice(ctx, contractEntity.QuickbooksCustomerId, invoice.QuickbooksInvoiceId, savedJournalEntry.JournalEntry.Id, invoice.IssuedDate, invoice.Amount)
+	if err != nil {
+		tracing.TraceErr(span, errors.Wrap(err, "error saving payment linking journal entry to invoice"))
+		return err
+	}
+
 	return nil
 }
 

--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -850,3 +850,66 @@ func (s *quickbooksService) GetAccountIdByName(ctx context.Context, accountName 
 	}
 	return "", nil
 }
+
+func (s *quickbooksService) SavePaymentLinkingJournalEntryToInvoice(ctx context.Context, quickbooksCustomerId string,
+	quickbooksInvoiceId string, quickbooksJournalEntryId string, txnDate time.Time, totalAmount float64) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "QuickbooksService.SavePaymentLinkingJournalEntryToInvoice")
+	defer span.Finish()
+	tenant := common.GetTenantFromContext(ctx)
+	tracing.TagTenant(span, tenant)
+	span.LogFields(
+		log.String("quickbooksCustomerId", quickbooksCustomerId),
+		log.String("quickbooksInvoiceId", quickbooksInvoiceId),
+		log.String("quickbooksJournalEntryId", quickbooksJournalEntryId),
+		log.Float64("totalAmount", totalAmount),
+		log.Object("txnDate", txnDate))
+
+	// Retrieve QuickBooks settings for the tenant.
+	qbSettings, err := s.postgres.QuickbooksSettingsRepository.Get(ctx, tenant)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return fmt.Errorf("failed to retrieve QuickBooks settings for tenant %s: %w", tenant, err)
+	}
+	if qbSettings == nil {
+		err = errors.New("QuickBooks settings not found")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	// Construct the payment payload.
+	paymentData := map[string]interface{}{
+		"TxnDate":  txnDate.Format("2006/01/02"),
+		"TotalAmt": totalAmount,
+		"CustomerRef": map[string]interface{}{
+			"value": quickbooksCustomerId,
+		},
+		"Line": []map[string]interface{}{
+			{
+				"Amount": totalAmount,
+				"LinkedTxn": []map[string]interface{}{
+					{
+						"TxnId":   quickbooksInvoiceId,
+						"TxnType": "Invoice",
+					},
+				},
+			},
+		},
+		"LinkedTxn": []map[string]interface{}{
+			{
+				"TxnId":   quickbooksJournalEntryId,
+				"TxnType": "JournalEntry",
+			},
+		},
+	}
+
+	// Construct the URL for creating the payment.
+	requestUrl := fmt.Sprintf("%s/v3/company/%s/payment", s.qbConfig.Url, qbSettings.RealmId)
+	// Perform the request.
+	_, err = s.performRequest(ctx, qbSettings, requestUrl, "POST", paymentData, true)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return fmt.Errorf("failed to save payment: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds functionality to link QuickBooks journal entries to invoices, enhancing invoice synchronization.
> 
>   - **Behavior**:
>     - Adds `SavePaymentLinkingJournalEntryToInvoice` to `QuickbooksService` interface in `quickbooks.go` to link journal entries to invoices.
>     - Updates `syncInvoiceToQuickbooksJournalEntry` in `capability_invoice_sync_to_accounting.go` to call `SavePaymentLinkingJournalEntryToInvoice` after saving a journal entry.
>   - **Functions**:
>     - Implements `SavePaymentLinkingJournalEntryToInvoice` in `quickbooks.go` to create a payment linking a journal entry to an invoice in QuickBooks.
>   - **Misc**:
>     - Adds error handling and logging for the new linking functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d46b4d3e2cf807dad8c677130facd6bbdb997bf0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->