### PR TITLE
add tempo/grafana to dev

### DIFF
--- a/deployment/docker-compose.yaml
+++ b/deployment/docker-compose.yaml
@@ -118,7 +118,6 @@ services:
       done &&
       PGPASSWORD=password psql -h timescaledb -p 5432 -U postgres -d telemetry -f /docker-entrypoint-initdb.d/timescaledb-init.sql"
 
-
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
     container_name: otel-collector
@@ -136,6 +135,33 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 10s
+
+  tempo:
+    image: grafana/tempo:latest
+    container_name: tempo
+    networks:
+      - openline
+    ports:
+      - "3200:3200" # Tempo API and UI endpoint
+      - "4317:4317" # OTLP gRPC endpoint
+      - "4318:4318" # OTLP HTTP endpoint
+    volumes:
+      - tempo_data:/var/tempo
+      - ./provision/tempo.yaml:/etc/tempo/tempo.yaml
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--spider",
+          "http://localhost:3200/api/echo",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
       start_period: 10s
 
   nats:
@@ -199,7 +225,6 @@ services:
         sleep 2
       done &&
       cat /provision/neo4j.cypher | cypher-shell -u neo4j -p password --format plain -a bolt://neo4j:7687"
-
 
   opensearch:
     image: opensearchproject/opensearch:2.11.1

--- a/deployment/provision/grafana/datasources/tempo.yaml
+++ b/deployment/provision/grafana/datasources/tempo.yaml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    orgId: 1
+    url: http://tempo:3200
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: true
+    uid: tempo
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus

--- a/deployment/provision/otel-collector-config.yaml
+++ b/deployment/provision/otel-collector-config.yaml
@@ -8,28 +8,37 @@ receivers:
 
 processors:
   batch:
+    send_batch_size: 10000
     timeout: 5s
-    send_batch_size: 5000
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 1000
+    spike_limit_mib: 200
 
 exporters:
-  timescaledb:
-    # Note: Tables must be created manually before starting the collector
-    # See SQL queries in the documentation for table creation
-    endpoint: postgresql://postgres:password@localhost:5556/telemetry
-    timeout: 5s
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_interval: 30s
-      max_elapsed_time: 300s
+  otlp:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    namespace: otelcol
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+  pprof:
+    endpoint: 0.0.0.0:1777
 
 service:
+  extensions: [health_check, pprof]
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
-      exporters: [timescaledb]
-    logs:
+      processors: [memory_limiter, batch]
+      exporters: [otlp]
+    metrics:
       receivers: [otlp]
-      processors: [batch]
-      exporters: [timescaledb]
+      processors: [memory_limiter, batch]
+      exporters: [prometheus]
+

--- a/deployment/provision/tempo.yaml
+++ b/deployment/provision/tempo.yaml
@@ -1,0 +1,44 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  max_block_duration: 5m
+  max_block_bytes: 500000000
+  lifecycler:
+    ring:
+      replication_factor: 1
+
+compactor:
+  compaction:
+    block_retention: 24h # Retain traces for 48 hours in dev
+  ring:
+    kvstore:
+      store: memberlist
+
+storage:
+  trace:
+    backend: local # Using local storage for development
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Grafana Tempo to the development environment, integrating it with OpenTelemetry Collector and Prometheus.
> 
>   - **Services**:
>     - Add `tempo` service to `docker-compose.yaml` with ports `3200`, `4317`, and `4318`.
>     - Configure `tempo` with local storage in `tempo.yaml`.
>   - **Grafana**:
>     - Add Tempo as a datasource in `grafana/datasources/tempo.yaml`.
>   - **OpenTelemetry Collector**:
>     - Update `otel-collector-config.yaml` to export traces to Tempo and metrics to Prometheus.
>     - Add `memory_limiter` processor to manage resource usage.
>   - **Misc**:
>     - Remove unnecessary blank lines in `docker-compose.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for fa70c72fb4b6f6c1c53fdd89940e50f19e6a1a33. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->