### PR TITLE
fix nil pointer dereference on agent retry

### DIFF
--- a/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
@@ -460,6 +460,10 @@ func (a *agentRunnerService) RerunExecution(ctx context.Context, executionID str
 	if paramsVal, ok := execution.StateData["params"]; ok {
 		if paramsMap, ok := paramsVal.(map[string]any); ok {
 			params = paramsMap
+		} else {
+			err := errors.New("paramsMap is invalid")
+			tracing.TraceErr(span, err)
+			return err
 		}
 	}
 

--- a/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
@@ -431,7 +431,6 @@ func (a *agentRunnerService) RerunExecution(ctx context.Context, executionID str
 		tracing.TraceErr(span, err)
 		return err
 	}
-
 	if execution.Status != enum.AgentExecutionRetrying {
 		return errors.New("execution is not in retry state")
 	}
@@ -452,8 +451,16 @@ func (a *agentRunnerService) RerunExecution(ctx context.Context, executionID str
 
 	// Resume from last known state
 	params := map[string]any{}
-	if execution.StateData != nil {
-		params = execution.StateData["params"].(map[string]any)
+	if execution.StateData == nil {
+		err := errors.New("StateData is empty, cannot retry")
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	if paramsVal, ok := execution.StateData["params"]; ok {
+		if paramsMap, ok := paramsVal.(map[string]any); ok {
+			params = paramsMap
+		}
 	}
 
 	// Retry execution


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix nil pointer dereference in `RerunExecution()` by adding checks for `StateData` and its contents in `agent_runner_service.go`.
> 
>   - **Error Handling**:
>     - Fix nil pointer dereference in `RerunExecution()` in `agent_runner_service.go` by checking if `execution.StateData` is nil before accessing it.
>     - Add error handling for invalid `params` in `execution.StateData` in `RerunExecution()`.
>   - **Misc**:
>     - Remove unnecessary newline in `RerunExecution()` in `agent_runner_service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a8723f11f4e391bbdd954f1f5113e703781148de. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->