### PR TITLE
remove openseaech service init check

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/opensearch.go
+++ b/packages/server/customer-os-common-module/interfaces/opensearch.go
@@ -7,7 +7,6 @@ type OpensearchService interface {
 	LLMObservabilityIndexCheck(ctx context.Context, indexName string) error
 	UpsertDocument(ctx context.Context, indexName string, documentId *string, document interface{}) error
 	HybridSearch(ctx context.Context, searchParams HybridSearchRequest) ([]HybridSearchResult, error)
-	IsInitialized() bool
 }
 
 type HybridSearchRequest struct {

--- a/packages/server/customer-os-common-module/services/opensearch/opensearch.go
+++ b/packages/server/customer-os-common-module/services/opensearch/opensearch.go
@@ -16,13 +16,11 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 )
 
 type opensearchService struct {
-	tracingClient *opensearch.Client
-	eventsClient  *opensearch.Client
-	aiClient      *opensearch.Client
+	eventsClient *opensearch.Client
+	aiClient     *opensearch.Client
 }
 
 const (
@@ -37,9 +35,8 @@ func NewOpensearchService(logger logger.Logger, config *config.OpensearchConfig)
 	}
 
 	return &opensearchService{
-		tracingClient: createOpensearchClient(logger, config.TracingUrl, config.TracingUsername, config.TracingPassword),
-		eventsClient:  createOpensearchClient(logger, config.EventsUrl, config.EventsUsername, config.EventsPassword),
-		aiClient:      createOpensearchClient(logger, config.AIUrl, config.AIUsername, config.AIPassword),
+		eventsClient: createOpensearchClient(logger, config.EventsUrl, config.EventsUsername, config.EventsPassword),
+		aiClient:     createOpensearchClient(logger, config.AIUrl, config.AIUsername, config.AIPassword),
 	}
 }
 
@@ -60,18 +57,9 @@ func createOpensearchClient(logger logger.Logger, url, username, password string
 	return client
 }
 
-func (s *opensearchService) IsInitialized() bool {
-	return utils.IsInitialized(s)
-}
-
 // add all supported indexes here
 func (c *opensearchService) getClientForIndex(indexName string) (*opensearch.Client, error) {
 	switch {
-	case strings.HasPrefix(indexName, "trace-") ||
-		strings.HasPrefix(indexName, "tracing-") ||
-		strings.HasPrefix(indexName, "jaeger-"):
-		return c.tracingClient, nil
-
 	case strings.HasPrefix(indexName, "events-") ||
 		strings.HasPrefix(indexName, "llm-"):
 		return c.eventsClient, nil


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `IsInitialized` method and `tracingClient` from `OpensearchService` and `opensearchService`.
> 
>   - **Interfaces**:
>     - Remove `IsInitialized()` from `OpensearchService` in `opensearch.go`.
>   - **Services**:
>     - Remove `IsInitialized()` implementation from `opensearchService` in `opensearch.go`.
>     - Remove `tracingClient` from `opensearchService` struct in `opensearch.go`.
>     - Adjust `NewOpensearchService()` to not initialize `tracingClient` in `opensearch.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for db943e69723cf57fd2be4c9077aaac916fe0cfc4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->