### PR TITLE
fix event exit timestamp

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_event_producers/new_web_session_producer.go
+++ b/packages/server/customer-os-common-module/services/agent_event_producers/new_web_session_producer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
@@ -182,7 +183,7 @@ func (s *NewWebSessionProducer) processClosedSession(ctx context.Context, sessio
 	// process page visits
 	identifiedVisitor := IdentifiedVisitor{}
 	for _, page := range pageViews {
-		visitor, err := s.processPageView(ctx, session.ID, page)
+		visitor, err := s.processPageView(ctx, session.ID, page, endTime)
 		if err != nil {
 			tracing.TraceErr(span, err)
 			continue
@@ -226,7 +227,7 @@ type IdentifiedVisitor struct {
 	EmailType enum.EmailType
 }
 
-func (s *NewWebSessionProducer) processPageView(ctx context.Context, sessionId, page string) (IdentifiedVisitor, error) {
+func (s *NewWebSessionProducer) processPageView(ctx context.Context, sessionId, page string, endTime time.Time) (IdentifiedVisitor, error) {
 	span, ctx := tracing.StartTracerSpan(ctx, "NewWebSessionProducer.processPageView")
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
@@ -270,6 +271,10 @@ func (s *NewWebSessionProducer) processPageView(ctx context.Context, sessionId, 
 			}
 
 		case "page_exit":
+			if event.Timestamp.IsZero() {
+				event.Timestamp = endTime
+			}
+
 			if visit.ExitTimestamp.IsZero() {
 				visit.ExitTimestamp = event.Timestamp
 			} else if event.Timestamp.After(visit.ExitTimestamp) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of `page_exit` events by setting zero timestamps to session end time in `new_web_session_producer.go`.
> 
>   - **Behavior**:
>     - Fixes handling of `page_exit` events in `processPageView()` by setting zero timestamps to `endTime`.
>     - Updates `processClosedSession()` to pass `endTime` to `processPageView()`.
>   - **Functions**:
>     - Modifies `processPageView()` in `new_web_session_producer.go` to accept `endTime` as a parameter.
>     - Updates `processClosedSession()` to call `processPageView()` with `endTime`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 07770762d595c0e76f443b53613fd8d3088488e3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->