### PR TITLE
add prometheus and grafana to docker compose

### DIFF
--- a/deployment/docker-compose.yaml
+++ b/deployment/docker-compose.yaml
@@ -7,6 +7,8 @@ volumes:
   neo4j_data:
   provision:
   opensearch-data:
+  prometheus_data:
+  grafana_data:
 
 services:
   rabbitmq:
@@ -232,3 +234,56 @@ services:
       - POSTGRES_HOST=postgres
       - NEO4J_TARGET=neo4j://neo4j:7687
       - RABBITMQ_URL=amqp://host.docker.internal:5672
+
+  prometheus:
+    image: prom/prometheus:v2.48.1
+    container_name: prometheus
+    networks:
+      - openline
+    ports:
+      - "9090:9090"
+    volumes:
+      - prometheus_data:/prometheus
+      - ./provision/prometheus:/etc/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:10.2.3
+    container_name: grafana
+    networks:
+      - openline
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector
+    networks:
+      - mailstack
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./provision/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4319:4317"  # OTLP gRPC receiver (mapped to 4319 externally)
+      - "4320:4318"  # OTLP HTTP receiver (mapped to 4320 externally)
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--spider", "http://localhost:13133"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s

--- a/deployment/provision/otel-collector-config.yaml
+++ b/deployment/provision/otel-collector-config.yaml
@@ -1,0 +1,39 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 5000
+
+exporters:
+  clickhouse:
+    endpoint: tcp://clickhouse:9000
+    username: default
+    password: password
+    database: logs
+    create_schema: true
+    logs_table_name: otel_logs
+    traces_table_name: otel_traces
+    timeout: 5s
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [clickhouse]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [clickhouse]

--- a/deployment/provision/prometheus/prometheus.yml
+++ b/deployment/provision/prometheus/prometheus.yml
@@ -1,0 +1,28 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'customer-os-api'
+    static_configs:
+      - targets: ['customer-os-api:10000']
+
+  - job_name: 'customer-os-webhooks'
+    static_configs:
+      - targets: ['customer-os-webhooks:10004']
+
+  - job_name: 'rabbitmq'
+    static_configs:
+      - targets: ['rabbitmq:15672']
+
+  - job_name: 'postgres'
+    static_configs:
+      - targets: ['postgres:5432']
+
+  - job_name: 'neo4j'
+    static_configs:
+      - targets: ['neo4j:7474'] 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add Prometheus, Grafana, and OpenTelemetry Collector to Docker Compose for monitoring and telemetry.
> 
>   - **Services Added**:
>     - Added `prometheus` service to `docker-compose.yaml` with configuration in `provision/prometheus/prometheus.yml`.
>     - Added `grafana` service to `docker-compose.yaml`.
>     - Added `otel-collector` service to `docker-compose.yaml` with configuration in `provision/otel-collector-config.yaml`.
>   - **Volumes**:
>     - Added `prometheus_data` and `grafana_data` volumes in `docker-compose.yaml`.
>   - **Prometheus Configuration**:
>     - Configured to scrape metrics from `customer-os-api`, `customer-os-webhooks`, `rabbitmq`, `postgres`, and `neo4j`.
>   - **OpenTelemetry Collector Configuration**:
>     - Configured to receive OTLP data and export to ClickHouse with retry logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7c91e7ba64eef391f5a913f0513af0e0067b8406. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->