### PR TITLE
fix missing opensearch config

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/config/config.go
+++ b/packages/runner/customer-os-data-upkeeper/config/config.go
@@ -34,6 +34,7 @@ type CommonConfig struct {
 	JinaConfig        commonconf.JinaConfig
 	AwsConfig         commonconf.AwsConfig
 	QuickbooksConfig  commonconf.QuickbooksConfig
+	OpensearchConfig  commonconf.OpensearchConfig
 }
 
 type AppConfig struct {
@@ -93,6 +94,7 @@ func Load() *Config {
 			Neo4jConfig:         cmnCfg.Neo4j,
 			GoogleOAuthConfig:   cmnCfg.GoogleOAuthConfig,
 			AzureOAuthConfig:    cmnCfg.AzureOAuthConfig,
+			OpensearchConfig:    cmnCfg.OpensearchConfig,
 		},
 		External: commonconf.ExternalServicesConfig{
 			EnrowConfig:         cmnCfg.Enrow,

--- a/packages/server/customer-os-common-module/services/init.go
+++ b/packages/server/customer-os-common-module/services/init.go
@@ -199,15 +199,8 @@ func InitCommonServices(
 		}
 	}
 
-	var opensearchImpl interfaces.OpensearchService
-	if cfg.Infrastructure.OpensearchConfig.Url != "" {
-		opensearchImpl = opensearch.NewOpensearchService(log, &cfg.Infrastructure.OpensearchConfig)
-	}
-	if opensearchImpl == nil {
-		log.Warn("opensearch service is nil")
-	}
-
 	// Simple - Services that depend only on base services
+	opensearchImpl := opensearch.NewOpensearchService(log, &cfg.Infrastructure.OpensearchConfig)
 	aiImpl := ai.NewAIService(log, &cfg.External.AnthropicConfig, &cfg.External.DeepseekConfig, &cfg.External.GroqConfig, &cfg.External.GeminiConfig, opensearchImpl)
 	attachmentImpl := attachment.NewAttachmentService(neo4jRepositories)
 	azureImpl := azure.NewAzureService(&cfg.Infrastructure.AzureOAuthConfig, postgresRepositories, neo4jRepositories)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add missing OpenSearch configuration to `CommonConfig` and ensure `opensearchImpl` is always initialized.
> 
>   - **Configuration**:
>     - Add `OpensearchConfig` to `CommonConfig` in `config.go`.
>     - Ensure `opensearchImpl` is initialized in `init.go`.
>   - **Behavior**:
>     - `opensearchImpl` is now always initialized, removing previous conditional initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 5f2ed1d242ffee9d21270449edc4953cc6f78109. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->