### PR TITLE
more ARM images

### DIFF
--- a/.github/workflows/build-browser-automation-api.yml
+++ b/.github/workflows/build-browser-automation-api.yml
@@ -2,7 +2,7 @@ name: browser-automation-service
 
 on:
   push:
-    branches: ["otter"]
+    branches: [ "otter" ]
     paths:
       - "packages/server/browser-automation-api/**"
       - ".github/workflows/build-browser-automation-api.yml"
@@ -11,7 +11,7 @@ on:
       - "packages/server/browser-automation-api/**"
       - ".github/workflows/build-browser-automation-api.yml"
   release:
-    types: [created, edited]
+    types: [ created, edited ]
 
 env:
   REGISTRY: ghcr.io
@@ -19,41 +19,176 @@ env:
 
 permissions:
   contents: read
+  pull-requests: read
   packages: write
 
 jobs:
-  build-publish:
+  # Generate common metadata for all builds
+  prepare:
     runs-on: ubicloud-standard-2
     if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      safe-tag: ${{ steps.safe-tag.outputs.value }}
     steps:
-      - name: Delete huge unnecessary tools folder
-        run: rm -rf /opt/hostedtoolcache
+      # Create a safe tag string from the branch name (replace / with -)
+      - name: Set safe tag
+        id: safe-tag
+        run: |
+          # For PR events, use pr-NUMBER format instead of the branch name
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "value=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            # For normal branches, replace / with - to make it safe for tags
+            SAFE_TAG=$(echo "${{ github.ref_name }}" | sed 's/\//-/g')
+            echo "value=$SAFE_TAG" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+        working-directory: .
 
+  build-amd64:
+    needs: [ prepare ]
+    runs-on: ubicloud-standard-2
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
+    steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: ubicloud/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-
+      # Log in to registry
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.REPOSITORY_READ_WRITE_USERNAME }}
-          password: ${{ secrets.REPOSITORY_READ_WRITE_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5.7.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Push Docker image
-        uses: docker/build-push-action@v6.15.0
+      # Build and push amd64 image
+      - name: Build and push amd64 image
+        id: docker_build
+        uses: docker/build-push-action@v6
         with:
-          context: packages/server/browser-automation-api
-          push: ${{ github.ref_name == 'otter' || github.event_name == 'release' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          context: ./packages/server/browser-automation-api
+          file: ./packages/server/browser-automation-api/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64
+          provenance: false
+          outputs: type=registry,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Get image digest
+      - name: Get image digest
+        id: digest
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 --format "{{json .Manifest}}" | jq -r '.digest')
+          echo "value=$digest" >> $GITHUB_OUTPUT
+        shell: bash
+
+  build-arm64:
+    needs: [ prepare ]
+    runs-on: ubicloud-standard-2-arm
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Log in to registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build and push arm64 image
+      - name: Build and push arm64 image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./packages/server/browser-automation-api
+          file: ./packages/server/browser-automation-api/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          provenance: false
+          outputs: type=registry,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Get image digest
+      - name: Get image digest
+        id: digest
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64 --format "{{json .Manifest}}" | jq -r '.digest')
+          echo "value=$digest" >> $GITHUB_OUTPUT
+        shell: bash
+
+  # Create multi-arch manifests
+  create-manifest:
+    needs: [ prepare, build-amd64, build-arm64 ]
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Log in to the Container registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Create and push manifests
+      - name: Create and push manifests
+        run: |
+          # Create and push the SHA manifest
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          
+          # Create and push the branch/PR manifest
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe-tag }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          
+          # If this is the otter branch, also tag as latest
+          if [[ "${{ github.ref_name }}" == "otter" ]]; then
+            docker buildx imagetools create \
+              --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          fi
+          
+          # For releases, also tag with the release tag
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            # For releases, the tag should be the release tag
+            RELEASE_TAG=$(echo "${{ github.ref_name }}" | sed 's/\//-/g')
+            docker buildx imagetools create \
+              --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$RELEASE_TAG \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          fi
+        shell: bash
+
+      # Inspect the created manifest
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe-tag }}
+        shell: bash
+        

--- a/.github/workflows/build-customer-os-api.yml
+++ b/.github/workflows/build-customer-os-api.yml
@@ -116,7 +116,7 @@ jobs:
   # Generate common metadata for all builds
   prepare:
     needs: [ test ]
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
     outputs:
       safe-tag: ${{ steps.safe-tag.outputs.value }}
