### PR TITLE
Add join function without username to channels

### DIFF
--- a/packages/server/realtime/lib/realtime_web/channels/finder_view_channel.ex
+++ b/packages/server/realtime/lib/realtime_web/channels/finder_view_channel.ex
@@ -8,6 +8,19 @@ defmodule RealtimeWeb.FinderChannel do
   alias RealtimeWeb.Presence
 
   @impl true
+  def join("finder:" <> _organization_id, %{"user_id" => user_id}, socket) do
+    {:ok, color} = ColorManager.assign_color(user_id)
+
+    socket =
+      socket
+      |> assign(:user_id, user_id)
+      |> assign(user_color: %{user_id => color})
+
+    send(self(), :after_join)
+    {:ok, socket}
+  end
+
+  @impl true
   def join("finder:" <> _organization_id, %{"user_id" => user_id, "username" => username}, socket) do
     {:ok, color} = ColorManager.assign_color(user_id)
 
@@ -27,20 +40,13 @@ defmodule RealtimeWeb.FinderChannel do
       Presence.track(socket, socket.assigns.user_id, %{
         online_at: inspect(System.system_time(:second)),
         metadata: %{"source" => "customerOS"},
-        username: socket.assigns.username,
+        username: Map.get(socket.assigns, :username, "Anonymous"),
         user_id: socket.assigns.user_id,
         color: Map.get(socket.assigns.user_color, socket.assigns.user_id)
       })
 
     push(socket, "presence_state", Presence.list(socket))
     {:noreply, socket}
-  end
-
-  # Channels can be used in a request/response fashion
-  # by sending replies to requests from the client
-  @impl true
-  def handle_in("ping", payload, socket) do
-    {:reply, {:ok, payload}, socket}
   end
 
   @impl true

--- a/packages/server/realtime/lib/realtime_web/channels/organization_view_channel.ex
+++ b/packages/server/realtime/lib/realtime_web/channels/organization_view_channel.ex
@@ -11,6 +11,23 @@ defmodule RealtimeWeb.OrganizationViewChannel do
   @impl true
   def join(
         "organization_presence:" <> _organization_id,
+        %{"user_id" => user_id},
+        socket
+      ) do
+    {:ok, color} = ColorManager.assign_color(user_id)
+
+    socket =
+      socket
+      |> assign(:user_id, user_id)
+      |> assign(user_color: %{user_id => color})
+
+    send(self(), :after_join)
+    {:ok, socket}
+  end
+
+  @impl true
+  def join(
+        "organization_presence:" <> _organization_id,
         %{"user_id" => user_id, "username" => username},
         socket
       ) do
@@ -32,53 +49,12 @@ defmodule RealtimeWeb.OrganizationViewChannel do
       Presence.track(socket, socket.assigns.user_id, %{
         online_at: inspect(System.system_time(:second)),
         metadata: %{"source" => "customerOS"},
-        username: socket.assigns.username,
+        username: Map.get(socket.assigns, :username, "Anonymous"),
         user_id: socket.assigns.user_id,
         color: Map.get(socket.assigns.user_color, socket.assigns.user_id)
       })
 
     push(socket, "presence_state", Presence.list(socket))
-    # push(socket, "feed", %{list: feed_items(socket)}) # push CRDT state to the client
-    {:noreply, socket}
-  end
-
-  # # Helper functions
-  # defp merge_states(crdt_state, client_state) do
-  #   Map.merge(client_state, crdt_state)
-  # end
-  # defp feed_items(socket) do
-  #   # Use the socket to fetch the feed items
-  #   # if client has data already in the socket, use that
-  #   # client_state = if Map.has_key?(payload, "body") do
-  #   #   Map.fetch!(payload, "body")
-  #   # else
-  #   #   %{"body" => ""}
-  #   # end
-  #   client_state = %{"body" => ""}
-  #   # Fetch current CRDT state
-  #   crdt_state = RealtimeWeb.GlobalConfig.get(:payload)
-  #   Logger.debug("CRDT state: #{inspect(crdt_state)}")
-
-  #   # Merge CRDT state with client state
-  #   merged_state = merge_states(crdt_state, client_state)
-  #   Logger.debug("Merged state: #{inspect(merged_state)}")
-
-  #   # Push merged state back to the client
-  #   push(socket, "shout", merged_state)
-  # end
-
-  # Channels can be used in a request/response fashion
-  # by sending replies to requests from the client
-  @impl true
-  def handle_in("ping", payload, socket) do
-    {:reply, {:ok, payload}, socket}
-  end
-
-  # It is also common to receive messages from the client and
-  # broadcast to everyone in the current topic (chat:lobby).
-  @impl true
-  def handle_in("shout", payload, socket) do
-    broadcast!(socket, "shout", payload)
     {:noreply, socket}
   end
 


### PR DESCRIPTION
Remove unused handle_in functions and comments
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `join` function without `username` to channels and remove unused code.
> 
>   - **Behavior**:
>     - Add `join/3` function in `finder_view_channel.ex` and `organization_view_channel.ex` to handle cases without `username`.
>     - Default `username` to "Anonymous" if not provided in `handle_info/2` in both files.
>   - **Code Cleanup**:
>     - Remove unused `handle_in/3` functions and comments from `finder_view_channel.ex` and `organization_view_channel.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 41def5733f3ada85d70df5ac1223d91e41c5aedf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->