### PR TITLE
fix token revocation

### DIFF
--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -768,11 +768,23 @@ func Revoke(s *cosapi_services.Services) gin.HandlerFunc {
 				body, _ := io.ReadAll(resp.Body)
 				span.LogFields(tracingLog.String("response.body", string(body)))
 
-				if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-					// Revocation failed
-					tracing.TraceErr(span, fmt.Errorf("revocation failed, status code: %d", resp.StatusCode))
-					c.JSON(http.StatusInternalServerError, gin.H{})
-					return
+				// For Google, if token is already revoked (invalid_token error), we can proceed
+				if workspaceProvider == common_enum.WorkspaceProviderGoogle.String() {
+					var errorResponse struct {
+						Error            string `json:"error"`
+						ErrorDescription string `json:"error_description"`
+					}
+					if err := json.Unmarshal(body, &errorResponse); err == nil {
+						if errorResponse.Error == "invalid_token" {
+							// Token is already revoked, we can proceed
+							span.LogFields(tracingLog.String("token_status", "already_revoked"))
+						} else if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+							// Other errors should be treated as failures
+							tracing.TraceErr(span, fmt.Errorf("revocation failed, status code: %d", resp.StatusCode))
+							c.JSON(http.StatusInternalServerError, gin.H{})
+							return
+						}
+					}
 				}
 
 				// For Google, also revoke the refresh token
@@ -806,6 +818,23 @@ func Revoke(s *cosapi_services.Services) gin.HandlerFunc {
 
 					body, _ = io.ReadAll(resp.Body)
 					span.LogFields(tracingLog.String("refresh_token_response.body", string(body)))
+
+					// Handle already revoked refresh token case
+					var errorResponse struct {
+						Error            string `json:"error"`
+						ErrorDescription string `json:"error_description"`
+					}
+					if err := json.Unmarshal(body, &errorResponse); err == nil {
+						if errorResponse.Error == "invalid_token" {
+							// Refresh token is already revoked, we can proceed
+							span.LogFields(tracingLog.String("refresh_token_status", "already_revoked"))
+						} else if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+							// Other errors should be treated as failures
+							tracing.TraceErr(span, fmt.Errorf("refresh token revocation failed, status code: %d", resp.StatusCode))
+							c.JSON(http.StatusInternalServerError, gin.H{})
+							return
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve Google token revocation handling in `Revoke` function by treating 'invalid_token' as already revoked.
> 
>   - **Behavior**:
>     - In `Revoke` function in `registration.go`, handle 'invalid_token' error for Google tokens by proceeding without error.
>     - For Google, if token revocation returns 'invalid_token', log as 'already_revoked' and continue.
>     - Similar handling added for refresh tokens, logging 'refresh_token_status' as 'already_revoked'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c68239c8f5e75e792381d83f4768146e7a233afa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->