### PR TITLE
store payment id

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/quickbooks.go
+++ b/packages/server/customer-os-common-module/interfaces/quickbooks.go
@@ -20,7 +20,7 @@ type QuickbooksService interface {
 	VoidInvoice(ctx context.Context, invoiceId string) (*QuickbooksSaveInvoiceResponse, error)
 	SaveJournalEntry(ctx context.Context, txnDate time.Time, journalLineItems []QuickbooksJournalEntryLine) (*QuickbooksJournalEntryResponse, error)
 	ZeroJournalEntry(ctx context.Context, journalEntryId string) error
-	SavePaymentLinkingJournalEntryToInvoice(ctx context.Context, quickbooksCustomerId string, quickbooksInvoiceId string, quickbooksJournalEntryId string, txnDate time.Time, totalAmount float64) error
+	SavePaymentLinkingJournalEntryToInvoice(ctx context.Context, quickbooksCustomerId string, quickbooksInvoiceId string, quickbooksJournalEntryId string, txnDate time.Time, totalAmount float64) (*QuickbooksSavePaymentResponse, error)
 }
 
 type QuickbooksInvoiceLine struct {

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -434,10 +434,17 @@ func (c *SyncInvoiceToAccountingCapability) syncInvoiceToQuickbooksJournalEntry(
 		return err
 	}
 
-	err = c.quickbooksService.SavePaymentLinkingJournalEntryToInvoice(ctx, contractEntity.QuickbooksCustomerId, invoice.QuickbooksInvoiceId, savedJournalEntry.JournalEntry.Id, invoice.IssuedDate, invoice.Amount)
+	quickbooksPayment, err := c.quickbooksService.SavePaymentLinkingJournalEntryToInvoice(ctx, contractEntity.QuickbooksCustomerId, invoice.QuickbooksInvoiceId, savedJournalEntry.JournalEntry.Id, invoice.IssuedDate, invoice.Amount)
 	if err != nil {
 		tracing.TraceErr(span, errors.Wrap(err, "error saving payment linking journal entry to invoice"))
 		return err
+	}
+	if quickbooksPayment != nil {
+		err = c.neo4jRepositories.CommonWriteRepository.UpdateStringProperty(ctx, nil, tenant, commonmodel.NodeLabelInvoice, invoice.Id, string(neo4jentity.InvoicePropertyQuickbooksPaymentId), quickbooksPayment.Payment.Id)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
 	}
 
 	return nil

--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -852,7 +852,7 @@ func (s *quickbooksService) GetAccountIdByName(ctx context.Context, accountName 
 }
 
 func (s *quickbooksService) SavePaymentLinkingJournalEntryToInvoice(ctx context.Context, quickbooksCustomerId string,
-	quickbooksInvoiceId string, quickbooksJournalEntryId string, txnDate time.Time, totalAmount float64) error {
+	quickbooksInvoiceId string, quickbooksJournalEntryId string, txnDate time.Time, totalAmount float64) (*interfaces.QuickbooksSavePaymentResponse, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "QuickbooksService.SavePaymentLinkingJournalEntryToInvoice")
 	defer span.Finish()
 	tenant := common.GetTenantFromContext(ctx)
@@ -868,12 +868,12 @@ func (s *quickbooksService) SavePaymentLinkingJournalEntryToInvoice(ctx context.
 	qbSettings, err := s.postgres.QuickbooksSettingsRepository.Get(ctx, tenant)
 	if err != nil {
 		tracing.TraceErr(span, err)
-		return fmt.Errorf("failed to retrieve QuickBooks settings for tenant %s: %w", tenant, err)
+		return nil, fmt.Errorf("failed to retrieve QuickBooks settings for tenant %s: %w", tenant, err)
 	}
 	if qbSettings == nil {
 		err = errors.New("QuickBooks settings not found")
 		tracing.TraceErr(span, err)
-		return err
+		return nil, err
 	}
 
 	// Construct the payment payload.
@@ -905,11 +905,24 @@ func (s *quickbooksService) SavePaymentLinkingJournalEntryToInvoice(ctx context.
 	// Construct the URL for creating the payment.
 	requestUrl := fmt.Sprintf("%s/v3/company/%s/payment", s.qbConfig.Url, qbSettings.RealmId)
 	// Perform the request.
-	_, err = s.performRequest(ctx, qbSettings, requestUrl, "POST", paymentData, true)
+	quickbooksResponse, err := s.performRequest(ctx, qbSettings, requestUrl, "POST", paymentData, true)
 	if err != nil {
 		tracing.TraceErr(span, err)
-		return fmt.Errorf("failed to save payment: %w", err)
+		return nil, fmt.Errorf("failed to save payment: %w", err)
 	}
 
-	return nil
+	// Unmarshal the response into QuickbooksSavePaymentResponse.
+	var qbPaymentResponse interfaces.QuickbooksSavePaymentResponse
+	err = json.Unmarshal(quickbooksResponse, &qbPaymentResponse)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+
+	if qbPaymentResponse.Fault != nil {
+		span.LogFields(log.Object("error", qbPaymentResponse.Fault))
+		return nil, fmt.Errorf("error: %s", qbPaymentResponse.Fault.Error[0].Message)
+	}
+
+	return &qbPaymentResponse, nil
 }

--- a/packages/server/customer-os-neo4j-repository/entity/invoice.go
+++ b/packages/server/customer-os-neo4j-repository/entity/invoice.go
@@ -25,6 +25,7 @@ const (
 	InvoicePropertyVoidInvoiceNotificationRequestAt     InvoiceProperty = "techVoidInvoiceNotificationSentAt"
 	InvoicePropertyQuickbooksInvoiceId                  InvoiceProperty = "quickbooksInvoiceId"
 	InvoicePropertyQuickbooksJournalEntryId             InvoiceProperty = "quickbooksJournalEntryId"
+	InvoicePropertyQuickbooksPaymentId                  InvoiceProperty = "quickbooksPaymentId"
 )
 
 type InvoiceEntity struct {
@@ -50,6 +51,7 @@ type InvoiceEntity struct {
 	Note                     string
 	QuickbooksInvoiceId      string
 	QuickbooksJournalEntryId string
+	QuickbooksPaymentId      string
 	PaymentDetails           PaymentDetails
 	OffCycle                 bool
 	Postpaid                 bool

--- a/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
+++ b/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
@@ -119,6 +119,7 @@ func MapDbNodeToInvoiceEntity(dbNode *dbtype.Node) *neo4j_entity.InvoiceEntity {
 		Note:                     utils.GetStringPropOrEmpty(props, "note"),
 		QuickbooksInvoiceId:      utils.GetStringPropOrEmpty(props, string(neo4j_entity.InvoicePropertyQuickbooksInvoiceId)),
 		QuickbooksJournalEntryId: utils.GetStringPropOrEmpty(props, string(neo4j_entity.InvoicePropertyQuickbooksJournalEntryId)),
+		QuickbooksPaymentId:      utils.GetStringPropOrEmpty(props, string(neo4j_entity.InvoicePropertyQuickbooksPaymentId)),
 		Customer: neo4j_entity.InvoiceCustomer{
 			Name:         utils.GetStringPropOrEmpty(props, "customerName"),
 			Email:        utils.GetStringPropOrEmpty(props, "customerEmail"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Store Quickbooks payment ID in Neo4j after linking payment to journal entry and invoice, updating relevant interfaces and models.
> 
>   - **Behavior**:
>     - `SavePaymentLinkingJournalEntryToInvoice` in `quickbooks.go` now returns `QuickbooksSavePaymentResponse` with payment ID.
>     - `syncInvoiceToQuickbooksJournalEntry` in `capability_invoice_sync_to_accounting.go` updates Neo4j with `QuickbooksPaymentId` if payment is successful.
>   - **Models**:
>     - Add `QuickbooksPaymentId` to `InvoiceEntity` in `invoice.go`.
>     - Update `MapDbNodeToInvoiceEntity` in `node_to_entity_mapper.go` to map `QuickbooksPaymentId`.
>   - **Interfaces**:
>     - Update `QuickbooksService` interface in `quickbooks.go` to reflect new return type for `SavePaymentLinkingJournalEntryToInvoice`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 26420d056399147a7a2c31b1c0d8154e34c7efd3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->