### PR TITLE
Add icon and color fields to documents

### DIFF
--- a/packages/server/realtime/lib/realtime/documents.ex
+++ b/packages/server/realtime/lib/realtime/documents.ex
@@ -19,10 +19,35 @@ defmodule Realtime.Documents do
     Ecto.Multi.new()
     |> Ecto.Multi.insert(:document, Document.changeset(%Document{}, payload))
     |> maybe_insert_organization_document(organization_id)
-    |> Ecto.Multi.run(:initialize_y_writing, fn _repo, %{document: document} ->
-      initialize_y_writing(document.id, payload.lexical_state)
-    end)
+    |> maybe_initialize_ydoc(Map.get(payload, :lexical_state))
     |> Repo.transaction()
+    |> case do
+      {:ok, %{document: document} = result} ->
+        decorated_doc = %Document{document | organization_id: organization_id}
+        {:ok, Map.put(result, :document, decorated_doc)}
+
+      error ->
+        error
+    end
+  end
+
+  def update_document(attrs \\ %{}) do
+    with %Document{} = document <- Repo.get(Document, attrs.id) do
+      document
+      |> Document.update_changeset(attrs)
+      |> Repo.update()
+    else
+      nil -> {:error, :not_found}
+    end
+  end
+
+  def delete_document(id) do
+    with %Document{} = document <- Repo.get(Document, id) do
+      document
+      |> Repo.delete()
+    else
+      nil -> {:error, :not_found}
+    end
   end
 
   def list_by_organization(organization_id, tenant) do
@@ -33,8 +58,11 @@ defmodule Realtime.Documents do
       select: %{
         id: d.id,
         name: d.name,
+        icon: d.icon,
+        color: d.color,
         tenant: d.tenant,
         user_id: d.user_id,
+        organization_id: od.organization_id,
         inserted_at: d.inserted_at,
         updated_at: d.updated_at
       }
@@ -42,13 +70,28 @@ defmodule Realtime.Documents do
     |> Repo.all()
   end
 
+  def get_document(id) do
+    query =
+      from(d in Document,
+        join: od in OrganizationDocument,
+        on: d.id == od.document_id,
+        where: d.id == ^id,
+        select: merge(d, %{organization_id: od.organization_id}),
+        limit: 1
+      )
+
+    case Repo.one(query) do
+      nil -> {:error, :not_found}
+      doc -> {:ok, doc}
+    end
+  end
+
   defp initialize_y_writing(doc_id, lexical_state) do
     script_path = Application.app_dir(:realtime, "priv/scripts/convert_lexical_to_yjs")
-    encoded_lexical_state = Jason.encode!(lexical_state)
 
     # Create a temporary file for the lexical state
     {:ok, temp_path} = Temp.path(%{suffix: ".json"})
-    File.write!(temp_path, encoded_lexical_state)
+    File.write!(temp_path, lexical_state)
 
     try do
       case System.cmd("sh", ["-c", "#{script_path} #{doc_id} @#{temp_path}"],
@@ -80,23 +123,40 @@ defmodule Realtime.Documents do
     end)
   end
 
+  defp maybe_initialize_ydoc(multi, nil), do: multi
+
+  defp maybe_initialize_ydoc(multi, lexical_state) do
+    Ecto.Multi.run(multi, :initialize_y_writing, fn _repo, %{document: document} ->
+      initialize_y_writing(document.id, lexical_state)
+    end)
+  end
+
   defp fromDto(dto) do
     %{
       "name" => name,
       "userId" => user_id,
       "tenant" => tenant,
       "body" => body,
-      "lexicalState" => lexical_state
+      "icon" => icon,
+      "color" => color
     } = dto
 
     organization_id = Map.get(dto, "organizationId", nil)
+
+    lexical_state =
+      case Map.get(dto, "lexicalState", nil) do
+        nil -> nil
+        value -> Jason.encode!(value)
+      end
 
     %{
       name: name,
       body: body,
       user_id: user_id,
       tenant: tenant,
-      lexical_state: Jason.encode!(lexical_state),
+      icon: icon,
+      color: color,
+      lexical_state: lexical_state,
       organization_id: organization_id
     }
   end

