### PR TITLE
fix web session event id

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_listeners/listener_new_web_session.go
+++ b/packages/server/customer-os-common-module/services/agent_listeners/listener_new_web_session.go
@@ -101,7 +101,7 @@ func (l *NewWebSessionListener) Handle(ctx context.Context, baseEvent any) error
 		return err
 	}
 
-	return l.handleExecution(ctx, event.Event.Id)
+	return l.handleExecution(ctx, event.Event.EntityId)
 }
 
 func (l *NewWebSessionListener) handleExecution(ctx context.Context, webSessionId string) error {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `Handle` method in `listener_new_web_session.go` to use `event.Event.EntityId` instead of `event.Event.Id`.
> 
>   - **Behavior**:
>     - Fixes `Handle` method in `listener_new_web_session.go` to use `event.Event.EntityId` instead of `event.Event.Id` for web session handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 67739a2492453be8eecb6971fb9c134a0830c02b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->