### PR TITLE
trace errors on revoke

### DIFF
--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -733,15 +733,14 @@ func Revoke(s *cosapi_services.Services) gin.HandlerFunc {
 				resp, err := http.Get(revocationURL)
 				if err != nil {
 					tracing.TraceErr(span, err)
-					body, _ := io.ReadAll(resp.Body)
-					span.LogFields(tracingLog.String("response.body", string(body)))
-
 					c.JSON(http.StatusInternalServerError, gin.H{})
 					return
 				}
 
 				if resp.StatusCode != http.StatusOK {
 					// Revocation failed
+					body, _ := io.ReadAll(resp.Body)
+					span.LogFields(tracingLog.String("response.body", string(body)))
 					tracing.TraceErr(span, fmt.Errorf("revocation failed, status code: %d", resp.StatusCode))
 					c.JSON(http.StatusInternalServerError, gin.H{})
 					return

--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
 	"github.com/customeros/customeros/packages/server/customer-os-api/utils"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -725,16 +726,22 @@ func Revoke(s *cosapi_services.Services) gin.HandlerFunc {
 			case common_enum.WorkspaceProviderAzure.String():
 				revocationURL = fmt.Sprintf("https://graph.microsoft.com/v1.0/me/revokeSignInSessions")
 			}
+			span.LogFields(tracingLog.String("revocationURL", revocationURL))
 
 			if revocationURL != "" {
 				resp, err := http.Get(revocationURL)
 				if err != nil {
+					tracing.TraceErr(span, err)
+					body, _ := io.ReadAll(resp.Body)
+					span.LogFields(tracingLog.String("response.body", string(body)))
+
 					c.JSON(http.StatusInternalServerError, gin.H{})
 					return
 				}
 
 				if resp.StatusCode != http.StatusOK {
 					// Revocation failed
+					tracing.TraceErr(span, fmt.Errorf("revocation failed, status code: %d", resp.StatusCode))
 					c.JSON(http.StatusInternalServerError, gin.H{})
 					return
 				}

--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -713,6 +713,7 @@ func Revoke(s *cosapi_services.Services) gin.HandlerFunc {
 
 		oauthToken, err := s.Repositories.PostgresRepositories.OAuthTokenRepository.GetByEmail(ctx, revokeRequest.Tenant, workspaceProvider, revokeRequest.Email)
 		if err != nil {
+			tracing.TraceErr(span, err)
 			c.JSON(http.StatusInternalServerError, gin.H{})
 			return
 		}
@@ -750,6 +751,7 @@ func Revoke(s *cosapi_services.Services) gin.HandlerFunc {
 
 		err = s.Repositories.PostgresRepositories.OAuthTokenRepository.DeleteByEmail(ctx, revokeRequest.Tenant, workspaceProvider, revokeRequest.Email)
 		if err != nil {
+			tracing.TraceErr(span, err)
 			c.JSON(http.StatusInternalServerError, gin.H{})
 			return
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance error tracing in `Revoke` function of `registration.go` by logging errors, revocation URLs, and response bodies.
> 
>   - **Error Tracing Enhancements**:
>     - Add `tracing.TraceErr(span, err)` in `Revoke` function to log errors when fetching OAuth tokens and deleting them.
>     - Log revocation URL and response body using `span.LogFields()` for better traceability.
>     - Handle HTTP response errors by logging status code and response body content.
>   - **Imports**:
>     - Add `io` package for reading HTTP response body.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d9990a2f5c6053b78b110b58b2bd39b46fd4494d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->