### PR TITLE
voiding qbo payment

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/quickbooks.go
+++ b/packages/server/customer-os-common-module/interfaces/quickbooks.go
@@ -21,6 +21,7 @@ type QuickbooksService interface {
 	SaveJournalEntry(ctx context.Context, txnDate time.Time, journalLineItems []QuickbooksJournalEntryLine) (*QuickbooksJournalEntryResponse, error)
 	ZeroJournalEntry(ctx context.Context, journalEntryId string) error
 	SavePaymentLinkingJournalEntryToInvoice(ctx context.Context, quickbooksCustomerId string, quickbooksInvoiceId string, quickbooksJournalEntryId string, txnDate time.Time, totalAmount float64) (*QuickbooksSavePaymentResponse, error)
+	ZeroPaymentLinkingJournalEntryToInvoice(ctx context.Context, quickbooksPaymentId, quickbooksJournalEntryId string) error
 }
 
 type QuickbooksInvoiceLine struct {

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -197,6 +197,13 @@ func (c *SyncInvoiceToAccountingCapability) Execute(ctx context.Context, executi
 				tracing.TraceErr(span, err)
 				return enum.CapabilityExecutionRetry, result, err
 			}
+			if invoiceEntity.QuickbooksPaymentId != "" {
+				err = c.quickbooksService.ZeroPaymentLinkingJournalEntryToInvoice(ctx, invoiceEntity.QuickbooksPaymentId, invoiceEntity.QuickbooksJournalEntryId)
+				if err != nil {
+					tracing.TraceErr(span, err)
+					return enum.CapabilityExecutionRetry, result, err
+				}
+			}
 		}
 	}
 

--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -926,3 +926,51 @@ func (s *quickbooksService) SavePaymentLinkingJournalEntryToInvoice(ctx context.
 
 	return &qbPaymentResponse, nil
 }
+
+func (s *quickbooksService) ZeroPaymentLinkingJournalEntryToInvoice(ctx context.Context, quickbooksPaymentId, quickbooksJournalEntryId string) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "QuickbooksService.ZeroPaymentLinkingJournalEntryToInvoice")
+	defer span.Finish()
+	tenant := common.GetTenantFromContext(ctx)
+	tracing.TagTenant(span, tenant)
+	span.LogFields(log.String("quickbooksPaymentId", quickbooksPaymentId), log.String("quickbooksJournalEntryId", quickbooksJournalEntryId))
+
+	// Retrieve QuickBooks settings for the tenant.
+	qbSettings, err := s.postgres.QuickbooksSettingsRepository.Get(ctx, tenant)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return fmt.Errorf("failed to retrieve QuickBooks settings for tenant %s: %w", tenant, err)
+	}
+	if qbSettings == nil {
+		err = errors.New("QuickBooks settings not found")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	// Construct the payment payload.
+	paymentData := map[string]interface{}{
+		"Id":       quickbooksPaymentId,
+		"TotalAmt": 0,
+		"Line": []map[string]interface{}{
+			{
+				"Amount": 0,
+				"LinkedTxn": []map[string]interface{}{
+					{
+						"TxnId":   quickbooksJournalEntryId,
+						"TxnType": "JournalEntry",
+					},
+				},
+			},
+		},
+	}
+
+	// Construct the URL for creating the payment.
+	requestUrl := fmt.Sprintf("%s/v3/company/%s/payment", s.qbConfig.Url, qbSettings.RealmId)
+	// Perform the request.
+	_, err = s.performRequest(ctx, qbSettings, requestUrl, "POST", paymentData, true)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return fmt.Errorf("failed to save payment: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `ZeroPaymentLinkingJournalEntryToInvoice` to handle voiding payments linked to journal entries in QuickBooks, integrated into invoice voiding process.
> 
>   - **Behavior**:
>     - Adds `ZeroPaymentLinkingJournalEntryToInvoice` to `QuickbooksService` in `quickbooks.go` to zero out payments linked to journal entries.
>     - Updates `Execute` in `capability_invoice_sync_to_accounting.go` to call `ZeroPaymentLinkingJournalEntryToInvoice` when voiding an invoice with a payment.
>   - **Interfaces**:
>     - Adds `ZeroPaymentLinkingJournalEntryToInvoice` to `QuickbooksService` interface in `quickbooks.go`.
>   - **Misc**:
>     - Minor logging and error handling improvements in `quickbooks.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for e8701bcd77198b138b1d4356a3438fe11b3fe0a0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->