### PR TITLE
Get tasks for opportunities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -177,3 +177,17 @@ updates:
     pull-request-branch-name:
       separator: "-"
     rebase-strategy: "auto"
+
+  - package-ecosystem: "gomod"
+    directory: "/packages/server/mailstack"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "go"
+      - "dependencies"
+      - "app/mailstack"
+    pull-request-branch-name:
+      separator: "-"
+    rebase-strategy: "auto"

--- a/packages/go-mod-tidy-all.sh
+++ b/packages/go-mod-tidy-all.sh
@@ -15,6 +15,8 @@ cd ../customer-os-webhooks
 go mod tidy
 cd ../mailsherpa-api
 go mod tidy
+cd ../mailstack
+go mod tidy
 cd ../..
 cd runner
 cd customer-os-data-upkeeper

--- a/packages/server/customer-os-api/dataloader/dataloader.go
+++ b/packages/server/customer-os-api/dataloader/dataloader.go
@@ -124,10 +124,14 @@ type Loaders struct {
 	FlowsWithContact                            *dataloader.Loader
 	FlowsWithSender                             *dataloader.Loader
 	FlowExecutionsForParticipant                *dataloader.Loader
+	TasksForOpportunity                         *dataloader.Loader
 }
 
 type tagBatcher struct {
 	tagService interfaces.TagService
+}
+type taskBatcher struct {
+	taskService interfaces.TaskService
 }
 type emailBatcher struct {
 	emailService       cosapi_interfaces.EmailService
@@ -236,6 +240,9 @@ type flowBatcher struct {
 func NewDataLoader(services *cosapi_services.Services) *Loaders {
 	tagBatcher := &tagBatcher{
 		tagService: services.CommonServices.TagService,
+	}
+	taskBatcher := &taskBatcher{
+		taskService: services.CommonServices.TaskService,
 	}
 	emailBatcher := &emailBatcher{
 		emailService:       services.EmailService,
@@ -438,6 +445,7 @@ func NewDataLoader(services *cosapi_services.Services) *Loaders {
 		FlowsWithContact:                            dataloader.NewBatchedLoader(flowBatcher.getFlowsWithContact, dataloader.WithClearCacheOnBatch(), dataloader.WithWait(defaultDataloaderWaitTime)),
 		FlowsWithSender:                             dataloader.NewBatchedLoader(flowBatcher.getFlowsWithSender, dataloader.WithClearCacheOnBatch(), dataloader.WithWait(defaultDataloaderWaitTime)),
 		FlowExecutionsForParticipant:                dataloader.NewBatchedLoader(flowBatcher.getFlowExecutionsForParticipant, dataloader.WithClearCacheOnBatch(), dataloader.WithWait(defaultDataloaderWaitTime)),
+		TasksForOpportunity:                         dataloader.NewBatchedLoader(taskBatcher.getTasksForOpportunities, dataloader.WithClearCacheOnBatch(), dataloader.WithWait(defaultDataloaderWaitTime)),
 	}
 }
 

--- a/packages/server/customer-os-api/dataloader/task_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/task_dataloader.go
@@ -1,0 +1,71 @@
+package dataloader
+
+import (
+	"context"
+	"errors"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
+	"github.com/graph-gophers/dataloader"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"reflect"
+)
+
+func (i *Loaders) GetTasksForOpportunity(ctx context.Context, opportunityId string) (*neo4jentity.TaskEntities, error) {
+	thunk := i.TasksForOpportunity.Load(ctx, dataloader.StringKey(opportunityId))
+	result, err := thunk()
+	if err != nil {
+		return nil, err
+	}
+	resultObj := result.(neo4jentity.TaskEntities)
+	return &resultObj, nil
+}
+
+func (b *taskBatcher) getTasksForOpportunities(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskDataLoader.getTasksForOpportunities")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+
+	ids, keyOrder := sortKeys(keys)
+
+	taskEntitiesPtr, err := b.taskService.GetTasksForOpportunities(ctx, ids)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		// check if context deadline exceeded error occurred
+		if ctx.Err() == context.DeadlineExceeded {
+			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get tasks for opportunities")}}
+		}
+		return []*dataloader.Result{{Data: nil, Error: err}}
+	}
+
+	taskEntitiesByOpportunityId := make(map[string]neo4jentity.TaskEntities)
+	for _, val := range *taskEntitiesPtr {
+		if list, ok := taskEntitiesByOpportunityId[val.DataloaderKey]; ok {
+			taskEntitiesByOpportunityId[val.DataloaderKey] = append(list, val)
+		} else {
+			taskEntitiesByOpportunityId[val.DataloaderKey] = neo4jentity.TaskEntities{val}
+		}
+	}
+
+	// construct an output array of dataloader results
+	results := make([]*dataloader.Result, len(keys))
+	for opportunityId, record := range taskEntitiesByOpportunityId {
+		if ix, ok := keyOrder[opportunityId]; ok {
+			results[ix] = &dataloader.Result{Data: record, Error: nil}
+			delete(keyOrder, opportunityId)
+		}
+	}
+	for _, ix := range keyOrder {
+		results[ix] = &dataloader.Result{Data: neo4jentity.TaskEntities{}, Error: nil}
+	}
+
+	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.TaskEntities{})); err != nil {
+		tracing.TraceErr(span, err)
+		return []*dataloader.Result{{nil, err}}
+	}
+
+	span.LogFields(log.Int("results_length", len(results)))
+
+	return results
+}

