### PR TITLE
ad groq tracing

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_event_producers/new_web_session_producer.go
+++ b/packages/server/customer-os-common-module/services/agent_event_producers/new_web_session_producer.go
@@ -228,9 +228,10 @@ type IdentifiedVisitor struct {
 }
 
 func (s *NewWebSessionProducer) processPageView(ctx context.Context, sessionId, page string, endTime time.Time) (IdentifiedVisitor, error) {
-	span, ctx := tracing.StartTracerSpan(ctx, "NewWebSessionProducer.processPageView")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "NewWebSessionProducer.processPageView")
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
+	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
 
 	visitor := IdentifiedVisitor{}
 

--- a/packages/server/customer-os-common-module/services/ai/groq_client.go
+++ b/packages/server/customer-os-common-module/services/ai/groq_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/opentracing/opentracing-go/log"
 	"io"
 	"net/http"
 	"time"
@@ -176,6 +177,8 @@ func (c *GroqClient) handleSuccessResponse(ctx context.Context, body []byte) (st
 func (c *GroqClient) handleErrorResponse(ctx context.Context, statusCode int, body []byte) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "GroqClient.handleErrorResponse")
 	defer span.Finish()
+	span.LogFields(log.Int("statusCode", statusCode))
+	span.LogFields(log.String("body", string(body)))
 
 	var errorResponse ErrorResponse
 	if err := json.Unmarshal(body, &errorResponse); err != nil {
@@ -183,6 +186,8 @@ func (c *GroqClient) handleErrorResponse(ctx context.Context, statusCode int, bo
 		tracing.TraceErr(span, err)
 		return err
 	}
+	span.LogFields(log.String("result.errorType", errorResponse.Error.Type))
+	span.LogFields(log.String("result.errorMessage", errorResponse.Error.Message))
 	return fmt.Errorf("%s: %s", errorResponse.Error.Type, errorResponse.Error.Message)
 }
 

--- a/packages/server/customer-os-common-module/services/ai/service.go
+++ b/packages/server/customer-os-common-module/services/ai/service.go
@@ -146,6 +146,7 @@ func (s *aiService) validateAIRequest(ctx context.Context, request *interfaces.A
 func (s *aiService) askAIWithRetry(ctx context.Context, request interfaces.AskAIRequest) (*string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "AIService.askAIWithRetry")
 	defer span.Finish()
+	tracing.LogObjectAsJson(span, "requestParams", request)
 
 	llmTracker := s.newObservabilityContainer(ctx, span, request)
 
@@ -480,6 +481,7 @@ func (s *aiService) askGroq(ctx context.Context, request interfaces.AskAIRequest
 
 	if response == "" {
 		err = s.NewRetryableError("Empty response from Groq", nil)
+		tracing.TraceErr(span, err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-common-module/services/webscraper/classify_topics.go
+++ b/packages/server/customer-os-common-module/services/webscraper/classify_topics.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (s *webscraperService) ClassifyWebpageTopics(ctx context.Context, url string, pageContent *string) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "webscraperService.ClassifyWebpageTopics")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebscraperService.ClassifyWebpageTopics")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance tracing and error logging in `GroqClient`, `AIService`, `NewWebSessionProducer`, and `WebscraperService`.
> 
>   - **Tracing Enhancements**:
>     - In `new_web_session_producer.go`, replace `tracing.StartTracerSpan` with `opentracing.StartSpanFromContext` in `processPageView()`.
>     - In `groq_client.go`, add logging of `statusCode` and `body` in `handleErrorResponse()`.
>     - In `service.go`, log `requestParams` in `askAIWithRetry()`.
>     - In `classify_topics.go`, rename span name to `WebscraperService.ClassifyWebpageTopics` in `ClassifyWebpageTopics()`.
>   - **Error Handling**:
>     - In `groq_client.go`, log `result.errorType` and `result.errorMessage` in `handleErrorResponse()`.
>     - In `service.go`, trace errors in `askGroq()` when response is empty.
>   - **Miscellaneous**:
>     - Add `tracing.TagTenant` in `processPageView()` in `new_web_session_producer.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 88f50bdb2147113a19e1eb3275e21d688909e3d5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->