### PR TITLE
fix account name

### DIFF
--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -834,7 +834,7 @@ func (s *quickbooksService) GetAccountIdByName(ctx context.Context, accountName 
 	defer span.Finish()
 	tenant := common.GetTenantFromContext(ctx)
 	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("accountName", accountName))
+	span.LogKV("accountName", accountName)
 
 	// Retrieve QuickBooks settings for the tenant.
 	qbSettings, err := s.postgres.QuickbooksSettingsRepository.Get(ctx, tenant)
@@ -848,8 +848,10 @@ func (s *quickbooksService) GetAccountIdByName(ctx context.Context, accountName 
 		return "", err
 	}
 
+	normalizedAccountName := strings.ReplaceAll(accountName, " ", "+")
+	span.LogKV("normalizedAccountName", normalizedAccountName)
 	// Construct the URL for querying the account by name.
-	queryURL := fmt.Sprintf("%s/v3/company/%s/query?query=select+Id+from+Account+where+Name='%s'", s.qbConfig.Url, qbSettings.RealmId, accountName)
+	queryURL := fmt.Sprintf("%s/v3/company/%s/query?query=select+Id+from+Account+where+Name='%s'", s.qbConfig.Url, qbSettings.RealmId, normalizedAccountName)
 	// Perform the request.
 	resp, err := s.performRequest(ctx, qbSettings, queryURL, "GET", nil, true)
 	if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Normalize `accountName` by replacing spaces with `+` in `GetAccountIdByName()` in `quickbooks.go` and update query URL construction accordingly.
> 
>   - **Behavior**:
>     - Normalize `accountName` by replacing spaces with `+` in `GetAccountIdByName()` in `quickbooks.go`.
>     - Update query URL construction to use `normalizedAccountName`.
>   - **Logging**:
>     - Log `normalizedAccountName` in `GetAccountIdByName()` in `quickbooks.go`.
>     - Change `span.LogFields` to `span.LogKV` for `accountName` logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7597b2f150f5448117d0d8b8934c0749f3d99387. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->