### PR TITLE
fix query escape

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -3,8 +3,6 @@ package agent_capability
 import (
 	"context"
 	"fmt"
-	"net/url"
-
 	commonmodel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
@@ -460,7 +458,7 @@ func (c *SyncInvoiceToAccountingCapability) syncInvoiceToQuickbooksJournalEntry(
 	debitJournalLineItem.JournalEntryLineDetail.PostingType = "Debit"
 	debitJournalLineItem.JournalEntryLineDetail.Entity.EntityRef.Value = contractEntity.QuickbooksCustomerId
 	debitJournalLineItem.JournalEntryLineDetail.AccountRef.Name = arIncomeAccountName
-	arIncomeAccountId, err := c.quickbooksService.GetAccountIdByName(ctx, url.QueryEscape(arIncomeAccountName))
+	arIncomeAccountId, err := c.quickbooksService.GetAccountIdByName(ctx, arIncomeAccountName)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err
@@ -586,7 +584,7 @@ func (c *SyncInvoiceToAccountingCapability) syncInvoiceToQuickbooksJournalEntryR
 	creditJournalLineItem.JournalEntryLineDetail.PostingType = "Credit"
 	creditJournalLineItem.JournalEntryLineDetail.Entity.EntityRef.Value = contractEntity.QuickbooksCustomerId
 	creditJournalLineItem.JournalEntryLineDetail.AccountRef.Name = arIncomeAccountName
-	arIncomeAccountId, err := c.quickbooksService.GetAccountIdByName(ctx, url.QueryEscape(arIncomeAccountName))
+	arIncomeAccountId, err := c.quickbooksService.GetAccountIdByName(ctx, arIncomeAccountName)
 	if err != nil {
 		tracing.TraceErr(span, err)
 		return err


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unnecessary URL escaping in `syncInvoiceToQuickbooksJournalEntry()` and `syncInvoiceToQuickbooksJournalEntryReverse()` in `capability_invoice_sync_to_accounting.go`.
> 
>   - **Behavior**:
>     - Removed `url.QueryEscape` from `arIncomeAccountName` in `syncInvoiceToQuickbooksJournalEntry()` and `syncInvoiceToQuickbooksJournalEntryReverse()`.
>   - **Imports**:
>     - Removed unused `net/url` import from `capability_invoice_sync_to_accounting.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 090fded95445d937e5fafdc8d3893daad84d0331. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->