### PR TITLE
publish images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,3 +186,56 @@ jobs:
         with:
           name: workflow-data
           path: workflow-data.json
+
+  publish-images:
+    needs: create-release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - customer-os-api
+          - customer-os-platform-admin-api
+          - customer-os-webhooks
+          - customer-os-data-upkeeper
+          - events-subscribers
+          - sync-customer-os-data
+          - sync-slack
+          - realtime
+          - mailsherpa-api
+          - integrity-checker
+          - apigator
+          - browser-automation-api
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set package path
+        id: package_path
+        run: |
+          if [[ "${{ matrix.service }}" == "customer-os-data-upkeeper" ]] || \
+             [[ "${{ matrix.service }}" == "sync-customer-os-data" ]] || \
+             [[ "${{ matrix.service }}" == "sync-slack" ]] || \
+             [[ "${{ matrix.service }}" == "integrity-checker" ]]; then
+            echo "path=runner" >> $GITHUB_OUTPUT
+          else
+            echo "path=server" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: packages/${{ steps.package_path.outputs.path }}/${{ matrix.service }}/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY_BASE }}/${{ matrix.service }}:latest
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY_BASE }}/${{ matrix.service }}:${{ needs.create-release.outputs.next_version }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `publish-images` job to GitHub Actions workflow to build and push Docker images for multiple services.
> 
>   - **New Job**:
>     - Adds `publish-images` job to `.github/workflows/release.yml`.
>     - Runs after `create-release` job.
>   - **Matrix Strategy**:
>     - Includes services: `customer-os-api`, `customer-os-platform-admin-api`, `customer-os-webhooks`, `customer-os-data-upkeeper`, `events-subscribers`, `sync-customer-os-data`, `sync-slack`, `realtime`, `mailsherpa-api`, `integrity-checker`, `apigator`, `browser-automation-api`.
>   - **Docker Setup**:
>     - Uses `docker/setup-buildx-action@v3` for Docker Buildx.
>     - Logs into GitHub Container Registry using `docker/login-action@v3`.
>   - **Package Path**:
>     - Sets `path=runner` for `customer-os-data-upkeeper`, `sync-customer-os-data`, `sync-slack`, `integrity-checker`.
>     - Sets `path=server` for other services.
>   - **Build and Push**:
>     - Uses `docker/build-push-action@v5` to build and push images.
>     - Tags images with `latest` and version from `create-release` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for b0e9495bc874b7c30d9202f18a65d3a0383c20c7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->