### PR TITLE
Final final fix

### DIFF
--- a/.github/workflows/pr-notifications.yml
+++ b/.github/workflows/pr-notifications.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   notify:
+    # Only run for non-draft PRs OR when a PR becomes ready for review
+    if: github.event.pull_request.draft == false || github.event.action == 'ready_for_review'
     runs-on: ubuntu-latest
     steps:
       - name: Handle PR Events


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add condition to `pr-notifications.yml` to run `notify` job only for non-draft PRs or when a PR becomes ready for review.
> 
>   - **Workflow**:
>     - In `.github/workflows/pr-notifications.yml`, added a condition to the `notify` job to only run for non-draft PRs or when a PR becomes ready for review.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for fb12256bf7ee7884de901a9470d3604d88d9246b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->