### PR TITLE
Fix 3

### DIFF
--- a/packages/server/customer-os-neo4j-repository/repository/invoice_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/invoice_read_repository.go
@@ -102,7 +102,7 @@ func (r *invoiceReadRepository) GetPaginatedInvoices(ctx context.Context, tenant
 	span.LogFields(log.Object("filterParams", filterParams))
 	span.LogFields(log.Object("sorting", sorting))
 
-	sortFragment := utils.IfNotNilString(sorting)
+	sortFragment := string(*sorting)
 	if sortFragment == "" {
 		sortFragment = "ORDER BY i.number ASC"
 	} else {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes string conversion of `sorting` parameter in `GetPaginatedInvoices()` in `invoice_read_repository.go`.
> 
>   - **Behavior**:
>     - Fixes string conversion of `sorting` parameter in `GetPaginatedInvoices()` in `invoice_read_repository.go`.
>     - Ensures `sorting` is correctly converted to a string using `string(*sorting)` instead of `utils.IfNotNilString(sorting)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 341082c2daac8d77beade14c47404246a9820030. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->