@@ -226,7 +226,7 @@ jobs:
   create-manifest:
     needs: [ prepare, build-amd64, build-arm64 ]
     if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-customer-os-platform-admin-api.yml
+++ b/.github/workflows/build-customer-os-platform-admin-api.yml
@@ -96,7 +96,7 @@ jobs:
   # Generate common metadata for all builds
   prepare:
     needs: [ test ]
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
     outputs:
       safe-tag: ${{ steps.safe-tag.outputs.value }}
@@ -206,7 +206,7 @@ jobs:
   create-manifest:
     needs: [ prepare, build-amd64, build-arm64 ]
     if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-customer-os-webhooks.yml
+++ b/.github/workflows/build-customer-os-webhooks.yml
@@ -40,6 +40,14 @@ defaults:
 jobs:
   test:
     runs-on: ubicloud-standard-2
+    env:
+      CGO_ENABLED: 0
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [ neo4j, postgres, other ]
     steps:
       - uses: actions/checkout@v4
 
@@ -53,14 +61,11 @@ jobs:
           GOSUMDB: "off"
           GOMODCACHE: ${{ github.workspace }}/go/pkg/mod
 
-      - name: Build
-        run: make all
-
-      - name: Configure Test Folders
-        id: test-folders
-        run: |
-          test_folders=$(go list ./... | grep -v /gen | grep -v /test | paste -sd "," -)
-          echo "{name}={test_folders}" >> $GITHUB_OUTPUT
+      - name: Cache Go tools
+        uses: ubicloud/cache@v4
+        with:
+          path: ${{ env.GOBIN }}
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('./packages/server/customer-os-webhooks/go.sum') }}
 
       - name: Install gotestsum
         run: |
@@ -70,56 +75,211 @@ jobs:
           fi
           echo "${{ env.GOBIN }}" >> $GITHUB_PATH
 
-      - name: Test
-        run: gotestsum --junitfile unit-tests.xml -- -coverprofile=cover.out -coverpkg=${{ steps.test-folders.outputs.test_folders }} ./...
-
-      - name: Test Report
-        uses: mikepenz/action-junit-report@v5
-        if: always()    # run this step even if previous step failed
+      - name: Go Cache
+        id: go-cache
+        uses: ubicloud/cache@v4
         with:
-          report_paths: ./packages/server/customer-os-webhooks/unit-tests.xml    # Path to test results
-          include_passed: true
-          annotate_only: true
-          detailed_summary: true
+          path: |
+            ~/.cache/go-build
+            ${{ env.GOMODCACHE }}
+          key: ${{ runner.os }}-go-${{ hashFiles('packages/server/customer-os-webhooks/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-      - name: Compute Code Coverage
-        id: compute_code_coverage
+      - name: Build
+        if: steps.go-cache.outputs.cache-hit != 'true'
+        run: make all
+
+      - name: Get test packages
+        id: get-packages
         run: |
-          echo "## Code Coverage" >> $GITHUB_STEP_SUMMARY
-          echo "|Filename|Function|Coverage|" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|--------|--------|" >> $GITHUB_STEP_SUMMARY
-          go tool cover -func=cover.out |sed -r  's/[[:space:]]+/|/g'|sed -r 's/$/|/g'|sed -r 's/^/|/g' >> $GITHUB_STEP_SUMMARY
-          go tool cover -func=cover.out | sed -r 's/[[:space:]]+/|/g' | sed -r 's/$/|/g' | sed -r 's/^/|/g' | tail -n 1 > test-coverage.txt
-          coverage=$(cat test-coverage.txt | awk -F'|' '{gsub(/%/, "", $(NF-1)); print $(NF-1)}')
-          echo "::set-output name=computed_coverage::$coverage"
+          # Get all packages except repository, rest, and graph/resolver
+          PACKAGES=$(go list ./... | grep -v /gen | grep -v /test | grep -v /testify | grep -v "/rest" | grep -v "/repository" | grep -v "/graphql/resolver" | paste -sd " " -)
+          echo "packages=${PACKAGES}" >> "$GITHUB_OUTPUT"
 
-  build-publish:
-    needs:
-      - test
+      - name: Run Tests
+        id: run-tests
+        run: |
+          echo "Running tests for ${{ matrix.test-group }} repositories..."
+          case ${{ matrix.test-group }} in
+            neo4j)
+            gotestsum --junitfile unit-tests.xml -- -coverprofile=cover.out ../customer-os-neo4j-repository/repository/...
+            ;;
+            postgres)
+            gotestsum --junitfile unit-tests.xml -- -coverprofile=cover.out ../customer-os-postgres-repository/repository/...
+            ;;
+            other)
+            gotestsum --junitfile unit-tests.xml -- -coverprofile=cover.out ${{ steps.get-packages.outputs.packages }}
+            ;;
+          esac
+
+  # Generate common metadata for all builds
+  prepare:
+    needs: [ test ]
     runs-on: ubicloud-standard-2
     if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      safe-tag: ${{ steps.safe-tag.outputs.value }}
