### PR TITLE
fix font reference

### DIFF
--- a/packages/server/customer-os-common-module/services/invoice/utils.go
+++ b/packages/server/customer-os-common-module/services/invoice/utils.go
@@ -120,10 +120,8 @@ func ConvertInvoiceHtmlToPdf(ctx context.Context, fsc interfaces.FileService, pd
 		{"line11681-7w4.svg", "line11681-7w4.svg"},
 		{"line21681-3s8.svg", "line21681-3s8.svg"},
 		{"line31681-nvh.svg", "line31681-nvh.svg"},
-		{"fonts/Barlow-Regular.woff2", "fonts/Barlow-Regular.woff2"},
-		{"fonts/Barlow-Medium.woff2", "fonts/Barlow-Medium.woff2"},
-		{"fonts/Barlow-SemiBold.woff2", "fonts/Barlow-SemiBold.woff2"},
-		{"fonts/Barlow-Bold.woff2", "fonts/Barlow-Bold.woff2"},
+		{"fonts/IBMPlexSans-Regular.woff2", "fonts/IBMPlexSans-Regular.woff2"},
+		{"fonts/IBMPlexSans-Medium.woff2", "fonts/IBMPlexSans-Medium.woff2"},
 	}
 	for _, rf := range resourceFiles {
 		err = addEmbeddedResourceFile(writer, rf.FileName, rf.PartName)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update font files in `ConvertInvoiceHtmlToPdf` in `utils.go` from Barlow to IBM Plex Sans.
> 
>   - **Behavior**:
>     - Update font files in `ConvertInvoiceHtmlToPdf` in `utils.go` from Barlow to IBM Plex Sans.
>     - Specifically, replace `Barlow-Regular.woff2`, `Barlow-Medium.woff2`, `Barlow-SemiBold.woff2`, and `Barlow-Bold.woff2` with `IBMPlexSans-Regular.woff2` and `IBMPlexSans-Medium.woff2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2e5d9cc613cd584ee217a47c86dfbb6abae006da. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->