### PR TITLE
Set linkedin alias

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/global_contact_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/global_contact_service.go
@@ -165,6 +165,7 @@ func (s *globalContactService) syncScrapinInRecordIntoGlobalContact(ctx context.
 			FirstName:               utils.CleanName(person.FirstName),
 			LastName:                utils.CleanName(person.LastName),
 			LinkedInIdentifier:      person.LinkedInIdentifier,
+			LinkedInAlias:           person.PublicIdentifier,
 			JobTitle:                currentPosition.Title,
 			JobStartedAt:            currentPosition.StartedOn,
 			JobEndedAt:              currentPosition.EndedOn,
@@ -190,7 +191,7 @@ func (s *globalContactService) SyncDataIntoGlobalContacts() {
 	defer span.Finish()
 	tracing.TagComponentService(span)
 
-	limit := 50
+	limit := 500
 
 	records, err := s.commonServices.PostgresRepositories.EnrichDetailsScrapInRepository.GetToSyncIntoGlobalContacts(ctx, limit)
 	if err != nil {

--- a/packages/runner/customer-os-data-upkeeper/service/media_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/media_service.go
@@ -168,6 +168,19 @@ func (s *mediaService) downloadContactPhoto(ctx context.Context, globalContactId
 	if err != nil {
 		if !errors.Is(err, coserrors.ErrResourceNotFound) && !errors.Is(err, coserrors.ErrResourceForbidden) {
 			tracing.TraceErr(span, err)
+		} else {
+			// clear global contact profile photo external url
+			globalContact, err := s.commonServices.PostgresRepositories.GlobalContactRepository.GetById(ctx, globalContactId)
+			if err != nil {
+				tracing.TraceErr(span, err)
+			}
+			if globalContact != nil {
+				globalContact.ProfilePhotoExternalUrl = ""
+				_, err = s.commonServices.PostgresRepositories.GlobalContactRepository.Update(ctx, globalContact)
+				if err != nil {
+					tracing.TraceErr(span, errors.Wrap(err, "failed to update global contact"))
+				}
+			}
 		}
 		err = s.commonServices.PostgresRepositories.GlobalContactRepository.SetDownloadStatus(ctx, globalContactId, enum.DownloadError)
 		if err != nil {
@@ -181,6 +194,10 @@ func (s *mediaService) downloadContactPhoto(ctx context.Context, globalContactId
 		if err != nil {
 			tracing.TraceErr(span, errors.Wrap(err, "failed to set image path"))
 			return false
+		}
+		err = s.commonServices.PostgresRepositories.GlobalContactRepository.SetDownloadStatus(ctx, globalContactId, enum.DownloadCompleted)
+		if err != nil {
+			tracing.TraceErr(span, errors.Wrap(err, "failed to set download status"))
 		}
 	}
 	return true

--- a/packages/server/customer-os-common-module/services/global_contacts/service.go
+++ b/packages/server/customer-os-common-module/services/global_contacts/service.go
@@ -136,6 +136,9 @@ func (s *globalContactService) updateContactFields(existing *postgres_entity.Glo
 	if new.LinkedInIdentifier != "" {
 		existing.LinkedInIdentifier = new.LinkedInIdentifier
 	}
+	if new.LinkedInAlias != "" {
+		existing.LinkedInAlias = new.LinkedInAlias
+	}
 	if new.ProfilePhotoExternalUrl != "" {
 		// if new URL is different then existing one and download status is error, reset download status
 		if existing.ProfilePhotoExternalUrl != new.ProfilePhotoExternalUrl && existing.DownloadStatus == enum.DownloadError {

--- a/packages/server/customer-os-postgres-repository/entity/global_contact.go
+++ b/packages/server/customer-os-postgres-repository/entity/global_contact.go
@@ -13,6 +13,7 @@ type GlobalContact struct {
 	FirstName               string              `gorm:"type:varchar(255)" json:"first_name"`
 	LastName                string              `gorm:"type:varchar(255)" json:"last_name"`
 	LinkedInIdentifier      string              `gorm:"type:varchar(255);index:idx_linkedin_identifier" json:"linkedin_identifier"`
+	LinkedInAlias           string              `gorm:"type:varchar(255);index:idx_linkedin_alias" json:"linkedin_alias"`
 	WorkEmail               string              `gorm:"type:varchar(255);index:idx_work_email" json:"work_email,omitempty"`
 	PersonalEmail           string              `gorm:"type:varchar(255);index:idx_personal_email" json:"personal_email,omitempty"`
 	JobTitle                string              `gorm:"type:varchar(255)" json:"job_title"`


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `LinkedInAlias` to `GlobalContact` and update services to handle it, increase sync limit, and handle missing profile photos.
> 
>   - **GlobalContact Entity**:
>     - Add `LinkedInAlias` field to `GlobalContact` in `global_contact.go`.
>   - **Service Updates**:
>     - Update `syncScrapinInRecordIntoGlobalContact()` in `global_contact_service.go` to set `LinkedInAlias`.
>     - Update `updateContactFields()` in `service.go` to handle `LinkedInAlias`.
>   - **Behavior Changes**:
>     - Increase sync limit from 50 to 500 in `SyncDataIntoGlobalContacts()` in `global_contact_service.go`.
>     - Clear `ProfilePhotoExternalUrl` if resource not found in `downloadContactPhoto()` in `media_service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2b70a9b85c27aadd457d9436a402cc893f0ec5a6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->