### PR TITLE
remove logrus from postgres

### DIFF
--- a/packages/runner/sync-gmail/repository/raw_email_repository.go
+++ b/packages/runner/sync-gmail/repository/raw_email_repository.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"github.com/google/uuid"
-	postgresentity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
@@ -16,7 +15,6 @@ type RawEmailRepository interface {
 	GetEmailsIdsForUserForSync(tenantName, userSource string) ([]entity.RawEmail, error)
 	GetEmailForSync(id uuid.UUID) (*entity.RawEmail, error)
 	GetEmailForSyncByMessageId(tenant, usernameSource, messageId string) (*entity.RawEmail, error)
-	MarkSentToEventStore(id uuid.UUID, sentToEventStoreState postgresentity.RawState, reason, error *string) error
 }
 
 type rawEmailRepositoryImpl struct {
@@ -81,20 +79,4 @@ func (repo *rawEmailRepositoryImpl) GetEmailForSyncByMessageId(tenant, usernameS
 	}
 
 	return &result, nil
-}
-
-func (repo *rawEmailRepositoryImpl) MarkSentToEventStore(id uuid.UUID, sentToEventStoreState postgresentity.RawState, reason, error *string) error {
-	tx := repo.gormDb.Model(&entity.RawEmail{}).Where("id = ?", id)
-
-	tx.Update("status", sentToEventStoreState)
-	tx.Update("reason", reason)
-	tx.Update("error", error)
-
-	err := tx.Error
-	if err != nil {
-		logrus.Errorf("Failed marking email as sent to event store: %v", id)
-		return err
-	}
-
-	return nil
 }

