### PR TITLE
fix role access

### DIFF
--- a/packages/server/customer-os-api/graphql/schemas/admin.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/admin.graphqls
@@ -6,7 +6,7 @@ extend type Mutation {
     admin_addWorkspaceAccess(authenticatedUserEmail: String!, tenant: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER]) @hasTenant
     admin_removeWorkspaceAccess(authenticatedUserEmail: String!, tenant: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER]) @hasTenant
 
-    admin_switchCurrentWorkspace(switchToTenant: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER]) @hasTenant
+    admin_switchCurrentWorkspace(switchToTenant: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER, IMPERSONATED]) @hasTenant
     admin_tenant_AddDomainAsWorkspace(domain: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER]) @hasTenant
     admin_tenant_hardDelete(tenant: String!, confirmTenant: String!): Boolean! @hasRole(roles: [PLATFORM_OWNER]) @hasTenant
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `IMPERSONATED` role to `admin_switchCurrentWorkspace` mutation in `admin.graphqls`.
> 
>   - **Role Access**:
>     - Updated `admin_switchCurrentWorkspace` mutation in `admin.graphqls` to include `IMPERSONATED` role, allowing users with this role to switch workspaces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for efe37f78cf8f8d40c754e32cec1ff738a8a94417. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->