### PR TITLE
remove default api url

### DIFF
--- a/packages/server/customer-os-common-module/config/mailstack_api_config.go
+++ b/packages/server/customer-os-common-module/config/mailstack_api_config.go
@@ -1,7 +1,7 @@
 package config
 
 type MailstackApiConfig struct {
-	ApiUrl string `env:"MAILSTACK_API_URL" envDefault:"https://api.mailstack.customeros.ai"`
+	ApiUrl string `env:"MAILSTACK_API_URL"`
 	ApiKey string `env:"MAILSTACK_API_KEY"`
 	// Deprecated, to be removed
 	SupportedTlds []string `env:"MAILSTACK_SUPPORTED_TLD" envDefault:"com"`


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove default API URL in `MailstackApiConfig`, requiring explicit environment configuration.
> 
>   - **Configuration**:
>     - Removed default value for `ApiUrl` in `MailstackApiConfig` in `mailstack_api_config.go`. Now requires explicit environment configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3ba9f4bcbb34cb0ac5b5e1e5ce36edd6e39d6e6c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->