### PR TITLE
Modify Tasks table view definition to be non-shared

### DIFF
--- a/packages/server/customer-os-api/graphql/resolver/view.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/view.resolvers.go
@@ -352,7 +352,7 @@ func (r *queryResolver) TableViewDefs(ctx context.Context) ([]*model.TableViewDe
 			span.LogKV("upcomingInvoicesTableId", def.ID)
 			upcomingInvoiceFound = true
 		}
-		if def.TableType == string(postgresEntity.TableViewTypeTasks) && def.TableId == string(postgresEntity.TableIDTypeTasks) {
+		if def.TableType == string(postgresEntity.TableViewTypeTasks) && def.TableId == string(postgresEntity.TableIDTypeTasks) && !def.IsShared {
 			span.LogKV("tasksTableId", def.ID)
 			tasksFound = true
 		}

--- a/packages/server/customer-os-common-module/services/table_view/view_helper.go
+++ b/packages/server/customer-os-common-module/services/table_view/view_helper.go
@@ -446,7 +446,7 @@ func DefaultTableViewDefinitionTasks(span opentracing.Span) (postgres_entity.Tab
 		DefaultFilters: ``,
 		Sorting:        ``,
 		IsPreset:       true,
-		IsShared:       true,
+		IsShared:       false,
 	}, nil
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify Tasks table view to be non-shared by default in `view.resolvers.go` and `view_helper.go`.
> 
>   - **Behavior**:
>     - Modify `TableViewDefs` in `view.resolvers.go` to check `!def.IsShared` for Tasks table view.
>     - Change `IsShared` to `false` in `DefaultTableViewDefinitionTasks` in `view_helper.go`.
>   - **Misc**:
>     - Ensure Tasks table view is non-shared by default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a8006426b30cff960ba5935b869c245e5f187d5a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->