### PR TITLE
ltv check

### DIFF
--- a/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
+++ b/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
@@ -94,6 +94,10 @@
         {
           "name": "Contracts with renewals with wrong live status",
           "query": "MATCH (:Organization {hide:false})--(c:Contract)-[:ACTIVE_RENEWAL]->(op:RenewalOpportunity) WhERE c.status = 'LIVE' AND (c.approved = false OR c.approved IS NULL OR date(op.renewedAt) < date()) RETURN count(c)"
+        },
+        {
+          "name": "Contracts with wrong ltv",
+          "query": "MATCH (c:Contract) OPTIONAL MATCH (c)--(i:Invoice) WHERE i.dryRun = false AND i.status <> 'VOID' WITH c, coalesce(sum(i.amount), 0) AS computedValue WHERE c.ltv <> computedValue RETURN count(c)"
         }
       ]
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add query to check contracts with incorrect LTV values in `neo4j-integrity-checker-queries.json`.
> 
>   - **Behavior**:
>     - Adds a new query named "Contracts with wrong ltv" to `neo4j-integrity-checker-queries.json`.
>     - The query checks for contracts where `ltv` does not match the sum of amounts from related invoices that are not `VOID` and not `dryRun`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f957cdec0a550dbb479262e6339b8d67b23e2e79. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->