### PR TITLE
fix

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_event_producers/send_invoice_producer.go
+++ b/packages/server/customer-os-common-module/services/agent_event_producers/send_invoice_producer.go
@@ -51,7 +51,7 @@ func (p *SendInvoiceProducer) Execute() {
 
 	limit := 100
 	minutesFromLastAttempt := 360
-	minutesFromCreation := 90
+	minutesFromCreation := 30
 	lookBackWindowDays := 5
 
 	for {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `minutesFromCreation` from 90 to 30 in `SendInvoiceProducer.Execute()` to reduce invoice processing wait time.
> 
>   - **Behavior**:
>     - Change `minutesFromCreation` from 90 to 30 in `Execute()` of `SendInvoiceProducer`.
>     - Affects the time window for processing invoices, reducing the wait time before an invoice is eligible for processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for fc6a7d8c6a003e518e7cf9449575d3f3dca59778. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->