### PR TITLE
Add username to socket assigns in join functions

### DIFF
--- a/packages/server/realtime/lib/realtime_web/channels/finder_view_channel.ex
+++ b/packages/server/realtime/lib/realtime_web/channels/finder_view_channel.ex
@@ -8,19 +8,6 @@ defmodule RealtimeWeb.FinderChannel do
   alias RealtimeWeb.Presence
 
   @impl true
-  def join("finder:" <> _organization_id, %{"user_id" => user_id}, socket) do
-    {:ok, color} = ColorManager.assign_color(user_id)
-
-    socket =
-      socket
-      |> assign(:user_id, user_id)
-      |> assign(user_color: %{user_id => color})
-
-    send(self(), :after_join)
-    {:ok, socket}
-  end
-
-  @impl true
   def join("finder:" <> _organization_id, %{"user_id" => user_id, "username" => username}, socket) do
     {:ok, color} = ColorManager.assign_color(user_id)
 
@@ -28,6 +15,19 @@ defmodule RealtimeWeb.FinderChannel do
       socket
       |> assign(:user_id, user_id)
       |> assign(:username, username)
+      |> assign(user_color: %{user_id => color})
+
+    send(self(), :after_join)
+    {:ok, socket}
+  end
+
+  @impl true
+  def join("finder:" <> _organization_id, %{"user_id" => user_id}, socket) do
+    {:ok, color} = ColorManager.assign_color(user_id)
+
+    socket =
+      socket
+      |> assign(:user_id, user_id)
       |> assign(user_color: %{user_id => color})
 
     send(self(), :after_join)

--- a/packages/server/realtime/lib/realtime_web/channels/organization_view_channel.ex
+++ b/packages/server/realtime/lib/realtime_web/channels/organization_view_channel.ex
@@ -11,23 +11,6 @@ defmodule RealtimeWeb.OrganizationViewChannel do
   @impl true
   def join(
         "organization_presence:" <> _organization_id,
-        %{"user_id" => user_id},
-        socket
-      ) do
-    {:ok, color} = ColorManager.assign_color(user_id)
-
-    socket =
-      socket
-      |> assign(:user_id, user_id)
-      |> assign(user_color: %{user_id => color})
-
-    send(self(), :after_join)
-    {:ok, socket}
-  end
-
-  @impl true
-  def join(
-        "organization_presence:" <> _organization_id,
         %{"user_id" => user_id, "username" => username},
         socket
       ) do
@@ -37,6 +20,23 @@ defmodule RealtimeWeb.OrganizationViewChannel do
       socket
       |> assign(:user_id, user_id)
       |> assign(:username, username)
+      |> assign(user_color: %{user_id => color})
+
+    send(self(), :after_join)
+    {:ok, socket}
+  end
+
+  @impl true
+  def join(
+        "organization_presence:" <> _organization_id,
+        %{"user_id" => user_id},
+        socket
+      ) do
+    {:ok, color} = ColorManager.assign_color(user_id)
+
+    socket =
+      socket
+      |> assign(:user_id, user_id)
       |> assign(user_color: %{user_id => color})
 
     send(self(), :after_join)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `username` to socket assigns in `join/3` functions of `finder_view_channel.ex` and `organization_view_channel.ex`.
> 
>   - **Behavior**:
>     - In `finder_view_channel.ex`, `join/3` now assigns `username` to the socket when provided.
>     - In `organization_view_channel.ex`, `join/3` now assigns `username` to the socket when provided.
>   - **Code Changes**:
>     - Removed redundant `join/3` function overloads that handled `username` separately in both `finder_view_channel.ex` and `organization_view_channel.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 431b07436d3927e958737f377dfeb2986d605e8e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->