--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -1303,6 +1303,7 @@ type ComplexityRoot struct {
 		Source                 func(childComplexity int) int
 		SourceOfTruth          func(childComplexity int) int
 		StageLastUpdated       func(childComplexity int) int
+		TaskIds                func(childComplexity int) int
 		UpdatedAt              func(childComplexity int) int
 	}
 
@@ -2191,6 +2192,7 @@ type OpportunityResolver interface {
 	CreatedBy(ctx context.Context, obj *model.Opportunity) (*model.User, error)
 	Owner(ctx context.Context, obj *model.Opportunity) (*model.User, error)
 	ExternalLinks(ctx context.Context, obj *model.Opportunity) ([]*model.ExternalSystem, error)
+	TaskIds(ctx context.Context, obj *model.Opportunity) ([]string, error)
 }
 type OrganizationResolver interface {
 	Contracts(ctx context.Context, obj *model.Organization) ([]*model.Contract, error)
@@ -9829,6 +9831,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Opportunity.StageLastUpdated(childComplexity), true
 
+	case "Opportunity.taskIds":
+		if e.complexity.Opportunity.TaskIds == nil {
+			break
+		}
+
+		return e.complexity.Opportunity.TaskIds(childComplexity), true
+
 	case "Opportunity.updatedAt":
 		if e.complexity.Opportunity.UpdatedAt == nil {
 			break
@@ -16436,6 +16445,7 @@ type Opportunity implements MetadataInterface {
     createdBy:          User @goField(forceResolver: true) @hasRole(roles: [ADMIN, USER]) @hasTenant
     owner:              User @goField(forceResolver: true) @hasRole(roles: [ADMIN, USER]) @hasTenant
     externalLinks:      [ExternalSystem!]! @goField(forceResolver: true) @hasRole(roles: [ADMIN, USER]) @hasTenant
+    taskIds:            [ID!]! @goField(forceResolver: true) @hasRole(roles: [ADMIN, USER]) @hasTenant
 
     """
     Deprecated, use metadata
@@ -38057,6 +38067,8 @@ func (ec *executionContext) fieldContext_Contract_opportunities(_ context.Contex
 				return ec.fieldContext_Opportunity_owner(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_Opportunity_externalLinks(ctx, field)
+			case "taskIds":
+				return ec.fieldContext_Opportunity_taskIds(ctx, field)
 			case "id":
 				return ec.fieldContext_Opportunity_id(ctx, field)
 			case "createdAt":
@@ -74349,6 +74361,8 @@ func (ec *executionContext) fieldContext_Mutation_opportunity_Save(ctx context.C
 				return ec.fieldContext_Opportunity_owner(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_Opportunity_externalLinks(ctx, field)
+			case "taskIds":
+				return ec.fieldContext_Opportunity_taskIds(ctx, field)
 			case "id":
 				return ec.fieldContext_Opportunity_id(ctx, field)
 			case "createdAt":
@@ -74561,6 +74575,8 @@ func (ec *executionContext) fieldContext_Mutation_opportunityRenewalUpdate(ctx c
 				return ec.fieldContext_Opportunity_owner(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_Opportunity_externalLinks(ctx, field)
+			case "taskIds":
+				return ec.fieldContext_Opportunity_taskIds(ctx, field)
 			case "id":
 				return ec.fieldContext_Opportunity_id(ctx, field)
 			case "createdAt":
@@ -84291,6 +84307,84 @@ func (ec *executionContext) fieldContext_Opportunity_externalLinks(_ context.Con
 	return fc, nil
 }
 
+func (ec *executionContext) _Opportunity_taskIds(ctx context.Context, field graphql.CollectedField, obj *model.Opportunity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Opportunity_taskIds(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		directive0 := func(rctx context.Context) (any, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Opportunity().TaskIds(rctx, obj)
+		}
+
+		directive1 := func(ctx context.Context) (any, error) {
+			roles, err := ec.unmarshalNRole2ᚕgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐRoleᚄ(ctx, []any{"ADMIN", "USER"})
+			if err != nil {
+				var zeroVal []string
+				return zeroVal, err
+			}
+			if ec.directives.HasRole == nil {
+				var zeroVal []string
+				return zeroVal, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, obj, directive0, roles)
+		}
+		directive2 := func(ctx context.Context) (any, error) {
+			if ec.directives.HasTenant == nil {
+				var zeroVal []string
+				return zeroVal, errors.New("directive hasTenant is not implemented")
+			}
+			return ec.directives.HasTenant(ctx, obj, directive1)
+		}
+
+		tmp, err := directive2(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.([]string); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be []string`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Opportunity_taskIds(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Opportunity",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Opportunity_id(ctx context.Context, field graphql.CollectedField, obj *model.Opportunity) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Opportunity_id(ctx, field)
 	if err != nil {
@@ -84629,6 +84723,8 @@ func (ec *executionContext) fieldContext_OpportunityPage_content(_ context.Conte
 				return ec.fieldContext_Opportunity_owner(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_Opportunity_externalLinks(ctx, field)
+			case "taskIds":
+				return ec.fieldContext_Opportunity_taskIds(ctx, field)
 			case "id":
 				return ec.fieldContext_Opportunity_id(ctx, field)
 			case "createdAt":
@@ -85343,6 +85439,8 @@ func (ec *executionContext) fieldContext_Organization_opportunities(_ context.Co
 				return ec.fieldContext_Opportunity_owner(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_Opportunity_externalLinks(ctx, field)
+			case "taskIds":
+				return ec.fieldContext_Opportunity_taskIds(ctx, field)
 			case "id":
 				return ec.fieldContext_Opportunity_id(ctx, field)
 			case "createdAt":
@@ -98791,6 +98889,8 @@ func (ec *executionContext) fieldContext_Query_opportunity(ctx context.Context, 
 				return ec.fieldContext_Opportunity_owner(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_Opportunity_externalLinks(ctx, field)
+			case "taskIds":
+				return ec.fieldContext_Opportunity_taskIds(ctx, field)
 			case "id":
 				return ec.fieldContext_Opportunity_id(ctx, field)
 			case "createdAt":
@@ -103593,6 +103693,8 @@ func (ec *executionContext) fieldContext_RenewalRecord_opportunity(_ context.Con
 				return ec.fieldContext_Opportunity_owner(ctx, field)
 			case "externalLinks":
 				return ec.fieldContext_Opportunity_externalLinks(ctx, field)
+			case "taskIds":
+				return ec.fieldContext_Opportunity_taskIds(ctx, field)
 			case "id":
 				return ec.fieldContext_Opportunity_id(ctx, field)
 			case "createdAt":
@@ -131727,6 +131829,42 @@ func (ec *executionContext) _Opportunity(ctx context.Context, sel ast.SelectionS
 					}
 				}()
 				res = ec._Opportunity_externalLinks(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "taskIds":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Opportunity_taskIds(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -1985,6 +1985,7 @@ type Opportunity struct {
 	CreatedBy              *User                        `json:"createdBy,omitempty"`
 	Owner                  *User                        `json:"owner,omitempty"`
 	ExternalLinks          []*ExternalSystem            `json:"externalLinks"`
+	TaskIds                []string                     `json:"taskIds"`
 	// Deprecated, use metadata
 	ID string `json:"id"`
 	// Deprecated, use metadata

--- a/packages/server/customer-os-api/graphql/resolver/opportunity.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/opportunity.resolvers.go
@@ -6,7 +6,6 @@ package resolver
 
 import (
 	"context"
-
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
 	"github.com/customeros/customeros/packages/server/customer-os-api/dataloader"
@@ -174,6 +173,24 @@ func (r *opportunityResolver) ExternalLinks(ctx context.Context, obj *model.Oppo
 		return nil, nil
 	}
 	return mapper.MapEntitiesToExternalSystems(entities), nil
+}
+
+// TaskIds is the resolver for the taskIds field.
+func (r *opportunityResolver) TaskIds(ctx context.Context, obj *model.Opportunity) ([]string, error) {
+	ctx = tracing.EnrichCtxWithSpanCtxForGraphQL(ctx, graphql.GetOperationContext(ctx))
+
+	entities, err := dataloader.For(ctx).GetTasksForOpportunity(ctx, obj.Metadata.ID)
+	if err != nil {
+		tracing.TraceErr(opentracing.SpanFromContext(ctx), err)
+		r.log.Errorf("Failed to get tasks for opportunity %s: %s", obj.Metadata.ID, err.Error())
+		graphql.AddErrorf(ctx, "Failed to get tasks for opportunity %s", obj.Metadata.ID)
+		return nil, nil
+	}
+	var taskIds []string
+	for _, entity := range *entities {
+		taskIds = append(taskIds, entity.Id)
+	}
+	return taskIds, nil
 }
 
 // Opportunity is the resolver for the opportunity field.

--- a/packages/server/customer-os-api/graphql/schemas/opportunity.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/opportunity.graphqls
@@ -36,6 +36,7 @@ type Opportunity implements MetadataInterface {
     createdBy:          User @goField(forceResolver: true) @hasRole(roles: [ADMIN, USER]) @hasTenant
     owner:              User @goField(forceResolver: true) @hasRole(roles: [ADMIN, USER]) @hasTenant
     externalLinks:      [ExternalSystem!]! @goField(forceResolver: true) @hasRole(roles: [ADMIN, USER]) @hasTenant
+    taskIds:            [ID!]! @goField(forceResolver: true) @hasRole(roles: [ADMIN, USER]) @hasTenant
 
     """
     Deprecated, use metadata

--- a/packages/server/customer-os-common-module/interfaces/task.go
+++ b/packages/server/customer-os-common-module/interfaces/task.go
@@ -14,4 +14,5 @@ type TaskService interface {
 	Save(ctx context.Context, txWithPostCommit *utils.TxWithPostCommit, id *string, taskFields data_fields.TaskFields) (string, error)
 	GetById(ctx context.Context, id string) (*neo4jentity.TaskEntity, error)
 	GetAllByIds(ctx context.Context, ids []string) (*neo4jentity.TaskEntities, error)
+	GetTasksForOpportunities(ctx context.Context, opportunityIds []string) (*neo4jentity.TaskEntities, error)
 }

--- a/packages/server/customer-os-common-module/services/task/service.go
+++ b/packages/server/customer-os-common-module/services/task/service.go
@@ -224,3 +224,25 @@ func (s *taskService) GetAllByIds(ctx context.Context, ids []string) (*neo4jenti
 	}
 	return &taskEntities, nil
 }
+
+func (s *taskService) GetTasksForOpportunities(ctx context.Context, opportunityIds []string) (*neo4jentity.TaskEntities, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskService.GetTasksForOpportunities")
+	defer span.Finish()
+	tracing.SetDefaultServiceSpanTags(ctx, span)
+
+	tenant := common.GetTenantFromContext(ctx)
+
+	tasks, err := s.neo4j.TaskReadRepository.GetTasksForOpportunities(ctx, tenant, opportunityIds)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+
+	var taskEntities neo4jentity.TaskEntities
+	for _, v := range tasks {
+		taskEntity := neo4jmapper.MapDbNodeToTaskEntity(v.Node)
+		taskEntity.DataloaderKey = v.LinkedNodeId
+		taskEntities = append(taskEntities, *taskEntity)
+	}
+	return &taskEntities, nil
+}

--- a/packages/server/customer-os-neo4j-repository/repository/social_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/social_read_repository.go
@@ -3,11 +3,11 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 )
@@ -220,6 +220,7 @@ func (r *socialReadRepository) GetAllLinkedinForEntities(ctx context.Context, te
 		}
 	})
 	if err != nil {
+		tracing.TraceErr(span, err)
 		return nil, err
 	}
 	dbNodeAndIds := result.([]*utils.DbNodeAndId)

