### PR TITLE
fix scrape status

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/.env
+++ b/packages/runner/customer-os-data-upkeeper/.env
@@ -44,9 +44,6 @@ RABBITMQ_URL: amqp://guest:guest@localhost:5672
 CUSTOMER_OS_API: http://localhost:10000/query
 CUSTOMER_OS_API_KEY: dd9d2474-b4a9-4799-b96f-73cd0a2917e4
 
-PLATFORM_ADMIN_API_URL=http://localhost:10005
-PLATFORM_ADMIN_API_KEY=73ab22e3-79ee-4498-a359-cce2695a69ef
-
 FRONTERA_URL: http://localhost:5173
 NOVU_API_KEY:
 

--- a/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
@@ -704,10 +704,12 @@ func (s *globalOrganizationService) ScrapeGlobalOrgs() {
 				}
 			}
 
-			err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetScrapeStatus(childCtx, org.ID, enum.ScrapeCompleted)
-			if err != nil {
-				tracing.TraceErr(childSpan, errors.Wrap(err, "error updating global org scraped status"))
-				return
+			if contents != "" {
+				err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetScrapeStatus(childCtx, org.ID, enum.ScrapeCompleted)
+				if err != nil {
+					tracing.TraceErr(childSpan, errors.Wrap(err, "error updating global org scraped status"))
+					return
+				}
 			}
 		}(org)
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `ScrapeGlobalOrgs()` in `global_organization_service.go` to set `ScrapeCompleted` status only if `contents` is not empty.
> 
>   - **Behavior**:
>     - Fixes `ScrapeGlobalOrgs()` in `global_organization_service.go` to set `ScrapeCompleted` status only if `contents` is not empty.
>     - Prevents setting `ScrapeCompleted` status on empty content, ensuring accurate scrape status updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a56786baab9745b5e9b86f87c30e7dcbd31a510b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->