### PR TITLE
Remove conditional SSL parameter from PostgreSQL connection URL

### DIFF
--- a/packages/server/browser-automation-api/src/infrastructure/persistance/postgresql/config.ts
+++ b/packages/server/browser-automation-api/src/infrastructure/persistance/postgresql/config.ts
@@ -6,4 +6,4 @@ const DATABASE = process.env.POSTGRES_NAME ?? "";
 
 const isDev = process.env.NODE_ENV === "development";
 
-export const connectionUrl = `postgresql://${USER}:${PASS}@${HOST}:${PORT}/${DATABASE}${!isDev ? "?ssl=true" : ""}`;
+export const connectionUrl = `postgresql://${USER}:${PASS}@${HOST}:${PORT}/${DATABASE}?ssl=true`;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove conditional SSL parameter from PostgreSQL connection URL in `config.ts`, enabling SSL by default.
> 
>   - **Behavior**:
>     - Removes conditional SSL parameter from `connectionUrl` in `config.ts`. SSL is now always enabled.
>   - **Environment**:
>     - The `isDev` variable is no longer used in `config.ts` after this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7229a66dcc05099f4600f2814a9d87568dcb4140. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->