### PR TITLE
Fix download image

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/media_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/media_service.go
@@ -134,7 +134,7 @@ func (s *mediaService) downloadImage(ctx context.Context, globalOrgId uint64, im
 
 	imagePath, err := s.commonServices.MediaService.DownloadImageToS3(ctx, imageUrl, BUCKET, imagePath)
 	if err != nil {
-		if !errors.Is(err, coserrors.ErrResourceNotFound) {
+		if !errors.Is(err, coserrors.ErrResourceNotFound) && !errors.Is(err, coserrors.ErrResourceForbidden) {
 			tracing.TraceErr(span, err)
 		}
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetDownloadStatus(ctx, globalOrgId, enum.DownloadError)
@@ -166,7 +166,7 @@ func (s *mediaService) downloadContactPhoto(ctx context.Context, globalContactId
 
 	imagePath, err := s.commonServices.MediaService.DownloadImageToS3(ctx, imageUrl, BUCKET, imagePath)
 	if err != nil {
-		if !errors.Is(err, coserrors.ErrResourceNotFound) {
+		if !errors.Is(err, coserrors.ErrResourceNotFound) && !errors.Is(err, coserrors.ErrResourceForbidden) {
 			tracing.TraceErr(span, err)
 		}
 		err = s.commonServices.PostgresRepositories.GlobalContactRepository.SetDownloadStatus(ctx, globalContactId, enum.DownloadError)

--- a/packages/server/customer-os-common-module/coserrors/errors.go
+++ b/packages/server/customer-os-common-module/coserrors/errors.go
@@ -16,6 +16,7 @@ var (
 	ErrConnectionTimeout   = errors.New("Connection timeout")
 	ErrOperationNotAllowed = errors.New("Operation not allowed")
 	ErrResourceNotFound    = errors.New("Resource not found")
+	ErrResourceForbidden   = errors.New("Resource forbidden")
 
 	// domain errors
 	ErrDomainUnavailable         = errors.New("domain unavailable")

--- a/packages/server/customer-os-common-module/services/media/service.go
+++ b/packages/server/customer-os-common-module/services/media/service.go
@@ -40,7 +40,7 @@ func NewMediaService(postgres *postgres_repository.Repositories) interfaces.Medi
 // DownloadImageToS3 downloads an image from a URL directly to an S3 bucket
 // using the existing S3Client implementation
 func (s *mediaService) DownloadImageToS3(ctx context.Context, imageURL, bucketName, s3FilePath string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "media.DownloadImageToS3")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "MediaService.DownloadImageToS3")
 	defer span.Finish()
 	span.LogFields(
 		tracingLog.String("url", imageURL),
@@ -85,10 +85,14 @@ func (s *mediaService) DownloadImageToS3(ctx context.Context, imageURL, bucketNa
 
 	// Check if request was successful
 	if resp.StatusCode != http.StatusOK {
+		span.LogFields(tracingLog.Int("response.statusCode", resp.StatusCode))
 		switch {
 		case resp.StatusCode == http.StatusNotFound:
 			return "", coserrors.ErrResourceNotFound
+		case resp.StatusCode == http.StatusForbidden:
+			return "", coserrors.ErrResourceForbidden
 		default:
+			err := errors.New("failed to download image")
 			tracing.TraceErr(span, err)
 			return "", err
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add handling for HTTP 403 errors in image download process by introducing `ErrResourceForbidden`.
> 
>   - **Error Handling**:
>     - Add `ErrResourceForbidden` to `coserrors/errors.go` for handling HTTP 403 errors.
>     - Update `downloadImage()` and `downloadContactPhoto()` in `media_service.go` to handle `ErrResourceForbidden`.
>   - **Functionality**:
>     - Modify `DownloadImageToS3()` in `service.go` to return `ErrResourceForbidden` for HTTP 403 responses.
>   - **Misc**:
>     - Update tracing span name in `DownloadImageToS3()` from `media.DownloadImageToS3` to `MediaService.DownloadImageToS3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for bb3f525b33bf018435d76041dc5482636c9bc95f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->