### PR TITLE
rework better contact find work email

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/global_contact_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/global_contact_service.go
@@ -15,7 +15,8 @@ import (
 	commonconstants "github.com/customeros/customeros/packages/server/customer-os-common-module/constants"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	commonService "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
+	commonservice "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
+	service_verify "github.com/customeros/customeros/packages/server/customer-os-common-module/services/verify"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgresentity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -32,10 +33,10 @@ type GlobalContactService interface {
 type globalContactService struct {
 	cfg            *config.Config
 	log            logger.Logger
-	commonServices *commonService.CommonServices
+	commonServices *commonservice.CommonServices
 }
 
-func NewGlobalContactService(cfg *config.Config, log logger.Logger, commonServices *commonService.CommonServices) GlobalContactService {
+func NewGlobalContactService(cfg *config.Config, log logger.Logger, commonServices *commonservice.CommonServices) GlobalContactService {
 	return &globalContactService{
 		cfg:            cfg,
 		log:            log,
@@ -238,12 +239,13 @@ func (s *globalContactService) sendRequestToBetterContact() {
 	// Better contact is limited to 60 requests per minute
 	// https://bettercontact.notion.site/Documentation-API-e8e1b352a0d647ee9ff898609bf1a168
 	limit := 40
+	retryAfterDays := 30
 
 	span, ctx := tracing.StartTracerSpan(ctx, "GlobalContactService.sendRequestToBetterContact")
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
 
-	records, err := s.commonServices.PostgresRepositories.GlobalContactRepository.GetContactsToFindWorkEmailWithBetterContact(ctx, limit)
+	records, err := s.commonServices.PostgresRepositories.GlobalContactRepository.GetContactsToFindWorkEmailWithBetterContact(ctx, retryAfterDays, limit)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return
@@ -334,8 +336,35 @@ func (s *globalContactService) processBetterContactResponses() {
 				tracing.TraceErr(innerSpan, err)
 			}
 
-			if betterContactResponse.Data[0].ContactEmailAddress != "" {
-				err = s.commonServices.GlobalContactService.SetWorkEmail(innerCtx, globalContact.ID, betterContactResponse.Data[0].ContactEmailAddress)
+			workEmail := betterContactResponse.Data[0].ContactEmailAddress
+			if workEmail != "" {
+				innerSpan.LogFields(log.String("bettercontact.email", workEmail))
+
+				// validate email with mailsherpa
+				emailValidation, err := s.commonServices.VerifyService.ValidateEmail(innerCtx, workEmail)
+				if err != nil {
+					tracing.TraceErr(innerSpan, err)
+				}
+				if emailValidation == nil {
+					err = errors.New("mailsherpa validation returned nil")
+					tracing.TraceErr(innerSpan, err)
+					return
+				}
+
+				if !emailValidation.Syntax.IsValid {
+					err = errors.New("invalid email syntax: " + workEmail)
+					tracing.TraceErr(innerSpan, err)
+					span.LogFields(log.String("result", "invalid email syntax"))
+					return
+				}
+				if emailValidation.EmailData.Deliverable == string(service_verify.EmailDeliverableStatusUndeliverable) {
+					err = errors.New("email undeliverable: " + workEmail)
+					tracing.TraceErr(innerSpan, err)
+					span.LogFields(log.String("result", "email undeliverable"))
+					return
+				}
+
+				err = s.commonServices.GlobalContactService.SetWorkEmail(innerCtx, globalContact.ID, workEmail)
 				if err != nil {
 					tracing.TraceErr(innerSpan, err)
 				}

--- a/packages/server/customer-os-common-module/services/enrichment/bettercontact.go
+++ b/packages/server/customer-os-common-module/services/enrichment/bettercontact.go
@@ -21,7 +21,9 @@ import (
 )
 
 const (
-	BetterContactTTL = 180 * 24 * time.Hour
+	// better contact cached results set to 29 days,
+	// this is to avoid the cache from being used 30 days retry
+	BetterContactTTL = 29 * 24 * time.Hour
 )
 
 type BetterContactResponseBody struct {

--- a/packages/server/customer-os-postgres-repository/repository/global_contact_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/global_contact_repository.go
@@ -30,7 +30,7 @@ type GlobalContactRepository interface {
 	GetContactsToFetchPhoto(ctx context.Context, limit int) ([]*postgres_entity.GlobalContact, error)
 	SetProfilePhoto(ctx context.Context, id uint64, photoPath string) error
 	SetDownloadStatus(ctx context.Context, id uint64, status enum.DownloadStatus) error
-	GetContactsToFindWorkEmailWithBetterContact(ctx context.Context, limit int) ([]*postgres_entity.GlobalContact, error)
+	GetContactsToFindWorkEmailWithBetterContact(ctx context.Context, retryAfterDays int, limit int) ([]*postgres_entity.GlobalContact, error)
 	MarkBetterContactRequested(ctx context.Context, id uint64, betterContactRequestId string) error
 	GetContactsToSetWorkEmailFromBetterContactResponse(ctx context.Context, limit int) ([]*postgres_entity.GlobalContact, error)
 	MarkBetterContactSet(ctx context.Context, id uint64) error
@@ -339,17 +339,19 @@ func (r *globalContactRepository) SetDownloadStatus(ctx context.Context, id uint
 	return nil
 }
 
-func (r *globalContactRepository) GetContactsToFindWorkEmailWithBetterContact(ctx context.Context, limit int) ([]*postgres_entity.GlobalContact, error) {
+func (r *globalContactRepository) GetContactsToFindWorkEmailWithBetterContact(ctx context.Context, retryAfterDays, limit int) ([]*postgres_entity.GlobalContact, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalContactRepository.GetContactsToFindWorkEmailWithBetterContact")
 	defer span.Finish()
-	tracing.TagComponentPostgresRepository(span)
+	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	span.LogFields(tracingLog.Int("retryAfterDays", retryAfterDays), tracingLog.Int("limit", limit))
 
 	contacts := make([]*postgres_entity.GlobalContact, 0)
 	result := r.db.WithContext(ctx).
 		Where("work_email IS NULL OR work_email = ''").
 		Where("primary_domain IS NOT NULL AND primary_domain != ''").
 		Where("linked_in_identifier IS NOT NULL AND linked_in_identifier != ''").
-		Where("bettercontact_request_id = ''").
+		Where("job_ended_at IS NULL").
+		Where("bettercontact_requested_at IS NULL OR bettercontact_requested_at < ?", utils.Now().Add(-time.Duration(retryAfterDays)*24*time.Hour)).
 		Order("bettercontact_requested_at IS NULL DESC, COALESCE(bettercontact_requested_at, created_at) ASC").
 		Limit(limit).
 		Find(&contacts)
@@ -371,7 +373,9 @@ func (r *globalContactRepository) MarkBetterContactRequested(ctx context.Context
 	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalContact{}).
 		Where("id = ?", id).
 		UpdateColumn("bettercontact_requested_at", utils.Now()).
-		UpdateColumn("bettercontact_request_id", betterContactRequestId)
+		UpdateColumn("bettercontact_request_id", betterContactRequestId).
+		UpdateColumn("bettercontact_set_at", nil).
+		UpdateColumn("bettercontact_check_response_at", nil)
 
 	if result.Error != nil {
 		tracing.TraceErr(span, result.Error)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhanced BetterContact integration for work email retrieval with improved retry logic and email validation.
> 
>   - **Behavior**:
>     - Updated `sendRequestToBetterContact()` in `global_contact_service.go` to include `retryAfterDays` parameter for `GetContactsToFindWorkEmailWithBetterContact()`.
>     - Added email validation logic using `mailsherpa` in `processBetterContactResponses()` in `global_contact_service.go`.
>     - Adjusted `BetterContactTTL` to 29 days in `bettercontact.go` to avoid cache usage on 30-day retries.
>   - **Repository**:
>     - Modified `GetContactsToFindWorkEmailWithBetterContact()` in `global_contact_repository.go` to include `retryAfterDays` parameter and additional filtering conditions.
>     - Updated `MarkBetterContactRequested()` in `global_contact_repository.go` to reset `bettercontact_set_at` and `bettercontact_check_response_at`.
>   - **Misc**:
>     - Renamed `commonService` to `commonservice` in `global_contact_service.go` and `bettercontact.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 4483f1c4ff1681839e00732643ab2e22aa742a48. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->