### PR TITLE
fli ids

### DIFF
--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -888,16 +888,16 @@ func (s *quickbooksService) SavePaymentLinkingJournalEntryToInvoice(ctx context.
 				"Amount": totalAmount,
 				"LinkedTxn": []map[string]interface{}{
 					{
-						"TxnId":   quickbooksInvoiceId,
-						"TxnType": "Invoice",
+						"TxnId":   quickbooksJournalEntryId,
+						"TxnType": "JournalEntry",
 					},
 				},
 			},
 		},
 		"LinkedTxn": []map[string]interface{}{
 			{
-				"TxnId":   quickbooksJournalEntryId,
-				"TxnType": "JournalEntry",
+				"TxnId":   quickbooksInvoiceId,
+				"TxnType": "Invoice",
 			},
 		},
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Swaps `TxnId` and `TxnType` values in `SavePaymentLinkingJournalEntryToInvoice` function in `quickbooks.go` to adjust QuickBooks payment linking.
> 
>   - **Behavior**:
>     - In `quickbooks.go`, `SavePaymentLinkingJournalEntryToInvoice` function swaps `TxnId` and `TxnType` values for `quickbooksInvoiceId` and `quickbooksJournalEntryId`.
>     - Changes affect how journal entries and invoices are linked in QuickBooks payments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for fc06905be784a27d56126bb2c6b22beb5d9849fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->