--- a/packages/server/realtime/lib/realtime/documents/document.ex
+++ b/packages/server/realtime/lib/realtime/documents/document.ex
@@ -3,7 +3,19 @@ defmodule Realtime.Documents.Document do
   import Ecto.Changeset
 
   @derive {Jason.Encoder,
-           only: [:id, :name, :body, :lexical_state, :tenant, :user_id, :inserted_at, :updated_at]}
+           only: [
+             :id,
+             :name,
+             :body,
+             :lexical_state,
+             :tenant,
+             :user_id,
+             :icon,
+             :color,
+             :organization_id,
+             :inserted_at,
+             :updated_at
+           ]}
   @primary_key {:id, :binary_id, autogenerate: true}
   schema "documents" do
     field(:name, :string)
@@ -11,13 +23,22 @@ defmodule Realtime.Documents.Document do
     field(:lexical_state, :string)
     field(:tenant, :string)
     field(:user_id, :binary_id)
+    field(:icon, :string)
+    field(:color, :string)
+    field(:organization_id, :string, virtual: true)
 
     timestamps(type: :utc_datetime)
   end
 
   def changeset(document, attrs) do
     document
-    |> cast(attrs, [:name, :body, :lexical_state, :tenant, :user_id])
-    |> validate_required([:name, :tenant])
+    |> cast(attrs, [:name, :body, :lexical_state, :tenant, :user_id, :icon, :color])
+    |> validate_required([:name, :tenant, :body, :user_id, :icon, :color])
+  end
+
+  def update_changeset(document, attrs) do
+    document
+    |> cast(attrs, [:id, :name, :icon, :color])
+    |> validate_required([:id, :name, :icon, :color])
   end
 end

--- a/packages/server/realtime/lib/realtime/documents/document_writes.ex
+++ b/packages/server/realtime/lib/realtime/documents/document_writes.ex
@@ -1,11 +1,17 @@
-defmodule Realtime.DocumentWrite do
+defmodule Realtime.Documents.DocumentWrite do
   use Ecto.Schema
   import Ecto.Changeset
 
   schema "document_writes" do
     field(:value, :binary)
     field(:version, Ecto.Enum, values: [:v1, :v1_sv])
-    field(:docName, :string)
+
+    belongs_to(
+      :document,
+      Realtime.Documents.Document,
+      type: :binary_id,
+      foreign_key: :docName
+    )
 
     timestamps(type: :utc_datetime)
   end

--- a/packages/server/realtime/lib/realtime/documents/y_doc.ex
+++ b/packages/server/realtime/lib/realtime/documents/y_doc.ex
@@ -1,5 +1,5 @@
 defmodule Realtime.YDoc do
-  use Realtime.YEcto, repo: Realtime.Repo, schema: Realtime.DocumentWrite
+  use Realtime.YEcto, repo: Realtime.Repo, schema: Realtime.Documents.DocumentWrite
 end
 
 defmodule Realtime.EctoPersistence do

--- a/packages/server/realtime/lib/realtime_web/channels/document_channel.ex
+++ b/packages/server/realtime/lib/realtime_web/channels/document_channel.ex
@@ -24,7 +24,6 @@ defmodule RealtimeWeb.DocumentChannel do
 
   @impl true
   def handle_in("yjs_sync", {:binary, chunk}, socket) do
-    dbg(~c"yjs_sync")
     SharedDoc.start_sync(socket.assigns.doc_pid, chunk)
     {:noreply, socket}
   end

--- a/packages/server/realtime/lib/realtime_web/channels/documents_channel.ex
+++ b/packages/server/realtime/lib/realtime_web/channels/documents_channel.ex
@@ -1,0 +1,6 @@
+defmodule RealtimeWeb.DocumentsChannel do
+  @moduledoc """
+  This Channel broadcasts sync events to all Documents entity subscribers.
+  """
+  use RealtimeWeb.EntitiesChannelMacro, "Documents"
+end

--- a/packages/server/realtime/lib/realtime_web/channels/user_socket.ex
+++ b/packages/server/realtime/lib/realtime_web/channels/user_socket.ex
@@ -77,6 +77,7 @@ defmodule RealtimeWeb.UserSocket do
   channel "Industries:*", RealtimeWeb.IndustriesChannel
   channel "JobRoles:*", RealtimeWeb.JobRolesChannel
   channel "Document:*", RealtimeWeb.DocumentChannel
+  channel "Documents:*", RealtimeWeb.DocumentsChannel
   channel "Tasks:*", RealtimeWeb.TasksChannel
 
   # Socket params are passed from the client and can

--- a/packages/server/realtime/lib/realtime_web/controllers/document_controller.ex
+++ b/packages/server/realtime/lib/realtime_web/controllers/document_controller.ex
@@ -10,6 +10,8 @@ defmodule RealtimeWeb.DocumentController do
           "body" => _body,
           "userId" => _user_id,
           "tenant" => _tenant,
