### PR TITLE
Handle clicks in reveal website events

### DIFF
--- a/packages/server/customer-os-api/rest/public/reveal_website_events.go
+++ b/packages/server/customer-os-api/rest/public/reveal_website_events.go
@@ -75,6 +75,13 @@ func (h *WebsiteTrackerEventsHandler) Handle() gin.HandlerFunc {
 			return
 		}
 
+		// check if the event type is known
+		if !enum.IsValidWebTrackerEvent(trackerData.EventType) {
+			err = fmt.Errorf("unsupported web-tracker event type: %s", trackerData.EventType)
+			tracing.TraceErr(span, err)
+			return
+		}
+
 		if err := h.assignEventToSession(ctx, trackerData); err != nil {
 			tracing.TraceErr(span, err)
 			return

--- a/packages/server/customer-os-api/rest/public/reveal_website_events.go
+++ b/packages/server/customer-os-api/rest/public/reveal_website_events.go
@@ -212,7 +212,7 @@ func (h *WebsiteTrackerEventsHandler) assignEventToSession(ctx context.Context, 
 		return err
 	}
 
-	if session == nil && trackerData.EventType == enum.WebTrackerPageView.String() {
+	if session == nil && (trackerData.EventType == enum.WebTrackerPageView.String() || trackerData.EventType == enum.WebTrackerClick.String()) {
 		session, err = h.createWebSession(ctx, trackerData)
 		if err != nil {
 			tracing.TraceErr(span, err)

--- a/packages/server/customer-os-api/rest/public/reveal_website_events.go
+++ b/packages/server/customer-os-api/rest/public/reveal_website_events.go
@@ -83,7 +83,9 @@ func (h *WebsiteTrackerEventsHandler) Handle() gin.HandlerFunc {
 		}
 
 		if err := h.assignEventToSession(ctx, trackerData); err != nil {
-			tracing.TraceErr(span, err)
+			if trackerData.EventType != enum.WebTrackerPageExit.String() {
+				tracing.TraceErr(span, err)
+			}
 			return
 		}
 
@@ -229,7 +231,9 @@ func (h *WebsiteTrackerEventsHandler) assignEventToSession(ctx context.Context, 
 
 	if session == nil {
 		err = errors.New("session not found and not created")
-		tracing.TraceErr(span, err)
+		if trackerData.EventType != enum.WebTrackerPageExit.String() {
+			tracing.TraceErr(span, err)
+		}
 		return err
 	}
 

--- a/packages/server/customer-os-common-module/enum/webtracker_types.go
+++ b/packages/server/customer-os-common-module/enum/webtracker_types.go
@@ -11,3 +11,15 @@ const (
 func (w WebTrackerEvent) String() string {
 	return string(w)
 }
+
+func IsValidWebTrackerEvent(event string) bool {
+	switch event {
+	case WebTrackerPageExit.String():
+		return true
+	case WebTrackerPageView.String():
+		return true
+	case WebTrackerClick.String():
+		return true
+	}
+	return false
+}

--- a/packages/server/customer-os-common-module/enum/webtracker_types.go
+++ b/packages/server/customer-os-common-module/enum/webtracker_types.go
@@ -5,6 +5,7 @@ type WebTrackerEvent string
 const (
 	WebTrackerPageExit WebTrackerEvent = "page_exit"
 	WebTrackerPageView WebTrackerEvent = "page_view"
+	WebTrackerClick    WebTrackerEvent = "click"
 )
 
 func (w WebTrackerEvent) String() string {

--- a/packages/server/customer-os-common-module/services/agent_event_producers/new_web_session_producer.go
+++ b/packages/server/customer-os-common-module/services/agent_event_producers/new_web_session_producer.go
@@ -3,10 +3,11 @@ package agent_producers
 import (
 	"context"
 	"fmt"
-	"github.com/opentracing/opentracing-go/log"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/opentracing/opentracing-go/log"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
@@ -47,6 +48,7 @@ func NewNewWebSessionProducer(
 const (
 	WebSessionTimeoutPageExit int = 5  // mins -- page exit without a following page view
 	WebSessionTimeoutPageView int = 30 // mins -- page view without a page exit
+	WebSessionTimeoutClick    int = 30 // mins -- click without a page exit
 )
 
 // Add all Agent types subscribed to this event here
@@ -95,7 +97,22 @@ func (s *NewWebSessionProducer) Execute() {
 			return
 		}
 	}
-	return
+
+	// find timed out click events
+	clickSessions, err := s.findTimedOutClickEvents(ctx)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return
+	}
+
+	// close sessions & fire webtracker event
+	if clickSessions != nil {
+		err = s.closeSessions(ctx, clickSessions)
+		if err != nil {
+			tracing.TraceErr(span, err)
+			return
+		}
+	}
 }
 
 func (s *NewWebSessionProducer) findTimedOutPageExitEvents(ctx context.Context) ([]postgres_entity.WebSession, error) {
@@ -121,7 +138,35 @@ func (s *NewWebSessionProducer) findTimedOutPageViewEvents(ctx context.Context) 
 		LastEventType: enum.WebTrackerPageView.String(),
 		IsActive:      true,
 	}
-	return s.postgresRepositories.WebSessionRepository.FindAllActiveSessions(ctx, query, &lookback)
+	activeSessions, err := s.postgresRepositories.WebSessionRepository.FindAllActiveSessions(ctx, query, &lookback)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+
+	span.LogFields(log.Int("result.count", len(activeSessions)))
+	return activeSessions, nil
+}
+
+func (s *NewWebSessionProducer) findTimedOutClickEvents(ctx context.Context) ([]postgres_entity.WebSession, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "NewWebSessionProducer.findTimedOutClickEvents")
+	defer span.Finish()
+	tracing.TagComponentCronJob(span)
+
+	lookback := WebSessionTimeoutClick
+	query := postgres_entity.WebSession{
+		LastEventType: enum.WebTrackerClick.String(),
+		IsActive:      true,
+	}
+
+	activeSessions, err := s.postgresRepositories.WebSessionRepository.FindAllActiveSessions(ctx, query, &lookback)
+	if err != nil {
+		tracing.TraceErr(span, err)
+		return nil, err
+	}
+
+	span.LogFields(log.Int("result.count", len(activeSessions)))
+	return activeSessions, nil
 }
 
 func (s *NewWebSessionProducer) closeSessions(ctx context.Context, sessions []postgres_entity.WebSession) error {
@@ -129,7 +174,7 @@ func (s *NewWebSessionProducer) closeSessions(ctx context.Context, sessions []po
 	defer span.Finish()
 	tracing.TagComponentCronJob(span)
 
-	if sessions == nil || len(sessions) == 0 {
+	if len(sessions) == 0 {
 		span.LogKV("result", "no_sessions_to_process")
 		return nil
 	}

--- a/packages/server/customer-os-postgres-repository/repository/websession_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/websession_repository.go
@@ -57,7 +57,7 @@ func (r *webSessionRepository) Create(ctx context.Context, webSessionData postgr
 func (r *webSessionRepository) FindAllActiveSessions(ctx context.Context, webSessionData postgres_entity.WebSession, sessionTimeoutInMins *int) ([]postgres_entity.WebSession, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.FindAll")
 	defer span.Finish()
-	tracing.TagComponentPostgresRepository(span)
+	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
 
 	// Start with a base query
 	query := r.gormDb.Model(&postgres_entity.WebSession{})
@@ -68,6 +68,9 @@ func (r *webSessionRepository) FindAllActiveSessions(ctx context.Context, webSes
 	}
 	if webSessionData.Domain != nil {
 		query = query.Where("domain = ?", *webSessionData.Domain)
+	}
+	if webSessionData.LastEventType != "" {
+		query = query.Where("last_event_type = ?", webSessionData.LastEventType)
 	}
 
 	// Explicitly add the is_active condition
@@ -90,15 +93,17 @@ func (r *webSessionRepository) FindAllActiveSessions(ctx context.Context, webSes
 }
 
 func (r *webSessionRepository) FindSession(ctx context.Context, webSessionData postgres_entity.WebSession, lookbackPeriodInMins *int) (*postgres_entity.WebSession, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.Find")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.FindSession")
 	defer span.Finish()
 	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	tracing.LogObjectAsJson(span, "webSessionData", webSessionData)
+	span.LogFields(log.Int("lookbackPeriodInMins", *lookbackPeriodInMins))
 
 	query := r.gormDb.Where(&webSessionData).Order("last_activity DESC")
 
 	// Add lookback period if provided
 	if lookbackPeriodInMins != nil {
-		lookbackDate := time.Now().Add(-time.Duration(*lookbackPeriodInMins) * time.Minute)
+		lookbackDate := utils.Now().Add(-time.Duration(*lookbackPeriodInMins) * time.Minute)
 		query = query.Where("last_activity > ?", lookbackDate)
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for handling 'click' events in web tracker by updating event validation, session management, and timeout handling.
> 
>   - **Behavior**:
>     - Add support for `click` events in `reveal_website_events.go` by checking event type validity and assigning events to sessions.
>     - Update `assignEventToSession()` to create sessions for `click` events if no session exists.
>     - Handle `click` events in `new_web_session_producer.go` by finding and closing timed-out click sessions.
>   - **Enums**:
>     - Add `WebTrackerClick` to `webtracker_types.go` and update `IsValidWebTrackerEvent()` to include `click`.
>   - **Repository**:
>     - Update `FindAllActiveSessions()` in `websession_repository.go` to filter by `last_event_type` for `click` events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for e03d25bab71b53e9b1e6ac92a30127736bc5cd6e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->