### PR TITLE
allow company description slighly over 300 chars

### DIFF
--- a/packages/server/customer-os-api/rest/private/askAI.go
+++ b/packages/server/customer-os-api/rest/private/askAI.go
@@ -37,6 +37,7 @@ type AskAIRequest struct {
 	SystemPrompt *string            `json:"systemPrompt,omitempty"`
 	Prompt       PromptContent      `json:"prompt"`
 	AIModel      commonEnum.AIModel `json:"-"`
+	OutputFormat string             `json:"outputFormat,omitempty"`
 }
 
 type PromptContent struct {
@@ -96,6 +97,11 @@ func (h *AskAIHandler) AskAI() gin.HandlerFunc {
 			Model:        request.AIModel,
 			SystemPrompt: request.SystemPrompt,
 			Prompt:       &promptStr,
+		}
+		if request.OutputFormat == commonEnum.AIOutputJson.String() {
+			AIRequest.OutputFormat = commonEnum.AIOutputJson
+		} else {
+			AIRequest.OutputFormat = commonEnum.AIOutputText
 		}
 
 		answer, err := h.services.CommonServices.AIService.AskAI(ctx, AIRequest)

--- a/packages/server/customer-os-common-module/data_fields/company_description.go
+++ b/packages/server/customer-os-common-module/data_fields/company_description.go
@@ -25,7 +25,7 @@ type CompanyDescriptionResponseValidator struct {
 
 func NewCompanyDescriptionResponseValidator() *CompanyDescriptionResponseValidator {
 	return &CompanyDescriptionResponseValidator{
-		MaxLength:     300, // As per the prompt requirement
+		MaxLength:     400, // Allow up to 400 chars, though we ask AI for 300 to be conservative
 		MinLength:     50,  // Reasonable minimum for a useful description
 		DisallowEmpty: true,
 		BlockedWords:  []string{},

--- a/packages/server/customer-os-common-module/services/webscraper/classify_topics.go
+++ b/packages/server/customer-os-common-module/services/webscraper/classify_topics.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/opentracing/opentracing-go/log"
 	"strings"
+
+	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/customeros/mailsherpa/domaincheck"
 	"github.com/opentracing/opentracing-go"
@@ -63,7 +64,8 @@ The confidence score should reflect how certain you are that the topic is releva
 	promptStr := prompt.String()
 
 	temperature := float32(0.2)
-	maxOutputTokens := int32(100)
+	maxOutputTokens := int32(250)
+	retries := 1
 	topics, err := s.aiService.AskAIForWebpageTopics(ctx, interfaces.AskAIRequest{
 		Model:            enum.AIModelLlama8B,
 		SystemPrompt:     &systemPrompt,
@@ -71,6 +73,7 @@ The confidence score should reflect how certain you are that the topic is releva
 		ModelTemperature: &temperature,
 		MaxOutputTokens:  &maxOutputTokens,
 		OutputFormat:     enum.AIOutputJson,
+		Retries:          &retries,
 	})
 	if err != nil {
 		tracing.TraceErr(span, err)

--- a/packages/server/customer-os-common-module/services/webscraper/service.go
+++ b/packages/server/customer-os-common-module/services/webscraper/service.go
@@ -44,8 +44,8 @@ const (
 )
 
 var (
-	ErrPaymentRequired = errors.New("Jina balance requires topup")
-	ErrUnprocessable   = errors.New("Jina cannot process webpage")
+	ErrPaymentRequired = errors.New("jina balance requires topup")
+	ErrUnprocessable   = errors.New("jina cannot process webpage")
 )
 
 func (s *webscraperService) Scrape(ctx context.Context, url string) (string, error) {
@@ -169,7 +169,9 @@ func (s *webscraperService) fetchPage(ctx context.Context, url string) (string, 
 	tracing.SetDefaultServiceSpanTags(ctx, span)
 
 	if s.config.ApiKey == "" {
-		return "", errors.New("Jina API key not set")
+		err := errors.New("jina API key not set")
+		tracing.TraceErr(span, err)
+		return "", err
 	}
 
 	requestUrl := s.config.Url + url


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Extend company description limit to 400 chars, add output format handling for AI requests, and update web scraper token limit and error messages.
> 
>   - **Behavior**:
>     - Increase `MaxLength` for `CompanyDescriptionResponseValidator` from 300 to 400 in `company_description.go`.
>     - Add `OutputFormat` field to `AskAIRequest` in `askAI.go` to handle JSON and text formats.
>   - **Web Scraper**:
>     - Increase `maxOutputTokens` from 100 to 250 in `classify_topics.go`.
>     - Add `retries` parameter set to 1 in `classify_topics.go`.
>   - **Error Handling**:
>     - Change error messages to lowercase in `service.go` for `ErrPaymentRequired` and `ErrUnprocessable`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for bb690d4082065477df92eff5a8c4f3ca0ddb3593. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->