+          "icon" => _icon,
+          "color" => _color,
           "lexicalState" => _lexical_state,
           "organizationId" => _organization_id
         } = params

--- a/packages/server/realtime/lib/realtime_web/graphql/resolvers/document_resolver.ex
+++ b/packages/server/realtime/lib/realtime_web/graphql/resolvers/document_resolver.ex
@@ -1,26 +1,30 @@
 defmodule RealtimeWeb.Graphql.Resolvers.DocumentResolver do
   alias Realtime.Documents
 
-  def list_documents(_parent, %{organization_id: id}, %{context: %{tenant: tenant}}) do
-    {:ok, Documents.list_by_organization(id, tenant)}
+  def list_documents(_parent, %{organization_id: id}, %{
+        context: ctx
+      }) do
+    {:ok, Documents.list_by_organization(id, ctx.tenant)}
+  end
+
+  def get_document(_parent, %{id: id}, _ctx) do
+    Documents.get_document(id)
   end
 
   def create_document(
         _parent,
-        %{
-          input: %{
-            name: _name,
-            body: _body,
-            user_id: _user_id,
-            tenant: _tenant,
-            lexical_state: _lexical_state,
-            organization_id: _organization_id
-          }
-        } = args,
+        %{input: input},
         _ctx
       ) do
-    dbg(args.input)
-    {:ok, %{document: document}} = Documents.create_document(args.input)
+    {:ok, %{document: document}} = Documents.create_document(input)
     {:ok, document}
+  end
+
+  def update_document(_parent, args, _ctx) do
+    Documents.update_document(args.input)
+  end
+
+  def delete_document(_parent, %{id: id}, _ctx) do
+    Documents.delete_document(id)
   end
 end

--- a/packages/server/realtime/lib/realtime_web/graphql/schema/document_types.ex
+++ b/packages/server/realtime/lib/realtime_web/graphql/schema/document_types.ex
@@ -9,6 +9,9 @@ defmodule RealtimeWeb.Graphql.DocumentTypes do
     field(:lexical_state, :string)
     field(:tenant, :string)
     field(:user_id, non_null(:id))
+    field(:icon, :string)
+    field(:color, :string)
+    field(:organization_id, :string)
     field(:inserted_at, non_null(:string))
     field(:updated_at, non_null(:string))
   end
@@ -18,8 +21,17 @@ defmodule RealtimeWeb.Graphql.DocumentTypes do
     field(:body, non_null(:string))
     field(:tenant, non_null(:string))
     field(:user_id, non_null(:id))
-    field(:lexical_state, non_null(:string))
+    field(:icon, non_null(:string))
+    field(:color, non_null(:string))
+    field(:lexical_state, :string)
     field(:organization_id, non_null(:id))
+  end
+
+  input_object :update_document_input do
+    field(:id, non_null(:id))
+    field(:name, non_null(:string))
+    field(:icon, non_null(:string))
+    field(:color, non_null(:string))
   end
 
   object :document_queries do
@@ -27,12 +39,27 @@ defmodule RealtimeWeb.Graphql.DocumentTypes do
       arg(:organization_id, non_null(:id))
       resolve(&DocumentResolver.list_documents/3)
     end
+
+    field :document, :document do
+      arg(:id, non_null(:id))
+      resolve(&DocumentResolver.get_document/3)
+    end
   end
 
   object :document_mutations do
     field :create_document, :document do
       arg(:input, non_null(:create_document_input))
       resolve(&DocumentResolver.create_document/3)
+    end
+
+    field :update_document, :document do
+      arg(:input, non_null(:update_document_input))
+      resolve(&DocumentResolver.update_document/3)
+    end
+
+    field :delete_document, :document do
+      arg(:id, non_null(:id))
+      resolve(&DocumentResolver.delete_document/3)
     end
   end
 end

--- a/packages/server/realtime/lib/realtime_web/plugs/validate_headers.ex
+++ b/packages/server/realtime/lib/realtime_web/plugs/validate_headers.ex
@@ -1,27 +1,62 @@
 defmodule RealtimeWeb.Plugs.ValidateHeaders do
   import Plug.Conn
 
-  @required_headers ["x-tenant"]
-
   def init(opts), do: opts
 
   def call(conn, _opts) do
