### PR TITLE
fix gemini calls

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
@@ -200,8 +202,8 @@ func (c *EvaluateICPFitCapability) buildPrompts(ctx context.Context, executionCo
 
 	homepage, err := c.webscraperService.Scrape(ctx, company.PrimaryDomain)
 	if err != nil {
-		tracing.TraceErr(span, err)
-		return "", "", err
+		span.LogKV("scapeResults", "none")
+		homepage = ""
 	}
 
 	systemPrompt := `You are a world class company analyst. Your objective is to determine whether the company I provide you fits our ideal customer profile or not. I will provide you with three datasets: 1. a description of our ideal customer, 2. criteria that automatically disqualifies companies, and 3. all the context I have about the company, including their name, location, and several descriptions taken from their website and linkedin pages.
@@ -222,20 +224,34 @@ Important:
 - Follow the JSON format exactly.
 - Pay special attention to location criteria in your decision making.`
 
-	content := fmt.Sprintf(`
-        ICP Qualificaton Criteria: %s
-        ICP Disqualification Criteria: %s
-        Company Name: %s
-        Company Domain: %s
-        Year Founded: %s
-        Employee Count: %d
-        Location: %s, %s, %s
-        Industry Name: %s
-		Company Homepage: %s
-        `, executionContainer.ConfigData.QualificationCriteria.Value, executionContainer.ConfigData.DisqualificationCriteria.Value,
-		company.CompanyName, company.PrimaryDomain, company.YearCompanyFounded, company.EmployeeCount,
-		company.CompanyCity, company.CompanyRegion, company.CompanyCountryA2,
-		company.IndustryNAICSName, homepage)
+	var contentBuilder strings.Builder
+
+	contentBuilder.WriteString("\n        ICP Qualificaton Criteria: ")
+	contentBuilder.WriteString(executionContainer.ConfigData.QualificationCriteria.Value)
+	contentBuilder.WriteString("\n        ICP Disqualification Criteria: ")
+	contentBuilder.WriteString(executionContainer.ConfigData.DisqualificationCriteria.Value)
+	contentBuilder.WriteString("\n        Company Name: ")
+	contentBuilder.WriteString(company.CompanyName)
+	contentBuilder.WriteString("\n        Company Domain: ")
+	contentBuilder.WriteString(company.PrimaryDomain)
+	contentBuilder.WriteString("\n        Year Founded: ")
+	contentBuilder.WriteString(company.YearCompanyFounded)
+	contentBuilder.WriteString("\n        Employee Count: ")
+	contentBuilder.WriteString(strconv.Itoa(int(company.EmployeeCount)))
+	contentBuilder.WriteString("\n        Location: ")
+	contentBuilder.WriteString(company.CompanyCity)
+	contentBuilder.WriteString(", ")
+	contentBuilder.WriteString(company.CompanyRegion)
+	contentBuilder.WriteString(", ")
+	contentBuilder.WriteString(company.CompanyCountryA2)
+	contentBuilder.WriteString("\n        Industry Name: ")
+	contentBuilder.WriteString(company.IndustryNAICSName)
+	if homepage != "" {
+		contentBuilder.WriteString("\n\t\tCompany Homepage: ")
+		contentBuilder.WriteString(homepage)
+	}
+
+	content := contentBuilder.String()
 
 	return systemPrompt, content, nil
 }

--- a/packages/server/customer-os-common-module/services/ai/service.go
+++ b/packages/server/customer-os-common-module/services/ai/service.go
@@ -263,8 +263,17 @@ func (s *aiService) askGemini(ctx context.Context, request interfaces.AskAIReque
 	defer client.Close()
 
 	model := client.GenerativeModel(request.Model.String())
-	model.SetTemperature(*request.ModelTemperature)
-	model.SetMaxOutputTokens(*request.MaxOutputTokens)
+	if request.ModelTemperature == nil {
+		model.SetTemperature(DefaultTemperature)
+	} else {
+		model.SetTemperature(*request.ModelTemperature)
+	}
+
+	if request.MaxOutputTokens == nil {
+		model.SetMaxOutputTokens(MaxTokens)
+	} else {
+		model.SetMaxOutputTokens(*request.MaxOutputTokens)
+	}
 
 	switch request.OutputFormat {
 	case enum.AIOutputText:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes and improves AI model parameter handling and error logging in `capability_evaluate_icp_fit.go` and `service.go`.
> 
>   - **Behavior**:
>     - In `capability_evaluate_icp_fit.go`, if `webscraperService.Scrape` fails, logs "scapeResults: none" and sets `homepage` to an empty string.
>     - In `service.go`, `askGemini()` sets default `ModelTemperature` and `MaxOutputTokens` if not provided.
>   - **Code Improvements**:
>     - Replaces `fmt.Sprintf` with `strings.Builder` in `buildPrompts()` in `capability_evaluate_icp_fit.go` for better performance.
>     - Adds checks for `nil` values for `ModelTemperature` and `MaxOutputTokens` in `askGemini()` in `service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 79d6a8efe89fc0e23156ab0f405386bc0bd7e0fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->