### PR TITLE
set domain on identified web session

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
@@ -2,6 +2,7 @@ package agent_capability
 
 import (
 	"context"
+	"time"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
@@ -15,6 +16,11 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/events"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+)
+
+const (
+	IPHistoryTTL = 30 * 24 * time.Hour
 )
 
 type IdentifyWebsiteVisitorCapability struct {
@@ -110,14 +116,14 @@ func (c *IdentifyWebsiteVisitorCapability) Execute(ctx context.Context, executio
 	}
 
 	// Get web session
-	websession, err := c.getWebSession(ctx, executionContainer.InputData.WebSessionID)
+	webSession, err := c.getWebSession(ctx, executionContainer.InputData.WebSessionID)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return enum.CapabilityExecutionError, result, err
 	}
 
 	// Check if identity already set
-	identityStatus, err := c.processExistingIdentity(ctx, websession, executionContainer.AgentExecutionID, &result)
+	identityStatus, err := c.processExistingIdentity(ctx, webSession, executionContainer.AgentExecutionID, &result)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return enum.CapabilityExecutionError, result, err
@@ -129,7 +135,7 @@ func (c *IdentifyWebsiteVisitorCapability) Execute(ctx context.Context, executio
 	}
 
 	// Check if we have identifiable information from other sessions with the same IP
-	identityFromIPStatus, err := c.tryIdentifyFromIPHistory(ctx, websession, executionContainer.AgentExecutionID, &result)
+	identityFromIPStatus, err := c.tryIdentifyFromIPHistory(ctx, webSession, executionContainer.AgentExecutionID, &result)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return enum.CapabilityExecutionError, result, err
@@ -142,7 +148,7 @@ func (c *IdentifyWebsiteVisitorCapability) Execute(ctx context.Context, executio
 	}
 
 	// Attempt to identify using third-party enrichment services
-	status, output, err := c.tryIdentifyFromEnrichment(ctx, websession, executionContainer.AgentExecutionID, &result)
+	status, output, err := c.tryIdentifyFromEnrichment(ctx, webSession, executionContainer.AgentExecutionID, &result)
 	tracing.LogObjectAsJson(span, "result", output)
 	return status, output, err
 }
@@ -245,11 +251,21 @@ func (c *IdentifyWebsiteVisitorCapability) tryIdentifyFromIPHistory(
 	if identifiedSession == nil || identifiedSession.Domain == nil || *identifiedSession.Domain == "" {
 		return nil, nil
 	}
+	// If identified session is older that TTL, continue with processing
+	if time.Since(identifiedSession.LastActivity) > IPHistoryTTL {
+		return nil, nil
+	}
 
 	// Identified from IP history
-	result.Domain = *identifiedSession.Domain
-	if identifiedSession.Email != nil && *identifiedSession.Email != "" {
-		result.EmailAddress = *identifiedSession.Email
+	result.Domain = utils.IfNotNilString(identifiedSession.Domain)
+	if utils.IfNotNilString(identifiedSession.Email) != "" {
+		result.EmailAddress = utils.IfNotNilString(identifiedSession.Email)
+	}
+
+	// update current session with identified domain
+	err = c.postgresRepositories.WebSessionRepository.SetVisitorIdentity(ctx, websession.ID, identifiedSession.Domain, nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to set visitor identity")
 	}
 
 	err = c.publishWebVisitorIdentifiedEvent(ctx, agentExecutionID)

--- a/packages/server/customer-os-postgres-repository/repository/websession_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/websession_repository.go
@@ -146,7 +146,7 @@ func (r *webSessionRepository) FindLastNotification(ctx context.Context, tenant,
 func (r *webSessionRepository) FindLatestSessionWithDomainByIP(ctx context.Context, ipAddress string) (*postgres_entity.WebSession, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.FindLatestSessionWithDomainByIP")
 	defer span.Finish()
-	tracing.TagComponentPostgresRepository(span)
+	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
 
 	// Build the query with IP and ensure domain is not null
 	query := r.gormDb.Where("ip = ?", ipAddress).
@@ -158,12 +158,15 @@ func (r *webSessionRepository) FindLatestSessionWithDomainByIP(ctx context.Conte
 	err := query.First(&result).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
+			span.LogFields(log.Bool("result.found", false))
 			return nil, nil
 		}
 		tracing.TraceErr(span, err)
 		return nil, err
 	}
 
+	span.LogFields(log.String("result.sessionId", result.ID))
+	span.LogFields(log.String("result.domain", *result.Domain))
 	return &result, nil
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance web visitor identification by setting domain on identified sessions and updating repository methods for logging and conditional updates.
> 
>   - **Behavior**:
>     - Set domain on identified web sessions in `tryIdentifyFromIPHistory()` and `tryIdentifyFromEnrichment()` in `capability_identify_web_visitor.go`.
>     - Update current session with identified domain using `SetVisitorIdentity()`.
>   - **Repository**:
>     - Modify `FindLatestSessionWithDomainByIP()` in `websession_repository.go` to log session ID and domain.
>     - Update `SetVisitorIdentity()` to conditionally update domain and email fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for e2f2db92978d403a5afad3ebc7914453c1035057. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->