### PR TITLE
Delete oauth token 2

### DIFF
--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
 	"github.com/customeros/customeros/packages/server/customer-os-api/utils"
 	"log"
 	"net/http"
@@ -698,7 +699,18 @@ func Revoke(s *cosapi_services.Services) gin.HandlerFunc {
 		}
 		log.Printf("parsed json: %v", revokeRequest)
 
-		oauthToken, err := s.Repositories.PostgresRepositories.OAuthTokenRepository.GetByEmail(ctx, revokeRequest.Tenant, revokeRequest.Provider, revokeRequest.Email)
+		workspaceProvider := ""
+		if revokeRequest.MailboxProvider == model.MailboxProviderGoogle.String() {
+			workspaceProvider = common_enum.WorkspaceProviderGoogle.String()
+		} else if revokeRequest.MailboxProvider == model.MailboxProviderMicrosoft.String() {
+			workspaceProvider = common_enum.WorkspaceProviderAzure.String()
+		}
+
+		if workspaceProvider == "" {
+			c.JSON(http.StatusBadRequest, gin.H{})
+		}
+
+		oauthToken, err := s.Repositories.PostgresRepositories.OAuthTokenRepository.GetByEmail(ctx, revokeRequest.Tenant, workspaceProvider, revokeRequest.Email)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{})
 			return
@@ -707,7 +719,7 @@ func Revoke(s *cosapi_services.Services) gin.HandlerFunc {
 		if oauthToken != nil && oauthToken.RefreshToken != "" {
 			// Handle revocation based on provider
 			var revocationURL string
-			switch revokeRequest.Provider {
+			switch workspaceProvider {
 			case common_enum.WorkspaceProviderGoogle.String():
 				revocationURL = fmt.Sprintf("https://accounts.google.com/o/oauth2/revoke?token=%s", oauthToken.RefreshToken)
 			case common_enum.WorkspaceProviderAzure.String():
@@ -729,7 +741,7 @@ func Revoke(s *cosapi_services.Services) gin.HandlerFunc {
 			}
 		}
 
-		err = s.Repositories.PostgresRepositories.OAuthTokenRepository.DeleteByEmail(ctx, revokeRequest.Tenant, revokeRequest.Provider, revokeRequest.Email)
+		err = s.Repositories.PostgresRepositories.OAuthTokenRepository.DeleteByEmail(ctx, revokeRequest.Tenant, workspaceProvider, revokeRequest.Email)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{})
 			return

--- a/packages/server/customer-os-api/rest/private/registration_model.go
+++ b/packages/server/customer-os-api/rest/private/registration_model.go
@@ -32,7 +32,7 @@ type UpdateUserRequest struct {
 }
 
 type RevokeRequest struct {
-	Tenant   string `json:"tenant"`
-	Provider string `json:"provider"`
-	Email    string `json:"email"`
+	Tenant          string `json:"tenant"`
+	MailboxProvider string `json:"provider"`
+	Email           string `json:"email"`
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `Revoke` function to use `MailboxProvider` for determining workspace provider, affecting OAuth token handling.
> 
>   - **Behavior**:
>     - In `registration.go`, `Revoke` function now uses `MailboxProvider` to determine `workspaceProvider` instead of `Provider`.
>     - If `MailboxProvider` is not Google or Microsoft, returns `400 Bad Request`.
>     - Uses `workspaceProvider` for OAuth token retrieval and deletion.
>   - **Models**:
>     - In `registration_model.go`, `RevokeRequest` field `Provider` renamed to `MailboxProvider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 97486f4cb5f199c71ab050d1c10095ac858c897e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->