### PR TITLE
Trace capabilities to new component

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_add_meeting_notes_to_company.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_add_meeting_notes_to_company.go
@@ -11,7 +11,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
@@ -99,8 +98,7 @@ type AddMeetingNotesToCompanyOutput struct {
 func (c *AddMeetingNotesToCompanyCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[AddMeetingNotesToCompanyInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, AddMeetingNotesToCompanyOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AddMeetingNotesToCompanyCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 
@@ -135,7 +133,7 @@ func (c *AddMeetingNotesToCompanyCapability) Execute(ctx context.Context, execut
 func (c *AddMeetingNotesToCompanyCapability) processMeetingParticipant(ctx context.Context, email, timelineEvent string, input AddMeetingNotesToCompanyInput, created []string) ([]string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AddMeetingNotesToCompanyCapability.processMeetingParticipant")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	// get org by email
 	var (
@@ -181,7 +179,7 @@ func (c *AddMeetingNotesToCompanyCapability) processMeetingParticipant(ctx conte
 func (c *AddMeetingNotesToCompanyCapability) createMarkdownTimelineEvent(ctx context.Context, input AddMeetingNotesToCompanyInput) string {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AddMeetingNotesToCompanyCapability.createMarkdownTimelineEvent")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	var b strings.Builder
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_analyze_web_session.go
@@ -111,8 +111,7 @@ type AnalyzeWebSessionOutput struct {
 func (c *AnalyzeWebSessionCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[AnalyzeWebSessionInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, AnalyzeWebSessionOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AnalyzeWebSessionCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 
@@ -219,7 +218,7 @@ const (
 func (c *AnalyzeWebSessionCapability) processPageVisit(ctx context.Context, sessisonId, page, domain string) (PageVisit, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AnalyzeWebSessionCapability.processPageVisit")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	url := page
 	if !strings.HasPrefix(page, "http") {
@@ -337,7 +336,7 @@ func (c *AnalyzeWebSessionCapability) processPageVisit(ctx context.Context, sess
 func (c *AnalyzeWebSessionCapability) writeSessionToTimeline(ctx context.Context, orgID, timelineMessage string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AnalyzeWebSessionCapability.writeSessionToTimeline")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	actionType := enum.ActionGeneric
 	metadata := "web_session"
@@ -360,7 +359,7 @@ func (c *AnalyzeWebSessionCapability) writeSessionToTimeline(ctx context.Context
 func (c *AnalyzeWebSessionCapability) sessionAnalytics(ctx context.Context, sessionID string) (AnalyzeWebSessionOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AnalyzeWebSessionCapability.sessionAnalytics")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	session, err := c.postgresRepositories.WebSessionRepository.FindSession(ctx, postgres_entity.WebSession{
 		ID:     sessionID,
@@ -407,7 +406,7 @@ func (c *AnalyzeWebSessionCapability) sessionAnalytics(ctx context.Context, sess
 func (c *AnalyzeWebSessionCapability) calculateSessionDuration(ctx context.Context, session *postgres_entity.WebSession) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AnalyzeWebSessionCapability.calculateSessionDuration")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	if session.EndTime == nil || session.EndTime.IsZero() {
 		err := errors.New("Session EndTime not set")
@@ -431,7 +430,7 @@ func (c *AnalyzeWebSessionCapability) calculateSessionDuration(ctx context.Conte
 func (c *AnalyzeWebSessionCapability) isNewCompanyVisit(ctx context.Context, domain string) (bool, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AnalyzeWebSessionCapability.isNewCompanyVisit")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -466,7 +465,7 @@ func (c *AnalyzeWebSessionCapability) isNewCompanyVisit(ctx context.Context, dom
 func (c *AnalyzeWebSessionCapability) isNewWebsiteVisitor(ctx context.Context, visitorId string) (bool, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AnalyzeWebSessionCapability.isNewWebsiteVisitor")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -498,7 +497,7 @@ func (c *AnalyzeWebSessionCapability) isNewWebsiteVisitor(ctx context.Context, v
 func (c *AnalyzeWebSessionCapability) buildTimelineMessage(ctx context.Context, sessionID string, analysis AnalyzeWebSessionOutput) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AnalyzeWebSessionCapability.buildTimelineMessage")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	// Build base message
 	var baseMessage string

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_apply_tag_to_company.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_apply_tag_to_company.go
@@ -83,8 +83,7 @@ func (c *ApplyTagToCompanyCapability) ValidateInput(input ApplyTagToCompanyInput
 func (c *ApplyTagToCompanyCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[ApplyTagToCompanyInput, ApplyTagToCompanyConfig]) (enum.CapabilityExecutionStatus, NoOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ApplyTagCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	result := NoOutput{}
 
@@ -117,7 +116,7 @@ func (c *ApplyTagToCompanyCapability) Execute(ctx context.Context, executionCont
 func (c *ApplyTagToCompanyCapability) applyTag(ctx context.Context, entityType model.EntityType, entityId string, tagName string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ApplyTagCapability.applyTag")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	// check if tag exists
 	tagEntity, err := c.tagService.GetTagByEntityTypeAndName(ctx, entityType, tagName)

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_classify_email.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_classify_email.go
@@ -10,7 +10,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -91,8 +90,7 @@ func (c *ClassifyEmailCapability) ValidateInput(input ClassifyEmailInput) error 
 func (c *ClassifyEmailCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[ClassifyEmailInput, ClassifyEmailConfig]) (enum.CapabilityExecutionStatus, ClassifyEmailOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ClassifyEmailCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "executionContainer", executionContainer)
 
 	if err := c.ValidateInput(executionContainer.InputData); err != nil {

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_create_and_enrich_company.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_create_and_enrich_company.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/dto"
@@ -94,8 +93,7 @@ type CreateOrganizationOutput struct {
 func (c *CreateOrganizationCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[CreateOrganizationInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, CreateOrganizationOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "CreateOrganizationCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_create_and_enrich_contact.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_create_and_enrich_contact.go
@@ -7,7 +7,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
@@ -76,8 +75,7 @@ type CreateContactOutput struct {
 func (c *CreateContactCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[CreateContactInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, CreateContactOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "CreateContactCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_create_markdown_timeline_event.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_create_markdown_timeline_event.go
@@ -81,8 +81,7 @@ func (c *CreateMarkdownTimelineEventCapability) ValidateInput(input CreateMarkdo
 func (c *CreateMarkdownTimelineEventCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[CreateMarkdownTimelineEventInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, CreateMarkdownTimelineEventOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "CreateMarkdownTimelineEventCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_detect_support_web_visit.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_detect_support_web_visit.go
@@ -7,7 +7,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/dto"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
@@ -99,8 +98,7 @@ func (c *DetectSupportWebVisitCapability) ValidateInput(input DetectSupportWebVi
 func (c *DetectSupportWebVisitCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[DetectSupportWebVisitInput, DetectSupportWebVisitConfig]) (enum.CapabilityExecutionStatus, NoOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "DetectSupportWebVisitCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	result := NoOutput{}
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_enrich_email_address.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_enrich_email_address.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -67,8 +66,7 @@ func (c *EnrichEmailAddressCapability) ValidateInput(input EnrichEmailAddressInp
 func (c *EnrichEmailAddressCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[EnrichEmailAddressInput, EnrichEmailAddressConfig]) (enum.CapabilityExecutionStatus, EnrichEmailAddressOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "EnrichEmailAddressCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	result := EnrichEmailAddressOutput{}
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_evaluate_icp_fit.go
@@ -11,7 +11,6 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -132,8 +131,7 @@ type ICPAnswer struct {
 func (c *EvaluateICPFitCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[EvaluateICPFitInput, EvaluateICPFitConfig]) (enum.CapabilityExecutionStatus, EvaluateICPFitOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "EvaluateICPFitCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "executionContainer", executionContainer)
 
 	result := EvaluateICPFitOutput{
@@ -196,7 +194,7 @@ func (c *EvaluateICPFitCapability) Execute(ctx context.Context, executionContain
 func (c *EvaluateICPFitCapability) buildPrompts(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[EvaluateICPFitInput, EvaluateICPFitConfig]) (string, string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "EvaluateICPFitCapability.buildPrompts")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	company := executionContainer.InputData
 
@@ -259,7 +257,7 @@ Important:
 func (c *EvaluateICPFitCapability) parseAnswer(ctx context.Context, answer string) (*ICPAnswer, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "EvaluateICPFitCapability.parseAnswer")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	var result ICPAnswer
 	err := json.Unmarshal([]byte(answer), &result)

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_extract_meeting_highlights.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_extract_meeting_highlights.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
@@ -79,8 +78,7 @@ type ExtractMeetingHighlightsOutput struct {
 func (c *ExtractMeetingHighlightsCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[ExtractMeetingHighlightsInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, ExtractMeetingHighlightsOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ExtractMeetingHighlightsCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 
@@ -136,7 +134,7 @@ Important: Always provide your answer as valid JSON. If there are no clear actio
 func (c *ExtractMeetingHighlightsCapability) parseAnswer(ctx context.Context, answer string) (ExtractMeetingHighlightsOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ExtractMeetingHighlightsCapability.parseAnswer")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	var result ExtractMeetingHighlightsOutput
 	err := json.Unmarshal([]byte(answer), &result)

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_extract_support_signals_from_meeting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_extract_support_signals_from_meeting.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
@@ -78,8 +77,7 @@ type ExtractSupportSignalsFromMeetingOutput struct {
 func (c *ExtractSupportSignalsFromMeetingCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[ExtractSupportSignalsFromMeetingInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, ExtractSupportSignalsFromMeetingOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ExtractSupportSignalsFromMeetingCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 
@@ -134,7 +132,7 @@ Important: Always provide your answer as valid JSON. If there is no help require
 func (c *ExtractSupportSignalsFromMeetingCapability) parseAnswer(ctx context.Context, answer string) (ExtractSupportSignalsFromMeetingOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ExtractSupportSignalsFromMeetingCapability.parseAnswer")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	var result ExtractSupportSignalsFromMeetingOutput
 	err := json.Unmarshal([]byte(answer), &result)

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_forward_email_reply.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_forward_email_reply.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -65,8 +64,7 @@ func (c *ForwardEmailReplyCapability) ValidateInput(input ForwardEmailReplyInput
 func (c *ForwardEmailReplyCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[ForwardEmailReplyInput, ForwardEmailReplyConfig]) (enum.CapabilityExecutionStatus, ForwardEmailReplyOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ForwardEmailReplyCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	result := ForwardEmailReplyOutput{}
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_gather_company_intelligence.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_gather_company_intelligence.go
@@ -10,7 +10,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -100,8 +99,7 @@ func (c *GatherCompanyIntelligenceCapability) ValidateInput(input GatherCompanyI
 func (c *GatherCompanyIntelligenceCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[GatherCompanyIntilligenceInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, GatherCompanyIntelligenceOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "GatherCompanyIntelligenceCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "executionContainer", executionContainer)
 
 	result := GatherCompanyIntelligenceOutput{}

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_identify_email_participants.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_identify_email_participants.go
@@ -10,7 +10,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -84,8 +83,7 @@ func (c *IdentifyEmailParticipantsCapability) ValidateInput(input IdentifyEmailP
 func (c *IdentifyEmailParticipantsCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[IdentifyEmailParticipantsInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, IdentifyEmailParticipantsOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "IdentifyEmailParticipantsCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "executionContainer", executionContainer)
 
 	if err := c.ValidateInput(executionContainer.InputData); err != nil {

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_identify_meeting_participants.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_identify_meeting_participants.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -78,8 +77,7 @@ func (c *IdentifyMeetingParticipantsCapability) ValidateInput(input IdentifyMeet
 func (c *IdentifyMeetingParticipantsCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[IdentifyMeetingParticipantsInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, IdentifyMeetingParticipantsOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "IdentifyMeetingParticipantsCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	result := IdentifyMeetingParticipantsOutput{}
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
@@ -94,8 +94,7 @@ type IdentifyWebsiteVisitorOutput struct {
 func (c *IdentifyWebsiteVisitorCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[IdentifyWebsiteVisitorInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, IdentifyWebsiteVisitorOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "IdentifyWebsiteVisitorCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "executionContainer", executionContainer)
 
 	result := IdentifyWebsiteVisitorOutput{}
@@ -149,7 +148,7 @@ func (c *IdentifyWebsiteVisitorCapability) Execute(ctx context.Context, executio
 func (c *IdentifyWebsiteVisitorCapability) getWebSession(ctx context.Context, sessionID string) (*postgres_entity.WebSession, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "IdentifyWebsiteVisitorCapability.getWebSession")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	websession, err := c.postgresRepositories.WebSessionRepository.FindSession(ctx, postgres_entity.WebSession{
 		ID:     sessionID,
@@ -176,7 +175,7 @@ func (c *IdentifyWebsiteVisitorCapability) processExistingIdentity(
 ) (*enum.CapabilityExecutionStatus, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "IdentifyWebsiteVisitorCapability.processExistingIdentity")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	// Check if identity already set
 	identitySet, primaryDomain, err := c.isIdentitySetOnWebSession(ctx, *websession)
@@ -231,7 +230,7 @@ func (c *IdentifyWebsiteVisitorCapability) tryIdentifyFromIPHistory(
 ) (*enum.CapabilityExecutionStatus, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "IdentifyWebsiteVisitorCapability.tryIdentifyFromIPHistory")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	// Find session with same IP that has domain information
 	identifiedSession, err := c.postgresRepositories.WebSessionRepository.FindLatestSessionWithDomainByIP(ctx, websession.IP)
@@ -268,7 +267,7 @@ func (c *IdentifyWebsiteVisitorCapability) tryIdentifyFromEnrichment(
 ) (enum.CapabilityExecutionStatus, IdentifyWebsiteVisitorOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "IdentifyWebsiteVisitorCapability.tryIdentifyFromEnrichment")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	// Try to identify IP via 3rd parties
 	domain, err := c.identifyIP(ctx, websession.IP)
@@ -320,7 +319,7 @@ func (c *IdentifyWebsiteVisitorCapability) tryIdentifyFromEnrichment(
 func (c *IdentifyWebsiteVisitorCapability) isIdentitySetOnWebSession(ctx context.Context, websession postgres_entity.WebSession) (bool, string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "IdentifyWebsiteVisitorCapability.isIdentitySetOnWebSession")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	if websession.Domain == nil || *websession.Domain == "" {
 		return false, "", nil
@@ -343,7 +342,7 @@ func (c *IdentifyWebsiteVisitorCapability) isIdentitySetOnWebSession(ctx context
 func (c *IdentifyWebsiteVisitorCapability) publishWebVisitorIdentifiedEvent(ctx context.Context, agentExecutionID string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "IdentifyWebsiteVisitorCapability.publishWebVisitorIdentifiedEvent")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	return c.events.Publisher.PublishFanoutEvent(ctx, agentExecutionID, model.AGENT_EXECUTION, dto.WebVisitorIdentified{
 		AgentExecutionId: agentExecutionID,
@@ -354,7 +353,7 @@ func (c *IdentifyWebsiteVisitorCapability) publishWebVisitorIdentifiedEvent(ctx 
 func (c *IdentifyWebsiteVisitorCapability) publishWebVisitorNotIdentifiedEvent(ctx context.Context, agentExecutionID string) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "IdentifyWebsiteVisitorCapability.publishWebVisitorNotIdentifiedEvent")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	return c.events.Publisher.PublishFanoutEvent(ctx, agentExecutionID, model.AGENT_EXECUTION, dto.WebVisitorNotIdentified{
 		AgentExecutionId: agentExecutionID,

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_ingest_email.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_ingest_email.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
@@ -88,8 +87,7 @@ func (c *IngestEmailCapability) ValidateInput(input IngestEmailInput) error {
 func (c *IngestEmailCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[IngestEmailInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, NoOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "IngestEmailCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "executionContainer", executionContainer)
 
 	if err := c.ValidateInput(executionContainer.InputData); err != nil {

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_generate.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_generate.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
@@ -133,8 +132,7 @@ func (c *GenerateInvoiceCapability) ValidateInput(input GenerateInvoiceInput) er
 func (c *GenerateInvoiceCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[GenerateInvoiceInput, GenerateInvoiceConfig]) (enum.CapabilityExecutionStatus, GenerateInvoiceOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "GenerateInvoiceCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "executionContainer", executionContainer)
 
 	result := GenerateInvoiceOutput{}

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_process_autopayment.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_process_autopayment.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -73,8 +72,7 @@ type ProcessAutopaymentOutput struct{}
 func (c *ProcessAutopaymentCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[ProcessAutopaymentInput, ProcessAutopaymentConfig]) (enum.CapabilityExecutionStatus, ProcessAutopaymentOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ProcessAutopaymentCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_send_paid_notification.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_send_paid_notification.go
@@ -7,7 +7,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -73,8 +72,7 @@ type SendPaidNotificationOutput struct{}
 func (c *SendPaidNotificationCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[SendPaidNotificationInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, SendPaidNotificationOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SendPaidNotificationCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_send_past_due_notification.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_send_past_due_notification.go
@@ -7,7 +7,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -73,8 +72,7 @@ type SendPastDueNotificationOutput struct{}
 func (c *SendPastDueNotificationCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[SendPastDueNotificationInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, SendPastDueNotificationOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SendPastDueNotificationCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_send_via_email.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_send_via_email.go
@@ -10,7 +10,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -78,8 +77,7 @@ type SendInvoiceViaEmailOutput struct{}
 func (c *SendInvoiceViaEmailCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[SendInvoiceViaEmailInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, SendInvoiceViaEmailOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SendInvoiceViaEmailCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_send_voided_notification.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_send_voided_notification.go
@@ -7,7 +7,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -73,8 +72,7 @@ type SendInvoiceVoidedNotificationOutput struct{}
 func (c *SendInvoiceVoidedNotificationCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[SendInvoiceVoidedNotificationInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, SendInvoiceVoidedNotificationOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SendInvoiceVoidedNotificationCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -97,8 +97,7 @@ type SyncInvoiceToAccountingConfig struct {
 func (c *SyncInvoiceToAccountingCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[SyncInvoiceToAccountingInput, SyncInvoiceToAccountingConfig]) (enum.CapabilityExecutionStatus, SyncInvoiceToAccountingOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SyncInvoiceToAccountingCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_log_requests_for_help.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_log_requests_for_help.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
@@ -79,8 +78,7 @@ type LogRequestsForHelpInput struct {
 func (c *LogRequestsForHelpCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[LogRequestsForHelpInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, NoOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "LogRequestsForHelpCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "input", executionContainer.InputData)
 	tracing.LogObjectAsJson(span, "config", executionContainer.ConfigData)
 
@@ -115,7 +113,7 @@ func (c *LogRequestsForHelpCapability) Execute(ctx context.Context, executionCon
 func (c *LogRequestsForHelpCapability) createMarkdownTimelineEvent(ctx context.Context, input LogRequestsForHelpInput) string {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "LogRequestsForHelpCapability.createMarkdownTimelineEvent")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	var b strings.Builder
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_manage_campaign_execution.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_manage_campaign_execution.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -65,8 +64,7 @@ func (c *ManageCampaignExecutionCapability) ValidateInput(input ManageCampaignEx
 func (c *ManageCampaignExecutionCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[ManageCampaignExecutionInput, ManageCampaignExecutionConfig]) (enum.CapabilityExecutionStatus, ManageCampaignExecutionOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ManageCampaignExecutionCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	result := ManageCampaignExecutionOutput{}
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_manage_email_delivery_failure.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_manage_email_delivery_failure.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -65,8 +64,7 @@ func (c *ManageEmailDeliveryFailureCapability) ValidateInput(input ManageEmailDe
 func (c *ManageEmailDeliveryFailureCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[ManageEmailDeliveryFailureInput, ManageEmailDeliveryFailureConfig]) (enum.CapabilityExecutionStatus, ManageEmailDeliveryFailureOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ManageEmailDeliveryFailureCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	result := ManageEmailDeliveryFailureOutput{}
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_select_optimal_sending_mailbox.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_select_optimal_sending_mailbox.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
@@ -65,8 +64,7 @@ func (c *SelectOptimalSendingMailboxCapability) ValidateInput(input SelectOptima
 func (c *SelectOptimalSendingMailboxCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[SelectOptimalSendingMailboxInput, SelectOptimalSendingMailboxConfig]) (enum.CapabilityExecutionStatus, SelectOptimalSendingMailboxOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SelectOptimalSendingMailboxCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 
 	result := SelectOptimalSendingMailboxOutput{}
 

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_send_notification_slack.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_send_notification_slack.go
@@ -83,8 +83,7 @@ type SlackChannelIdConfig struct {
 func (c *SendSlackNotificationCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[SendSlackNotificationInput, SendSlackNotificationConfig]) (enum.CapabilityExecutionStatus, NoOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SendSlackNotificationCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "executionContainer", executionContainer)
 
 	result := NoOutput{}

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_send_web_visitor_notification_slack.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_send_web_visitor_notification_slack.go
@@ -135,8 +135,7 @@ func (c *SendWebVisitorSlackNotificationCapability) ValidateInput(input SendWebV
 func (c *SendWebVisitorSlackNotificationCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[SendWebVisitorSlackNotificationInput, SendWebVisitorSlackNotificationConfig]) (enum.CapabilityExecutionStatus, NoOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "SendWebVisitorSlackNotificationCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "executionContainer", executionContainer)
 
 	result := NoOutput{}

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_update_company_status.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_update_company_status.go
@@ -2,6 +2,7 @@ package agent_capability
 
 import (
 	"context"
+
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
@@ -9,7 +10,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
@@ -95,8 +95,7 @@ func (c *UpdateCompanyStatusCapability) ValidateInput(input UpdateCompanyStatusI
 func (c *UpdateCompanyStatusCapability) Execute(ctx context.Context, executionContainer interfaces.TypedExecutionContainer[UpdateCompanyStatusInput, postgres_entity.NoConfig]) (enum.CapabilityExecutionStatus, NoOutput, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "UpdateCompanyStatusCapability.Execute")
 	defer span.Finish()
-	tracing.TagComponentService(span)
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.LogObjectAsJson(span, "executionContainer", executionContainer)
 
 	if err := c.ValidateInput(executionContainer.InputData); err != nil {
@@ -143,9 +142,10 @@ func (c *UpdateCompanyStatusCapability) Execute(ctx context.Context, executionCo
 }
 
 func (c *UpdateCompanyStatusCapability) processICPFit(ctx context.Context, organizationID string, reasons []string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ICPQualificationCapability.processICPFit")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "UpdateCompanyStatusCapability.processICPFit")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
+	tracing.TagEntity(span, organizationID)
 
 	_, err := c.organizationService.Save(ctx, nil, &organizationID, data_fields.OrganizationFields{
 		Relationship:  utils.ToPtr(neo4jenum.OrganizationRelationshipProspect),
@@ -161,9 +161,10 @@ func (c *UpdateCompanyStatusCapability) processICPFit(ctx context.Context, organ
 }
 
 func (c *UpdateCompanyStatusCapability) processICPNotAFit(ctx context.Context, organizationID string, reasons []string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ICPQualificationCapability.processICPFit")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "UpdateCompanyStatusCapability.processICPFit")
 	defer span.Finish()
-	tracing.TagComponentService(span)
+	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
+	tracing.TagEntity(span, organizationID)
 
 	_, err := c.organizationService.Save(ctx, nil, &organizationID, data_fields.OrganizationFields{
 		Relationship:  utils.ToPtr(neo4jenum.OrganizationRelationshipNotAFit),

--- a/packages/server/customer-os-common-module/services/agent_capability/capability_update_company_status.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_update_company_status.go
@@ -161,7 +161,7 @@ func (c *UpdateCompanyStatusCapability) processICPFit(ctx context.Context, organ
 }
 
 func (c *UpdateCompanyStatusCapability) processICPNotAFit(ctx context.Context, organizationID string, reasons []string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UpdateCompanyStatusCapability.processICPFit")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "UpdateCompanyStatusCapability.processICPNotAFit")
 	defer span.Finish()
 	tracing.SetDefaultAgentCapabilitySpanTags(ctx, span)
 	tracing.TagEntity(span, organizationID)

--- a/packages/server/customer-os-common-module/tracing/utils.go
+++ b/packages/server/customer-os-common-module/tracing/utils.go
@@ -259,7 +259,7 @@ func TagComponentNeo4jRepository(span opentracing.Span) {
 }
 
 func TagComponentAgentCapability(span opentracing.Span) {
-	span.SetTag(SpanTagComponent, SpanTagComponentNeo4jRepository)
+	span.SetTag(SpanTagComponent, SpanTagComponentAgentCapability)
 }
 
 func TagTenant(span opentracing.Span, tenant string) {

--- a/packages/server/customer-os-common-module/tracing/utils.go
+++ b/packages/server/customer-os-common-module/tracing/utils.go
@@ -42,6 +42,7 @@ const (
 	SpanTagComponentCronJob            = "cronJob"
 	SpanTagComponentService            = "service"
 	SpanTagComponentListener           = "listener"
+	SpanTagComponentAgentCapability    = "agentCapability"
 )
 
 func GraphQlTracingEnhancer(ctx context.Context) func(c *gin.Context) {
@@ -203,6 +204,11 @@ func SetDefaultPostgresRepositorySpanTags(ctx context.Context, span opentracing.
 	TagComponentPostgresRepository(span)
 }
 
+func SetDefaultAgentCapabilitySpanTags(ctx context.Context, span opentracing.Span) {
+	setDefaultSpanTags(ctx, span)
+	TagComponentAgentCapability(span)
+}
+
 func TraceErr(span opentracing.Span, err error, fields ...log.Field) {
 	if span == nil || err == nil || coserrors.SkipTracing(err) {
 		return
@@ -249,6 +255,10 @@ func TagComponentPostgresRepository(span opentracing.Span) {
 }
 
 func TagComponentNeo4jRepository(span opentracing.Span) {
+	span.SetTag(SpanTagComponent, SpanTagComponentNeo4jRepository)
+}
+
+func TagComponentAgentCapability(span opentracing.Span) {
 	span.SetTag(SpanTagComponent, SpanTagComponentNeo4jRepository)
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor tracing logic by consolidating span tagging into a single function and applying it across multiple agent capabilities.
> 
>   - **Tracing Enhancements**:
>     - Replaces `tracing.TagComponentService()` and `tracing.TagTenant()` with `tracing.SetDefaultAgentCapabilitySpanTags()` in `Execute()` functions across multiple capability files.
>     - Removes redundant import of `common` package in several capability files.
>   - **New Functionality**:
>     - Adds `SetDefaultAgentCapabilitySpanTags()` function in `utils.go` to set default span tags for agent capabilities.
>   - **Miscellaneous**:
>     - Fixes span naming in `processICPFit()` and `processICPNotAFit()` in `capability_update_company_status.go`.
>     - Removes unused import in `capability_add_meeting_notes_to_company.go` and `capability_classify_email.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a3e92a1e04f402f0a22b463e20ce3ced371d4189. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->