+    steps:
+      # Create a safe tag string from the branch name (replace / with -)
+      - name: Set safe tag
+        id: safe-tag
+        run: |
+          # For PR events, use pr-NUMBER format instead of the branch name
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "value=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            # For normal branches, replace / with - to make it safe for tags
+            SAFE_TAG=$(echo "${{ github.ref_name }}" | sed 's/\//-/g')
+            echo "value=$SAFE_TAG" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+        working-directory: .
+
+  build-amd64:
+    needs: [ prepare ]
+    runs-on: ubicloud-standard-2
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Log in to registry
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.REPOSITORY_READ_WRITE_USERNAME }}
-          password: ${{ secrets.REPOSITORY_READ_WRITE_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5.7.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Push Docker image
-        uses: docker/build-push-action@v6.15.0
+      # Build and push amd64 image
+      - name: Build and push amd64 image
+        id: docker_build
+        uses: docker/build-push-action@v6
         with:
-          context: ./packages/server/
+          context: ./packages/server
           file: ./packages/server/customer-os-webhooks/Dockerfile
-          push: ${{ github.ref_name == 'otter' || github.event_name == 'release' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64
+          provenance: false
+          outputs: type=registry,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Get image digest
+      - name: Get image digest
+        id: digest
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 --format "{{json .Manifest}}" | jq -r '.digest')
+          echo "value=$digest" >> $GITHUB_OUTPUT
+        shell: bash
+
+  build-arm64:
+    needs: [ prepare ]
+    runs-on: ubicloud-standard-2-arm
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Log in to registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build and push arm64 image
+      - name: Build and push arm64 image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./packages/server
+          file: ./packages/server/customer-os-webhooks/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          provenance: false
+          outputs: type=registry,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Get image digest
+      - name: Get image digest
+        id: digest
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64 --format "{{json .Manifest}}" | jq -r '.digest')
+          echo "value=$digest" >> $GITHUB_OUTPUT
+        shell: bash
+
+  # Create multi-arch manifests
+  create-manifest:
+    needs: [ prepare, build-amd64, build-arm64 ]
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Log in to the Container registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Create and push manifests
+      - name: Create and push manifests
+        run: |
+          # Create and push the SHA manifest
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          
+          # Create and push the branch/PR manifest
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe-tag }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          
+          # If this is the otter branch, also tag as latest
+          if [[ "${{ github.ref_name }}" == "otter" ]]; then
+            docker buildx imagetools create \
+              --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          fi
+          
+          # For releases, also tag with the release tag
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            # For releases, the tag should be the release tag
+            RELEASE_TAG=$(echo "${{ github.ref_name }}" | sed 's/\//-/g')
+            docker buildx imagetools create \
+              --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$RELEASE_TAG \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          fi
+        shell: bash
+
+      # Inspect the created manifest
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe-tag }}
+        shell: bash
+        

