### PR TITLE
Apigator arm build

### DIFF
--- a/.github/workflows/build-apigator.yml
+++ b/.github/workflows/build-apigator.yml
@@ -22,11 +22,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/apigator
-  GOMODCACHE: ${{ github.workspace }}/go/pkg/mod
-  GOBIN: ${{ github.workspace }}/go/bin
-  CGO_ENABLED: 0
-  LANG: C.UTF-8
-  LC_ALL: C.UTF-8
 
 permissions:
   contents: read

--- a/.github/workflows/build-apigator.yml
+++ b/.github/workflows/build-apigator.yml
@@ -2,7 +2,7 @@ name: apigator
 
 on:
   push:
-    branches: ["otter"]
+    branches: [ "otter" ]
     paths:
       - packages/server/customer-os-common-module/**
       - packages/server/customer-os-postgres-repository/**
@@ -17,11 +17,16 @@ on:
       - packages/server/apigator/**
       - .github/workflows/build-apigator.yml
   release:
-    types: [created, edited]
+    types: [ created, edited ]
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/apigator
+  GOMODCACHE: ${{ github.workspace }}/go/pkg/mod
+  GOBIN: ${{ github.workspace }}/go/bin
+  CGO_ENABLED: 0
+  LANG: C.UTF-8
+  LC_ALL: C.UTF-8
 
 permissions:
   contents: read
@@ -72,33 +77,173 @@ jobs:
           echo "|--------|--------|--------|" >> $GITHUB_STEP_SUMMARY
           go tool cover -func=cover.out |sed -r  's/[[:space:]]+/|/g'|sed -r 's/$/|/g'|sed -r 's/^/|/g' >> $GITHUB_STEP_SUMMARY
 
-  build-publish:
-    needs:
-      - test
+  # Generate common metadata for all builds
+  prepare:
+    needs: [ test ]
     runs-on: ubicloud-standard-2
     if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      safe-tag: ${{ steps.safe-tag.outputs.value }}
+    steps:
+      # Create a safe tag string from the branch name (replace / with -)
+      - name: Set safe tag
+        id: safe-tag
+        run: |
+          # For PR events, use pr-NUMBER format instead of the branch name
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "value=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            # For normal branches, replace / with - to make it safe for tags
+            SAFE_TAG=$(echo "${{ github.ref_name }}" | sed 's/\//-/g')
+            echo "value=$SAFE_TAG" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+        working-directory: .
+
+  build-amd64:
+    needs: [ prepare ]
+    runs-on: ubicloud-standard-2
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Log in to registry
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.REPOSITORY_READ_WRITE_USERNAME }}
-          password: ${{ secrets.REPOSITORY_READ_WRITE_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5.7.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Push Docker image
+      # Build and push amd64 image
+      - name: Build and push amd64 image
+        id: docker_build
         uses: docker/build-push-action@v6
         with:
-          context: ./packages/server/
+          context: ./packages/server
           file: ./packages/server/apigator/Dockerfile
-          push: ${{ github.ref_name == 'otter' || github.event_name == 'release' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64
+          provenance: false
+          outputs: type=registry,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Get image digest
+      - name: Get image digest
+        id: digest
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 --format "{{json .Manifest}}" | jq -r '.digest')
+          echo "value=$digest" >> $GITHUB_OUTPUT
+        shell: bash
+
+  build-arm64:
+    needs: [ prepare ]
+    runs-on: ubicloud-standard-2-arm
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Log in to registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build and push arm64 image
+      - name: Build and push arm64 image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./packages/server
+          file: ./packages/server/apigator/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          provenance: false
+          outputs: type=registry,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Get image digest
+      - name: Get image digest
+        id: digest
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64 --format "{{json .Manifest}}" | jq -r '.digest')
+          echo "value=$digest" >> $GITHUB_OUTPUT
+        shell: bash
+
+  # Create multi-arch manifests
+  create-manifest:
+    needs: [ prepare, build-amd64, build-arm64 ]
+    if: github.ref == 'refs/heads/otter' || github.event_name == 'release'
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Log in to the Container registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Create and push manifests
+      - name: Create and push manifests
+        run: |
+          # Create and push the SHA manifest
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          
+          # Create and push the branch/PR manifest
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe-tag }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          
+          # If this is the otter branch, also tag as latest
+          if [[ "${{ github.ref_name }}" == "otter" ]]; then
+            docker buildx imagetools create \
+              --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          fi
+          
+          # For releases, also tag with the release tag
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            # For releases, the tag should be the release tag
+            RELEASE_TAG=$(echo "${{ github.ref_name }}" | sed 's/\//-/g')
+            docker buildx imagetools create \
+              --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$RELEASE_TAG \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          fi
+        shell: bash
+
+      # Inspect the created manifest
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe-tag }}
+        shell: bash
+        


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances GitHub Actions workflow to build and publish Docker images for amd64 and arm64 architectures, and create multi-arch manifests.
> 
>   - **Workflow Changes**:
>     - Adds `build-amd64` and `build-arm64` jobs to `.github/workflows/build-apigator.yml` for building Docker images for amd64 and arm64 architectures.
>     - Introduces `create-manifest` job to create and push multi-arch Docker manifests.
>     - Workflow triggers on `otter` branch and release events.
>   - **Docker Setup**:
>     - Uses `docker/setup-buildx-action@v3` for setting up Docker Buildx.
>     - Uses `docker/build-push-action@v6` for building and pushing images.
>     - Logs in to the container registry using `docker/login-action@v3`.
>   - **Misc**:
>     - Adjusts branch and release handling for tagging Docker images.
>     - Updates `build-apigator.yml` to include spaces in array definitions for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for de22ae6727fe48199f8ae64571af57d1b7f39eed. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->