### PR TITLE
Improve Hyperbrowser session management in Browser class

### DIFF
--- a/packages/server/browser-automation-api/src/infrastructure/scraper/browser.ts
+++ b/packages/server/browser-automation-api/src/infrastructure/scraper/browser.ts
@@ -25,6 +25,7 @@ const hyperbrowser = new Hyperbrowser({
 export class Browser {
   private static instances: Map<string, Browser>;
   public browser: BrowserType | null = null;
+  private hyperbrowserSessionId: string | null = null;
 
   constructor(private debug?: boolean, private debugRemote?: boolean) {}
 
@@ -82,6 +83,8 @@ export class Browser {
               useStealth: true,
               ...proxyConfig,
             });
+
+            this.hyperbrowserSessionId = session.id;
 
             if (!session.wsEndpoint) {
               throw new StandardError({
@@ -148,6 +151,11 @@ export class Browser {
     if (this.browser) {
       await this.browser.close();
       this.browser = null;
+    }
+
+    if (this.hyperbrowserSessionId) {
+      await hyperbrowser.sessions.stop(this.hyperbrowserSessionId);
+      this.hyperbrowserSessionId = null;
     }
   }
 


### PR DESCRIPTION
- Add hyperbrowserSessionId tracking
- Ensure Hyperbrowser sessions are properly stopped when closing browser
- Store and clean up session ID during browser lifecycle
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve Hyperbrowser session management in `Browser` class by tracking and stopping sessions properly.
> 
>   - **Session Management**:
>     - Add `hyperbrowserSessionId` to track session ID in `Browser` class.
>     - Ensure Hyperbrowser sessions are stopped in `close()` method.
>     - Store session ID during browser initialization in `init()` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 007d9105c66104658005caede0b308e3c1636fba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->