### PR TITLE
patch: Fix panic in upkeeper

### DIFF
--- a/packages/server/customer-os-common-module/services/webscraper/classify_category.go
+++ b/packages/server/customer-os-common-module/services/webscraper/classify_category.go
@@ -58,9 +58,11 @@ func (s *webscraperService) ClassifyWebpageCategory(ctx context.Context, url str
 	}
 
 	prompt.WriteString(fmt.Sprintf("Webpage url: %s\n", url))
-	if *pageContent != "" {
+	if pageContent != nil && *pageContent != "" {
 		prompt.WriteString("--- Webpage content --- \n")
 		prompt.WriteString(*pageContent)
+	} else {
+		prompt.WriteString("--- No content available ---\n")
 	}
 	promptStr := prompt.String()
 

--- a/packages/server/customer-os-common-module/services/webscraper/classify_category.go
+++ b/packages/server/customer-os-common-module/services/webscraper/classify_category.go
@@ -49,8 +49,14 @@ func (s *webscraperService) ClassifyWebpageCategory(ctx context.Context, url str
 
 	var prompt strings.Builder
 
-	prompt.WriteString(fmt.Sprintf("Company name: %s\n", globalOrg.Name))
-	prompt.WriteString(fmt.Sprintf("Company description: %s\n", globalOrg.Description))
+	if globalOrg != nil {
+		prompt.WriteString(fmt.Sprintf("Company name: %s\n", globalOrg.Name))
+		prompt.WriteString(fmt.Sprintf("Company description: %s\n", globalOrg.Description))
+	} else {
+		// If no organization found, just use the domain
+		prompt.WriteString(fmt.Sprintf("Website domain: %s\n", primaryDomain))
+	}
+
 	prompt.WriteString(fmt.Sprintf("Webpage url: %s\n", url))
 	if *pageContent != "" {
 		prompt.WriteString("--- Webpage content --- \n")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes potential panic in `ClassifyWebpageCategory` by adding nil checks for `globalOrg` and `pageContent`.
> 
>   - **Behavior**:
>     - Fixes potential panic in `ClassifyWebpageCategory` by adding nil checks for `globalOrg` and `pageContent`.
>     - If `globalOrg` is nil, uses `primaryDomain` instead of organization details.
>     - If `pageContent` is nil or empty, adds "--- No content available ---" to the prompt.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 6d888dfb1857054539669b4a070ca10cc7059529. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->