### PR TITLE
Set default sync to qbo config

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -66,6 +66,9 @@ func (c *SyncInvoiceToAccountingCapability) NewConfig() SyncInvoiceToAccountingC
 
 func (c *SyncInvoiceToAccountingCapability) DefaultConfig() any {
 	config := c.NewConfig()
+	config.Quickbooks.Value = false
+	config.AccountingMethodAccrual.Value = false
+	config.ARIncomeAccountName.Value = "Accounts receivable (A/R)"
 	return &config
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set default values in `DefaultConfig()` of `SyncInvoiceToAccountingCapability` for Quickbooks integration.
> 
>   - **Behavior**:
>     - Set default values in `DefaultConfig()` of `SyncInvoiceToAccountingCapability`.
>     - `Quickbooks.Value` set to `false`.
>     - `AccountingMethodAccrual.Value` set to `false`.
>     - `ARIncomeAccountName.Value` set to `"Accounts receivable (A/R)"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 6b5080ac9f530ebe0e4f66289917f4394820931d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->