### PR TITLE
Fix payment link

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -191,14 +191,6 @@ func (c *SyncInvoiceToAccountingCapability) Execute(ctx context.Context, executi
 				return enum.CapabilityExecutionRetry, result, err
 			}
 		}
-
-		if invoiceEntity.QuickbooksPaymentIdReverse == "" {
-			err = c.syncPaymentLinkingJournalEntryToInvoiceReverse(ctx, *invoiceEntity)
-			if err != nil {
-				tracing.TraceErr(span, err)
-				return enum.CapabilityExecutionRetry, result, err
-			}
-		}
 	}
 
 	// re-fetch invoice to get updated quickbooks journal id
@@ -663,45 +655,6 @@ func (c *SyncInvoiceToAccountingCapability) syncPaymentLinkingJournalEntryToInvo
 		}
 	}
 
-	return nil
-}
-
-func (c *SyncInvoiceToAccountingCapability) syncPaymentLinkingJournalEntryToInvoiceReverse(ctx context.Context, invoice neo4jentity.InvoiceEntity) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SyncInvoiceToAccountingCapability.syncPaymentLinkingJournalEntryToInvoiceReverse")
-	defer span.Finish()
-	tracing.TagTenant(span, common.GetTenantFromContext(ctx))
-	tenant := common.GetTenantFromContext(ctx)
-
-	quickbooksSettingsEntity, err := c.postgresRepositories.QuickbooksSettingsRepository.Get(ctx, tenant)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return err
-	}
-	if quickbooksSettingsEntity == nil {
-		err = errors.New("Quickbooks settings not found")
-		tracing.TraceErr(span, err)
-		return err
-	}
-
-	contractEntity, err := c.contractService.GetContractForInvoice(ctx, invoice.Id)
-	if err != nil {
-		tracing.TraceErr(span, err)
-		return err
-	}
-
-	// Link reverse journal entry to invoice
-	quickbooksPaymentReverse, err := c.quickbooksService.SavePaymentLinkingJournalEntryToInvoice(ctx, contractEntity.QuickbooksCustomerId, invoice.QuickbooksInvoiceId, invoice.QuickbooksJournalEntryIdReverse, invoice.IssuedDate, invoice.Amount)
-	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error saving payment linking journal entry to invoice"))
-		return err
-	}
-	if quickbooksPaymentReverse != nil {
-		err = c.neo4jRepositories.CommonWriteRepository.UpdateStringProperty(ctx, nil, tenant, commonmodel.NodeLabelInvoice, invoice.Id, string(neo4jentity.InvoicePropertyQuickbooksPaymentIdReverse), quickbooksPaymentReverse.Payment.Id)
-		if err != nil {
-			tracing.TraceErr(span, err)
-			return err
-		}
-	}
 	return nil
 }
 

--- a/packages/server/customer-os-neo4j-repository/entity/invoice.go
+++ b/packages/server/customer-os-neo4j-repository/entity/invoice.go
@@ -27,7 +27,6 @@ const (
 	InvoicePropertyQuickbooksJournalEntryId             InvoiceProperty = "quickbooksJournalEntryId"
 	InvoicePropertyQuickbooksJournalEntryIdReverse      InvoiceProperty = "quickbooksJournalEntryIdReverse"
 	InvoicePropertyQuickbooksPaymentId                  InvoiceProperty = "quickbooksPaymentId"
-	InvoicePropertyQuickbooksPaymentIdReverse           InvoiceProperty = "quickbooksPaymentIdReverse"
 	InvoicePropertyProviderBankDetailsAvailable         InvoiceProperty = "providerBankDetailsAvailable"
 	InvoicePropertyProviderBankAccountName              InvoiceProperty = "providerBankAccountName"
 	InvoicePropertyProviderBankAccountNumber            InvoiceProperty = "providerBankAccountNumber"
@@ -63,7 +62,6 @@ type InvoiceEntity struct {
 	QuickbooksJournalEntryId        string
 	QuickbooksJournalEntryIdReverse string
 	QuickbooksPaymentId             string
-	QuickbooksPaymentIdReverse      string
 	PaymentDetails                  PaymentDetails
 	OffCycle                        bool
 	Postpaid                        bool

--- a/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
+++ b/packages/server/customer-os-neo4j-repository/mapper/node_to_entity_mapper.go
@@ -119,7 +119,6 @@ func MapDbNodeToInvoiceEntity(dbNode *dbtype.Node) *neo4j_entity.InvoiceEntity {
 		QuickbooksJournalEntryId:        utils.GetStringPropOrEmpty(props, string(neo4j_entity.InvoicePropertyQuickbooksJournalEntryId)),
 		QuickbooksJournalEntryIdReverse: utils.GetStringPropOrEmpty(props, string(neo4j_entity.InvoicePropertyQuickbooksJournalEntryIdReverse)),
 		QuickbooksPaymentId:             utils.GetStringPropOrEmpty(props, string(neo4j_entity.InvoicePropertyQuickbooksPaymentId)),
-		QuickbooksPaymentIdReverse:      utils.GetStringPropOrEmpty(props, string(neo4j_entity.InvoicePropertyQuickbooksPaymentIdReverse)),
 		Customer: neo4j_entity.InvoiceCustomer{
 			Name:         utils.GetStringPropOrEmpty(props, "customerName"),
 			Email:        utils.GetStringPropOrEmpty(props, "customerEmail"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `QuickbooksPaymentIdReverse` property and related logic from invoice synchronization.
> 
>   - **Behavior**:
>     - Removes `syncPaymentLinkingJournalEntryToInvoiceReverse()` function from `capability_invoice_sync_to_accounting.go`.
>     - Removes logic checking `QuickbooksPaymentIdReverse` in `Execute()` in `capability_invoice_sync_to_accounting.go`.
>   - **Models**:
>     - Removes `QuickbooksPaymentIdReverse` from `InvoiceEntity` and `InvoiceProperty` in `invoice.go`.
>   - **Mapping**:
>     - Updates `MapDbNodeToInvoiceEntity()` in `node_to_entity_mapper.go` to remove `QuickbooksPaymentIdReverse` mapping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for e71a905ec53233bc617baaab075271ced21329cb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->