--- a/.github/workflows/build-events-subscribers.yml
+++ b/.github/workflows/build-events-subscribers.yml
@@ -19,7 +19,7 @@ on:
       - packages/server/events-subscribers/**
       - .github/workflows/build-events-subscribers.yml
   release:
-    types: [created, edited]
+    types: [ created, edited ]
 
 env:
   REGISTRY: ghcr.io
@@ -42,6 +42,14 @@ defaults:
 jobs:
   test:
     runs-on: ubicloud-standard-2
+    env:
+      CGO_ENABLED: 0
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [ neo4j, postgres, other ]
     steps:
       - uses: actions/checkout@v4
 
@@ -55,14 +63,11 @@ jobs:
           GOSUMDB: "off"
           GOMODCACHE: ${{ github.workspace }}/go/pkg/mod
 
-      - name: Build
-        run: make all
-
-      - name: Configure Test Folders
-        id: test-folders
-        run: |
-          test_folders=$(go list ./... | grep -v /gen | grep -v /test | paste -sd "," -)
-          echo "{name}={test_folders}" >> $GITHUB_OUTPUT
+      - name: Cache Go tools
+        uses: ubicloud/cache@v4
+        with:
+          path: ${{ env.GOBIN }}
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('./packages/server/events-subscribers/go.sum') }}
 
       - name: Install gotestsum
         run: |
@@ -72,56 +77,211 @@ jobs:
           fi
           echo "${{ env.GOBIN }}" >> $GITHUB_PATH
 
-      - name: Test
-        run: gotestsum --junitfile unit-tests.xml -- -coverprofile=cover.out -coverpkg=${{ steps.test-folders.outputs.test_folders }} ./...
-
-      - name: Test Report
-        uses: mikepenz/action-junit-report@v5
-        if: always() # run this step even if previous step failed
+      - name: Go Cache
+        id: go-cache
+        uses: ubicloud/cache@v4
         with:
-          report_paths: ./packages/server/events-subscribers/unit-tests.xml # Path to test results
-          include_passed: true
-          annotate_only: true
-          detailed_summary: true
+          path: |
+            ~/.cache/go-build
+            ${{ env.GOMODCACHE }}
+          key: ${{ runner.os }}-go-${{ hashFiles('packages/server/events-subscribers/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-      - name: Compute Code Coverage
-        id: compute_code_coverage
+      - name: Build
+        if: steps.go-cache.outputs.cache-hit != 'true'
+        run: make all
+
+      - name: Get test packages
+        id: get-packages
         run: |
-          echo "## Code Coverage" >> $GITHUB_STEP_SUMMARY
-          echo "|Filename|Function|Coverage|" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|--------|--------|" >> $GITHUB_STEP_SUMMARY
-          go tool cover -func=cover.out |sed -r  's/[[:space:]]+/|/g'|sed -r 's/$/|/g'|sed -r 's/^/|/g' >> $GITHUB_STEP_SUMMARY
-          go tool cover -func=cover.out | sed -r 's/[[:space:]]+/|/g' | sed -r 's/$/|/g' | sed -r 's/^/|/g' | tail -n 1 > test-coverage.txt
-          coverage=$(cat test-coverage.txt | awk -F'|' '{gsub(/%/, "", $(NF-1)); print $(NF-1)}')
-          echo "::set-output name=computed_coverage::$coverage"
+          # Get all packages except repository, rest, and graph/resolver
+          PACKAGES=$(go list ./... | grep -v /gen | grep -v /test | grep -v /testify | grep -v "/rest" | grep -v "/repository" | grep -v "/graphql/resolver" | paste -sd " " -)
+          echo "packages=${PACKAGES}" >> "$GITHUB_OUTPUT"
 
-  build-publish:
-    needs:
-      - test
+      - name: Run Tests
+        id: run-tests
+        run: |
+          echo "Running tests for ${{ matrix.test-group }} repositories..."
+          case ${{ matrix.test-group }} in
+            neo4j)
+            gotestsum --junitfile unit-tests.xml -- -coverprofile=cover.out ../customer-os-neo4j-repository/repository/...
+            ;;
+            postgres)
+            gotestsum --junitfile unit-tests.xml -- -coverprofile=cover.out ../customer-os-postgres-repository/repository/...
+            ;;
+            other)
+            gotestsum --junitfile unit-tests.xml -- -coverprofile=cover.out ${{ steps.get-packages.outputs.packages }}
+            ;;
+          esac
+
+  # Generate common metadata for all builds
+  prepare:
+    needs: [ test ]
     runs-on: ubicloud-standard-2
     if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      safe-tag: ${{ steps.safe-tag.outputs.value }}
+    steps:
+      # Create a safe tag string from the branch name (replace / with -)
+      - name: Set safe tag
+        id: safe-tag
+        run: |
+          # For PR events, use pr-NUMBER format instead of the branch name
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "value=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            # For normal branches, replace / with - to make it safe for tags
+            SAFE_TAG=$(echo "${{ github.ref_name }}" | sed 's/\//-/g')
+            echo "value=$SAFE_TAG" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+        working-directory: .
+
+  build-amd64:
+    needs: [ prepare ]
+    runs-on: ubicloud-standard-2
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Log in to registry
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.REPOSITORY_READ_WRITE_USERNAME }}
-          password: ${{ secrets.REPOSITORY_READ_WRITE_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5.7.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Push Docker image
-        uses: docker/build-push-action@v6.15.0
+      # Build and push amd64 image
+      - name: Build and push amd64 image
+        id: docker_build
+        uses: docker/build-push-action@v6
         with:
-          context: ./packages/server/
+          context: ./packages/server
           file: ./packages/server/events-subscribers/Dockerfile
-          push: ${{ github.ref_name == 'otter' || github.event_name == 'release' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64
+          provenance: false
+          outputs: type=registry,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Get image digest
+      - name: Get image digest
+        id: digest
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 --format "{{json .Manifest}}" | jq -r '.digest')
+          echo "value=$digest" >> $GITHUB_OUTPUT
+        shell: bash
+
+  build-arm64:
+    needs: [ prepare ]
+    runs-on: ubicloud-standard-2-arm
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Log in to registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build and push arm64 image
+      - name: Build and push arm64 image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./packages/server
+          file: ./packages/server/events-subscribers/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          provenance: false
+          outputs: type=registry,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Get image digest
+      - name: Get image digest
+        id: digest
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64 --format "{{json .Manifest}}" | jq -r '.digest')
+          echo "value=$digest" >> $GITHUB_OUTPUT
+        shell: bash
+
+  # Create multi-arch manifests
+  create-manifest:
+    needs: [ prepare, build-amd64, build-arm64 ]
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Log in to the Container registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Create and push manifests
+      - name: Create and push manifests
+        run: |
+          # Create and push the SHA manifest
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          
+          # Create and push the branch/PR manifest
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe-tag }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          
+          # If this is the otter branch, also tag as latest
+          if [[ "${{ github.ref_name }}" == "otter" ]]; then
+            docker buildx imagetools create \
+              --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          fi
+          
+          # For releases, also tag with the release tag
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            # For releases, the tag should be the release tag
+            RELEASE_TAG=$(echo "${{ github.ref_name }}" | sed 's/\//-/g')
+            docker buildx imagetools create \
+              --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$RELEASE_TAG \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          fi
+        shell: bash
+
+      # Inspect the created manifest
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe-tag }}
+        shell: bash
+        

--- a/.github/workflows/build-realtime.yml
+++ b/.github/workflows/build-realtime.yml
@@ -2,7 +2,7 @@ name: realtime
 
 on:
   push:
-    branches: ["otter"]
+    branches: [ "otter" ]
     paths:
       - packages/server/realtime/**
       - .github/workflows/realtime.yml
@@ -11,7 +11,7 @@ on:
       - packages/server/realtime/**
       - .github/workflows/realtime.yml
   release:
-    types: [created, edited]
+    types: [ created, edited ]
 
 env:
   REGISTRY: ghcr.io
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubicloud-standard-2
     strategy:
       matrix:
-        elixir: ["1.16.1"]
-        otp: ["26.2.1"]
+        elixir: [ "1.16.1" ]
+        otp: [ "26.2.1" ]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.12.1
@@ -62,13 +62,12 @@ jobs:
       - run: mix format --check-formatted
       - run: mix credo --mute-exit-status
       - run: mix dialyzer --no-check --ignore-exit-status
-
   test:
     runs-on: ubicloud-standard-2
     strategy:
       matrix:
-        elixir: ["1.16.1"]
-        otp: ["26.2.1"]
+        elixir: [ "1.16.1" ]
+        otp: [ "26.2.1" ]
 
     steps:
       - name: Cancel previous runs
@@ -99,32 +98,174 @@ jobs:
           fi
           echo "$GOBIN" >> $GITHUB_PATH
       - run: echo "skip tests"
-  build-publish:
-    needs:
-      - static-code-analysis
-      - test
+
+  # Generate common metadata for all builds
+  prepare:
+    needs: [ test ]
+    runs-on: ubicloud-standard-2
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      safe-tag: ${{ steps.safe-tag.outputs.value }}
+    steps:
+      # Create a safe tag string from the branch name (replace / with -)
+      - name: Set safe tag
+        id: safe-tag
+        run: |
+          # For PR events, use pr-NUMBER format instead of the branch name
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "value=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            # For normal branches, replace / with - to make it safe for tags
+            SAFE_TAG=$(echo "${{ github.ref_name }}" | sed 's/\//-/g')
+            echo "value=$SAFE_TAG" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+        working-directory: .
+
+  build-amd64:
+    needs: [ prepare ]
+    runs-on: ubicloud-standard-2
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Log in to registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build and push amd64 image
+      - name: Build and push amd64 image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./packages/server/realtime/
+          file: ./packages/server/realtime/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64
+          provenance: false
+          outputs: type=registry,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Get image digest
+      - name: Get image digest
+        id: digest
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 --format "{{json .Manifest}}" | jq -r '.digest')
+          echo "value=$digest" >> $GITHUB_OUTPUT
+        shell: bash
+
+  build-arm64:
+    needs: [ prepare ]
+    runs-on: ubicloud-standard-2-arm
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Log in to registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build and push arm64 image
+      - name: Build and push arm64 image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./packages/server/realtime/
+          file: ./packages/server/realtime/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          provenance: false
+          outputs: type=registry,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Get image digest
+      - name: Get image digest
+        id: digest
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64 --format "{{json .Manifest}}" | jq -r '.digest')
+          echo "value=$digest" >> $GITHUB_OUTPUT
+        shell: bash
+
+  # Create multi-arch manifests
+  create-manifest:
+    needs: [ prepare, build-amd64, build-arm64 ]
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
     runs-on: ubicloud-standard-2
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Log in to the Container registry
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.REPOSITORY_READ_WRITE_USERNAME }}
-          password: ${{ secrets.REPOSITORY_READ_WRITE_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5.7.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Push Docker image
-        uses: docker/build-push-action@v6.15.0
-        with:
-          context: packages/server/realtime/
-          push: ${{ github.ref_name == 'otter' || github.event_name == 'release' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      # Create and push manifests
+      - name: Create and push manifests
+        run: |
+          # Create and push the SHA manifest
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          
+          # Create and push the branch/PR manifest
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe-tag }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          
+          # If this is the otter branch, also tag as latest
+          if [[ "${{ github.ref_name }}" == "otter" ]]; then
+            docker buildx imagetools create \
+              --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          fi
+          
+          # For releases, also tag with the release tag
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            # For releases, the tag should be the release tag
+            RELEASE_TAG=$(echo "${{ github.ref_name }}" | sed 's/\//-/g')
+            docker buildx imagetools create \
+              --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$RELEASE_TAG \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          fi
+        shell: bash
+
+      # Inspect the created manifest
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe-tag }}
+        shell: bash
+        

--- a/.github/workflows/pr-notifications.yml
+++ b/.github/workflows/pr-notifications.yml
@@ -12,7 +12,7 @@ jobs:
   notify:
     # Only run for non-draft PRs OR when a PR becomes ready for review
     if: github.event.pull_request.draft == false || github.event.action == 'ready_for_review'
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - name: Handle PR Events
         uses: actions/github-script@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   check-release-needed:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'otter'
     outputs:
       version_bump: ${{ steps.commit_message.outputs.version_bump }}
@@ -116,7 +116,7 @@ jobs:
   create-release:
     needs: check-release-needed
     if: needs.check-release-needed.outputs.version_bump != 'skip'
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     outputs:
       next_version: ${{ steps.generate_version.outputs.next_version }}
     steps:
@@ -189,7 +189,7 @@ jobs:
 
   publish-images:
     needs: create-release
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     strategy:
       matrix:
         service:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add ARM64 support and multi-arch manifest creation to multiple GitHub Actions workflows, updating runners to `ubicloud-standard-2`.
> 
>   - **ARM64 Support**:
>     - Added `build-arm64` job to `build-browser-automation-api.yml`, `build-customer-os-api.yml`, `build-customer-os-platform-admin-api.yml`, `build-customer-os-webhooks.yml`, `build-events-subscribers.yml`, and `build-realtime.yml`.
>     - Each job builds and pushes ARM64 Docker images to the registry.
>   - **Multi-Arch Manifests**:
>     - Added `create-manifest` job to combine AMD64 and ARM64 images into a single multi-arch manifest in the same workflows.
>   - **Runner Update**:
>     - Changed runner from `ubuntu-latest` to `ubicloud-standard-2` in `build-customer-os-api.yml`, `build-customer-os-platform-admin-api.yml`, `build-customer-os-webhooks.yml`, `build-events-subscribers.yml`, `build-realtime.yml`, `pr-notifications.yml`, and `release.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 69447fa4fc1e6d391ff83f1482045e365c5f2f99. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->