### PR TITLE
default sorting in task

### DIFF
--- a/packages/server/customer-os-common-module/services/agent/agent_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_service.go
@@ -255,7 +255,7 @@ func (r *agentService) GetAgentInfo(ctx context.Context) (*map[enum.AgentType]in
 }
 
 func (a *agentService) GetNorthStarMetricById(ctx context.Context, agentID string, agentType enum.AgentType) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "agentService.GetNorthStarMetricById")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentService.GetNorthStarMetricById")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 
@@ -302,6 +302,7 @@ func (a *agentService) GetNorthStarMetricById(ctx context.Context, agentID strin
 			}
 		}
 		output = strings.Replace(output, "{amount}", humanize.CommafWithDigits(amount, 2), 1)
+		span.LogKV("output", output)
 		return output, nil
 	default:
 		goalAchievedCount, err := a.postgresRepositories.AgentExecutionRepository.GetGoalAchievedCountLast30Days(ctx, agentID)
@@ -309,7 +310,9 @@ func (a *agentService) GetNorthStarMetricById(ctx context.Context, agentID strin
 			tracing.TraceErr(span, err)
 			return "", err
 		}
-		return strings.Replace(registryAgent.Metric, "{count}", strconv.FormatInt(goalAchievedCount, 10), 1), nil
+		output := strings.Replace(registryAgent.Metric, "{count}", strconv.FormatInt(goalAchievedCount, 10), 1)
+		span.LogKV("output", output)
+		return output, nil
 	}
 }
 

--- a/packages/server/customer-os-common-module/services/table_view/view_helper.go
+++ b/packages/server/customer-os-common-module/services/table_view/view_helper.go
@@ -444,7 +444,7 @@ func DefaultTableViewDefinitionTasks(span opentracing.Span) (postgres_entity.Tab
 		Icon:           "ClipboardCheck",
 		Filters:        ``,
 		DefaultFilters: ``,
-		Sorting:        ``,
+		Sorting:        `{"id": "TASKS_UPDATED_AT", "desc": true}`,
 		IsPreset:       true,
 		IsShared:       false,
 	}, nil


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add default sorting to tasks and enhance logging in `GetNorthStarMetricById`.
> 
>   - **Behavior**:
>     - Add default sorting `{"id": "TASKS_UPDATED_AT", "desc": true}` to `DefaultTableViewDefinitionTasks` in `view_helper.go`.
>     - Log `output` in `GetNorthStarMetricById` in `agent_service.go` for both `AgentCashflowGuardian` and default cases.
>   - **Tracing**:
>     - Rename tracing span from `agentService.GetNorthStarMetricById` to `AgentService.GetNorthStarMetricById` in `agent_service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b10c12f88ed96fc2726f7ae433dc6ea8d5c06952. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->