--- a/packages/server/customer-os-common-module/services/mail/processor.go
+++ b/packages/server/customer-os-common-module/services/mail/processor.go
@@ -33,7 +33,7 @@ func (s *mailService) GetEmailsForProcessingForUser(ctx context.Context, tenant,
 	defer span.Finish()
 	span.LogKV("userEmailAddress", userEmailAddress)
 
-	rawEmailsIdsForProcess, err := s.postgres.RawEmailRepository.GetEmailsIdsForUserForSync(tenant, userEmailAddress)
+	rawEmailsIdsForProcess, err := s.postgres.RawEmailRepository.GetEmailsIdsForUserForSync(ctx, tenant, userEmailAddress)
 	if err != nil {
 		tracing.TraceErr(span, errors.Wrap(err, "failed to get emails for sync"))
 		return
@@ -74,7 +74,7 @@ func (s *mailService) ProcessEmail(ctx context.Context, tenant string, rawEmailI
 	defer span.Finish()
 	span.LogFields(log.String("rawEmailId", rawEmailId.String()))
 
-	rawEmail, err := s.postgres.RawEmailRepository.GetEmailForProcess(rawEmailId)
+	rawEmail, err := s.postgres.RawEmailRepository.GetEmailForProcess(ctx, rawEmailId)
 	if err != nil {
 		tracing.TraceErr(span, errors.Wrap(err, "failed to get email for process"))
 		db.EmailProcessingStatus = postgresentity.ERROR
@@ -173,7 +173,7 @@ func (s *mailService) ProcessEmailByMessageId(ctx context.Context, tenant, usern
 		log.String("userSource", usernameSource),
 		log.String("messageId", messageId))
 
-	rawEmail, err := s.postgres.RawEmailRepository.GetEmailForSyncByMessageId(tenant, usernameSource, messageId)
+	rawEmail, err := s.postgres.RawEmailRepository.GetEmailForSyncByMessageId(ctx, tenant, usernameSource, messageId)
 	if err != nil {
 		err = fmt.Errorf("failed to get emails for sync: %v", err)
 		tracing.TraceErr(span, err)
@@ -199,7 +199,7 @@ func (s *mailService) processRawEmails(ctx context.Context, tenant string, rawEm
 	for _, rawEmail := range rawEmails {
 		dbUpdateRecord := s.ProcessEmail(ctx, tenant, rawEmail.ID)
 
-		err := s.postgres.RawEmailRepository.UpdateRawEmailTable(rawEmail.ID, dbUpdateRecord)
+		err := s.postgres.RawEmailRepository.UpdateRawEmailTable(ctx, rawEmail.ID, dbUpdateRecord)
 		if err != nil {
 			tracing.TraceErr(span, errors.Wrap(err, "failed to mark raw email as processed in postgres"))
 		}

--- a/packages/server/customer-os-postgres-repository/go.mod
+++ b/packages/server/customer-os-postgres-repository/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
-	github.com/sirupsen/logrus v1.9.3
 	github.com/testcontainers/testcontainers-go v0.35.0
 	golang.org/x/net v0.37.0
 	gorm.io/datatypes v1.2.5
@@ -93,6 +92,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect

--- a/packages/server/customer-os-postgres-repository/repository/raw_email_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/raw_email_repository.go
@@ -10,7 +10,6 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/google/uuid"
 	"github.com/opentracing/opentracing-go"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 
@@ -23,11 +22,12 @@ type RawEmailRepository interface {
 	GetByMessageId(ctx context.Context, externalSystem, tenant, username, messageId string) (*postgres_entity.RawEmail, error)
 	EmailExistsByMessageId(ctx context.Context, externalSystem, tenant, username, messageId string) (bool, error)
 	Store(ctx context.Context, externalSystem, tenant, username, providerMessageId, messageId, rawEmail string, sentAt time.Time, state postgres_entity.EmailImportState) error
-	GetEmailsIdsForSync(externalSystem, tenantName string) ([]postgres_entity.RawEmail, error)
-	GetEmailsIdsForUserForSync(tenantName, userEmailAddress string) ([]postgres_entity.RawEmail, error)
-	GetEmailForProcess(id uuid.UUID) (*postgres_entity.RawEmail, error)
-	GetEmailForSyncByMessageId(tenant, usernameSource, messageId string) (*postgres_entity.RawEmail, error)
-	UpdateRawEmailTable(id uuid.UUID, dbUpdateRecord postgres_entity.UpdateRawEmailTable) error
+	GetEmailsIdsForSync(ctx context.Context, externalSystem, tenantName string) ([]postgres_entity.RawEmail, error)
+	GetEmailsIdsForUserForSync(ctx context.Context, tenantName, userSource string) ([]postgres_entity.RawEmail, error)
+	GetEmailForProcess(ctx context.Context, id uuid.UUID) (*postgres_entity.RawEmail, error)
+	GetEmailForSyncByMessageId(ctx context.Context, tenant, usernameSource, messageId string) (*postgres_entity.RawEmail, error)
+	UpdateRawEmailTable(ctx context.Context, id uuid.UUID, dbUpdateRecord postgres_entity.UpdateRawEmailTable) error
+	MarkEmailAsSentToEventStore(ctx context.Context, id uuid.UUID) error
 }
 
 type rawEmailRepositoryImpl struct {
@@ -129,51 +129,71 @@ func (repo *rawEmailRepositoryImpl) Store(ctx context.Context, externalSystem, t
 	return nil
 }
 
-func (repo *rawEmailRepositoryImpl) GetEmailsIdsForSync(externalSystem, tenantName string) ([]postgres_entity.RawEmail, error) {
+func (repo *rawEmailRepositoryImpl) GetEmailsIdsForSync(ctx context.Context, externalSystem, tenantName string) ([]postgres_entity.RawEmail, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "RawEmailRepository.GetEmailsIdsForSync")
+	defer span.Finish()
+	tracing.TagComponentPostgresRepository(span)
+
 	result := []postgres_entity.RawEmail{}
 	err := repo.gormDb.Order("sent_at desc").Select([]string{"id"}).Limit(25).Find(&result, "external_system = ? AND tenant = ? AND status = 'PENDING'", externalSystem, tenantName).Error
 	if err != nil {
-		logrus.Errorf("Failed getting rawEmails: %s; %s", externalSystem, tenantName)
+		tracing.TraceErr(span, err)
 		return nil, err
 	}
 
 	return result, nil
 }
 
-func (repo *rawEmailRepositoryImpl) GetEmailsIdsForUserForSync(tenantName, userSource string) ([]postgres_entity.RawEmail, error) {
+func (repo *rawEmailRepositoryImpl) GetEmailsIdsForUserForSync(ctx context.Context, tenantName, userSource string) ([]postgres_entity.RawEmail, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "RawEmailRepository.GetEmailsIdsForUserForSync")
+	defer span.Finish()
+	tracing.TagComponentPostgresRepository(span)
+
 	result := []postgres_entity.RawEmail{}
 	err := repo.gormDb.Order("sent_at desc").Select([]string{"id", "external_system"}).Limit(100).Find(&result, "tenant = ? AND username = ? AND status = 'PENDING'", tenantName, userSource).Error
 	if err != nil {
-		logrus.Errorf("Failed getting rawEmails: %s; %s", tenantName, userSource)
+		tracing.TraceErr(span, err)
 		return nil, err
 	}
 
 	return result, nil
 }
 
-func (repo *rawEmailRepositoryImpl) GetEmailForProcess(id uuid.UUID) (*postgres_entity.RawEmail, error) {
+func (repo *rawEmailRepositoryImpl) GetEmailForProcess(ctx context.Context, id uuid.UUID) (*postgres_entity.RawEmail, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "RawEmailRepository.GetEmailForProcess")
+	defer span.Finish()
+	tracing.TagComponentPostgresRepository(span)
+
 	result := postgres_entity.RawEmail{}
 	err := repo.gormDb.First(&result, id).Error
 	if err != nil {
-		logrus.Errorf("Failed getting rawEmail: %s", id)
+		tracing.TraceErr(span, err)
 		return nil, err
 	}
 
 	return &result, nil
 }
 
-func (repo *rawEmailRepositoryImpl) GetEmailForSyncByMessageId(tenant, usernameSource, messageId string) (*postgres_entity.RawEmail, error) {
+func (repo *rawEmailRepositoryImpl) GetEmailForSyncByMessageId(ctx context.Context, tenant, usernameSource, messageId string) (*postgres_entity.RawEmail, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "RawEmailRepository.GetEmailForSyncByMessageId")
+	defer span.Finish()
+	tracing.TagComponentPostgresRepository(span)
+
 	var result postgres_entity.RawEmail
 	err := repo.gormDb.Where("tenant = ? AND username = ? AND message_id = ?", tenant, usernameSource, messageId).Find(&result).Error
 	if err != nil {
-		logrus.Errorf("GetEmailForSyncByMessageId - failed: %s; %s; %s", tenant, usernameSource, messageId)
+		tracing.TraceErr(span, err)
 		return nil, err
 	}
 
 	return &result, nil
 }
 
-func (repo *rawEmailRepositoryImpl) UpdateRawEmailTable(id uuid.UUID, dbUpdateRecord postgres_entity.UpdateRawEmailTable) error {
+func (repo *rawEmailRepositoryImpl) UpdateRawEmailTable(ctx context.Context, id uuid.UUID, dbUpdateRecord postgres_entity.UpdateRawEmailTable) error {
+	span, _ := opentracing.StartSpanFromContext(ctx, "RawEmailRepository.UpdateRawEmailTable")
+	defer span.Finish()
+	tracing.TagComponentPostgresRepository(span)
+
 	tx := repo.gormDb.Model(&postgres_entity.RawEmail{}).Where("id = ?", id)
 
 	tx.Update("status", dbUpdateRecord.EmailProcessingStatus)
@@ -189,7 +209,21 @@ func (repo *rawEmailRepositoryImpl) UpdateRawEmailTable(id uuid.UUID, dbUpdateRe
 
 	err := tx.Error
 	if err != nil {
-		logrus.Errorf("Failed marking email as sent to event store: %v", id)
+		tracing.TraceErr(span, err)
+		return err
+	}
+
+	return nil
+}
+
+func (repo *rawEmailRepositoryImpl) MarkEmailAsSentToEventStore(ctx context.Context, id uuid.UUID) error {
+	span, _ := opentracing.StartSpanFromContext(ctx, "RawEmailRepository.MarkEmailAsSentToEventStore")
+	defer span.Finish()
+	tracing.TagComponentPostgresRepository(span)
+
+	err := repo.gormDb.Model(&postgres_entity.RawEmail{}).Where("id = ?", id).Update("status", "SENT").Error
+	if err != nil {
+		tracing.TraceErr(span, err)
 		return err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/tenant_settings_email_exclusion_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/tenant_settings_email_exclusion_repository.go
@@ -5,7 +5,6 @@ import (
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -31,7 +30,7 @@ func (repo *tenantSettingsEmailExclusionRepositoryImpl) GetExclusionList(ctx con
 	err := repo.gormDb.Find(&result).Limit(5000).Error
 
 	if err != nil {
-		logrus.Errorf("error while getting personal email provider list: %v", err)
+		tracing.TraceErr(span, err)
 		return nil, err
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `logrus` with `opentracing` for logging in `raw_email_repository.go` and remove `MarkSentToEventStore` function.
> 
>   - **Logging and Tracing**:
>     - Replace `logrus` logging with `opentracing` in `raw_email_repository.go` and `tenant_settings_email_exclusion_repository.go`.
>     - Functions affected include `GetEmailsIdsForSync`, `GetEmailsIdsForUserForSync`, `GetEmailForProcess`, `GetEmailForSyncByMessageId`, `UpdateRawEmailTable`, and `MarkEmailAsSentToEventStore`.
>   - **Function Removal**:
>     - Remove `MarkSentToEventStore` from `raw_email_repository.go` in `sync-gmail` package.
>   - **Dependency Management**:
>     - Remove direct `logrus` dependency from `go.mod` in `customer-os-postgres-repository`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 177623838567bb6f85a25894a2e2229644ec1f71. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->