### PR TITLE
check linked in from brandfetch

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
@@ -381,9 +381,41 @@ func (s *globalOrganizationService) syncBrandfetchToGlobalOrganization() {
 		otherSocials := []string{}
 		for _, link := range data.Links {
 			if link.Url != "" && strings.Contains(link.Url, "linkedin.com/company") && globalOrganization.LinkedInUrl == "" {
-				globalOrganization.LinkedInUrl = link.Url
-				break
-			} else if link.Url != "" && !strings.Contains(link.Url, "linkedin.com/company") {
+				_, scrapinResponse, err := s.commonServices.EnrichmentService.ScrapInCompanyProfile(ctx, link.Url)
+				if err != nil {
+					tracing.TraceErr(span, errors.Wrap(err, "error calling scrapin for company profile"))
+					s.log.Errorf("Error calling scrapin for company profile: %s", err.Error())
+					continue
+				}
+
+				if scrapinResponse != nil && scrapinResponse.Company != nil {
+					globalOrganization.LinkedInUrl = scrapinResponse.Company.LinkedInUrl
+					if scrapinResponse.Company.UniversalName != "" && globalOrganization.LinkedInAlias == "" {
+						globalOrganization.LinkedInAlias = scrapinResponse.Company.UniversalName
+					}
+					if scrapinResponse.Company.Logo != "" && globalOrganization.LogoUrl == "" {
+						globalOrganization.LogoUrl = scrapinResponse.Company.Logo
+					}
+					if scrapinResponse.Company.Headquarter.City != "" && globalOrganization.City == "" {
+						globalOrganization.City = scrapinResponse.Company.Headquarter.City
+					}
+					if scrapinResponse.Company.Headquarter.GeographicArea != "" && globalOrganization.Region == "" {
+						globalOrganization.Region = scrapinResponse.Company.Headquarter.GeographicArea
+					}
+					if scrapinResponse.Company.Headquarter.Country != "" && globalOrganization.CountryA2 == "" {
+						if strings.ToUpper(scrapinResponse.Company.Headquarter.Country) == "OO" {
+							globalOrganization.CountryA2 = ""
+						} else {
+							country := countries.ByName(scrapinResponse.Company.Headquarter.Country)
+							if country != countries.Unknown {
+								globalOrganization.CountryA2 = country.Alpha2()
+							} else {
+								globalOrganization.CountryA2 = ""
+							}
+						}
+					}
+				}
+			} else if link.Url != "" && !strings.Contains(link.Url, "linkedin.com") {
 				otherSocials = append(otherSocials, link.Url)
 			}
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `syncBrandfetchToGlobalOrganization` to enrich LinkedIn data using `ScrapInCompanyProfile`, updating `globalOrganization` fields accordingly.
> 
>   - **Behavior**:
>     - In `syncBrandfetchToGlobalOrganization`, added logic to call `ScrapInCompanyProfile` for LinkedIn URLs to enrich `globalOrganization` with LinkedIn data.
>     - Updates `globalOrganization` fields like `LinkedInUrl`, `LinkedInAlias`, `LogoUrl`, `City`, `Region`, and `CountryA2` based on `scrapinResponse`.
>   - **Error Handling**:
>     - Logs errors to Sentry and continues processing other records if `ScrapInCompanyProfile` fails.
>   - **Misc**:
>     - Refactored LinkedIn URL handling to include additional checks and data enrichment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 91d31fc97622c5d8639679a3f768219d3a849aae. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->