### PR TITLE
Fix registration

### DIFF
--- a/.github/workflows/build-customer-os-api.yml
+++ b/.github/workflows/build-customer-os-api.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: [neo4j, postgres, other]
+        test-group: [neo4j, postgres, rest, other]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-customer-os-api.yml
+++ b/.github/workflows/build-customer-os-api.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: [neo4j, postgres, rest, other]
+        test-group: [neo4j, postgres, other]
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -361,7 +361,6 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 				if err != nil {
 					return nil, err
 				}
-
 			}
 
 			span.LogKV("authId", authId)
@@ -404,6 +403,8 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 					} else {
 						isNewTenant = true
 					}
+				} else {
+					isNewTenant = true
 				}
 
 				if isNewTenant {
@@ -427,10 +428,6 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 					currentTenant = tenantEntity.Name
 					defaultTenant = tenantEntity.Name
 
-					ctx = common.WithCustomContext(ctx, &common.CustomContext{
-						Tenant: currentTenant,
-					})
-
 					if !isPersonalEmail {
 						_, err = services.CommonServices.WorkspaceService.MergeToTenant(ctx, txWithPostCommit.Tx, neoEntity.WorkspaceEntity{
 							Name:     domain,
@@ -441,6 +438,10 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 						}
 					}
 				}
+
+				ctx = common.WithCustomContext(ctx, &common.CustomContext{
+					Tenant: currentTenant,
+				})
 
 				err = services.CommonServices.Neo4jRepositories.AuthenticationWriteRepository.LinkAuthenticationUserWithTenant(ctx, txWithPostCommit.Tx, authUserId, defaultTenant)
 				if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes tenant context setting in `signIn()` in `registration.go` to ensure `currentTenant` is set correctly for both new and existing tenants.
> 
>   - **Behavior**:
>     - Fixes tenant context setting in `signIn()` in `registration.go` by moving `common.WithCustomContext` call to ensure `currentTenant` is set correctly for both new and existing tenants.
>   - **Misc**:
>     - Removes redundant context setting block for `currentTenant` in `signIn()` in `registration.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for e0120c0213e1335e8aab18ba4bace35c8b0c1e42. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->