### PR TITLE
Exclude ws from cors

### DIFF
--- a/packages/server/realtime/lib/realtime_web/endpoint.ex
+++ b/packages/server/realtime/lib/realtime_web/endpoint.ex
@@ -38,7 +38,7 @@ defmodule RealtimeWeb.Endpoint do
     param_key: "request_logger",
     cookie_key: "request_logger"
 
-  plug CORSPlug,
+  plug RealtimeWeb.Plugs.CORSWebSocket,
     origin: "*",
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     headers: [

--- a/packages/server/realtime/lib/realtime_web/plugs/maybe_cors.ex
+++ b/packages/server/realtime/lib/realtime_web/plugs/maybe_cors.ex
@@ -1,0 +1,18 @@
+defmodule RealtimeWeb.Plugs.CORSWebSocket do
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, opts) do
+    if websocket_request?(conn) do
+      # Skip CORS for WebSockets
+      conn
+    else
+      CORSPlug.call(conn, CORSPlug.init(opts))
+    end
+  end
+
+  defp websocket_request?(conn) do
+    conn |> get_req_header("upgrade") |> List.first() |> String.downcase() == "websocket"
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `CORSWebSocket` plug to bypass CORS for WebSocket requests and integrate `cors_plug` for HTTP requests.
> 
>   - **CORS Handling**:
>     - Introduced `RealtimeWeb.Plugs.CORSWebSocket` to bypass CORS for WebSocket requests in `maybe_cors.ex`.
>     - Integrated `CORSWebSocket` plug into `RealtimeWeb.Endpoint` to handle CORS for HTTP requests.
>   - **Dependencies**:
>     - Added `cors_plug` dependency in `mix.exs` and `mix.lock` for CORS handling.
>   - **Configuration**:
>     - Enabled HTTP and HTTPS compression in `prod.exs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3e66eff31f6c4a2485629d688994f5bbf4032802. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->