### PR TITLE
add types to ai observability

### DIFF
--- a/packages/server/customer-os-common-module/dto/llm_observability.go
+++ b/packages/server/customer-os-common-module/dto/llm_observability.go
@@ -4,10 +4,11 @@ import "time"
 
 type LLMObservability struct {
 	// Basic request metadata
-	RequestID string    `json:"request_id"`
-	Timestamp time.Time `json:"timestamp"`
-	UserID    string    `json:"user_id,omitempty"`
-	Tenant    string    `json:"tenant,omitempty"`
+	RequestID   string    `json:"request_id"`
+	RequestType string    `json:"request_type"`
+	Timestamp   time.Time `json:"timestamp"`
+	UserID      string    `json:"user_id,omitempty"`
+	Tenant      string    `json:"tenant,omitempty"`
 
 	// Model information
 	Model       string  `json:"model"`

--- a/packages/server/customer-os-common-module/enum/ai.go
+++ b/packages/server/customer-os-common-module/enum/ai.go
@@ -54,3 +54,16 @@ const (
 func (a AIOutputFormat) String() string {
 	return string(a)
 }
+
+type AIRequestType string
+
+const (
+	AIRequestGeneric         AIRequestType = "generic"
+	AIRequestWebpageCategory AIRequestType = "webpage_category"
+	AIRequestContentStage    AIRequestType = "content_journey_stage"
+	AIRequestWebpageTopics   AIRequestType = "webpage_topics"
+)
+
+func (a AIRequestType) String() string {
+	return string(a)
+}

--- a/packages/server/customer-os-common-module/interfaces/ai.go
+++ b/packages/server/customer-os-common-module/interfaces/ai.go
@@ -16,6 +16,7 @@ type AIService interface {
 }
 
 type AskAIRequest struct {
+	RequestType      enum.AIRequestType
 	Model            enum.AIModel
 	SystemPrompt     *string
 	Prompt           *string

--- a/packages/server/customer-os-common-module/services/ai/ask_ai_content_stage.go
+++ b/packages/server/customer-os-common-module/services/ai/ask_ai_content_stage.go
@@ -23,7 +23,8 @@ func (s *aiService) AskAIForContentStage(ctx context.Context, request interfaces
 		return "", err
 	}
 
-	// Always use text output for enums
+	// defaults
+	request.RequestType = enum.AIRequestContentStage
 	request.OutputFormat = enum.AIOutputText
 
 	// Get the output validator

--- a/packages/server/customer-os-common-module/services/ai/ask_ai_for_string.go
+++ b/packages/server/customer-os-common-module/services/ai/ask_ai_for_string.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
@@ -23,6 +24,10 @@ func (s *aiService) AskAIForString(ctx context.Context, request interfaces.AskAI
 		tracing.TraceErr(span, err)
 		return nil, err
 	}
+
+	// defaults
+	request.RequestType = enum.AIRequestGeneric
+	request.OutputFormat = enum.AIOutputText
 
 	var lastError error
 	var answer *string

--- a/packages/server/customer-os-common-module/services/ai/ask_ai_webpage_category.go
+++ b/packages/server/customer-os-common-module/services/ai/ask_ai_webpage_category.go
@@ -23,7 +23,8 @@ func (s *aiService) AskAIForWebpageCategory(ctx context.Context, request interfa
 		return "", err
 	}
 
-	// Always use text output for enums
+	// defaults
+	request.RequestType = enum.AIRequestWebpageCategory
 	request.OutputFormat = enum.AIOutputText
 
 	// Get the answer validator

--- a/packages/server/customer-os-common-module/services/ai/ask_ai_webpage_topics.go
+++ b/packages/server/customer-os-common-module/services/ai/ask_ai_webpage_topics.go
@@ -27,7 +27,8 @@ func (s *aiService) AskAIForWebpageTopics(ctx context.Context, request interface
 	// Create output validator
 	validator := data_fields.NewTopicsResponseValidator()
 
-	// Always use JSON output format
+	// defaults
+	request.RequestType = enum.AIRequestWebpageTopics
 	request.OutputFormat = enum.AIOutputJson
 
 	// Enhance the system prompt with the expected schema if needed

--- a/packages/server/customer-os-common-module/services/ai/service.go
+++ b/packages/server/customer-os-common-module/services/ai/service.go
@@ -321,6 +321,7 @@ func (s *aiService) newObservabilityContainer(ctx context.Context, span opentrac
 
 	return &dto.LLMObservability{
 		RequestID:    utils.GenerateNanoIdWithPrefix("llm", 16),
+		RequestType:  request.RequestType.String(),
 		Timestamp:    utils.Now(),
 		UserID:       common.GetUserIdFromContext(ctx),
 		Tenant:       common.GetTenantFromContext(ctx),

--- a/packages/server/customer-os-common-module/utils/backoff_utils.go
+++ b/packages/server/customer-os-common-module/utils/backoff_utils.go
@@ -15,7 +15,7 @@ type BackoffConfig struct {
 
 func DefaultBackoffConfig() BackoffConfig {
 	return BackoffConfig{
-		InitialDelay: 100 * time.Millisecond,
+		InitialDelay: 50 * time.Millisecond,
 		MaxDelay:     5 * time.Second,
 		Factor:       2.0,
 		Jitter:       0.1,

--- a/packages/server/customer-os-common-module/utils/backoff_utils_test.go
+++ b/packages/server/customer-os-common-module/utils/backoff_utils_test.go
@@ -8,8 +8,8 @@ import (
 func TestDefaultBackoffConfig(t *testing.T) {
 	config := DefaultBackoffConfig()
 
-	if config.InitialDelay != 100*time.Millisecond {
-		t.Errorf("InitialDelay = %v; want %v", config.InitialDelay, 100*time.Millisecond)
+	if config.InitialDelay != 50*time.Millisecond {
+		t.Errorf("InitialDelay = %v; want %v", config.InitialDelay, 50*time.Millisecond)
 	}
 	if config.MaxDelay != 5*time.Second {
 		t.Errorf("MaxDelay = %v; want %v", config.MaxDelay, 5*time.Second)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `RequestType` to `LLMObservability`, introduce `AIRequestType` enum, set default request types in AI services, and reduce backoff initial delay.
> 
>   - **LLMObservability**:
>     - Add `RequestType` field to `LLMObservability` struct in `llm_observability.go`.
>     - Update `newObservabilityContainer()` in `service.go` to set `RequestType`.
>   - **Enums**:
>     - Introduce `AIRequestType` enum in `ai.go` with values `generic`, `webpage_category`, `content_journey_stage`, `webpage_topics`.
>   - **AI Service**:
>     - Set default `RequestType` in `AskAIForContentStage()`, `AskAIForString()`, `AskAIForWebpageCategory()`, `AskAIForWebpageTopics()`.
>   - **Backoff Configuration**:
>     - Change `InitialDelay` in `DefaultBackoffConfig()` in `backoff_utils.go` from 100ms to 50ms.
>     - Update `TestDefaultBackoffConfig()` in `backoff_utils_test.go` to reflect new initial delay.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for dc95572e53062be1e1caa94b696c5b9ab87f454a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->