-    missing_headers =
-      @required_headers
-      |> Enum.filter(fn header -> get_req_header(conn, header) == [] end)
+    tenant =
+      case get_req_header(conn, "x-tenant") do
+        [] -> get_req_header(conn, "x-openline-tenant") |> List.first()
+        [value] -> value
+      end
 
-    if missing_headers == [] do
-      context = %{tenant: get_req_header(conn, "x-tenant") |> List.first()}
+    username =
+      case get_req_header(conn, "x-username") do
+        [] -> get_req_header(conn, "x-openline-username") |> List.first()
+        [value] -> value
+      end
 
-      Absinthe.Plug.put_options(conn, context: context)
-    else
+    internal_api_key = get_req_header(conn, "x-openline-api-key") |> List.first()
+
+    api_token = System.get_env("API_TOKEN")
+
+    if internal_api_key && internal_api_key != api_token do
       conn
       |> put_resp_content_type("application/json")
       |> send_resp(
-        400,
-        Jason.encode!(%{error: "Missing required headers", missing: missing_headers})
+        401,
+        Jason.encode!(%{error: "Unauthorized", message: "Invalid internal app token"})
+      )
+      |> halt()
+    else
+      conn
+    end
+
+    if !tenant do
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(
+        401,
+        Jason.encode!(%{error: "Unauthorized", message: "missing tenant header"})
       )
       |> halt()
     end
+
+    if !username do
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(
+        401,
+        Jason.encode!(%{error: "Unauthorized", message: "missing username header"})
+      )
+      |> halt()
+    end
+
+    context = %{
+      tenant: tenant,
+      username: username
+    }
+
+    Absinthe.Plug.put_options(conn, context: context)
   end
 end

--- a/packages/server/realtime/priv/repo/migrations/20250320125948_add_icon_to_document.exs
+++ b/packages/server/realtime/priv/repo/migrations/20250320125948_add_icon_to_document.exs
@@ -1,0 +1,9 @@
+defmodule Realtime.Repo.Migrations.AddIconToDocument do
+  use Ecto.Migration
+
+  def change do
+    alter table(:documents) do
+      add :icon, :string
+    end
+  end
+end

--- a/packages/server/realtime/priv/repo/migrations/20250324131637_add-color-to-document.exs
+++ b/packages/server/realtime/priv/repo/migrations/20250324131637_add-color-to-document.exs
@@ -1,0 +1,9 @@
+defmodule :"Elixir.Realtime.Repo.Migrations.Add-color-to-document" do
+  use Ecto.Migration
+
+  def change do
+    alter table(:documents) do
+      add :color, :string
+    end
+  end
+end

--- a/packages/server/realtime/priv/repo/migrations/20250325113909_update_doc_name_to_be_uuid.exs
+++ b/packages/server/realtime/priv/repo/migrations/20250325113909_update_doc_name_to_be_uuid.exs
@@ -1,0 +1,10 @@
+defmodule Realtime.Repo.Migrations.UpdateDocNameToBeUuid do
+  use Ecto.Migration
+
+  def change do
+    alter table(:document_writes) do
+      remove :docName
+      add :docName, references(:documents, type: :uuid, on_delete: :delete_all), null: false
+    end
+  end
+end


### PR DESCRIPTION
- Added `icon` and `color` fields to the `documents` table
- Updated schema and changesets to include new fields
- Implemented CRUD operations for documents
- Added GraphQL queries and mutations for documents
- Updated header validation plug to include `x-openline-tenant` and `x-openline-username`
- Removed debug statement from `DocumentChannel`
- Added `DocumentsChannel` for broadcasting sync events
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `icon` and `color` fields to documents, update CRUD operations, GraphQL API, and header validation.
> 
>   - **Schema Changes**:
>     - Added `icon` and `color` fields to `documents` table.
>     - Updated `document_writes` to use UUID for `docName`.
>   - **CRUD Operations**:
>     - Implemented `create_document`, `update_document`, and `delete_document` in `documents.ex`.
>     - Updated `Document` schema and changesets to include `icon` and `color`.
>   - **GraphQL**:
>     - Added `icon` and `color` to `document` type in `document_types.ex`.
>     - Added `get_document`, `update_document`, and `delete_document` resolvers in `document_resolver.ex`.
>   - **Channels**:
>     - Added `DocumentsChannel` for broadcasting sync events.
>     - Updated `user_socket.ex` to include `DocumentsChannel`.
>   - **Header Validation**:
>     - Updated `validate_headers.ex` to include `x-openline-tenant` and `x-openline-username`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f74d9f69fbfdd53ca9909cef7d290e222e21dfcf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->