### PR TITLE
Skip auth for WebSocket upgrade requests

### DIFF
--- a/packages/server/apigator/main.go
+++ b/packages/server/apigator/main.go
@@ -153,6 +153,12 @@ func validate(
 			}
 		}()
 
+		// ✅ Skip auth entirely for WebSocket upgrade requests
+		if strings.EqualFold(c.GetHeader("Upgrade"), "websocket") {
+			c.Status(http.StatusOK)
+			return
+		}
+
 		if isIntrospectionQuery(c.Request) {
 			c.Next()
 			return


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Skip authentication for WebSocket upgrade requests in `validate()` by checking the `Upgrade` header.
> 
>   - **Behavior**:
>     - Skips authentication for WebSocket upgrade requests in `validate()` in `main.go` by checking the `Upgrade` header for "websocket" and returning `StatusOK`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 263499ec4a63846d85d725995649f801bf4281c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->