### PR TITLE
patch: fix timestamp format for opensearch

### DIFF
--- a/packages/server/customer-os-common-module/services/events/publisher.go
+++ b/packages/server/customer-os-common-module/services/events/publisher.go
@@ -464,7 +464,7 @@ func (r *RabbitMQPublisher) publishEventOnExchange(ctx context.Context, entityId
 			AppSource:   common.GetAppSourceFromContext(ctx),
 			UserId:      common.GetUserIdFromContext(ctx),
 			UserEmail:   common.GetUserEmailFromContext(ctx),
-			Timestamp:   utils.Now().String(),
+			Timestamp:   utils.Now().Format(time.RFC3339),
 		},
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes timestamp format in `publishEventOnExchange` in `publisher.go` to use `time.RFC3339` for OpenSearch compatibility.
> 
>   - **Behavior**:
>     - Fixes timestamp format in `publishEventOnExchange` in `publisher.go` to use `time.RFC3339`.
>     - Ensures compatibility with OpenSearch by using a standard timestamp format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 93c76aafbe5c6931c328ab05b181516b1858f181. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->