### PR TITLE
Fix panic on agent execution retry

### DIFF
--- a/packages/runner/integrity-checker/service/neo4j_integrity_checker_service.go
+++ b/packages/runner/integrity-checker/service/neo4j_integrity_checker_service.go
@@ -231,6 +231,7 @@ func (h *neo4jIntegrityCheckerService) alertInSlack(ctx context.Context, results
 
 	// if no webhook is configured, return early
 	if h.cfg.SlackConfig.DataAlertsRegisteredWebhook == "" {
+		tracing.TraceErr(span, errors.New("no slack webhook configured"))
 		return nil
 	}
 

--- a/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
@@ -361,9 +361,7 @@ func (a *agentRunnerService) createAgentExecutionRecord(ctx context.Context, age
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 	span.LogKV("agentID", agentID, "triggerEventType", triggerEventName, "traceId", traceId)
 
-	agent, err := a.postgresRepositories.AgentRepository.Find(ctx, postgres_entity.Agent{
-		ID: agentID,
-	})
+	agent, err := a.postgresRepositories.AgentRepository.GetById(ctx, agentID)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return "", err
@@ -400,9 +398,7 @@ func (a *agentRunnerService) ResumeExecution(ctx context.Context, executionID st
 	}
 
 	// Get agent details
-	agent, err := a.postgresRepositories.AgentRepository.Find(ctx, postgres_entity.Agent{
-		ID: *execution.AgentID,
-	})
+	agent, err := a.postgresRepositories.AgentRepository.GetById(ctx, *execution.AgentID)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err
@@ -441,12 +437,28 @@ func (a *agentRunnerService) RerunExecution(ctx context.Context, executionID str
 	}
 
 	// Get agent details
-	agent, err := a.postgresRepositories.AgentRepository.Find(ctx, postgres_entity.Agent{
-		ID: *execution.AgentID,
-	})
+	agent, err := a.postgresRepositories.AgentRepository.GetById(ctx, *execution.AgentID)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err
+	}
+	// if agent was removed stop retrying
+	if agent == nil {
+		err = a.postgresRepositories.AgentExecutionRepository.Fail(ctx, executionID, "Stop retrying, agent not found")
+		if err != nil {
+			tracing.TraceErr(span, errors.Wrap(err, "unable to stop retrying"))
+			return err
+		}
+		return nil
+	}
+	// if agent is not active re-schedule retry
+	if !agent.IsActive {
+		err = a.postgresRepositories.AgentExecutionRepository.ScheduleRetry(ctx, executionID, errors.New(utils.IfNotNilString(execution.ErrorMessage)), execution.StateData)
+		if err != nil {
+			tracing.TraceErr(span, errors.Wrap(err, "unable to schedule retry"))
+			return err
+		}
+		return nil
 	}
 
 	// Resume from last known state

--- a/packages/server/customer-os-postgres-repository/repository/agents_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agents_repository.go
@@ -17,7 +17,6 @@ import (
 
 type AgentRepository interface {
 	Create(ctx context.Context, agent postgres_entity.Agent) (*postgres_entity.Agent, error)
-	Find(ctx context.Context, agent postgres_entity.Agent) (*postgres_entity.Agent, error)
 	GetById(ctx context.Context, id string) (*postgres_entity.Agent, error)
 	GetAll(ctx context.Context) ([]*postgres_entity.Agent, error)
 	GetAllAgentsByTypes(ctx context.Context, agents []enum.AgentType) ([]postgres_entity.Agent, error)
@@ -331,32 +330,6 @@ func (f *agentsRepository) GetActiveConfiguredAgentsByTypesCrossTenant(ctx conte
 	}
 	span.LogFields(log.Int("result.count", len(records)))
 	return records, nil
-}
-
-func (f *agentsRepository) Find(ctx context.Context, agent postgres_entity.Agent) (*postgres_entity.Agent, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.Find")
-	defer span.Finish()
-	tracing.TagComponentPostgresRepository(span)
-
-	var result postgres_entity.Agent
-	err := f.gormDb.
-		Preload("Capabilities", func(db *gorm.DB) *gorm.DB {
-			return db.Order("position ASC")
-		}).
-		Preload("Listeners", func(db *gorm.DB) *gorm.DB {
-			return db.Order("position ASC")
-		}).
-		Where(&agent).
-		Where("is_active = true").
-		First(&result).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
-		tracing.TraceErr(span, err)
-		return nil, err
-	}
-	return &result, nil
 }
 
 func (f *agentsRepository) Update(ctx context.Context, agent postgres_entity.Agent) (*postgres_entity.Agent, error) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix panic on agent execution retry by replacing `Find` with `GetById` and adding checks for agent existence and activity in `agent_runner_service.go`.
> 
>   - **Behavior**:
>     - In `agent_runner_service.go`, replace `Find` with `GetById` for agent retrieval in `createAgentExecutionRecord()`, `ResumeExecution()`, and `RerunExecution()`.
>     - Add checks in `RerunExecution()` to stop retry if agent is removed or inactive.
>   - **Repository**:
>     - Remove `Find()` method from `agents_repository.go`.
>   - **Logging**:
>     - Add error logging in `alertInSlack()` in `neo4j_integrity_checker_service.go` when no Slack webhook is configured.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 27dd06110cacfd66b16cb42a6c145d94f3a4bf05. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->