### PR TITLE
use sync token

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/quickbooks.go
+++ b/packages/server/customer-os-common-module/interfaces/quickbooks.go
@@ -206,3 +206,12 @@ type QuickbooksAccountRef struct {
 	// Name is an optional friendly name for the account.
 	Name string `json:"name,omitempty"`
 }
+
+type Payment struct {
+	Id        string `json:"Id"`
+	SyncToken string `json:"SyncToken"`
+}
+
+type QuickbooksGetPaymentResponse struct {
+	Payment Payment `json:"Payment"`
+}

--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -948,10 +948,35 @@ func (s *quickbooksService) ZeroPaymentLinkingJournalEntryToInvoice(ctx context.
 		return err
 	}
 
+	// Step 1: Fetch the existing payment to get its SyncToken.
+	getURL := fmt.Sprintf("%s/v3/company/%s/payment/%s", s.qbConfig.Url, qbSettings.RealmId, quickbooksPaymentId)
+	resp, err := s.performRequest(ctx, qbSettings, getURL, "GET", nil, true)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return fmt.Errorf("failed to fetch existing payment: %w", err)
+	}
+
+	// Unmarshal the GET response into a Quickbooks payment response structure.
+	var qbGetPaymentResp interfaces.QuickbooksGetPaymentResponse
+	err = json.Unmarshal(resp, &qbGetPaymentResp)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return fmt.Errorf("failed to unmarshal payment response: %w", err)
+	}
+
+	// Extract the SyncToken from the fetched payment.
+	syncToken := qbGetPaymentResp.Payment.SyncToken
+	if syncToken == "" {
+		err = errors.New("no SyncToken found in payment record")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
 	// Construct the payment payload.
 	paymentData := map[string]interface{}{
-		"Id":       quickbooksPaymentId,
-		"TotalAmt": 0,
+		"Id":        quickbooksPaymentId,
+		"SyncToken": syncToken,
+		"TotalAmt":  0,
 		"CustomerRef": map[string]interface{}{
 			"value": quickbooksCustomerId,
 		},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fetch and use `SyncToken` in `ZeroPaymentLinkingJournalEntryToInvoice` to ensure correct QuickBooks payment updates.
> 
>   - **Behavior**:
>     - `ZeroPaymentLinkingJournalEntryToInvoice` in `quickbooks.go` now fetches the `SyncToken` of a payment before updating it.
>     - If `SyncToken` is missing, logs an error and returns.
>   - **Models**:
>     - Adds `Payment` and `QuickbooksGetPaymentResponse` structs to `interfaces/quickbooks.go`.
>   - **Misc**:
>     - Adds error handling for missing `SyncToken` in `quickbooks.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8f0d25df9ceb8191a39c152e02897cfd2ebd9ad2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->