### PR TITLE
fix uniqueness of agent capability execution id

### DIFF
--- a/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
+++ b/packages/server/customer-os-common-module/services/agent/agent_runner_service.go
@@ -575,7 +575,7 @@ func (a *agentRunnerService) GetExecutionStatus(ctx context.Context, executionID
 
 func (a *agentRunnerService) newObservabilityContainer(ctx context.Context, executionParams executionParams) *dto.AgentExecutionObservability {
 	return &dto.AgentExecutionObservability{
-		CapabilityExecutionID: utils.GenerateNanoIdWithPrefix("cap", 16),
+		CapabilityExecutionID: utils.GenerateNanoIdWithPrefix("ace", 16),
 		ExecutionID:           executionParams.executionID,
 		AgentID:               executionParams.agent.ID,
 		AgentType:             executionParams.agent.Type.String(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change prefix for `CapabilityExecutionID` generation in `newObservabilityContainer()` to ensure uniqueness.
> 
>   - **Behavior**:
>     - Change prefix in `utils.GenerateNanoIdWithPrefix` from `"cap"` to `"ace"` in `newObservabilityContainer()` in `agent_runner_service.go`.
>   - **Misc**:
>     - Ensures uniqueness of `CapabilityExecutionID` by using a more specific prefix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c36e2002634f5afe92a519eae4553657fe100583. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->