### PR TITLE
re-fetch failed images

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/global_contact_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/global_contact_service.go
@@ -170,34 +170,10 @@ func (s *globalContactService) syncScrapinInRecordIntoGlobalContact(ctx context.
 			ProfilePhotoExternalUrl: person.PhotoUrl,
 		}
 
-		// Try to find existing contact by LinkedIn identifier and primary domain
-		existingContact, err := s.commonServices.PostgresRepositories.GlobalContactRepository.GetByLinkedInIdentifier(ctx, contact.LinkedInIdentifier)
+		err = s.commonServices.GlobalContactService.SaveContact(ctx, contact)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error getting contact by LinkedIn identifier"))
+			tracing.TraceErr(span, errors.Wrap(err, "error saving global contact"))
 			return err
-		}
-
-		if existingContact != nil {
-			// Update existing contact
-			existingContact.FirstName = contact.FirstName
-			existingContact.LastName = contact.LastName
-			existingContact.JobTitle = contact.JobTitle
-			existingContact.JobStartedAt = contact.JobStartedAt
-			existingContact.JobEndedAt = contact.JobEndedAt
-			existingContact.PrimaryDomain = contact.PrimaryDomain
-
-			_, err = s.commonServices.PostgresRepositories.GlobalContactRepository.Update(ctx, existingContact)
-			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "error updating global contact"))
-				return err
-			}
-		} else {
-			// Create new contact
-			_, err = s.commonServices.PostgresRepositories.GlobalContactRepository.Create(ctx, contact)
-			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "error creating global contact"))
-				return err
-			}
 		}
 	}
 

--- a/packages/server/customer-os-common-module/services/global_contacts/service.go
+++ b/packages/server/customer-os-common-module/services/global_contacts/service.go
@@ -2,6 +2,7 @@ package globalcontacts
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 
@@ -134,6 +135,10 @@ func (s *globalContactService) updateContactFields(existing *postgres_entity.Glo
 		existing.LinkedInIdentifier = new.LinkedInIdentifier
 	}
 	if new.ProfilePhotoExternalUrl != "" {
+		// if new URL is different then existing one and download status is error, reset download status
+		if existing.ProfilePhotoExternalUrl != new.ProfilePhotoExternalUrl && existing.DownloadStatus == enum.DownloadError {
+			existing.DownloadStatus = enum.DownloadNotStarted
+		}
 		existing.ProfilePhotoExternalUrl = new.ProfilePhotoExternalUrl
 	}
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor contact saving logic in `global_contact_service.go` to use `SaveContact()` and reset download status for profile photos on URL change in `service.go`.
> 
>   - **Behavior**:
>     - Refactor `syncScrapinInRecordIntoGlobalContact()` in `global_contact_service.go` to use `SaveContact()` for saving contacts, removing redundant update/create logic.
>     - In `updateContactFields()` in `service.go`, reset `DownloadStatus` to `DownloadNotStarted` if `ProfilePhotoExternalUrl` changes and previous status was `DownloadError`.
>   - **Functions**:
>     - Remove logic for updating/creating contacts in `syncScrapinInRecordIntoGlobalContact()`.
>     - Use `SaveContact()` in `service.go` to handle contact saving logic.
>   - **Misc**:
>     - Add import for `enum` in `service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c4ba4c20ce59ad50df8ca375686f2e82fc94a568. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->