### PR TITLE
Add entrypoint script and update Dockerfile

### DIFF
--- a/packages/server/realtime/Dockerfile
+++ b/packages/server/realtime/Dockerfile
@@ -93,12 +93,10 @@ ENV MIX_ENV="prod"
 
 # Only copy the final release from the build stage
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/realtime ./
+# Copy the entrypoint script
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 USER nobody
 
-# If using an environment that doesn't automatically reap zombie processes, it is
-# advised to add an init process such as tini via `apt-get install`
-# above and adding an entrypoint. See https://github.com/krallin/tini for details
-# ENTRYPOINT ["/tini", "--"]
-
-CMD ["/app/bin/server"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/packages/server/realtime/config/runtime.exs
+++ b/packages/server/realtime/config/runtime.exs
@@ -32,7 +32,7 @@ config :realtime, Realtime.Repo,
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10,
-  ssl: true,
+  ssl: config_env() == :prod,
   ssl_opts: [verify: :verify_none]
 
 config :opentelemetry,

--- a/packages/server/realtime/entrypoint.sh
+++ b/packages/server/realtime/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Run migrations before starting the app
+bin/realtime eval "Realtime.Release.migrate()"
+
+# Start the app
+exec bin/realtime start


### PR DESCRIPTION
- Added entrypoint.sh to handle migrations before starting the app
- Updated Dockerfile to use the new entrypoint script
- Adjusted SSL configuration to only enable in production environment
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `entrypoint.sh` for migrations, update `Dockerfile` to use it, and adjust SSL config for production.
> 
>   - **Entrypoint Script**:
>     - Adds `entrypoint.sh` to run migrations using `Realtime.Release.migrate()` before starting the app.
>   - **Dockerfile**:
>     - Updates `Dockerfile` to copy and use `entrypoint.sh` as the entrypoint.
>     - Removes previous `CMD` and comments related to `tini`.
>   - **Configuration**:
>     - Changes SSL configuration in `runtime.exs` to enable only in production (`ssl: config_env() == :prod`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for fa94068adbcc841b456f5b39e3689001e87dd17e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->