### PR TITLE
remove get mailbox by domain direct query

### DIFF
--- a/packages/server/customer-os-api/graphql/resolver/mailstack.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/mailstack.resolvers.go
@@ -6,6 +6,7 @@ package resolver
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -14,8 +15,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-api/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	tracingLog "github.com/opentracing/opentracing-go/log"
 )
 
@@ -181,26 +181,29 @@ func (r *queryResolver) MailstackMailboxes(ctx context.Context) ([]*model.Mailbo
 	span.LogKV("request.userId", userId)
 	isImpersonated := common.IsImpersonatedUserInContext(ctx)
 
-	var allMailboxes []*postgres_entity.TenantSettingsMailbox
-	var err error
-
+	tenant := common.GetTenantFromContext(ctx)
+	requestUserId := userId
 	if isImpersonated {
-		allMailboxes, err = r.Services.Repositories.PostgresRepositories.TenantSettingsMailboxRepository.GetAll(ctx)
-	} else {
-		allMailboxes, err = r.Services.Repositories.PostgresRepositories.TenantSettingsMailboxRepository.GetAllByUserId(ctx, userId)
+		requestUserId = ""
 	}
+
+	statusCode, errMessage, mailboxes, err := r.Services.CommonServices.MailstackService.GetMailboxes(ctx, tenant, "", requestUserId)
 	if err != nil {
-		tracing.TraceErr(opentracing.SpanFromContext(ctx), err)
-		r.log.Errorf("Failed to get all mailboxes")
-		graphql.AddErrorf(ctx, "Failed to get all mailboxes")
+		tracing.TraceErr(span, err)
+		graphql.AddErrorf(ctx, "Failed to get mailboxes")
+		return nil, nil
+	}
+	if statusCode != http.StatusOK {
+		tracing.TraceErr(span, errors.New(errMessage))
+		graphql.AddErrorf(ctx, errMessage)
 		return nil, nil
 	}
 
 	var response []*model.Mailbox
-	for _, mailbox := range allMailboxes {
+	for _, mailbox := range mailboxes {
 		response = append(response, &model.Mailbox{
 			Provider:           model.MailboxProviderMailstack,
-			Mailbox:            mailbox.MailboxUsername,
+			Mailbox:            mailbox.Email,
 			RampUpCurrent:      40,
 			RampUpMax:          40,
 			RampUpRate:         3,

--- a/packages/server/customer-os-api/graphql/resolver/user.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/user.resolvers.go
@@ -7,6 +7,8 @@ package resolver
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/dataloader"
@@ -200,16 +202,23 @@ func (r *userResolver) Mailboxes(ctx context.Context, obj *model.User) ([]string
 	span.LogFields(log.String("request.user", obj.ID))
 
 	mailboxes := make([]string, 0)
+	tenant := common.GetTenantFromContext(ctx)
 
-	mb, err := r.Services.Repositories.PostgresRepositories.TenantSettingsMailboxRepository.GetAllByUserId(ctx, obj.ID)
+	statusCode, _, mb, err := r.Services.CommonServices.MailstackService.GetMailboxes(ctx, tenant, "", obj.ID)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		graphql.AddErrorf(ctx, "Failed to get mailboxes for user %s", obj.ID)
 		return nil, err
 	}
 
+	if statusCode != http.StatusOK {
+		tracing.TraceErr(span, fmt.Errorf("failed to get mailboxes, status code: %d", statusCode))
+		graphql.AddErrorf(ctx, "Failed to get mailboxes for user %s", obj.ID)
+		return nil, nil
+	}
+
 	for _, mailbox := range mb {
-		mailboxes = append(mailboxes, mailbox.MailboxUsername)
+		mailboxes = append(mailboxes, mailbox.Email)
 	}
 
 	return mailboxes, nil
@@ -223,25 +232,32 @@ func (r *userResolver) MailboxesV2(ctx context.Context, obj *model.User) ([]*mod
 	span.LogFields(log.String("request.user", obj.ID))
 
 	mailboxes := make([]*model.Mailbox, 0)
+	tenant := common.GetTenantFromContext(ctx)
 
-	mb, err := r.Services.Repositories.PostgresRepositories.TenantSettingsMailboxRepository.GetAllByUserId(ctx, obj.ID)
+	statusCode, _, mb, err := r.Services.CommonServices.MailstackService.GetMailboxes(ctx, tenant, "", obj.ID)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		graphql.AddErrorf(ctx, "Failed to get mailboxes for user %s", obj.ID)
 		return nil, err
 	}
 
+	if statusCode != http.StatusOK {
+		tracing.TraceErr(span, fmt.Errorf("failed to get mailboxes, status code: %d", statusCode))
+		graphql.AddErrorf(ctx, "Failed to get mailboxes for user %s", obj.ID)
+		return nil, nil
+	}
+
 	for _, mailbox := range mb {
 		mb := model.Mailbox{
 			Provider:           model.MailboxProviderMailstack,
-			Mailbox:            mailbox.MailboxUsername,
+			Mailbox:            mailbox.Email,
 			RampUpCurrent:      40,
 			RampUpMax:          40,
 			RampUpRate:         3,
 			NeedsManualRefresh: false,
 		}
 
-		userUsedInFlows, err := r.Services.Repositories.Neo4jRepositories.FlowSenderReadRepository.GetUsersUsedInFlows(ctx, []string{mailbox.UserId})
+		userUsedInFlows, err := r.Services.Repositories.Neo4jRepositories.FlowSenderReadRepository.GetUsersUsedInFlows(ctx, []string{obj.ID})
 		if err != nil {
 			tracing.TraceErr(span, err)
 			graphql.AddErrorf(ctx, "Failed to get users used in flows")

--- a/packages/server/customer-os-api/rest/mailstack/mailbox.go
+++ b/packages/server/customer-os-api/rest/mailstack/mailbox.go
@@ -140,7 +140,7 @@ func (h *MailstackHandler) GetMailboxes() gin.HandlerFunc {
 		}
 
 		// Get mailboxes using service
-		statusCode, errMsg, mailboxes, err := h.services.CommonServices.MailstackService.GetMailboxes(ctx, tenant, domain)
+		statusCode, errMsg, mailboxes, err := h.services.CommonServices.MailstackService.GetMailboxes(ctx, tenant, domain, "")
 		if err != nil {
 			message := "Internal server error"
 			h.responseHandler.HandleError(c, http.StatusInternalServerError, &message)

--- a/packages/server/customer-os-api/rest/private/mailboxes.go
+++ b/packages/server/customer-os-api/rest/private/mailboxes.go
@@ -27,7 +27,7 @@ func GetMailboxes(s *cosapi_services.Services) gin.HandlerFunc {
 		}
 
 		// Get mailboxes using service
-		statusCode, _, mailboxes, err := s.CommonServices.MailstackService.GetMailboxes(ctx, tenant, "")
+		statusCode, _, mailboxes, err := s.CommonServices.MailstackService.GetMailboxes(ctx, tenant, "", "")
 		if err != nil {
 			tracing.TraceErr(span, err)
 			c.Status(http.StatusInternalServerError)

--- a/packages/server/customer-os-common-module/interfaces/mailstack.go
+++ b/packages/server/customer-os-common-module/interfaces/mailstack.go
@@ -19,6 +19,7 @@ type MailboxRecord struct {
 	ForwardingTo      []string `json:"forwardingTo"`
 	ForwardingEnabled bool     `json:"forwardingEnabled"`
 	WebmailEnabled    bool     `json:"webmailEnabled"`
+	Provisioned       bool     `json:"provisioned"`
 }
 
 type DomainRecord struct {

--- a/packages/server/customer-os-common-module/interfaces/mailstack.go
+++ b/packages/server/customer-os-common-module/interfaces/mailstack.go
@@ -15,6 +15,8 @@ type CreateMailboxRequest struct {
 type MailboxRecord struct {
 	ID                string   `json:"id"`
 	Email             string   `json:"email"`
+	Username          string   `json:"username"`
+	Domain            string   `json:"domain"`
 	Password          string   `json:"password"`
 	ForwardingTo      []string `json:"forwardingTo"`
 	ForwardingEnabled bool     `json:"forwardingEnabled"`
@@ -42,7 +44,7 @@ type MailstackService interface {
 	// mailboxes
 	RegisterMailbox(ctx context.Context, tenant, domain string, request CreateMailboxRequest) (int, string, *MailboxRecord, error)
 	ConfigureMailbox(ctx context.Context, tenant, mailboxId string) error
-	GetMailboxes(ctx context.Context, tenant, domain string) (int, string, []MailboxRecord, error)
+	GetMailboxes(ctx context.Context, tenant, domain, userId string) (int, string, []MailboxRecord, error)
 	// domains
 	RegisterNewDomain(ctx context.Context, tenant, domain, website string) (int, string, *DomainRecord, error)
 	ConfigureDomain(ctx context.Context, tenant, domain, website string) (int, string, *DomainRecord, error)

--- a/packages/server/customer-os-common-module/services/flow_execution/service.go
+++ b/packages/server/customer-os-common-module/services/flow_execution/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -27,24 +28,26 @@ import (
 )
 
 type flowExecutionService struct {
-	neo4j    *neo4j_repository.Repositories
-	postgres *postgres_repository.Repositories
-	events   *events.EventsService
-	email    interfaces.EmailService
-	flow     interfaces.FlowService
-	org      interfaces.OrganizationService
-	social   interfaces.SocialService
+	neo4j     *neo4j_repository.Repositories
+	postgres  *postgres_repository.Repositories
+	events    *events.EventsService
+	email     interfaces.EmailService
+	flow      interfaces.FlowService
+	org       interfaces.OrganizationService
+	social    interfaces.SocialService
+	mailstack interfaces.MailstackService
 }
 
-func NewFlowExecutionService(neo4j *neo4j_repository.Repositories, postgres *postgres_repository.Repositories, events *events.EventsService, email interfaces.EmailService, flow interfaces.FlowService, org interfaces.OrganizationService, social interfaces.SocialService) interfaces.FlowExecutionService {
+func NewFlowExecutionService(neo4j *neo4j_repository.Repositories, postgres *postgres_repository.Repositories, events *events.EventsService, email interfaces.EmailService, flow interfaces.FlowService, org interfaces.OrganizationService, social interfaces.SocialService, mailstack interfaces.MailstackService) interfaces.FlowExecutionService {
 	return &flowExecutionService{
-		neo4j:    neo4j,
-		postgres: postgres,
-		events:   events,
-		email:    email,
-		flow:     flow,
-		org:      org,
-		social:   social,
+		neo4j:     neo4j,
+		postgres:  postgres,
+		events:    events,
+		email:     email,
+		flow:      flow,
+		org:       org,
+		social:    social,
+		mailstack: mailstack,
 	}
 }
 
@@ -489,20 +492,25 @@ func (s *flowExecutionService) scheduleEmailAction(ctx context.Context, txWithPo
 				continue
 			}
 
-			mailboxes, err := s.postgres.TenantSettingsMailboxRepository.GetAllByUserId(ctx, *flowActionSender.UserId)
+			statusCode, errMsg, mailboxes, err := s.mailstack.GetMailboxes(ctx, tenant, "", *flowActionSender.UserId)
 			if err != nil {
+				tracing.TraceErr(span, err)
+				return err
+			}
+			if statusCode != http.StatusOK {
+				err = errors.New(errMsg)
 				tracing.TraceErr(span, err)
 				return err
 			}
 
 			for _, mailbox := range mailboxes {
-				scheduledAt, err := s.neo4j.FlowActionExecutionReadRepository.GetFirstSlotForMailbox(ctx, txWithPostCommit.Tx, mailbox.MailboxUsername)
+				scheduledAt, err := s.neo4j.FlowActionExecutionReadRepository.GetFirstSlotForMailbox(ctx, txWithPostCommit.Tx, mailbox.Email)
 				if err != nil {
 					tracing.TraceErr(span, err)
 					return err
 				}
 
-				mailboxesScheduledAt[mailbox.MailboxUsername] = scheduledAt
+				mailboxesScheduledAt[mailbox.Email] = scheduledAt
 			}
 		}
 

--- a/packages/server/customer-os-common-module/services/flow_execution/service.go
+++ b/packages/server/customer-os-common-module/services/flow_execution/service.go
@@ -1137,9 +1137,14 @@ func (s *flowExecutionService) ProcessActionExecution(ctx context.Context, sched
 
 					contact := mapper.MapDbNodeToContactEntity(contactNode)
 
+					// Replace parameters in both body and subject templates
 					bodyTemplate = s.ReplacePlaceholder(bodyTemplate, "contact_first_name", contact.FirstName)
 					bodyTemplate = s.ReplacePlaceholder(bodyTemplate, "contact_last_name", contact.LastName)
 					bodyTemplate = s.ReplacePlaceholder(bodyTemplate, "contact_email", toEmail)
+
+					subjectTemplate = s.ReplacePlaceholder(subjectTemplate, "contact_first_name", contact.FirstName)
+					subjectTemplate = s.ReplacePlaceholder(subjectTemplate, "contact_last_name", contact.LastName)
+					subjectTemplate = s.ReplacePlaceholder(subjectTemplate, "contact_email", toEmail)
 
 					contactWithOrganizations, err := s.org.GetPrimaryOrganizationsWithJobRoleForContacts(ctx, []string{contact.Id})
 					if err != nil {
@@ -1149,12 +1154,11 @@ func (s *flowExecutionService) ProcessActionExecution(ctx context.Context, sched
 					if len(*contactWithOrganizations) > 0 {
 						contactWithOrganization := (*contactWithOrganizations)[0]
 						bodyTemplate = s.ReplacePlaceholder(bodyTemplate, "organization_name", contactWithOrganization.Organization.Name)
-						subjectTemplate = strings.ReplaceAll(subjectTemplate, "{{organization_name}}", contactWithOrganization.Organization.Name)
+						subjectTemplate = s.ReplacePlaceholder(subjectTemplate, "organization_name", contactWithOrganization.Organization.Name)
 					} else {
 						bodyTemplate = s.ReplacePlaceholder(bodyTemplate, "organization_name", "")
-						subjectTemplate = strings.ReplaceAll(subjectTemplate, "{{organization_name}}", "")
+						subjectTemplate = s.ReplacePlaceholder(subjectTemplate, "organization_name", "")
 					}
-
 				}
 
 				mailbox, err = s.postgres.TenantSettingsMailboxRepository.GetByMailbox(ctx, *scheduledActionExecution.Mailbox)
@@ -1175,6 +1179,9 @@ func (s *flowExecutionService) ProcessActionExecution(ctx context.Context, sched
 
 				bodyTemplate = s.ReplacePlaceholder(bodyTemplate, "sender_first_name", user.FirstName)
 				bodyTemplate = s.ReplacePlaceholder(bodyTemplate, "sender_last_name", user.LastName)
+
+				subjectTemplate = s.ReplacePlaceholder(subjectTemplate, "sender_first_name", user.FirstName)
+				subjectTemplate = s.ReplacePlaceholder(subjectTemplate, "sender_last_name", user.LastName)
 
 				addBillableEvent = true
 				emailMessage := &postgres_entity.EmailMessage{

--- a/packages/server/customer-os-common-module/services/init.go
+++ b/packages/server/customer-os-common-module/services/init.go
@@ -253,7 +253,7 @@ func InitCommonServices(
 	interactionEventImpl := interaction_event.NewInteractionEventService(neo4jRepositories, emailImpl)
 	mailstackImpl := mailstack.NewMailstackService(cfg, eventsImpl, postgresRepositories, neo4jRepositories, openSRSImpl, emailImpl)
 	mailImpl := mail.NewMailService(cacheImpl, postgresRepositories, neo4jRepositories, azureImpl, contactImpl, emailImpl, googleImpl, interactionEventImpl, interactionSessionImpl, openSRSImpl, orgImpl, workspaceImpl)
-	flowExecutionImpl := flow_execution.NewFlowExecutionService(neo4jRepositories, postgresRepositories, eventsImpl, emailImpl, nil, orgImpl, socialImpl)
+	flowExecutionImpl := flow_execution.NewFlowExecutionService(neo4jRepositories, postgresRepositories, eventsImpl, emailImpl, nil, orgImpl, socialImpl, mailstackImpl)
 	flowImpl := flow.NewFlowService(neo4jRepositories, postgresRepositories, eventsImpl, flowExecutionImpl)
 	locationImpl := location.NewLocationService(log, neo4jRepositories, postgresRepositories, eventsImpl, &cfg.External.AnthropicConfig.Prompts, aiImpl, contactImpl, orgImpl)
 	enrichmentImpl := enrichment.NewEnrichmentService(log, &cfg.External, cacheImpl, eventsImpl, postgresRepositories, neo4jRepositories, contactImpl, domainImpl, locationImpl, orgImpl, socialImpl, globalContactImpl)

--- a/packages/server/customer-os-common-module/services/mailstack/service.go
+++ b/packages/server/customer-os-common-module/services/mailstack/service.go
@@ -1097,15 +1097,23 @@ func (s *mailstackService) ProcessDMARCMonitoringReport(ctx context.Context, ema
 	return nil
 }
 
-func (s *mailstackService) GetMailboxes(ctx context.Context, tenant, domain string) (int, string, []interfaces.MailboxRecord, error) {
+func (s *mailstackService) GetMailboxes(ctx context.Context, tenant, domain, userId string) (int, string, []interfaces.MailboxRecord, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "MailstackService.GetMailboxes")
 	defer span.Finish()
 	tracing.SetDefaultServiceSpanTags(ctx, span)
+	span.LogFields(tracingLog.String("domain", domain), tracingLog.String("userId", userId))
 
 	// Create request to Mailstack API
 	url := s.cfg.Internal.MailstackApiConfig.ApiUrl + "/v1/mailboxes"
+	params := make([]string, 0)
 	if domain != "" {
-		url += "?domain=" + domain
+		params = append(params, "domain="+domain)
+	}
+	if userId != "" {
+		params = append(params, "userId="+userId)
+	}
+	if len(params) > 0 {
+		url += "?" + strings.Join(params, "&")
 	}
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {

--- a/packages/server/customer-os-postgres-repository/repository/tenant_settings_mailbox_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/tenant_settings_mailbox_repository.go
@@ -19,7 +19,6 @@ type tenantSettingsMailboxRepository struct {
 type TenantSettingsMailboxRepository interface {
 	GetAll(ctx context.Context) ([]*postgres_entity.TenantSettingsMailbox, error)
 	GetByMailbox(ctx context.Context, mailbox string) (*postgres_entity.TenantSettingsMailbox, error)
-	GetAllByDomain(ctx context.Context, domain string) ([]*postgres_entity.TenantSettingsMailbox, error)
 	GetAllByUserId(ctx context.Context, userId string) ([]*postgres_entity.TenantSettingsMailbox, error)
 }
 
@@ -76,29 +75,6 @@ func (r *tenantSettingsMailboxRepository) GetByMailbox(ctx context.Context, mail
 	span.LogFields(tracingLog.Bool("result.found", true))
 
 	return &result, nil
-}
-
-func (r *tenantSettingsMailboxRepository) GetAllByDomain(ctx context.Context, domain string) ([]*postgres_entity.TenantSettingsMailbox, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TenantSettingsMailboxRepository.GetAllByDomain")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-
-	tenant := common.GetTenantFromContext(ctx)
-
-	span.LogKV("domain", domain)
-
-	var result []*postgres_entity.TenantSettingsMailbox
-	err := r.gormDb.WithContext(ctx).
-		Where("tenant = ? and domain = ?", tenant, domain).
-		Find(&result).
-		Error
-
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return nil, err
-	}
-
-	return result, nil
 }
 
 func (r *tenantSettingsMailboxRepository) GetAllByUserId(ctx context.Context, userId string) ([]*postgres_entity.TenantSettingsMailbox, error) {

--- a/packages/server/customer-os-postgres-repository/repository/tenant_settings_mailbox_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/tenant_settings_mailbox_repository.go
@@ -19,7 +19,6 @@ type tenantSettingsMailboxRepository struct {
 type TenantSettingsMailboxRepository interface {
 	GetAll(ctx context.Context) ([]*postgres_entity.TenantSettingsMailbox, error)
 	GetByMailbox(ctx context.Context, mailbox string) (*postgres_entity.TenantSettingsMailbox, error)
-	GetAllByUserId(ctx context.Context, userId string) ([]*postgres_entity.TenantSettingsMailbox, error)
 }
 
 func NewTenantSettingsMailboxRepository(db *gorm.DB) TenantSettingsMailboxRepository {
@@ -75,28 +74,4 @@ func (r *tenantSettingsMailboxRepository) GetByMailbox(ctx context.Context, mail
 	span.LogFields(tracingLog.Bool("result.found", true))
 
 	return &result, nil
-}
-
-func (r *tenantSettingsMailboxRepository) GetAllByUserId(ctx context.Context, userId string) ([]*postgres_entity.TenantSettingsMailbox, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TenantSettingsMailboxRepository.GetAllByUserId")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-
-	tenant := common.GetTenantFromContext(ctx)
-
-	span.LogKV("userId", userId)
-
-	var result []*postgres_entity.TenantSettingsMailbox
-	err := r.gormDb.WithContext(ctx).
-		Where("tenant = ? and user_id = ?", tenant, userId).
-		Find(&result).
-		Error
-
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return nil, err
-	}
-
-	span.LogFields(tracingLog.Int("result.count", len(result)))
-	return result, nil
 }

--- a/packages/server/events-subscribers/listeners/events/mailstack_provision_buy_request.go
+++ b/packages/server/events-subscribers/listeners/events/mailstack_provision_buy_request.go
@@ -97,7 +97,7 @@ func (l *MailstackProvisionBuyRequestListener) handle(ctx context.Context, entit
 			continue
 		}
 
-		statusCode, errMessage, mailboxes, err := l.dependencies.CommonServices.MailstackService.GetMailboxes(ctx, domain.Tenant, domain.Domain)
+		statusCode, errMessage, mailboxes, err := l.dependencies.CommonServices.MailstackService.GetMailboxes(ctx, domain.Tenant, domain.Domain, "")
 		if err != nil {
 			tracing.TraceErr(span, err)
 			return err
@@ -284,7 +284,7 @@ func (l *MailstackProvisionBuyRequestListener) processMailboxes(ctx context.Cont
 			sem <- struct{}{}        // Acquire semaphore
 			defer func() { <-sem }() // Release semaphore
 
-			statusCode, errMessage, mailboxes, err := l.dependencies.CommonServices.MailstackService.GetMailboxes(ctx, domain.Tenant, domain.Domain)
+			statusCode, errMessage, mailboxes, err := l.dependencies.CommonServices.MailstackService.GetMailboxes(ctx, domain.Tenant, domain.Domain, "")
 			if err != nil {
 				tracing.TraceErr(span, err)
 				return // Exit the goroutine on error

--- a/packages/server/events-subscribers/listeners/events/mailstack_provision_buy_request.go
+++ b/packages/server/events-subscribers/listeners/events/mailstack_provision_buy_request.go
@@ -97,14 +97,19 @@ func (l *MailstackProvisionBuyRequestListener) handle(ctx context.Context, entit
 			continue
 		}
 
-		mailboxes, err := l.dependencies.PostgresRepositories.TenantSettingsMailboxRepository.GetAllByDomain(ctx, domain.Domain)
+		statusCode, errMessage, mailboxes, err := l.dependencies.CommonServices.MailstackService.GetMailboxes(ctx, domain.Tenant, domain.Domain)
 		if err != nil {
+			tracing.TraceErr(span, err)
+			return err
+		}
+		if statusCode != http.StatusOK {
+			err = errors.New(errMessage)
 			tracing.TraceErr(span, err)
 			return err
 		}
 
 		for _, mailbox := range mailboxes {
-			if mailbox.Status != postgres_entity.MailboxStatusPendingProvisioning {
+			if mailbox.Provisioned {
 				continue
 			}
 
@@ -279,14 +284,20 @@ func (l *MailstackProvisionBuyRequestListener) processMailboxes(ctx context.Cont
 			sem <- struct{}{}        // Acquire semaphore
 			defer func() { <-sem }() // Release semaphore
 
-			mailboxes, err := l.dependencies.PostgresRepositories.TenantSettingsMailboxRepository.GetAllByDomain(ctx, domain.Domain)
+			statusCode, errMessage, mailboxes, err := l.dependencies.CommonServices.MailstackService.GetMailboxes(ctx, domain.Tenant, domain.Domain)
 			if err != nil {
 				tracing.TraceErr(span, err)
 				return // Exit the goroutine on error
 			}
 
+			if statusCode != http.StatusOK {
+				err = errors.New(errMessage)
+				tracing.TraceErr(span, err)
+				return // Exit the goroutine on error
+			}
+
 			for _, mailbox := range mailboxes {
-				if mailbox.Status != postgres_entity.MailboxStatusPendingProvisioning {
+				if mailbox.Provisioned {
 					continue
 				}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor mailbox retrieval to use `MailstackService.GetMailboxes()` instead of direct database queries, enhancing modularity and error handling.
> 
>   - **Behavior**:
>     - Replaces direct database queries for mailboxes with `MailstackService.GetMailboxes()` in `mailstack.resolvers.go`, `user.resolvers.go`, and `mailbox.go`.
>     - Updates error handling to check `statusCode` and `errMessage` from `MailstackService.GetMailboxes()`.
>   - **Service Changes**:
>     - Adds `userId` parameter to `MailstackService.GetMailboxes()` in `mailstack.go`.
>     - Updates `MailstackService` initialization in `init.go` to include `mailstackImpl`.
>   - **Repository Changes**:
>     - Removes `GetAllByDomain()` and `GetAllByUserId()` from `tenant_settings_mailbox_repository.go`.
>   - **Misc**:
>     - Updates `MailboxRecord` struct in `interfaces/mailstack.go` to include `Provisioned` field.
>     - Adjusts `flow_execution/service.go` to use `mailbox.Email` instead of `mailbox.MailboxUsername`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2bdd06762a768fc48a3236a70a1a4e31bd362d0b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->