--- a/packages/server/customer-os-neo4j-repository/repository/task_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/task_read_repository.go
@@ -33,6 +33,7 @@ type TaskReadRepository interface {
 	GetAllByIds(ctx context.Context, tenant string, ids []string) ([]*dbtype.Node, error)
 	CountByTenant(ctx context.Context, tenant string) (int64, error)
 	SearchTasks(ctx context.Context, tenant string, limit int, where *model.Filter, sort *model.SortBy) (*utils.StringsWithTotalCount, error)
+	GetTasksForOpportunities(ctx context.Context, tenant string, opportunityIds []string) ([]*utils.DbNodeAndId, error)
 }
 
 type taskReadRepository struct {
@@ -469,4 +470,40 @@ func createTimeFilter(filter *model.Filter, cypherFilter *utils.CypherFilter, ne
 	} else if filter.Filter.Operation == model.ComparisonOperatorLt && filter.Filter.Value.Time != nil {
 		cypherFilter.Filters = append(cypherFilter.Filters, utils.CreateCypherFilter(neo4jProperty, *filter.Filter.Value.Time, model.ComparisonOperatorLt))
 	}
+}
+
+func (r *taskReadRepository) GetTasksForOpportunities(ctx context.Context, tenant string, opportunityIds []string) ([]*utils.DbNodeAndId, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskReadRepository.GetTasksForOpportunities")
+	defer span.Finish()
+	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	tracing.LogObjectAsJson(span, "opportunityIds", opportunityIds)
+
+	cypher := `MATCH (:Tenant {name:$tenant})<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task)-[:LINKED_TO]->(opp:Opportunity)
+				WHERE opp.id IN $opportunityIds
+				RETURN tsk, opp.id`
+	params := map[string]any{
+		"tenant":         tenant,
+		"opportunityIds": opportunityIds,
+	}
+
+	span.LogFields(log.String("cypher", cypher))
+	tracing.LogObjectAsJson(span, "params", params)
+
+	session := utils.NewNeo4jReadSession(ctx, *r.driver)
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
+			return nil, err
+		} else {
+			return utils.ExtractAllRecordsAsDbNodeAndId(ctx, queryResult, err)
+		}
+	})
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+	dbNodeAndIds := result.([]*utils.DbNodeAndId)
+	span.LogFields(log.Int("result.count", len(dbNodeAndIds)))
+	return dbNodeAndIds, err
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add functionality to fetch tasks associated with opportunities, including GraphQL schema updates and Neo4j queries.
> 
>   - **Behavior**:
>     - Add `TasksForOpportunity` loader in `dataloader.go` to fetch tasks linked to opportunities.
>     - Implement `GetTasksForOpportunity` in `task_dataloader.go` to retrieve tasks using opportunity ID.
>     - Add `taskIds` field to `Opportunity` type in `opportunity.graphqls`.
>     - Implement `TaskIds` resolver in `opportunity.resolvers.go` to resolve `taskIds` for an opportunity.
>   - **Services**:
>     - Add `GetTasksForOpportunities` method to `TaskService` in `task.go` and implement in `service.go`.
>   - **Repositories**:
>     - Add `GetTasksForOpportunities` method to `TaskReadRepository` in `task_read_repository.go` to query tasks linked to opportunities in Neo4j.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 18c4ef732d60b1578aedc70bf960df4bf70ef525. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->