### PR TITLE
correct register mailbox api

### DIFF
--- a/packages/server/customer-os-api/rest/mailstack/mailbox.go
+++ b/packages/server/customer-os-api/rest/mailstack/mailbox.go
@@ -71,7 +71,7 @@ func (h *MailstackHandler) RegisterNewMailbox() gin.HandlerFunc {
 		}
 
 		// Create mailbox using service
-		result, err := h.services.CommonServices.MailstackService.RegisterMailbox(ctx, tenant, domain, interfaces.CreateMailboxRequest{
+		statusCode, errMsg, result, err := h.services.CommonServices.MailstackService.RegisterMailbox(ctx, tenant, domain, interfaces.CreateMailboxRequest{
 			Username:        mailboxRequest.Username,
 			Password:        mailboxRequest.Password,
 			ForwardingTo:    mailboxRequest.ForwardingTo,
@@ -79,30 +79,23 @@ func (h *MailstackHandler) RegisterNewMailbox() gin.HandlerFunc {
 			LinkedUserEmail: mailboxRequest.LinkedUser,
 		})
 		if err != nil {
-			message := "Internal server error"
-			h.responseHandler.HandleError(c, http.StatusInternalServerError, &message)
+			h.responseHandler.HandleError(c, statusCode, &errMsg)
 			tracing.TraceErr(span, err)
 			return
 		}
 
-		// Handle non-201 responses
-		if result.StatusCode != http.StatusCreated {
-			if result.StatusCode == http.StatusInternalServerError || result.StatusCode == http.StatusUnauthorized {
-				message := "Internal server error"
-				h.responseHandler.HandleError(c, http.StatusInternalServerError, &message)
-				return
-			}
-			h.responseHandler.HandleError(c, result.StatusCode, &result.ErrorMsg)
+		if statusCode != http.StatusOK {
+			h.responseHandler.HandleError(c, statusCode, &errMsg)
 			return
 		}
 
 		h.responseHandler.HandleSuccess(c, MailboxResponse{
 			Mailbox: MailboxRecord{
-				Email:             result.Mailbox.Email,
-				Password:          result.Mailbox.Password,
-				ForwardingTo:      result.Mailbox.ForwardingTo,
-				ForwardingEnabled: result.Mailbox.ForwardingEnabled,
-				WebmailEnabled:    result.Mailbox.WebmailEnabled,
+				Email:             result.Email,
+				Password:          result.Password,
+				ForwardingTo:      result.ForwardingTo,
+				ForwardingEnabled: result.ForwardingEnabled,
+				WebmailEnabled:    result.WebmailEnabled,
 			},
 		})
 	}

--- a/packages/server/customer-os-common-module/interfaces/mailstack.go
+++ b/packages/server/customer-os-common-module/interfaces/mailstack.go
@@ -21,12 +21,6 @@ type MailboxRecord struct {
 	WebmailEnabled    bool     `json:"webmailEnabled"`
 }
 
-type RegisterMailboxResponse struct {
-	Mailbox    *MailboxRecord
-	StatusCode int
-	ErrorMsg   string
-}
-
 type DomainRecord struct {
 	Domain      string   `json:"domain"`
 	CreatedDate string   `json:"createdDate"`
@@ -45,7 +39,7 @@ type MailstackService interface {
 	GetPaymentIntent(ctx context.Context, domains []string, usernames []string, amount int64) (string, error)
 	RegisterBuyDomainsWithMailboxes(ctx context.Context, test bool, paymentIntentId string, domains []string, usernames []string, redirectWebsite string) error
 	// mailboxes
-	RegisterMailbox(ctx context.Context, tenant, domain string, request CreateMailboxRequest) (*RegisterMailboxResponse, error)
+	RegisterMailbox(ctx context.Context, tenant, domain string, request CreateMailboxRequest) (int, string, *MailboxRecord, error)
 	ConfigureMailbox(ctx context.Context, tenant, mailboxId string) error
 	GetMailboxes(ctx context.Context, tenant, domain string) (int, string, []MailboxRecord, error)
 	// domains

--- a/packages/server/customer-os-common-module/services/mailstack/service.go
+++ b/packages/server/customer-os-common-module/services/mailstack/service.go
@@ -246,7 +246,7 @@ func (s *mailstackService) RegisterBuyDomainsWithMailboxes(ctx context.Context, 
 			}
 
 			for _, username := range usernames {
-				result, err := s.RegisterMailbox(ctx, tenant, domain, interfaces.CreateMailboxRequest{
+				statusCode, errMessage, _, err := s.RegisterMailbox(ctx, tenant, domain, interfaces.CreateMailboxRequest{
 					IgnoreDomainOwnership: true,
 					Domain:                domain,
 					Username:              username,
@@ -258,8 +258,8 @@ func (s *mailstackService) RegisterBuyDomainsWithMailboxes(ctx context.Context, 
 				if err != nil {
 					return err
 				}
-				if result.StatusCode != http.StatusCreated {
-					return errors.New(result.ErrorMsg)
+				if statusCode != http.StatusOK {
+					return errors.New(errMessage)
 				}
 			}
 		}
@@ -282,7 +282,7 @@ func (s *mailstackService) RegisterBuyDomainsWithMailboxes(ctx context.Context, 
 	return nil
 }
 
-func (s *mailstackService) RegisterMailbox(ctx context.Context, tenant string, domain string, request interfaces.CreateMailboxRequest) (*interfaces.RegisterMailboxResponse, error) {
+func (s *mailstackService) RegisterMailbox(ctx context.Context, tenant string, domain string, request interfaces.CreateMailboxRequest) (int, string, *interfaces.MailboxRecord, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "MailstackService.RegisterMailbox")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
@@ -295,7 +295,7 @@ func (s *mailstackService) RegisterMailbox(ctx context.Context, tenant string, d
 		userDbNode, err := s.neo4j.UserReadRepository.GetFirstUserByEmail(ctx, tenant, request.LinkedUserEmail)
 		if err != nil {
 			tracing.TraceErr(span, errors.Wrap(err, "Error finding linked user"))
-			return nil, err
+			return http.StatusInternalServerError, "Error finding linked user for linked email", nil, err
 		}
 		if userDbNode != nil {
 			userEntity := neo4jmapper.MapDbNodeToUserEntity(userDbNode)
@@ -324,13 +324,13 @@ func (s *mailstackService) RegisterMailbox(ctx context.Context, tenant string, d
 
 	jsonBody, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to marshal request body")
+		return http.StatusInternalServerError, "Internal server error", nil, errors.Wrap(err, "Unable to marshal request body")
 	}
 
 	// Create request to Mailstack API
 	mailstackReq, err := http.NewRequestWithContext(ctx, "POST", s.cfg.Internal.MailstackApiConfig.ApiUrl+"/v1/mailboxes", bytes.NewBuffer(jsonBody))
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to create request to Mailstack API")
+		return http.StatusInternalServerError, "Internal server error", nil, errors.Wrap(err, "Unable to create request to Mailstack API")
 	}
 
 	// Add required headers
@@ -353,13 +353,9 @@ func (s *mailstackService) RegisterMailbox(ctx context.Context, tenant string, d
 	// Make request to Mailstack API
 	resp, err := client.Do(mailstackReq)
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to connect to Mailstack API")
+		return http.StatusInternalServerError, "Internal server error", nil, errors.Wrap(err, "Unable to connect to Mailstack API")
 	}
 	defer resp.Body.Close()
-
-	response := &interfaces.RegisterMailboxResponse{
-		StatusCode: resp.StatusCode,
-	}
 
 	// Check response status
 	if resp.StatusCode != http.StatusCreated {
@@ -370,15 +366,21 @@ func (s *mailstackService) RegisterMailbox(ctx context.Context, tenant string, d
 		if err := json.NewDecoder(resp.Body).Decode(&errorResponse); err != nil {
 			errorResponse.Error = "Unknown error occurred"
 		}
-		response.ErrorMsg = errorResponse.Error
 		tracing.TraceErr(span, errors.New(errorResponse.Error))
-		return response, nil
+
+		// For 500 errors, use a generic message
+		if resp.StatusCode == http.StatusInternalServerError || resp.StatusCode == http.StatusUnauthorized {
+			return http.StatusInternalServerError, "Internal server error", nil, errors.New(errorResponse.Error)
+		}
+
+		// For other errors, propagate the message from Mailstack
+		return resp.StatusCode, errorResponse.Error, nil, errors.New(errorResponse.Error)
 	}
 
 	// Parse response
 	var mailboxRecord interfaces.MailboxRecord
 	if err := json.NewDecoder(resp.Body).Decode(&mailboxRecord); err != nil {
-		return nil, errors.Wrap(err, "Unable to parse Mailstack API response")
+		return http.StatusInternalServerError, "Internal server error", nil, errors.Wrap(err, "Unable to parse Mailstack API response")
 	}
 
 	// Create email node and link with user if identified
@@ -395,18 +397,16 @@ func (s *mailstackService) RegisterMailbox(ctx context.Context, tenant string, d
 	_, err = s.email.Merge(ctx, nil, tenant, emailFields, linkWith)
 	if err != nil {
 		tracing.TraceErr(span, errors.Wrap(err, "Error creating email node"))
-		return nil, err
+		return http.StatusInternalServerError, "Internal server error", nil, err
 	}
 
 	// Publish fanout event to provision mailbox
 	err = s.events.Publisher.PublishFanoutEvent(ctx, mailboxRecord.ID, model.MAILBOX, dto.MailstackProvisionMailbox{})
 	if err != nil {
 		tracing.TraceErr(span, errors.Wrap(err, "Error publishing mailbox provision event"))
-		return nil, err
 	}
 
-	response.Mailbox = &mailboxRecord
-	return response, nil
+	return http.StatusOK, "", &mailboxRecord, nil
 }
 
 func (s *mailstackService) ConfigureMailbox(ctx context.Context, tenant string, mailboxId string) error {

--- a/packages/server/customer-os-common-module/services/registration/service.go
+++ b/packages/server/customer-os-common-module/services/registration/service.go
@@ -565,7 +565,7 @@ func (s *registrationService) createMailboxIfNotExists(ctx context.Context, span
 	}
 
 	if mailbox == nil {
-		result, err := s.mailstack.RegisterMailbox(ctx, tenant, mailstack.TEST_MAILBOX_DOMAIN, interfaces.CreateMailboxRequest{
+		statusCode, errMsg, _, err := s.mailstack.RegisterMailbox(ctx, tenant, mailstack.TEST_MAILBOX_DOMAIN, interfaces.CreateMailboxRequest{
 			Domain:          mailstack.TEST_MAILBOX_DOMAIN,
 			Username:        strings.ToLower(tenant),
 			Password:        utils.GenerateLowerAlpha(1) + utils.GenerateKey(11, false),
@@ -578,9 +578,9 @@ func (s *registrationService) createMailboxIfNotExists(ctx context.Context, span
 			return err
 		}
 
-		// Handle non-201 responses
-		if result.StatusCode != http.StatusCreated {
-			err = errors.New(result.ErrorMsg)
+		// Handle non-200 responses
+		if statusCode != http.StatusOK {
+			err = errors.New(errMsg)
 			tracing.TraceErr(span, errors.Wrap(err, "failed to add mailbox"))
 			return err
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `RegisterMailbox` to return status code, error message, and mailbox record, improving error handling across related services.
> 
>   - **Behavior**:
>     - `RegisterMailbox` in `mailbox.go` now returns `statusCode`, `errMsg`, and `MailboxRecord` instead of `RegisterMailboxResponse`.
>     - Updates error handling to use `statusCode` and `errMsg` directly from Mailstack API.
>   - **Interfaces**:
>     - Changes `RegisterMailbox` signature in `mailstack.go` to return `(int, string, *MailboxRecord, error)`.
>   - **Services**:
>     - Updates `RegisterMailbox` in `service.go` to handle new return values and improve error handling.
>     - Modifies `createMailboxIfNotExists` in `service.go` to handle new `RegisterMailbox` return values.
>   - **Misc**:
>     - Removes `RegisterMailboxResponse` struct from `interfaces/mailstack.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for ebd8722704c18366507efacc410ddb886fd44847. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->