### PR TITLE
use mailstack for domain recommendations

### DIFF
--- a/packages/server/customer-os-api/rest/mailstack/domain.go
+++ b/packages/server/customer-os-api/rest/mailstack/domain.go
@@ -341,10 +341,10 @@ func (h *MailstackHandler) GetDomains() gin.HandlerFunc {
 		if resp.StatusCode != http.StatusOK {
 			// Read error response body
 			var errorResponse struct {
-				Message string `json:"message"`
+				Error string `json:"error"`
 			}
 			if err := json.NewDecoder(resp.Body).Decode(&errorResponse); err != nil {
-				errorResponse.Message = "Unknown error occurred"
+				errorResponse.Error = "Unknown error occurred"
 			}
 
 			// For 500 errors, use a generic message
@@ -356,8 +356,8 @@ func (h *MailstackHandler) GetDomains() gin.HandlerFunc {
 			}
 
 			// For other errors, propagate the status code and message from Mailstack
-			tracing.TraceErr(span, errors.New(errorResponse.Message))
-			h.responseHandler.HandleError(c, resp.StatusCode, &errorResponse.Message)
+			tracing.TraceErr(span, errors.New(errorResponse.Error))
+			h.responseHandler.HandleError(c, resp.StatusCode, &errorResponse.Error)
 			return
 		}
 
@@ -397,8 +397,71 @@ func (h *MailstackHandler) RecommendDomain() gin.HandlerFunc {
 			return
 		}
 
-		// get domain recommendations
-		recommendations := h.services.CommonServices.MailboxService.RecommendOutboundDomains(ctx, baseName, 20)
+		// Create request to Mailstack API
+		req, err := http.NewRequestWithContext(ctx, "GET", h.services.Cfg.Common.Internal.MailstackApiConfig.ApiUrl+"/v1/domains/recommendations?baseName="+baseName, nil)
+		if err != nil {
+			message := "Unable to create request to Mailstack API"
+			tracing.TraceErr(span, errors.Wrap(err, message))
+			h.responseHandler.HandleError(c, http.StatusInternalServerError, &message)
+			return
+		}
+
+		// Add required headers
+		req.Header.Set("X-CUSTOMER-OS-API-KEY", h.services.Cfg.Common.Internal.MailstackApiConfig.ApiKey)
+		req.Header.Set("tenant", tenant)
+
+		// Forward Jaeger trace context
+		carrier := opentracing.HTTPHeadersCarrier(req.Header)
+		err = opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, carrier)
+		if err != nil {
+			span.LogFields(tracingLog.Error(err))
+		}
+
+		// Create HTTP client with default transport
+		client := &http.Client{}
+
+		// Make request to Mailstack API
+		resp, err := client.Do(req)
+		if err != nil {
+			message := "Unable to connect to Mailstack API"
+			tracing.TraceErr(span, errors.Wrap(err, message))
+			h.responseHandler.HandleError(c, http.StatusInternalServerError, &message)
+			return
+		}
+		defer resp.Body.Close()
+
+		// Check response status
+		if resp.StatusCode != http.StatusOK {
+			// Read error response body
+			var errorResponse struct {
+				Error string `json:"error"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&errorResponse); err != nil {
+				errorResponse.Error = "Unknown error occurred"
+			}
+
+			// For 500 errors, use a generic message
+			if resp.StatusCode == http.StatusInternalServerError {
+				message := "Internal server error"
+				tracing.TraceErr(span, errors.New(message))
+				h.responseHandler.HandleError(c, http.StatusInternalServerError, &message)
+				return
+			}
+
+			// For other errors, propagate the status code and message from Mailstack
+			tracing.TraceErr(span, errors.New(errorResponse.Error))
+			h.responseHandler.HandleError(c, resp.StatusCode, &errorResponse.Error)
+			return
+		}
+
+		// Parse response
+		var recommendations []string
+		if err := json.NewDecoder(resp.Body).Decode(&recommendations); err != nil {
+			message := "Unable to parse Mailstack API response"
+			tracing.TraceErr(span, errors.Wrap(err, message))
+			h.responseHandler.HandleError(c, http.StatusInternalServerError, &message)
+			return
+		}
 
 		h.responseHandler.HandleSuccess(c, DomainRecommendationResponse{
 			Domains: recommendations,

--- a/packages/server/customer-os-common-module/services/mailbox/domain_suggestions.go
+++ b/packages/server/customer-os-common-module/services/mailbox/domain_suggestions.go
@@ -45,6 +45,7 @@ func (s *mailboxService) IsDomainAvailable(ctx context.Context, domain string) (
 	return true, true
 }
 
+// TODO delete once not used
 func (s *mailboxService) RecommendOutboundDomains(ctx context.Context, domainRoot string, count int) []string {
 	span, ctx := s.initializeTracing(ctx, "MailboxService.RecommendOutboundDomains")
 	span.LogFields(log.String("domainRoot", domainRoot))

--- a/packages/server/customer-os-common-module/services/namecheap/service.go
+++ b/packages/server/customer-os-common-module/services/namecheap/service.go
@@ -374,7 +374,7 @@ func (s *namecheapService) GetDomainPrice(ctx context.Context, domain string) (f
 	return 0, coserrors.ErrDomainPriceNotFound
 }
 
-// TODO to be rmoved once not used
+// TODO delete once not used
 func (s *namecheapService) GetDomainInfo(ctx context.Context, tenant, domain string) (interfaces.NamecheapDomainInfo, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "NamecheapService.GetDomainInfo")
 	defer span.Finish()

--- a/packages/server/customer-os-postgres-repository/repository/mailstack_domain_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/mailstack_domain_repository.go
@@ -116,7 +116,7 @@ func (r *mailStackDomainRepository) CheckDomainOwnership(ctx context.Context, te
 	return true, nil
 }
 
-// TODO to be rmoved once not used
+// TODO delete once not used
 func (r *mailStackDomainRepository) GetActiveDomains(ctx context.Context, tenant string) ([]postgres_entity.MailStackDomain, error) {
 	span, _ := opentracing.StartSpanFromContext(ctx, "MailStackDomainRepository.GetActiveDomains")
 	defer span.Finish()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Integrate Mailstack API for domain recommendations in `RecommendDomain()` and update error handling in `domain.go`.
> 
>   - **Behavior**:
>     - `RecommendDomain()` in `domain.go` now uses Mailstack API for domain recommendations.
>     - Handles HTTP errors and parses responses from Mailstack API.
>   - **Error Handling**:
>     - Renames `Message` to `Error` in error response handling in `domain.go`.
>   - **Misc**:
>     - Updates TODO comments in `domain_suggestions.go`, `service.go`, and `mailstack_domain_repository.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d88a7a8cfcdae51c52789569e22f7e3b84a53afb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->