### PR TITLE
Add TasksChannel and Release module for DB tasks

### DIFF
--- a/packages/server/realtime/lib/realtime/release.ex
+++ b/packages/server/realtime/lib/realtime/release.ex
@@ -1,0 +1,28 @@
+defmodule Realtime.Release do
+  @moduledoc """
+  Used for executing DB release tasks when run in production without Mix
+  installed.
+  """
+  @app :realtime
+
+  def migrate do
+    load_app()
+
+    for repo <- repos() do
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+    end
+  end
+
+  def rollback(repo, version) do
+    load_app()
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+  end
+
+  defp repos do
+    Application.fetch_env!(@app, :ecto_repos)
+  end
+
+  defp load_app do
+    Application.load(@app)
+  end
+end

--- a/packages/server/realtime/lib/realtime_web/channels/tasks_channel.ex
+++ b/packages/server/realtime/lib/realtime_web/channels/tasks_channel.ex
@@ -1,0 +1,6 @@
+defmodule RealtimeWeb.TasksChannel do
+  @moduledoc """
+  This Channel broadcasts sync events to all Tasks entity subscribers.
+  """
+  use RealtimeWeb.EntitiesChannelMacro, "Tasks"
+end

--- a/packages/server/realtime/lib/realtime_web/channels/user_socket.ex
+++ b/packages/server/realtime/lib/realtime_web/channels/user_socket.ex
@@ -77,6 +77,7 @@ defmodule RealtimeWeb.UserSocket do
   channel "Industries:*", RealtimeWeb.IndustriesChannel
   channel "JobRoles:*", RealtimeWeb.JobRolesChannel
   channel "Document:*", RealtimeWeb.DocumentChannel
+  channel "Tasks:*", RealtimeWeb.TasksChannel
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/packages/server/realtime/rel/overlays/bin/server
+++ b/packages/server/realtime/rel/overlays/bin/server
@@ -2,4 +2,4 @@
 set -eu
 
 cd -P -- "$(dirname -- "$0")"
-./realtime eval Realtime.Release.migrate && PHX_SERVER=true exec ./realtime start
+PHX_SERVER=true exec ./realtime start


### PR DESCRIPTION
Remove migration command from server start script
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `TasksChannel` for sync events and `Release` module for DB tasks, and remove migration command from server start script.
> 
>   - **New Features**:
>     - Add `TasksChannel` in `tasks_channel.ex` for broadcasting sync events to Tasks entity subscribers.
>     - Add `Release` module in `release.ex` for executing DB release tasks without Mix.
>   - **Modifications**:
>     - Register `TasksChannel` in `user_socket.ex` to handle "Tasks:*" channels.
>     - Remove migration command from `server` start script, simplifying startup process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c8048440b05c6cc46a3665ccdcce4158c93ff799. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->