### PR TITLE
use telemetry in upkeeper 1

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/contact_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/contact_service.go
@@ -14,7 +14,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	commonService "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
 	common_srv "github.com/customeros/customeros/packages/server/customer-os-common-module/services/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
@@ -23,8 +23,6 @@ import (
 	postgresrepository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 	"github.com/customeros/mailsherpa/emailparser"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/config"
@@ -86,16 +84,15 @@ func (s *contactService) UpkeepContacts() {
 }
 
 func (s *contactService) removeEmptySocials(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.removeEmptySocials")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.removeEmptySocials")
+	defer spans.Finish()
 
 	limit := 100
 	minutesSinceLastUpdate := 180
 
 	records, err := s.commonServices.Neo4jRepositories.SocialReadRepository.GetEmptySocialsForEntityType(ctx, model.NodeLabelContact, minutesSinceLastUpdate, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error getting socials: %v", err)
 		return
 	}
@@ -113,42 +110,40 @@ func (s *contactService) removeEmptySocials(ctx context.Context) {
 		})
 		err := s.commonServices.Neo4jRepositories.SocialWriteRepository.RemoveSocialForEntityById(innerCtx, record.Tenant, record.LinkedEntityId, model.NodeLabelContact, record.SocialId)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error removing social {%s}: %s", record.SocialId, err.Error())
 		}
 	}
 }
 
 func (s *contactService) removeDuplicatedSocials(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.removeDuplicatedSocials")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.removeDuplicatedSocials")
+	defer spans.Finish()
 
 	limit := 100
 	minutesSinceLastUpdate := 5
 
 	records, err := s.commonServices.Neo4jRepositories.SocialReadRepository.GetDuplicatedSocialsForEntityType(ctx, model.NodeLabelContact, minutesSinceLastUpdate, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error getting socials: %v", err)
 		return
 	}
-	span.LogKV("result.count", len(records))
+	spans.LogKV("result.count", len(records))
 
 	// remove socials from contact
 	for _, record := range records {
 		err := s.commonServices.Neo4jRepositories.SocialWriteRepository.RemoveSocialForEntityById(ctx, record.Tenant, record.LinkedEntityId, model.NodeLabelContact, record.SocialId)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error removing social {%s}: %s", record.SocialId, err.Error())
 		}
 	}
 }
 
 func (s *contactService) hideContactsWithGroupOrSystemGeneratedEmail(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.hideContactsWithGroupOrSystemGeneratedEmail")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.hideContactsWithGroupOrSystemGeneratedEmail")
+	defer spans.Finish()
 
 	limit := 100
 
@@ -163,7 +158,7 @@ func (s *contactService) hideContactsWithGroupOrSystemGeneratedEmail(ctx context
 
 		records, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsWithGroupOrSystemGeneratedEmail(ctx, limit)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error getting contacts: %v", err)
 			return
 		}
@@ -183,7 +178,7 @@ func (s *contactService) hideContactsWithGroupOrSystemGeneratedEmail(ctx context
 
 			err = s.commonServices.ContactService.HideContact(innerCtx, nil, record.ContactId)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error hiding contact {%s}: %s", record.ContactId, err.Error())
 			}
 		}
@@ -199,9 +194,8 @@ func (s *contactService) hideContactsWithGroupOrSystemGeneratedEmail(ctx context
 }
 
 func (s *contactService) checkContacts(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.checkContacts")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.checkContacts")
+	defer spans.Finish()
 
 	limit := 1000
 	minutesSinceLastUpdate := 30
@@ -209,7 +203,7 @@ func (s *contactService) checkContacts(ctx context.Context) {
 
 	records, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsToCheck(ctx, minutesSinceLastUpdate, hoursSinceLastCheck, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error getting contacts: %v", err)
 		return
 	}
@@ -240,7 +234,7 @@ func (s *contactService) checkContacts(ctx context.Context) {
 		if saveContact {
 			_, err = s.commonServices.ContactService.Save(innerCtx, nil, &contactEntity.Id, contactFields, false)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "ContactService.Save"))
+				spans.TraceError(errors.Wrap(err, "ContactService.Save"))
 				s.log.Errorf("Error updating contact {%s}: %s", contactEntity.Id, err.Error())
 			}
 		}
@@ -248,7 +242,7 @@ func (s *contactService) checkContacts(ctx context.Context) {
 		// mark contact as checked
 		err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(innerCtx, record.Tenant, model.NodeLabelContact, contactEntity.Id, string(neo4jentity.ContactPropertyCheckedAt), utils.NowPtr())
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error updating contact' checked at: %s", err.Error())
 		}
 	}
@@ -256,9 +250,8 @@ func (s *contactService) checkContacts(ctx context.Context) {
 }
 
 func (s *contactService) updateContactNamesFromEmails(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.updateContactNamesFromEmails")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.updateContactNamesFromEmails")
+	defer spans.Finish()
 
 	limit := 100
 
@@ -273,7 +266,7 @@ func (s *contactService) updateContactNamesFromEmails(ctx context.Context) {
 
 		records, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsWithEmailForNameUpdate(ctx, limit)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error getting contacts: %v", err)
 			return
 		}
@@ -293,7 +286,7 @@ func (s *contactService) updateContactNamesFromEmails(ctx context.Context) {
 
 			parsedEmail, err := emailparser.Parse(record.FieldStr1)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error parsing email {%s}: %s", record.FieldStr1, err.Error())
 				continue
 			}
@@ -311,7 +304,7 @@ func (s *contactService) updateContactNamesFromEmails(ctx context.Context) {
 			if saveContact {
 				_, err = s.commonServices.ContactService.Save(innerCtx, nil, &record.ContactId, contactFields, false)
 				if err != nil {
-					tracing.TraceErr(span, errors.Wrap(err, "ContactService.Save"))
+					spans.TraceError(err)
 					s.log.Errorf("Error updating contact {%s}: %s", record.ContactId, err.Error())
 				}
 			}
@@ -328,15 +321,14 @@ func (s *contactService) updateContactNamesFromEmails(ctx context.Context) {
 }
 
 func (s *contactService) setPrimaryJobRole(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.setPrimaryJobRole")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.setPrimaryJobRole")
+	defer spans.Finish()
 
 	limit := 500
 
 	records, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsToSetPrimaryJobRole(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error getting contacts: %v", err)
 		return
 	}
@@ -349,7 +341,7 @@ func (s *contactService) setPrimaryJobRole(ctx context.Context) {
 		})
 		err = s.commonServices.ContactService.SetPrimaryJobRole(innerCtx, nil, record.ContactId, nil)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			continue
 		}
 	}
@@ -396,17 +388,16 @@ type BetterContactResponseBody struct {
 }
 
 func (s *contactService) askForLinkedInConnections(c context.Context) {
-	span, ctx := tracing.StartTracerSpan(c, "ContactService.askForLinkedInConnections")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(c, "ContactService.askForLinkedInConnections")
+	defer spans.Finish()
 
 	linkedinTokens, err := s.commonServices.PostgresRepositories.BrowserConfigRepository.Get(ctx)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
-	span.LogFields(log.Int("linkedinTokens", len(linkedinTokens)))
+	spans.LogKV("linkedinTokens", len(linkedinTokens))
 
 	for _, linkedinToken := range linkedinTokens {
 		// todo check if there is already a scheduled job for this token today
@@ -419,7 +410,7 @@ func (s *contactService) askForLinkedInConnections(c context.Context) {
 			Payload:         "\"\"",
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			break
 		}
 	}
@@ -428,17 +419,17 @@ func (s *contactService) askForLinkedInConnections(c context.Context) {
 func (s *contactService) ProcessLinkedInConnections() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.ProcessLinkedInConnections")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.ProcessLinkedInConnections")
+	defer spans.Finish()
 
 	automationsRuns, err := s.commonServices.PostgresRepositories.BrowserAutomationRunRepository.Get(ctx, "FIND_CONNECTIONS", "COMPLETED")
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
-	span.LogFields(log.Int("processing", len(automationsRuns)))
+	spans.LogKV("processing", len(automationsRuns))
 
 	for _, automationRun := range automationsRuns {
 		ctx = common.WithCustomContext(ctx, &common.CustomContext{
@@ -450,28 +441,27 @@ func (s *contactService) ProcessLinkedInConnections() {
 }
 
 func (s *contactService) processAutomationRunResult(ctx context.Context, automationRun postgresentity.BrowserAutomationsRun) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.processAutomationRunResult")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.processAutomationRunResult")
+	defer spans.Finish()
 
 	result, err := s.commonServices.PostgresRepositories.BrowserAutomationRunResultRepository.Get(ctx, automationRun.Id)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
 	if result == nil || result.ResultData == "" {
-		span.LogFields(log.String("results", "empty"))
+		spans.LogKV("results", "empty")
 		return
 	}
 
 	useByEmailNode, err := s.commonServices.Neo4jRepositories.UserReadRepository.GetUserById(ctx, automationRun.Tenant, automationRun.UserId)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "UserReadRepository.GetUserById"))
+		spans.TraceError(err)
 		return
 	}
 	if useByEmailNode == nil {
-		tracing.TraceErr(span, errors.Wrap(err, "User does not exist"))
+		spans.TraceError(errors.Wrap(err, "User does not exist"))
 		return
 	}
 
@@ -485,11 +475,11 @@ func (s *contactService) processAutomationRunResult(ctx context.Context, automat
 
 	err = json.Unmarshal([]byte(result.ResultData), &results)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
-	span.LogFields(log.Int("results", len(results)))
+	spans.LogKV("results.count", len(results))
 
 	tenant := automationRun.Tenant
 	userId := automationRun.UserId
@@ -497,7 +487,7 @@ func (s *contactService) processAutomationRunResult(ctx context.Context, automat
 	for _, linkedinUrl := range results {
 		err := s.processLinkedInUrl(ctx, tenant, linkedinUrl, userId)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 
@@ -505,15 +495,14 @@ func (s *contactService) processAutomationRunResult(ctx context.Context, automat
 
 	err = s.commonServices.PostgresRepositories.BrowserAutomationRunRepository.MarkAsProcessed(ctx, automationRun.Id)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 }
 
 func (s *contactService) processLinkedInUrl(ctx context.Context, tenant, linkedinUrl, userId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.processLinkedInUrl")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.processLinkedInUrl")
+	defer spans.Finish()
 
 	linkedinProfileUrl := linkedinUrl
 	if linkedinProfileUrl != "" && linkedinProfileUrl[len(linkedinProfileUrl)-1] != '/' {
@@ -524,7 +513,7 @@ func (s *contactService) processLinkedInUrl(ctx context.Context, tenant, linkedi
 
 	contactsWithLinkedin, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsWithSocialUrl(ctx, tenant, linkedinProfileUrl)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "ContactReadRepository.GetContactsWithSocialUrl"))
+		spans.TraceError(errors.Wrap(err, "ContactReadRepository.GetContactsWithSocialUrl"))
 		return err
 	}
 
@@ -532,7 +521,7 @@ func (s *contactService) processLinkedInUrl(ctx context.Context, tenant, linkedi
 	if len(contactsWithLinkedin) == 0 {
 		contactId, _, err := s.commonServices.ContactService.CreateContactByLinkedIn(ctx, nil, linkedinProfileUrl)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 		contactIds = append(contactIds, contactId)
@@ -549,7 +538,7 @@ func (s *contactService) processLinkedInUrl(ctx context.Context, tenant, linkedi
 
 			isLinkedWith, err := s.commonServices.Neo4jRepositories.CommonReadRepository.IsLinkedWith(ctx, tenant, cid, model.CONTACT, model.CONNECTED_WITH.String(), userId, model.USER)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "CommonReadRepository.IsLinkedWith"))
+				spans.TraceError(errors.Wrap(err, "CommonReadRepository.IsLinkedWith"))
 				return err
 			}
 
@@ -562,7 +551,7 @@ func (s *contactService) processLinkedInUrl(ctx context.Context, tenant, linkedi
 					ToEntityType:   model.USER,
 				})
 				if err != nil {
-					tracing.TraceErr(span, errors.Wrap(err, "CommonWriteRepository.Link"))
+					spans.TraceError(errors.Wrap(err, "CommonWriteRepository.Link"))
 					return err
 				}
 			}
@@ -571,7 +560,7 @@ func (s *contactService) processLinkedInUrl(ctx context.Context, tenant, linkedi
 
 	pendingLinkedinRequests, err := s.commonServices.Neo4jRepositories.LinkedinConnectionRequestReadRepository.GetPendingRequestByUserForSocialUrl(ctx, nil, tenant, userId, linkedinProfileUrl)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "LinkedinConnectionRequestReadRepository.GetPendingRequestByUserForSocialUrl"))
+		spans.TraceError(errors.Wrap(err, "LinkedinConnectionRequestReadRepository.GetPendingRequestByUserForSocialUrl"))
 		return err
 	}
 
@@ -579,7 +568,7 @@ func (s *contactService) processLinkedInUrl(ctx context.Context, tenant, linkedi
 		for _, cid := range contactIds {
 			flowActionExecutions, err := s.commonServices.FlowExecutionService.GetFlowActionExecutionsForParticipantWithActionType(ctx, cid, model.CONTACT, neo4jentity.FlowActionTypeLinkedinConnectionRequest)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "FlowService.FlowGetByParticipant"))
+				spans.TraceError(errors.Wrap(err, "FlowService.FlowGetByParticipant"))
 				return err
 			}
 
@@ -605,7 +594,7 @@ func (s *contactService) processLinkedInUrl(ctx context.Context, tenant, linkedi
 						return nil, nil
 					})
 					if err != nil {
-						tracing.TraceErr(span, errors.Wrap(err, "ExecuteWriteInTransaction"))
+						spans.TraceError(errors.Wrap(err, "ExecuteWriteInTransaction"))
 						return err
 					}
 				}
@@ -617,20 +606,19 @@ func (s *contactService) processLinkedInUrl(ctx context.Context, tenant, linkedi
 }
 
 func (s *contactService) linkOrphanContactsToOrganizationBasedOnLinkedin(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.linkOrphanContactsToOrganizationBasedOnLinkedin")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.linkOrphanContactsToOrganizationBasedOnLinkedin")
+	defer spans.Finish()
 
 	limit := 200
 	delayFromPreviousAttemptDays := 14
 
 	orphanContacts, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsEnrichedNotLinkedToOrganization(ctx, delayFromPreviousAttemptDays, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
-	span.LogFields(log.Int("orphanContactsCount", len(orphanContacts)))
+	spans.LogKV("orphanContactsCount", len(orphanContacts))
 
 	for _, orphanContact := range orphanContacts {
 		innerCtx := common.WithCustomContext(ctx, &common.CustomContext{
@@ -642,21 +630,20 @@ func (s *contactService) linkOrphanContactsToOrganizationBasedOnLinkedin(ctx con
 }
 
 func (s *contactService) processLinkOrphanContactToOrganizationBasedOnLinkedin(ctx context.Context, record neo4jrepository.TenantAndContactIdAndParams) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.processLinkOrphanContactToOrganizationBasedOnLinkedin")
-	defer span.Finish()
-	tracing.TagTenant(span, record.Tenant)
-	tracing.TagEntity(span, record.ContactId)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.processLinkOrphanContactToOrganizationBasedOnLinkedin")
+	defer spans.Finish()
+	spans.TagEntity(record.ContactId)
 
 	// Mark contact with link requested
 	err := s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(ctx, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyLinkWithOrgRequestedAt), utils.NowPtr())
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
 	scrapIn, err := s.commonServices.PostgresRepositories.EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow(ctx, record.FieldStr1, postgresentity.ScrapInFlowPersonProfile)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow"))
+		spans.TraceError(errors.Wrap(err, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow"))
 		return
 	}
 
@@ -665,7 +652,7 @@ func (s *contactService) processLinkOrphanContactToOrganizationBasedOnLinkedin(c
 		var scrapinContactResponse postgresentity.ScrapInResponseBody
 		err := json.Unmarshal([]byte(scrapIn.Data), &scrapinContactResponse)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "json.Unmarshal"))
+			spans.TraceError(errors.Wrap(err, "json.Unmarshal"))
 			return
 		}
 
@@ -676,9 +663,7 @@ func (s *contactService) processLinkOrphanContactToOrganizationBasedOnLinkedin(c
 
 		organizationByDomainNode, err := s.commonServices.Neo4jRepositories.OrganizationReadRepository.GetOrganizationByDomain(ctx, nil, record.Tenant, domain)
 		if err != nil {
-			// TODO uncomment when data is fixed in DB
-			// tracing.TraceErr(innerSpan, errors.Wrap(err, "OrganizationReadRepository.GetOrganizationByDomain"))
-			// return
+			spans.TraceError(errors.Wrap(err, "OrganizationReadRepository.GetOrganizationByDomain"))
 			return
 		}
 
@@ -698,7 +683,7 @@ func (s *contactService) processLinkOrphanContactToOrganizationBasedOnLinkedin(c
 			err = s.commonServices.ContactService.LinkContactWithOrganization(ctx, nil, record.ContactId, organizationId, positionName, "",
 				neo4jentity.DataSourceOpenline.String(), false, nil, nil)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 			}
 		}
 	}
@@ -708,15 +693,14 @@ func (s *contactService) EnrichWithWorkEmailFromBetterContact() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.EnrichWithWorkEmailFromBetterContact")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.EnrichWithWorkEmailFromBetterContact")
+	defer spans.Finish()
 
 	limit := 250
 
 	records, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsToEnrichWithEmailFromBetterContact(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -730,26 +714,26 @@ func (s *contactService) EnrichWithWorkEmailFromBetterContact() {
 		// mark contact with update requested
 		err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(innerCtx, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyUpdateWithWorkEmailRequestedAt), utils.NowPtr())
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 		}
 
 		detailsBetterContact, err := s.commonServices.PostgresRepositories.EnrichDetailsBetterContactRepository.GetByRequestId(innerCtx, record.FieldStr1)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 
 		if detailsBetterContact == nil {
-			tracing.TraceErr(span, errors.New("better contact details by request id not found"))
+			spans.TraceError(errors.New("better contact details by request id not found"))
 
 			detailsBetterContact, err = s.commonServices.PostgresRepositories.EnrichDetailsBetterContactRepository.GetById(innerCtx, record.FieldStr1)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				return
 			}
 
 			if detailsBetterContact == nil {
-				tracing.TraceErr(span, errors.New("better contact details by id not found"))
+				spans.TraceError(errors.New("better contact details by id not found"))
 				continue
 			}
 		}
@@ -760,7 +744,7 @@ func (s *contactService) EnrichWithWorkEmailFromBetterContact() {
 
 		var betterContactResponse postgresentity.BetterContactResponseBody
 		if err = json.Unmarshal([]byte(detailsBetterContact.Response), &betterContactResponse); err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 
@@ -768,7 +752,7 @@ func (s *contactService) EnrichWithWorkEmailFromBetterContact() {
 		var currentEmails []string
 		emailDbNodes, err := s.commonServices.Neo4jRepositories.EmailReadRepository.GetAllEmailNodesForLinkedEntityIds(innerCtx, record.Tenant, model.CONTACT, []string{record.ContactId})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 		}
 		for _, emailDbNode := range emailDbNodes {
 			emailEntity := neo4jmapper.MapDbNodeToEmailEntity(emailDbNode.Node)
@@ -781,7 +765,7 @@ func (s *contactService) EnrichWithWorkEmailFromBetterContact() {
 		var currentPhones []string
 		phoneDbNodes, err := s.commonServices.Neo4jRepositories.PhoneNumberReadRepository.GetAllForLinkedEntityIds(innerCtx, record.Tenant, model.CONTACT, []string{record.ContactId})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 		}
 		for _, phoneDbNode := range phoneDbNodes {
 			phoneEntity := neo4jmapper.MapDbNodeToPhoneNumberEntity(phoneDbNode.Node)
@@ -810,7 +794,7 @@ func (s *contactService) EnrichWithWorkEmailFromBetterContact() {
 							Id:   record.ContactId,
 						})
 					if err != nil {
-						tracing.TraceErr(span, err)
+						spans.TraceError(err)
 						continue
 					}
 					emailLinked = true
@@ -826,13 +810,13 @@ func (s *contactService) EnrichWithWorkEmailFromBetterContact() {
 
 						phoneNumberId, err := s.commonServices.PhoneNumberService.Merge(innerCtx, phoneNumber, neo4jentity.DataSourceOpenline)
 						if err != nil {
-							tracing.TraceErr(span, err)
+							spans.TraceError(err)
 							continue
 						}
 
 						err = s.commonServices.Neo4jRepositories.PhoneNumberWriteRepository.LinkWithContact(innerCtx, record.Tenant, record.ContactId, phoneNumberId, "WORK", false)
 						if err != nil {
-							tracing.TraceErr(span, err)
+							spans.TraceError(err)
 							s.log.Errorf("Error from events processing %s", err.Error())
 							continue
 						}
@@ -853,7 +837,7 @@ func (s *contactService) EnrichWithWorkEmailFromBetterContact() {
 				},
 			)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "failed to store billable event"))
+				spans.TraceError(errors.Wrap(err, "failed to store billable event"))
 			}
 		}
 		if phoneLinked {
@@ -864,24 +848,24 @@ func (s *contactService) EnrichWithWorkEmailFromBetterContact() {
 				},
 			)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "failed to store billable event"))
+				spans.TraceError(errors.Wrap(err, "failed to store billable event"))
 			}
 		}
 
 		// mark contact enrich fields for email
 		err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(innerCtx, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyFindWorkEmailWithBetterContactCompletedAt), utils.NowPtr())
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 		}
 		if emailLinked {
 			err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateBoolProperty(innerCtx, nil, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyFindWorkEmailWithBetterContactFound), true)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 			}
 		} else {
 			err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateBoolProperty(innerCtx, nil, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyFindWorkEmailWithBetterContactFound), false)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 			}
 		}
 
@@ -889,17 +873,17 @@ func (s *contactService) EnrichWithWorkEmailFromBetterContact() {
 		if detailsBetterContact.EnrichPhoneNumber {
 			err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(innerCtx, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyFindMobilePhoneWithBetterContactCompletedAt), utils.NowPtr())
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 			}
 			if phoneLinked {
 				err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateBoolProperty(innerCtx, nil, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyFindMobilePhoneWithBetterContactFound), true)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 				}
 			} else {
 				err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateBoolProperty(innerCtx, nil, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyFindMobilePhoneWithBetterContactFound), false)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 				}
 			}
 		}
@@ -908,21 +892,20 @@ func (s *contactService) EnrichWithWorkEmailFromBetterContact() {
 }
 
 func (s *contactService) checkBetterContactRequestsWithoutResponse(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.checkBetterContactRequestsWithoutResponse")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.checkBetterContactRequestsWithoutResponse")
+	defer spans.Finish()
 
 	// validate bettercontact is configured
 	if s.cfg.Common.External.BetterContactConfig.ApiKey == "" || s.cfg.Common.External.BetterContactConfig.Url == "" {
 		err := errors.New("bettercontact is not configured")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("BetterContact is not configured")
 		return
 	}
 
 	betterContactRequestsWithoutResponse, err := s.commonServices.PostgresRepositories.EnrichDetailsBetterContactRepository.GetWithoutResponses(ctx, 50)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -934,7 +917,7 @@ func (s *contactService) checkBetterContactRequestsWithoutResponse(ctx context.C
 		// Create POST request
 		req, err := http.NewRequest("GET", fmt.Sprintf("%s?api_key=%s", s.cfg.Common.External.BetterContactConfig.Url+"/"+record.RequestID, s.cfg.Common.External.BetterContactConfig.ApiKey), nil)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 
@@ -944,14 +927,14 @@ func (s *contactService) checkBetterContactRequestsWithoutResponse(ctx context.C
 		// Perform the request
 		resp, err := client.Do(req)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 		defer resp.Body.Close()
 
 		responseBody, err := io.ReadAll(resp.Body)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 
@@ -962,21 +945,21 @@ func (s *contactService) checkBetterContactRequestsWithoutResponse(ctx context.C
 		// Parse the JSON request body
 		var betterContactResponse postgresentity.BetterContactResponseBody
 		if err = json.Unmarshal(responseBody, &betterContactResponse); err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 
 		if betterContactResponse.Status == "terminated" {
 			err = s.commonServices.PostgresRepositories.EnrichDetailsBetterContactRepository.AddResponse(ctx, record.RequestID, string(responseBody))
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				return
 			}
 			// store billable events
 			// first check if it was requested externally
 			personEnrichmentRequest, err := s.commonServices.PostgresRepositories.CosApiEnrichPersonTempResultRepository.GetByBettercontactRecordId(ctx, betterContactResponse.Id)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "failed to check if bettercontact record was requested from person enrichment"))
+				spans.TraceError(errors.Wrap(err, "failed to check if bettercontact record was requested from person enrichment"))
 			} else if personEnrichmentRequest != nil {
 				emailFound, phoneFound := false, false
 				for _, item := range betterContactResponse.Data {
@@ -994,7 +977,7 @@ func (s *contactService) checkBetterContactRequestsWithoutResponse(ctx context.C
 							ReferenceData: "generated in upkeeper",
 						})
 					if err != nil {
-						tracing.TraceErr(span, errors.Wrap(err, "failed to store billable event"))
+						spans.TraceError(errors.Wrap(err, "failed to store billable event"))
 					}
 				}
 				if phoneFound {
@@ -1004,7 +987,7 @@ func (s *contactService) checkBetterContactRequestsWithoutResponse(ctx context.C
 							ReferenceData: "generated in upkeeper",
 						})
 					if err != nil {
-						tracing.TraceErr(span, errors.Wrap(err, "failed to store billable event"))
+						spans.TraceError(errors.Wrap(err, "failed to store billable event"))
 					}
 				}
 			}
@@ -1020,69 +1003,53 @@ func (s *contactService) EnrichContacts() {
 }
 
 func (s *contactService) enrichContacts(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContactService.enrichContacts")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContactService.enrichContacts")
+	defer spans.Finish()
 
 	limit := 20
 
-	for {
-		select {
-		case <-ctx.Done():
-			s.log.Infof("Context cancelled, stopping")
-			return
-		default:
-			// continue as normal
-		}
-
-		minutesFromLastContactUpdate := 3
-		minutesFromLastContactEnrichAttempt := 1 * 24 * 60 // 1 day
-		records, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsToEnrich(ctx, minutesFromLastContactUpdate, minutesFromLastContactEnrichAttempt, limit)
-		if err != nil {
-			tracing.TraceErr(span, err)
-			s.log.Errorf("Error getting socials: %v", err)
-			return
-		}
-
-		// no record
-		if len(records) == 0 {
-			return
-		}
-
-		for _, record := range records {
-			// create new context from main one with custom context
-			innerCtx := common.WithCustomContext(ctx, &common.CustomContext{
-				Tenant:    record.Tenant,
-				AppSource: constants.AppSourceDataUpkeeper,
-			})
-
-			err = s.commonServices.Events.Publisher.PublishFanoutEvent(innerCtx, record.ContactId, model.CONTACT, dto.RequestEnrichContact{})
-			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "unable to publish message RequestEnrichContact"))
-				s.log.Errorf("Error requesting enrich contact {%s}: %s", record.ContactId, err.Error())
-			}
-
-			// mark contact with enrich requested
-			err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(innerCtx, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyEnrichRequestedAt), utils.NowPtr())
-			if err != nil {
-				tracing.TraceErr(span, err)
-				s.log.Errorf("Error updating contact' enrich requested: %s", err.Error())
-			}
-
-			// increment enrich attempts
-			err = s.commonServices.Neo4jRepositories.CommonWriteRepository.IncrementProperty(innerCtx, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyEnrichAttempts))
-			if err != nil {
-				tracing.TraceErr(span, err)
-				s.log.Errorf("Error incrementing contact' enrich attempts: %s", err.Error())
-			}
-		}
-
-		// if less than limit records are returned, we are done
-		if len(records) < limit {
-			return
-		}
-
-		// force exit after single iteration
+	minutesFromLastContactUpdate := 3
+	minutesFromLastContactEnrichAttempt := 1 * 24 * 60 // 1 day
+	records, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsToEnrich(ctx, minutesFromLastContactUpdate, minutesFromLastContactEnrichAttempt, limit)
+	if err != nil {
+		spans.TraceError(err)
+		s.log.Errorf("Error getting socials: %v", err)
 		return
 	}
+
+	spans.LogKV("records.count", len(records))
+
+	// no record
+	if len(records) == 0 {
+		return
+	}
+
+	for _, record := range records {
+		// create new context from main one with custom context
+		innerCtx := common.WithCustomContext(ctx, &common.CustomContext{
+			Tenant:    record.Tenant,
+			AppSource: constants.AppSourceDataUpkeeper,
+		})
+
+		err = s.commonServices.Events.Publisher.PublishFanoutEvent(innerCtx, record.ContactId, model.CONTACT, dto.RequestEnrichContact{})
+		if err != nil {
+			spans.TraceError(errors.Wrap(err, "unable to publish message RequestEnrichContact"))
+			s.log.Errorf("Error requesting enrich contact {%s}: %s", record.ContactId, err.Error())
+		}
+
+		// mark contact with enrich requested
+		err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(innerCtx, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyEnrichRequestedAt), utils.NowPtr())
+		if err != nil {
+			spans.TraceError(err)
+			s.log.Errorf("Error updating contact' enrich requested: %s", err.Error())
+		}
+
+		// increment enrich attempts
+		err = s.commonServices.Neo4jRepositories.CommonWriteRepository.IncrementProperty(innerCtx, record.Tenant, model.NodeLabelContact, record.ContactId, string(neo4jentity.ContactPropertyEnrichAttempts))
+		if err != nil {
+			spans.TraceError(err)
+			s.log.Errorf("Error incrementing contact' enrich attempts: %s", err.Error())
+		}
+	}
+
 }

--- a/packages/runner/customer-os-data-upkeeper/service/contract_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/contract_service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	service "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"time"
 )
@@ -48,9 +48,8 @@ func (s *contractService) UpkeepContracts() {
 }
 
 func (s *contractService) updateContractStatuses(ctx context.Context, referenceTime time.Time) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContractService.updateContractStatuses")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContractService.updateContractStatuses")
+	defer spans.Finish()
 
 	limit := 100
 	delayFromPreviousCheckHours := 3
@@ -66,7 +65,7 @@ func (s *contractService) updateContractStatuses(ctx context.Context, referenceT
 
 		records, err := s.repositories.Neo4jRepositories.ContractReadRepository.GetContractsForStatusRenewal(ctx, referenceTime, limit, delayFromPreviousCheckHours)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error getting contracts for status update: %v", err)
 			return
 		}
@@ -85,13 +84,13 @@ func (s *contractService) updateContractStatuses(ctx context.Context, referenceT
 
 			err = s.services.ContractService.RefreshContractStatus(innerCtx, record.ContractId)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error refreshing contract status: %s", err.Error())
 			}
 
 			err = s.repositories.Neo4jRepositories.ContractWriteRepository.MarkStatusRenewalRequested(ctx, record.Tenant, record.ContractId)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error marking status renewal requested: %s", err.Error())
 			}
 		}
@@ -107,9 +106,8 @@ func (s *contractService) updateContractStatuses(ctx context.Context, referenceT
 }
 
 func (s *contractService) rolloutContractRenewals(ctx context.Context, referenceTime time.Time) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContractService.rolloutContractRenewals")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContractService.rolloutContractRenewals")
+	defer spans.Finish()
 
 	limit := 100
 
@@ -124,7 +122,7 @@ func (s *contractService) rolloutContractRenewals(ctx context.Context, reference
 
 		records, err := s.repositories.Neo4jRepositories.ContractReadRepository.GetContractsForRenewalRollout(ctx, referenceTime, limit)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error getting contracts for renewal rollout: %v", err)
 			return
 		}
@@ -142,12 +140,12 @@ func (s *contractService) rolloutContractRenewals(ctx context.Context, reference
 			})
 			err = s.services.OpportunityService.RolloutRenewalOpportunity(innerCtx, record.ContractId)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error rollout renewal opportunity: %s", err.Error())
 			}
 			err = s.repositories.Neo4jRepositories.ContractWriteRepository.MarkRolloutRenewalRequested(ctx, record.Tenant, record.ContractId)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error marking renewal rollout requested: %s", err.Error())
 			}
 		}
@@ -163,9 +161,8 @@ func (s *contractService) rolloutContractRenewals(ctx context.Context, reference
 }
 
 func (s *contractService) closeActiveRenewalOpportunitiesForEndedContracts(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContractService.closeActiveRenewalOpportunitiesForEndedContracts")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContractService.closeActiveRenewalOpportunitiesForEndedContracts")
+	defer spans.Finish()
 
 	limit := 100
 
@@ -180,7 +177,7 @@ func (s *contractService) closeActiveRenewalOpportunitiesForEndedContracts(ctx c
 
 		records, err := s.repositories.Neo4jRepositories.OpportunityReadRepository.GetRenewalOpportunitiesForClosingAsLost(ctx, limit)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error getting opportunities for closing: %v", err)
 			return
 		}
@@ -198,12 +195,12 @@ func (s *contractService) closeActiveRenewalOpportunitiesForEndedContracts(ctx c
 			})
 			err = s.services.OpportunityService.CloseLost(innerCtx, nil, record.Tenant, record.OpportunityId)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error closing renewal opportunity: %s", err.Error())
 			} else {
 				err = s.repositories.Neo4jRepositories.OpportunityWriteRepository.MarkRenewalRequested(ctx, record.Tenant, record.OpportunityId)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					s.log.Errorf("Error marking renewal rollout requested: %s", err.Error())
 				}
 			}
@@ -220,9 +217,8 @@ func (s *contractService) closeActiveRenewalOpportunitiesForEndedContracts(ctx c
 }
 
 func (s *contractService) createRenewalOpportunitiesIfMissing(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "ContractService.createRenewalOpportunitiesIfMissing")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "ContractService.createRenewalOpportunitiesIfMissing")
+	defer spans.Finish()
 
 	limit := 100
 
@@ -237,7 +233,7 @@ func (s *contractService) createRenewalOpportunitiesIfMissing(ctx context.Contex
 
 		records, err := s.repositories.Neo4jRepositories.ContractReadRepository.GetLiveContractsWithoutRenewalOpportunities(ctx, limit)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error getting opportunities for closing: %v", err)
 			return
 		}
@@ -257,7 +253,7 @@ func (s *contractService) createRenewalOpportunitiesIfMissing(ctx context.Contex
 				ContractId: &record.ContractId,
 			})
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error creating renewal opportunity: %s", err.Error())
 			}
 		}

--- a/packages/runner/customer-os-data-upkeeper/service/currency_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/currency_service.go
@@ -5,7 +5,7 @@ import (
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/config"
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/logger"
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/repository"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"golang.org/x/net/context"
 	"io/ioutil"
@@ -35,14 +35,13 @@ func (c currencyService) GetCurrencyRatesECB() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "CurrencyService.GetCurrencyRatesECB")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "CurrencyService.GetCurrencyRatesECB")
+	defer spans.Finish()
 
 	// Make HTTP GET request to ECB API endpoint
 	resp, err := http.Get("https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml")
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		c.log.Errorf("Error making HTTP request to ECB API: %s", err.Error())
 		return
 	}
@@ -51,7 +50,7 @@ func (c currencyService) GetCurrencyRatesECB() {
 	// Read response body
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		c.log.Errorf("Error reading response body: %s", err.Error())
 		return
 	}
@@ -73,7 +72,7 @@ func (c currencyService) GetCurrencyRatesECB() {
 	var envelope Envelope
 	err = xml.Unmarshal(body, &envelope)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		c.log.Errorf("Error unmarshalling XML response: %s", err.Error())
 		return
 	}
@@ -81,7 +80,7 @@ func (c currencyService) GetCurrencyRatesECB() {
 	// Extract date from response
 	date, err := time.Parse("2006-01-02", envelope.Cube.Cube.Time)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		c.log.Errorf("Error parsing date: %s", err.Error())
 		return
 	}
@@ -93,7 +92,7 @@ func (c currencyService) GetCurrencyRatesECB() {
 			usdToEurRate = utils.TruncateFloat64(float64(1)/currency.Rate, 5)
 			err := c.repositories.PostgresRepositories.CurrencyRateRepository.SaveCurrencyRate(ctx, "EUR", usdToEurRate, date, "European Central Bank")
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				c.log.Errorf("Error saving currency rate: %s", err.Error())
 				return
 			}
@@ -106,7 +105,7 @@ func (c currencyService) GetCurrencyRatesECB() {
 			usdToCurrency := utils.TruncateFloat64(usdToEurRate*currency.Rate, 5)
 			err := c.repositories.PostgresRepositories.CurrencyRateRepository.SaveCurrencyRate(ctx, currency.Currency, usdToCurrency, date, "European Central Bank")
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				c.log.Errorf("Error saving currency rate: %s", err.Error())
 			}
 		}

--- a/packages/runner/customer-os-data-upkeeper/service/domain_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/domain_service.go
@@ -5,7 +5,7 @@ import (
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/config"
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/logger"
 	service "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/pkg/errors"
 )
 
@@ -31,16 +31,15 @@ func (s *domainService) CheckDomains() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "DomainService.CheckDomains")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "DomainService.CheckDomains")
+	defer spans.Finish()
 
 	limit := 50
 	delayFromLastUpdateInDays := 30
 
 	records, err := s.commonServices.Neo4jRepositories.DomainReadRepository.GetDomainsForPrimaryCheck(ctx, delayFromLastUpdateInDays, limit)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "Error getting domains for primary check"))
+		spans.TraceError(errors.Wrap(err, "Error getting domains for primary check"))
 		return
 	}
 
@@ -52,7 +51,7 @@ func (s *domainService) CheckDomains() {
 	for _, domain := range records {
 		err = s.commonServices.DomainService.UpdateDomainPrimaryDetails(ctx, domain)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "Error updating domain primary details"))
+			spans.TraceError(errors.Wrap(err, "Error updating domain primary details"))
 			s.log.Errorf("Error updating domain primary details: %s", err.Error())
 		}
 	}

--- a/packages/runner/customer-os-data-upkeeper/service/email_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/email_service.go
@@ -18,13 +18,11 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	commonservice "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	postgresentity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgresrepository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/config"
@@ -57,21 +55,21 @@ type emailService struct {
 func (s *emailService) CheckEnrowRequestsWithoutResponse() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
-	span, ctx := tracing.StartTracerSpan(ctx, "EmailService.CheckEnrowRequestsWithoutResponse")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+
+	spans, ctx := telemetry.StartCronSpan(ctx, "EmailService.CheckEnrowRequestsWithoutResponse")
+	defer spans.Finish()
 
 	// validate enrow is configured
 	if s.cfg.Common.External.EnrowConfig.ApiUrl == "" || s.cfg.Common.External.EnrowConfig.ApiKey == "" {
 		err := errors.New("Enrow API URL or API Key not set")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Error(err)
 		return
 	}
 
 	enrowRequestsWithoutResponse, err := s.commonServices.PostgresRepositories.CacheEmailEnrowRepository.GetWithoutResponses(ctx)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -82,7 +80,7 @@ func (s *emailService) CheckEnrowRequestsWithoutResponse() {
 		// Create POST request
 		req, err := http.NewRequest("GET", fmt.Sprintf("%s/email/verify/single?id=%s", s.cfg.Common.External.EnrowConfig.ApiUrl, url.QueryEscape(record.RequestID)), nil)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to create request"))
+			spans.TraceError(errors.Wrap(err, "failed to create request"))
 			return
 		}
 
@@ -94,14 +92,14 @@ func (s *emailService) CheckEnrowRequestsWithoutResponse() {
 		// Perform the request
 		resp, err := client.Do(req)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 		defer resp.Body.Close()
 
 		responseBody, err := io.ReadAll(resp.Body)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			continue
 		}
 
@@ -112,19 +110,19 @@ func (s *emailService) CheckEnrowRequestsWithoutResponse() {
 		// Parse the JSON request body
 		var enrowResponseBody postgresentity.EnrowResponseBody
 		if err = json.Unmarshal(responseBody, &enrowResponseBody); err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error unmarshalling request body"))
+			spans.TraceError(errors.Wrap(err, "error unmarshalling request body"))
 			continue
 		}
 
 		if enrowResponseBody.Qualification != "" {
 			err = s.commonServices.PostgresRepositories.CacheEmailEnrowRepository.AddResponse(ctx, enrowResponseBody.Id, enrowResponseBody.Qualification, string(responseBody))
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "error saving Enrow response to db"))
+				spans.TraceError(errors.Wrap(err, "error saving Enrow response to db"))
 				return
 			}
 		} else {
 			err = errors.New("Enrow response qualification is empty")
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 		}
 	}
 }
@@ -141,9 +139,8 @@ func (s *emailService) ValidateEmails() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "EmailService.ValidateEmails")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "EmailService.ValidateEmails")
+	defer spans.Finish()
 
 	limit := s.cfg.App.Limits.EmailsValidationLimit
 	delayFromLastUpdateInSeconds := 10
@@ -160,7 +157,7 @@ func (s *emailService) ValidateEmails() {
 
 		records, err := s.commonServices.Neo4jRepositories.EmailReadRepository.GetEmailsForValidation(ctx, delayFromLastUpdateInSeconds, delayFromLastValidationAttemptInMinutes, limit)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 
@@ -177,13 +174,13 @@ func (s *emailService) ValidateEmails() {
 
 			err = s.commonServices.EmailService.RequestEmailValidation(innerCtx, record.EmailId)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "Error requesting email validation"))
+				spans.TraceError(errors.Wrap(err, "Error requesting email validation"))
 				s.log.Errorf("Error publishing email validation request: %s", err.Error())
 			}
 
 			err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(ctx, record.Tenant, model.NodeLabelEmail, record.EmailId, string(neo4jentity.EmailPropertyValidationRequestedAt), utils.NowPtr())
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 			}
 
 			// pause 1 second before next request
@@ -202,16 +199,15 @@ func (s *emailService) ValidateEmailsFromBulkRequests() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "EmailService.ValidateEmailsFromBulkRequests")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "EmailService.ValidateEmailsFromBulkRequests")
+	defer spans.Finish()
 
 	limit := 200
 	workers := s.cfg.App.Limits.BulkEmailsValidationThreads
 
 	records, err := s.commonServices.PostgresRepositories.EmailValidationRecordRepository.GetUnprocessedEmailRecords(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -230,14 +226,14 @@ func (s *emailService) ValidateEmailsFromBulkRequests() {
 					// Call the email validation method (Placeholder)
 					validationResult, err := s.commonServices.VerifyService.ValidateEmail(ctx, record.Email)
 					if err != nil {
-						tracing.TraceErr(span, errors.Wrap(err, "Error validating email"))
+						spans.TraceError(errors.Wrap(err, "Error validating email"))
 						s.log.Errorf("Error validating email: %v", err)
 						continue
 					}
 
 					data, err := json.Marshal(validationResult)
 					if err != nil {
-						tracing.TraceErr(span, errors.Wrap(err, "Error marshalling data"))
+						spans.TraceError(errors.Wrap(err, "Error marshalling data"))
 						s.log.Errorf("Error marshalling data: %v", err)
 						continue
 					}
@@ -245,7 +241,7 @@ func (s *emailService) ValidateEmailsFromBulkRequests() {
 					// Update the record with the validation result
 					err = s.commonServices.PostgresRepositories.EmailValidationRecordRepository.UpdateEmailRecord(ctx, record.ID, string(data))
 					if err != nil {
-						tracing.TraceErr(span, errors.Wrap(err, "Error updating email record"))
+						spans.TraceError(errors.Wrap(err, "Error updating email record"))
 						s.log.Errorf("Failed to update email record: %s", err.Error())
 						continue
 					}
@@ -262,7 +258,7 @@ func (s *emailService) ValidateEmailsFromBulkRequests() {
 								ReferenceData: record.Email,
 							})
 						if err != nil {
-							tracing.TraceErr(span, errors.Wrap(err, "failed to register billable event"))
+							spans.TraceError(errors.Wrap(err, "failed to register billable event"))
 						}
 					}
 
@@ -298,7 +294,7 @@ func (s *emailService) ValidateEmailsFromBulkRequests() {
 	// additionally include oldest 5 uncompleted requests for check
 	oldestUncompletedRequests, err := s.commonServices.PostgresRepositories.EmailValidationRequestBulkRepository.GetOldestUncompletedRequests(ctx, 5)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "Error getting oldest uncompleted requests"))
+		spans.TraceError(errors.Wrap(err, "Error getting oldest uncompleted requests"))
 	}
 	for _, request := range oldestUncompletedRequests {
 		requestsToCheck[request.RequestID] = struct{}{}
@@ -311,14 +307,14 @@ func (s *emailService) ValidateEmailsFromBulkRequests() {
 
 // Check if all records for each request are processed and update bulk request status
 func (s *emailService) checkAndUpdateBulkRequests(ctx context.Context, requestsToCheck map[string]struct{}) {
-	span, ctx := tracing.StartTracerSpan(ctx, "EmailService.checkAndUpdateBulkRequests")
-	defer span.Finish()
+	spans, ctx := telemetry.StartCronSpan(ctx, "EmailService.checkAndUpdateBulkRequests")
+	defer spans.Finish()
 
 	// For each unique Request ID, check if all records are processed
 	for requestID := range requestsToCheck {
 		unprocessedCount, err := s.commonServices.PostgresRepositories.EmailValidationRecordRepository.CountPendingRequestsByRequestID(ctx, requestID)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "Error counting pending records"))
+			spans.TraceError(errors.Wrap(err, "Error counting pending records"))
 			s.log.Errorf("Failed to count pending records for request %s: %v", requestID, err)
 			continue
 		}
@@ -326,7 +322,7 @@ func (s *emailService) checkAndUpdateBulkRequests(ctx context.Context, requestsT
 		// get request by requestID
 		request, err := s.commonServices.PostgresRepositories.EmailValidationRequestBulkRepository.GetByRequestID(ctx, requestID)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "Error getting request by requestID"))
+			spans.TraceError(errors.Wrap(err, "Error getting request by requestID"))
 			s.log.Errorf("Failed to get request %s: %v", requestID, err)
 			continue
 		}
@@ -336,31 +332,31 @@ func (s *emailService) checkAndUpdateBulkRequests(ctx context.Context, requestsT
 			// generate csv result file
 			csvContent, err := s.generateBulkEmailValidationResponseCSVFileContent(ctx, requestID)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "Error generating CSV content"))
+				spans.TraceError(errors.Wrap(err, "Error generating CSV content"))
 				s.log.Errorf("Failed to generate CSV content for request %s: %v", requestID, err.Error())
 				continue
 			}
 
 			// log csv content size
-			span.LogFields(log.Int("csvContent.size.request."+requestID, len(csvContent)))
+			spans.LogKV("csvContent.size.request."+requestID, len(csvContent))
 
 			// Upload result file to S3
 			basePath := fmt.Sprintf("/EMAIL_VALIDATION/BULK/%d", utils.Now().Year())
 
 			fileDTO, err := s.commonServices.FileService.UploadSingleFileBytesDirect(ctx, basePath, requestID, requestID+".csv", &csvContent, false)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "UploadSingleFileBytes"))
+				spans.TraceError(errors.Wrap(err, "UploadSingleFileBytes"))
 				continue
 			}
 
 			if fileDTO.ID == "" {
-				tracing.TraceErr(span, errors.New("fileDTO.Id is empty"))
+				spans.TraceError(errors.New("fileDTO.Id is empty"))
 				continue
 			}
 
 			err = s.commonServices.PostgresRepositories.EmailValidationRequestBulkRepository.MarkRequestAsCompleted(ctx, requestID, fileDTO.ID)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "Error marking request as completed"))
+				spans.TraceError(errors.Wrap(err, "Error marking request as completed"))
 				s.log.Errorf("Failed to mark request %s as completed: %v", requestID, err)
 			}
 		}
@@ -371,9 +367,8 @@ func (s *emailService) CheckScrubbyResult() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "EmailService.CheckScrubbyResult")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "EmailService.CheckScrubbyResult")
+	defer spans.Finish()
 
 	limit := 100
 	delayFromPreviousCheckInHours := 12
@@ -389,7 +384,7 @@ func (s *emailService) CheckScrubbyResult() {
 
 		records, err := s.commonServices.PostgresRepositories.CacheEmailScrubbyRepository.GetToCheck(ctx, delayFromPreviousCheckInHours, limit)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 
@@ -408,19 +403,19 @@ func (s *emailService) CheckScrubbyResult() {
 			internalCounter++
 			scrubbyResult, err := s.callScrubbyIo(ctx, record.Email)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "Error calling scrubby.io"))
+				spans.TraceError(errors.Wrap(err, "Error calling scrubby.io"))
 				s.log.Errorf("Error calling scrubby.io for email {%s}: %s", record.Email, err.Error())
 			}
 			if scrubbyResult.Status != string(postgresentity.ScrubbyStatusPending) {
 				err = s.commonServices.PostgresRepositories.CacheEmailScrubbyRepository.SetStatus(ctx, record.Email, strings.ToLower(scrubbyResult.Status))
 				if err != nil {
-					tracing.TraceErr(span, errors.Wrap(err, "Error setting scrubby status"))
+					spans.TraceError(errors.Wrap(err, "Error setting scrubby status"))
 					s.log.Errorf("Error setting scrubby status for email {%s}: %s", record.Email, err.Error())
 				}
 			} else {
 				_, err = s.commonServices.PostgresRepositories.CacheEmailScrubbyRepository.SetJustChecked(ctx, record.ID)
 				if err != nil {
-					tracing.TraceErr(span, errors.Wrap(err, "Error setting scrubby just checked"))
+					spans.TraceError(errors.Wrap(err, "Error setting scrubby just checked"))
 					s.log.Errorf("Error setting scrubby just checked for email {%s}: %s", record.Email, err.Error())
 				}
 			}
@@ -435,14 +430,14 @@ func (s *emailService) CheckScrubbyResult() {
 }
 
 func (s *emailService) callScrubbyIo(ctx context.Context, email string) (ScrubbyIoResponse, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailService.callScrubbyIo")
-	defer span.Finish()
-	span.LogFields(log.String("email", email))
+	spans, ctx := telemetry.StartCronSpan(ctx, "EmailService.callScrubbyIo")
+	defer spans.Finish()
+	spans.LogKV("email", email)
 
 	// validate if scrubby is configured
 	if s.cfg.Common.External.ScrubbyIoConfig.ApiUrl == "" || s.cfg.Common.External.ScrubbyIoConfig.ApiKey == "" {
 		err := errors.New("scrubby.io is not configured")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Error(err)
 		return ScrubbyIoResponse{}, err
 	}
@@ -450,7 +445,7 @@ func (s *emailService) callScrubbyIo(ctx context.Context, email string) (Scrubby
 	encodedEmail := url.QueryEscape(email)
 	req, err := http.NewRequest("GET", s.cfg.Common.External.ScrubbyIoConfig.ApiUrl+"/fetch_email/"+encodedEmail, nil)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to create request"))
+		spans.TraceError(errors.Wrap(err, "failed to create request"))
 		return ScrubbyIoResponse{}, err
 	}
 
@@ -462,33 +457,32 @@ func (s *emailService) callScrubbyIo(ctx context.Context, email string) (Scrubby
 	client := &http.Client{}
 	response, err := client.Do(req)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to perform request"))
+		spans.TraceError(errors.Wrap(err, "failed to perform request"))
 		return ScrubbyIoResponse{}, err
 	}
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		err = errors.New(fmt.Sprintf("scrubby.io returned %d status code", response.StatusCode))
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return ScrubbyIoResponse{}, err
 	}
 
 	var scrubbyIoResponse ScrubbyIoResponse
 	err = json.NewDecoder(response.Body).Decode(&scrubbyIoResponse)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to decode scrubby.io response"))
+		spans.TraceError(errors.Wrap(err, "failed to decode scrubby.io response"))
 		return ScrubbyIoResponse{}, err
 	}
-	tracing.LogObjectAsJson(span, "response.scrubby", scrubbyIoResponse)
+	spans.LogObjectAsJson("response.scrubby", scrubbyIoResponse)
 
 	return scrubbyIoResponse, nil
 }
 
 func (s *emailService) generateBulkEmailValidationResponseCSVFileContent(ctx context.Context, requestId string) ([]byte, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailService.generateBulkEmailValidationResponseCSVFileContent")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogKV("requestId", requestId)
+	spans, ctx := telemetry.StartCronSpan(ctx, "EmailService.generateBulkEmailValidationResponseCSVFileContent")
+	defer spans.Finish()
+	spans.LogKV("requestId", requestId)
 
 	// Create an in-memory buffer to write the CSV content
 	var buffer bytes.Buffer
@@ -520,7 +514,7 @@ func (s *emailService) generateBulkEmailValidationResponseCSVFileContent(ctx con
 			// Parse the record data (assuming it's in JSON format) into ValidateEmailMailSherpaData
 			var validationData interfaces.ValidateEmailMailSherpaData
 			if record.Data == "" {
-				tracing.TraceErr(span, fmt.Errorf("validation data is empty for email %s and requestId %s", record.Email, record.RequestID))
+				spans.TraceError(fmt.Errorf("validation data is empty for email %s and requestId %s", record.Email, record.RequestID))
 				continue
 			}
 			if err := json.Unmarshal([]byte(record.Data), &validationData); err != nil {
@@ -595,16 +589,15 @@ func (s *emailService) deleteOrphanEmails() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "EmailService.deleteOrphanEmails")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "EmailService.deleteOrphanEmails")
+	defer spans.Finish()
 
 	limit := 500
 	delayFromLastUpdateInHours := 24 // 24 hours
 
 	records, err := s.commonServices.Neo4jRepositories.EmailReadRepository.GetOrphanEmailNodes(ctx, limit, delayFromLastUpdateInHours)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "Error getting orphan emails"))
+		spans.TraceError(errors.Wrap(err, "Error getting orphan emails"))
 		return
 	}
 
@@ -621,7 +614,7 @@ func (s *emailService) deleteOrphanEmails() {
 
 		err = s.commonServices.EmailService.DeleteOrphanEmail(innerCtx, record.EmailId)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "Error deleting orphan email"))
+			spans.TraceError(errors.Wrap(err, "Error deleting orphan email"))
 			s.log.Errorf("Error deleting orphan email {%s}: %s", record.EmailId, err.Error())
 		}
 	}
@@ -635,13 +628,12 @@ func (s *emailService) sendEmails() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "EmailService.sendEmails")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "EmailService.sendEmails")
+	defer spans.Finish()
 
 	emailMessages, err := s.commonServices.PostgresRepositories.EmailMessageRepository.GetForSending(ctx)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return // return if error
 	}
 
@@ -657,7 +649,7 @@ func (s *emailService) sendEmails() {
 
 		err := s.commonServices.MailService.SendMail(localCtx, emailMessage)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 
 			s2 := err.Error()
 
@@ -666,7 +658,7 @@ func (s *emailService) sendEmails() {
 
 			err := s.commonServices.PostgresRepositories.EmailMessageRepository.Store(ctx, emailMessage.Tenant, emailMessage)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				break
 			}
 
@@ -683,13 +675,12 @@ func (s *emailService) processSentEmails() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "EmailService.processSentEmails")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "EmailService.processSentEmails")
+	defer spans.Finish()
 
 	emailMessages, err := s.commonServices.PostgresRepositories.EmailMessageRepository.GetForProcessing(ctx)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return // return if error
 	}
 
@@ -705,7 +696,7 @@ func (s *emailService) processSentEmails() {
 
 		_, err := s.commonServices.MailService.ProcessSentEmail(localCtx, nil, emailMessage)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 
 			s2 := err.Error()
 
@@ -714,7 +705,7 @@ func (s *emailService) processSentEmails() {
 
 			err := s.commonServices.PostgresRepositories.EmailMessageRepository.Store(ctx, emailMessage.Tenant, emailMessage)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				break
 			}
 

--- a/packages/runner/customer-os-data-upkeeper/service/flow_execution_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/flow_execution_service.go
@@ -6,11 +6,10 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	commonService "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jEntity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/config"
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/constants"
@@ -40,17 +39,16 @@ func (s *flowExecutionService) ExecuteScheduledFlowActions() {
 	ctx, cancel := utils.GetContextWithTimeout(context.Background(), utils.HalfOfHourDuration)
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "FlowExecutionService.ExecuteScheduledFlowActions")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "FlowExecutionService.ExecuteScheduledFlowActions")
+	defer spans.Finish()
 
 	actionsToExecute, err := s.commonServices.Neo4jRepositories.FlowActionExecutionReadRepository.GetScheduledBefore(ctx, utils.Now())
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
-	span.LogFields(log.Int("actionsToExecute.count", len(actionsToExecute)))
+	spans.LogKV("actionsToExecute.count", len(actionsToExecute))
 
 	for _, actionExecutionNode := range actionsToExecute {
 		actionExecution := neo4jmapper.MapDbNodeToFlowActionExecutionEntity(actionExecutionNode)
@@ -63,14 +61,14 @@ func (s *flowExecutionService) ExecuteScheduledFlowActions() {
 
 		err := s.commonServices.FlowExecutionService.ProcessActionExecution(ctx, actionExecution)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 
 			actionExecution.StatusUpdatedAt = utils.Now()
 			actionExecution.Status = neo4jEntity.FlowActionExecutionStatusTechError
 
 			_, err = s.commonServices.Neo4jRepositories.FlowActionExecutionWriteRepository.Merge(ctx, nil, actionExecution)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 			}
 
 			continue
@@ -82,13 +80,12 @@ func (s *flowExecutionService) ComputeFlowStatistics() {
 	ctx, cancel := utils.GetContextWithTimeout(context.Background(), utils.HalfOfHourDuration)
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "FlowExecutionService.ComputeFlowStatistics")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "FlowExecutionService.ComputeFlowStatistics")
+	defer spans.Finish()
 
 	flowsUpdated, err := s.commonServices.Neo4jRepositories.FlowWriteRepository.UpdateStatistics(ctx)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 

--- a/packages/runner/customer-os-data-upkeeper/service/global_contact_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/global_contact_service.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/opentracing/opentracing-go/log"
-
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/config"
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/constants"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
@@ -17,10 +15,9 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	commonservice "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
 	service_verify "github.com/customeros/customeros/packages/server/customer-os-common-module/services/verify"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgresentity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -45,9 +42,8 @@ func NewGlobalContactService(cfg *config.Config, log logger.Logger, commonServic
 }
 
 func (s *globalContactService) findPrimaryDomainFromGlobalOrg(ctx context.Context, linkedInUrl string, linkedInId string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalContactService.findPrimaryDomainFromGlobalOrg")
-	defer span.Finish()
-	tracing.TagComponentService(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalContactService.findPrimaryDomainFromGlobalOrg")
+	defer spans.Finish()
 
 	var org *postgresentity.GlobalOrganization
 	var err error
@@ -58,7 +54,7 @@ func (s *globalContactService) findPrimaryDomainFromGlobalOrg(ctx context.Contex
 		linkedInUrl = strings.TrimSuffix(linkedInUrl, "/")
 		org, err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetByLinkedInUrl(ctx, linkedInUrl)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error getting organization by LinkedIn URL"))
+			spans.TraceError(errors.Wrap(err, "error getting organization by LinkedIn URL"))
 			return "", err
 		}
 		if org != nil {
@@ -71,7 +67,7 @@ func (s *globalContactService) findPrimaryDomainFromGlobalOrg(ctx context.Contex
 		linkedInUrl = "https://www.linkedin.com/company/" + linkedInId
 		org, err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetByLinkedInUrl(ctx, linkedInUrl)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error getting organization by LinkedIn ID"))
+			spans.TraceError(errors.Wrap(err, "error getting organization by LinkedIn ID"))
 			return "", err
 		}
 		if org != nil {
@@ -83,14 +79,13 @@ func (s *globalContactService) findPrimaryDomainFromGlobalOrg(ctx context.Contex
 }
 
 func (s *globalContactService) syncScrapinInRecordIntoGlobalContact(ctx context.Context, record *postgresentity.EnrichDetailsScrapIn) error {
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalContactService.syncScrapinInRecordIntoGlobalContact")
-	defer span.Finish()
-	tracing.TagComponentService(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalContactService.syncScrapinInRecordIntoGlobalContact")
+	defer spans.Finish()
 
 	// Mark as synced to avoid double processing
 	err := s.commonServices.PostgresRepositories.EnrichDetailsScrapInRepository.MarkSyncedToGlobalContacts(ctx, record.ID)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error marking scrapin data as synced to global contacts"))
+		spans.TraceError(errors.Wrap(err, "error marking scrapin data as synced to global contacts"))
 		return err
 	}
 
@@ -101,7 +96,7 @@ func (s *globalContactService) syncScrapinInRecordIntoGlobalContact(ctx context.
 	// unmarshal cached data
 	data := postgresentity.ScrapInResponseBody{}
 	if err = json.Unmarshal([]byte(record.Data), &data); err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to unmarshal scrapin data"))
+		spans.TraceError(errors.Wrap(err, "failed to unmarshal scrapin data"))
 		return err
 	}
 
@@ -160,7 +155,7 @@ func (s *globalContactService) syncScrapinInRecordIntoGlobalContact(ctx context.
 		// Find primary domain from global organizations
 		primaryDomain, err := s.findPrimaryDomainFromGlobalOrg(ctx, currentPosition.LinkedInUrl, currentPosition.LinkedInId)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error finding primary domain from global organizations"))
+			spans.TraceError(errors.Wrap(err, "error finding primary domain from global organizations"))
 			return err
 		}
 
@@ -188,7 +183,7 @@ func (s *globalContactService) syncScrapinInRecordIntoGlobalContact(ctx context.
 
 		err = s.commonServices.GlobalContactService.SaveContact(ctx, contact)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error saving global contact"))
+			spans.TraceError(errors.Wrap(err, "error saving global contact"))
 			return err
 		}
 	}
@@ -200,15 +195,14 @@ func (s *globalContactService) SyncDataIntoGlobalContacts() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalContactService.SyncDataIntoGlobalContacts")
-	defer span.Finish()
-	tracing.TagComponentService(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalContactService.SyncDataIntoGlobalContacts")
+	defer spans.Finish()
 
 	limit := 500
 
 	records, err := s.commonServices.PostgresRepositories.EnrichDetailsScrapInRepository.GetToSyncIntoGlobalContacts(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting records to sync"))
+		spans.TraceError(errors.Wrap(err, "error getting records to sync"))
 		s.log.Errorf("Error getting records to sync: %s", err.Error())
 		return
 	}
@@ -241,13 +235,12 @@ func (s *globalContactService) sendRequestToBetterContact() {
 	limit := 40
 	retryAfterDays := 30
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalContactService.sendRequestToBetterContact")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalContactService.sendRequestToBetterContact")
+	defer spans.Finish()
 
 	records, err := s.commonServices.PostgresRepositories.GlobalContactRepository.GetContactsToFindWorkEmailWithBetterContact(ctx, retryAfterDays, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -258,15 +251,15 @@ func (s *globalContactService) sendRequestToBetterContact() {
 
 	for _, record := range records {
 		func(globalContact *postgresentity.GlobalContact) {
-			innerSpan, innerCtx := tracing.StartTracerSpan(ctx, "GlobalContactService.sendRequestToBetterContact.Record")
-			defer innerSpan.Finish()
-			tracing.TagEntity(innerSpan, strconv.FormatUint(globalContact.ID, 10))
+			innerSpans, innerCtx := telemetry.StartCronSpan(ctx, "GlobalContactService.sendRequestToBetterContact.Record")
+			defer innerSpans.Finish()
+			innerSpans.LogKV("globalContactId", globalContact.ID)
 
 			linkedInUrl := "https://linkedin.com/in/" + globalContact.LinkedInIdentifier
 			// get global organization by primary domain
 			globalOrg, err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetByPrimaryDomain(innerCtx, globalContact.PrimaryDomain)
 			if err != nil {
-				tracing.TraceErr(innerSpan, err)
+				innerSpans.TraceError(err)
 			}
 			companyName := ""
 			if globalOrg != nil {
@@ -275,16 +268,16 @@ func (s *globalContactService) sendRequestToBetterContact() {
 
 			_, betterContactRequestId, _, err := s.commonServices.EnrichmentService.FindWorkEmailWithBetterContact(innerCtx, linkedInUrl, globalContact.FirstName, globalContact.LastName, companyName, globalContact.PrimaryDomain, false)
 			if err != nil {
-				tracing.TraceErr(innerSpan, err)
+				innerSpans.TraceError(err)
 			} else {
 				if betterContactRequestId == "" {
 					err = errors.New("better contact request id is empty")
-					tracing.TraceErr(innerSpan, err)
+					innerSpans.TraceError(err)
 				}
 				// mark contact with enrich requested
 				err = s.commonServices.PostgresRepositories.GlobalContactRepository.MarkBetterContactRequested(innerCtx, globalContact.ID, betterContactRequestId)
 				if err != nil {
-					tracing.TraceErr(innerSpan, err)
+					innerSpans.TraceError(err)
 				}
 			}
 		}(record)
@@ -295,15 +288,14 @@ func (s *globalContactService) processBetterContactResponses() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalContactService.processBetterContactResponses")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalContactService.processBetterContactResponses")
+	defer spans.Finish()
 
 	limit := 250
 
 	records, err := s.commonServices.PostgresRepositories.GlobalContactRepository.GetContactsToSetWorkEmailFromBetterContactResponse(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -314,63 +306,63 @@ func (s *globalContactService) processBetterContactResponses() {
 
 	for _, record := range records {
 		func(globalContact *postgresentity.GlobalContact) {
-			innerSpan, innerCtx := tracing.StartTracerSpan(ctx, "GlobalContactService.processBetterContactResponses.Record")
-			defer innerSpan.Finish()
+			innerSpans, innerCtx := telemetry.StartCronSpan(ctx, "GlobalContactService.processBetterContactResponses.Record")
+			defer innerSpans.Finish()
+			innerSpans.LogKV("globalContactId", globalContact.ID)
 
 			// get better contact response
 			betterContactRecord, err := s.commonServices.PostgresRepositories.EnrichDetailsBetterContactRepository.GetByRequestId(innerCtx, globalContact.BetterContactRequestId)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				innerSpans.TraceError(err)
 				return
 			}
 
 			if betterContactRecord == nil || betterContactRecord.Response == "" {
-				innerSpan.LogFields(log.String("message", "better contact response not ready"))
+				innerSpans.LogKV("message", "better contact response not ready")
 				return
 			}
 
 			var betterContactResponse postgresentity.BetterContactResponseBody
 			if err = json.Unmarshal([]byte(betterContactRecord.Response), &betterContactResponse); err != nil {
-				tracing.TraceErr(span, err)
+				innerSpans.TraceError(err)
 				return
 			}
 
 			err = s.commonServices.PostgresRepositories.GlobalContactRepository.MarkBetterContactSet(innerCtx, globalContact.ID)
 			if err != nil {
-				tracing.TraceErr(innerSpan, err)
+				innerSpans.TraceError(err)
 			}
 
 			workEmail := betterContactResponse.Data[0].ContactEmailAddress
 			if workEmail != "" {
-				innerSpan.LogFields(log.String("bettercontact.email", workEmail))
+				innerSpans.LogKV("bettercontact.email", workEmail)
 
 				// validate email with mailsherpa
 				emailValidation, err := s.commonServices.VerifyService.ValidateEmail(innerCtx, workEmail)
 				if err != nil {
-					tracing.TraceErr(innerSpan, err)
+					innerSpans.TraceError(err)
 				}
 				if emailValidation == nil {
 					err = errors.New("mailsherpa validation returned nil")
-					tracing.TraceErr(innerSpan, err)
+					innerSpans.TraceError(err)
 					return
 				}
 
 				if !emailValidation.Syntax.IsValid {
 					err = errors.New("invalid email syntax: " + workEmail)
-					tracing.TraceErr(innerSpan, err)
-					span.LogFields(log.String("result", "invalid email syntax"))
+					innerSpans.TraceError(err)
 					return
 				}
 				if emailValidation.EmailData.Deliverable == string(service_verify.EmailDeliverableStatusUndeliverable) {
 					err = errors.New("email undeliverable: " + workEmail)
-					tracing.TraceErr(innerSpan, err)
-					span.LogFields(log.String("result", "email undeliverable"))
+					innerSpans.TraceError(err)
+					innerSpans.LogKV("result", "email undeliverable")
 					return
 				}
 
 				err = s.commonServices.GlobalContactService.SetWorkEmail(innerCtx, globalContact.ID, workEmail)
 				if err != nil {
-					tracing.TraceErr(innerSpan, err)
+					innerSpans.TraceError(err)
 				}
 			}
 
@@ -382,9 +374,8 @@ func (s *globalContactService) SyncGlobalContactsToTenantContacts() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalContactService.SyncGlobalContactsToTenantContacts")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalContactService.SyncGlobalContactsToTenantContacts")
+	defer spans.Finish()
 
 	limit := 250
 	daysFromPreviousSync := 1
@@ -392,7 +383,7 @@ func (s *globalContactService) SyncGlobalContactsToTenantContacts() {
 
 	records, err := s.commonServices.PostgresRepositories.GlobalContactRepository.GetGlobalContactsToSyncIntoTenantContacts(ctx, daysFromPreviousSync, forceSyncAfterDays, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -406,10 +397,9 @@ func (s *globalContactService) SyncGlobalContactsToTenantContacts() {
 }
 
 func (s *globalContactService) syncGlobalContactToTenantContact(ctx context.Context, globalContact *postgresentity.GlobalContact) {
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalContactService.syncGlobalContactToTenantContact")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
-	tracing.TagEntity(span, strconv.FormatUint(globalContact.ID, 10))
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalContactService.syncGlobalContactToTenantContact")
+	defer spans.Finish()
+	spans.TagEntity(strconv.FormatUint(globalContact.ID, 10))
 
 	// sync photo
 	if globalContact.ProfilePhotoExternalUrl != "" && globalContact.ProfilePhotoPath != "" {
@@ -421,14 +411,14 @@ func (s *globalContactService) syncGlobalContactToTenantContact(ctx context.Cont
 	globalContact.SyncedToNeoAt = utils.TimePtr(utils.Now().Add(10 * time.Second))
 	_, err := s.commonServices.PostgresRepositories.GlobalContactRepository.Update(ctx, globalContact)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 }
 
 func (s *globalContactService) syncGlobalContactPhotoToTenantContact(ctx context.Context, globalContact *postgresentity.GlobalContact) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalContactService.syncGlobalContactPhotoToTenantContact")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalContactService.syncGlobalContactPhotoToTenantContact")
+	defer spans.Finish()
+	spans.TagEntity(strconv.FormatUint(globalContact.ID, 10))
 
 	if globalContact.ProfilePhotoPath == "" {
 		return
@@ -439,7 +429,7 @@ func (s *globalContactService) syncGlobalContactPhotoToTenantContact(ctx context
 
 	tenantContact, err := s.commonServices.Neo4jRepositories.ContactReadRepository.GetContactsWithProfilePhotoUrlCrossTenant(ctx, globalContact.ProfilePhotoExternalUrl)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 

--- a/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/global_organization_service.go
@@ -22,15 +22,13 @@ import (
 	common_srv "github.com/customeros/customeros/packages/server/customer-os-common-module/services/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/security"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/webscraper"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jrepository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgresentity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/customeros/mailsherpa/domaincheck"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/config"
@@ -80,15 +78,14 @@ func (s *globalOrganizationService) syncScrapinToGlobalOrganization() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.syncScrapinToGlobalOrganization")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.syncScrapinToGlobalOrganization")
+	defer spans.Finish()
 
 	limit := 50
 
 	records, err := s.commonServices.PostgresRepositories.EnrichDetailsScrapInRepository.GetToSyncIntoGlobalOrganizations(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting records to sync"))
+		spans.TraceError(errors.Wrap(err, "error getting records to sync"))
 		s.log.Errorf("Error getting records to sync: %s", err.Error())
 		return
 	}
@@ -105,14 +102,13 @@ func (s *globalOrganizationService) syncScrapinToGlobalOrganization() {
 }
 
 func (s *globalOrganizationService) syncScrapinToGlobalOrganizationRecord(ctx context.Context, record *postgres_entity.EnrichDetailsScrapIn) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationService.syncScrapinToGlobalOrganizationRecord")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.syncScrapinToGlobalOrganizationRecord")
+	defer spans.Finish()
 
 	// mark record as synced initially to not process same record again, even if error occurs
 	err := s.commonServices.PostgresRepositories.EnrichDetailsScrapInRepository.MarkSyncedToGlobalOrganizations(ctx, record.ID)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error marking record as synced"))
+		spans.TraceError(errors.Wrap(err, "error marking record as synced"))
 		s.log.Errorf("Error marking record as synced: %s", err.Error())
 		return
 	}
@@ -124,7 +120,7 @@ func (s *globalOrganizationService) syncScrapinToGlobalOrganizationRecord(ctx co
 	// unmarshal cached data
 	data := postgresentity.ScrapInResponseBody{}
 	if err = json.Unmarshal([]byte(record.Data), &data); err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to unmarshal scrapin data"))
+		spans.TraceError(errors.Wrap(err, "failed to unmarshal scrapin data"))
 		return
 	}
 
@@ -164,7 +160,7 @@ func (s *globalOrganizationService) syncScrapinToGlobalOrganizationRecord(ctx co
 	// if global organization already exists, update otherwise create
 	globalOrganization, err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetByPrimaryDomain(ctx, primaryDomain)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting global organization by primary domain"))
+		spans.TraceError(errors.Wrap(err, "error getting global organization by primary domain"))
 		s.log.Errorf("Error getting global organization by primary domain: %s", err.Error())
 		return
 	}
@@ -235,18 +231,18 @@ func (s *globalOrganizationService) syncScrapinToGlobalOrganizationRecord(ctx co
 		// create global organization
 		_, err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.Create(ctx, globalOrganization)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error creating global organization"))
+			spans.TraceError(errors.Wrap(err, "error creating global organization"))
 			s.log.Errorf("Error creating global organization: %s", err.Error())
 			return
 		}
 		_, err := s.commonServices.WebscraperService.Scrape(ctx, "https://"+globalOrganization.PrimaryDomain)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 		}
 	} else {
 		_, err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.Update(ctx, globalOrganization)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error updating global organization"))
+			spans.TraceError(errors.Wrap(err, "error updating global organization"))
 			s.log.Errorf("Error updating global organization: %s", err.Error())
 			return
 		}
@@ -257,15 +253,14 @@ func (s *globalOrganizationService) syncBrandfetchToGlobalOrganization() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.syncBrandfetchToGlobalOrganization")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.syncBrandfetchToGlobalOrganization")
+	defer spans.Finish()
 
 	limit := 50
 
 	records, err := s.commonServices.PostgresRepositories.EnrichDetailsBrandfetchRepository.GetToSyncIntoGlobalOrganizations(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting records to sync"))
+		spans.TraceError(errors.Wrap(err, "error getting records to sync"))
 		s.log.Errorf("Error getting records to sync: %s", err.Error())
 		return
 	}
@@ -282,14 +277,13 @@ func (s *globalOrganizationService) syncBrandfetchToGlobalOrganization() {
 }
 
 func (s *globalOrganizationService) syncBrandfetchToGlobalOrganizationRecord(ctx context.Context, record *postgres_entity.EnrichDetailsBrandfetch) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationService.syncBrandfetchToGlobalOrganizationRecord")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.syncBrandfetchToGlobalOrganizationRecord")
+	defer spans.Finish()
 
 	// mark record as synced initially to not process same record again, even if error occurs
 	err := s.commonServices.PostgresRepositories.EnrichDetailsBrandfetchRepository.MarkSyncedToGlobalOrganizations(ctx, record.ID)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error marking record as synced"))
+		spans.TraceError(errors.Wrap(err, "error marking record as synced"))
 		s.log.Errorf("Error marking record as synced: %s", err.Error())
 		return
 	}
@@ -301,7 +295,7 @@ func (s *globalOrganizationService) syncBrandfetchToGlobalOrganizationRecord(ctx
 	// unmarshal cached data
 	data := postgresentity.BrandfetchResponseBody{}
 	if err = json.Unmarshal([]byte(record.Data), &data); err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to unmarshal brandfetch data"))
+		spans.TraceError(errors.Wrap(err, "failed to unmarshal brandfetch data"))
 		return
 	}
 
@@ -336,7 +330,7 @@ func (s *globalOrganizationService) syncBrandfetchToGlobalOrganizationRecord(ctx
 
 	globalOrganization, err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetByPrimaryDomain(ctx, primaryDomain)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting global organization by primary domain"))
+		spans.TraceError(errors.Wrap(err, "error getting global organization by primary domain"))
 		s.log.Errorf("Error getting global organization by primary domain: %s", err.Error())
 		return
 	}
@@ -402,7 +396,7 @@ func (s *globalOrganizationService) syncBrandfetchToGlobalOrganizationRecord(ctx
 		if link.Url != "" && strings.Contains(link.Url, "linkedin.com/company") && globalOrganization.LinkedInUrl == "" {
 			_, scrapinResponse, err := s.commonServices.EnrichmentService.ScrapInCompanyProfile(ctx, link.Url)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "error calling scrapin for company profile"))
+				spans.TraceError(errors.Wrap(err, "error calling scrapin for company profile"))
 				s.log.Errorf("Error calling scrapin for company profile: %s", err.Error())
 				continue
 			}
@@ -451,18 +445,18 @@ func (s *globalOrganizationService) syncBrandfetchToGlobalOrganizationRecord(ctx
 		// create global organization
 		_, err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.Create(ctx, globalOrganization)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error creating global organization"))
+			spans.TraceError(errors.Wrap(err, "error creating global organization"))
 			s.log.Errorf("Error creating global organization: %s", err.Error())
 			return
 		}
 		_, err := s.commonServices.WebscraperService.Scrape(ctx, "https://"+globalOrganization.PrimaryDomain)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 		}
 	} else {
 		_, err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.Update(ctx, globalOrganization)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error updating global organization"))
+			spans.TraceError(errors.Wrap(err, "error updating global organization"))
 			s.log.Errorf("Error updating global organization: %s", err.Error())
 			return
 		}
@@ -470,7 +464,7 @@ func (s *globalOrganizationService) syncBrandfetchToGlobalOrganizationRecord(ctx
 	if len(otherSocials) > 0 {
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.AddOtherSocials(ctx, globalOrganization.PrimaryDomain, otherSocials)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error adding other socials"))
+			spans.TraceError(errors.Wrap(err, "error adding other socials"))
 			s.log.Errorf("Error adding other socials: %s", err.Error())
 		}
 	}
@@ -480,15 +474,14 @@ func (s *globalOrganizationService) ScrapinCompanyByWebsite() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.ScrapinCompanyByWebsite")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.ScrapinCompanyByWebsite")
+	defer spans.Finish()
 
 	limit := 10
 
 	records, err := s.commonServices.PostgresRepositories.GlobalOrganizationWebsiteToProcessRepository.GetWebsitesToProcess(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting records to process"))
+		spans.TraceError(errors.Wrap(err, "error getting records to process"))
 		s.log.Errorf("Error getting records to process: %s", err.Error())
 		return
 	}
@@ -510,7 +503,7 @@ func (s *globalOrganizationService) ScrapinCompanyByWebsite() {
 		// mark record as processed initially to not process same record again, even if error occurs
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationWebsiteToProcessRepository.MarkAsProcessed(ctx, record.ID, notes)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error marking record as synced"))
+			spans.TraceError(errors.Wrap(err, "error marking record as synced"))
 			s.log.Errorf("Error marking record as synced: %s", err.Error())
 			continue
 		}
@@ -522,32 +515,32 @@ func (s *globalOrganizationService) ScrapinCompanyByWebsite() {
 		// call scrapin for primary domain
 		err = s.callApiScrapinOrganization(ctx, primaryDomain)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error calling enrichment api"))
+			spans.TraceError(errors.Wrap(err, "error calling enrichment api"))
 			return
 		}
 	}
 }
 
 func (s *globalOrganizationService) callApiScrapinOrganization(ctx context.Context, domain string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationService.callApiScrapinOrganization")
-	defer span.Finish()
-	span.LogKV("domain", domain)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.callApiScrapinOrganization")
+	defer spans.Finish()
+	spans.LogKV("domain", domain)
 
 	requestJSON, err := json.Marshal(EnrichOrganizationRequest{
 		Domain: domain,
 	})
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to marshal request"))
+		spans.TraceError(errors.Wrap(err, "failed to marshal request"))
 		return err
 	}
 	requestBody := []byte(string(requestJSON))
 	req, err := http.NewRequestWithContext(ctx, "GET", s.cfg.Common.Internal.CustomerOsApi.ApiUrl+"/scrapinOrganization", bytes.NewBuffer(requestBody))
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to create request"))
+		spans.TraceError(errors.Wrap(err, "failed to create request"))
 		return err
 	}
 	// Inject span context into the HTTP request
-	req = tracing.InjectSpanContextIntoHTTPRequest(req, span)
+	req = telemetry.InjectSpanContextIntoHTTPRequest(req, spans)
 
 	// Set the request headers
 	req.Header.Set(security.ApiKeyHeader, s.cfg.Common.Internal.CustomerOsApi.ApiKey)
@@ -559,12 +552,12 @@ func (s *globalOrganizationService) callApiScrapinOrganization(ctx context.Conte
 	// Make the HTTP request
 	response, err = client.Do(req)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to perform request"))
+		spans.TraceError(errors.Wrap(err, "failed to perform request"))
 		return err
 	}
 	defer response.Body.Close() // Ensures the body is closed only once
 
-	span.LogFields(log.Int("response.statusCode", response.StatusCode))
+	spans.LogKV("response.statusCode", response.StatusCode)
 
 	if response.StatusCode != http.StatusOK {
 		s.log.Errorf("Scrapin organization API response status code is : %d", response.StatusCode)
@@ -577,19 +570,18 @@ func (s *globalOrganizationService) ExtractWebpageLinks() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.ExtractWebpageLinks")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.ExtractWebpageLinks")
+	defer spans.Finish()
 
 	limit := 100
 	webpages, err := s.commonServices.PostgresRepositories.ScrapedWebpageRepository.GetWebpagesWithoutLinks(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting records to scrape"))
+		spans.TraceError(errors.Wrap(err, "error getting records to scrape"))
 		return
 	}
 
 	if len(webpages) == 0 {
-		span.LogFields(log.Int("result.count", len(webpages)))
+		spans.LogKV("result.count", len(webpages))
 		return
 	}
 
@@ -608,9 +600,9 @@ func (s *globalOrganizationService) ExtractWebpageLinks() {
 			childCtx, childCancel := context.WithTimeout(ctx, 90*time.Second)
 			defer childCancel()
 
-			childSpan, childCtx := tracing.StartTracerSpan(childCtx, "GlobalOrganizationService.ExtractWebpageLinks")
+			childSpan, childCtx := telemetry.StartCronSpan(childCtx, "GlobalOrganizationService.ExtractWebpageLinks")
 			defer childSpan.Finish()
-			childSpan.LogFields(log.String("url", scrapedWebpage.Url))
+			childSpan.LogKV("url", scrapedWebpage.Url)
 
 			defer wg.Done()
 			defer func() { <-semaphore }() // Release semaphore when done
@@ -618,11 +610,11 @@ func (s *globalOrganizationService) ExtractWebpageLinks() {
 			content, links := s.commonServices.WebscraperService.ProcessWebContent(childCtx, scrapedWebpage.Content)
 			err := s.commonServices.PostgresRepositories.ScrapedWebpageRepository.SetLinks(childCtx, scrapedWebpage.Url, links)
 			if err != nil {
-				tracing.TraceErr(childSpan, err)
+				childSpan.TraceError(err)
 			}
 			err = s.commonServices.PostgresRepositories.ScrapedWebpageRepository.SetContent(childCtx, scrapedWebpage.Url, content)
 			if err != nil {
-				tracing.TraceErr(childSpan, err)
+				childSpan.TraceError(err)
 			}
 		}(page)
 	}
@@ -635,29 +627,29 @@ func (s *globalOrganizationService) scrapeGlobalOrganization(ctx context.Context
 	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
 
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationService.scrapeGlobalOrganization")
-	defer span.Finish()
-	tracing.TagEntity(span, org.PrimaryDomain)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.scrapeGlobalOrganization")
+	defer spans.Finish()
+	spans.TagEntity(org.PrimaryDomain)
 
 	page := "https://" + org.PrimaryDomain
 	contents, err := s.commonServices.WebscraperService.Scrape(ctx, page)
 	if err != nil {
 		switch {
 		case errors.Is(err, webscraper.ErrUnprocessable):
-			span.LogKV("error", "Unprocessable content")
-			span.LogKV("url", page)
+			spans.LogKV("error", "Unprocessable content")
+			spans.LogKV("url", page)
 		default:
-			tracing.TraceErr(span, errors.Wrap(err, "error scraping global org primary domain"))
+			spans.TraceError(errors.Wrap(err, "error scraping global org primary domain"))
 		}
 
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetScrapeStatus(ctx, org.ID, enum.ScrapeError)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error updating global org scraped status"))
+			spans.TraceError(errors.Wrap(err, "error updating global org scraped status"))
 		}
 	} else if contents == "" {
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetScrapeStatus(ctx, org.ID, enum.ScrapeError)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error updating global org scraped status"))
+			spans.TraceError(errors.Wrap(err, "error updating global org scraped status"))
 		}
 	}
 
@@ -666,7 +658,7 @@ func (s *globalOrganizationService) scrapeGlobalOrganization(ctx context.Context
 		if org.ScrapeAttempt >= 5 {
 			err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.Delete(ctx, org.ID)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "error deleting global org"))
+				spans.TraceError(errors.Wrap(err, "error deleting global org"))
 			}
 		}
 	}
@@ -674,7 +666,7 @@ func (s *globalOrganizationService) scrapeGlobalOrganization(ctx context.Context
 	if contents != "" {
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetScrapeStatus(ctx, org.ID, enum.ScrapeCompleted)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "error updating global org scraped status"))
+			spans.TraceError(errors.Wrap(err, "error updating global org scraped status"))
 			return
 		}
 	}
@@ -684,14 +676,13 @@ func (s *globalOrganizationService) ScrapeGlobalOrgs() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.ScrapeGlobalOrgs")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.ScrapeGlobalOrgs")
+	defer spans.Finish()
 
 	limit := 100
 	orgs, err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetOrganizationsToScrape(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting records to scrape"))
+		spans.TraceError(errors.Wrap(err, "error getting records to scrape"))
 		return
 	}
 
@@ -730,9 +721,8 @@ func (s *globalOrganizationService) enrichIndustries() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.enrichIndustries")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.enrichIndustries")
+	defer spans.Finish()
 
 	limit := 30
 	hoursFromPreviousAttempt := 24
@@ -740,7 +730,7 @@ func (s *globalOrganizationService) enrichIndustries() {
 
 	records, err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetOrganizationsToEnrichIndustry(ctx, hoursFromPreviousAttempt, maxAttempts, limit)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting records to process"))
+		spans.TraceError(errors.Wrap(err, "error getting records to process"))
 		s.log.Errorf("Error getting records to process: %s", err.Error())
 		return
 	}
@@ -757,15 +747,14 @@ func (s *globalOrganizationService) enrichIndustries() {
 }
 
 func (s *globalOrganizationService) enrichIndustry(ctx context.Context, globalOrganization *postgresentity.GlobalOrganization) {
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.enrichIndustry")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
-	tracing.TagEntity(span, strconv.FormatUint(globalOrganization.ID, 10))
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.enrichIndustry")
+	defer spans.Finish()
+	spans.TagEntity(strconv.FormatUint(globalOrganization.ID, 10))
 
 	// mark globalOrganization as processed initially to not process same globalOrganization again, even if error occurs
 	err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.MarkIndustryEnrichRequested(ctx, globalOrganization.ID)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error marking globalOrganization as processed"))
+		spans.TraceError(errors.Wrap(err, "error marking globalOrganization as processed"))
 		s.log.Errorf("Error marking globalOrganization as processed: %s", err.Error())
 		return
 	}
@@ -773,7 +762,7 @@ func (s *globalOrganizationService) enrichIndustry(ctx context.Context, globalOr
 	url := "https://" + globalOrganization.PrimaryDomain
 	scrapedPage, err := s.commonServices.WebscraperService.Scrape(ctx, url)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	// Construct the prompt
@@ -806,36 +795,36 @@ func (s *globalOrganizationService) enrichIndustry(ctx context.Context, globalOr
 		Retries:          utils.IntPtr(2),
 	})
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error asking AI"))
+		spans.TraceError(errors.Wrap(err, "error asking AI"))
 		return
 	}
 
-	span.LogFields(log.Float64("result.confidence", aiOutput.Confidence))
+	spans.LogKV("result.confidence", aiOutput.Confidence)
 
 	if aiOutput.Confidence < 0.5 {
 		return
 	}
 
-	span.LogFields(log.String("result.code", aiOutput.Code))
+	spans.LogKV("result.code", aiOutput.Code)
 
 	// get industry for organization
 	industryEntity, err := s.commonServices.IndustryService.GetClosestByCode(ctx, aiOutput.Code)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting industry by code"))
+		spans.TraceError(errors.Wrap(err, "error getting industry by code"))
 		s.log.Errorf("Error getting industry by code: %s", err.Error())
 		return
 	}
 
 	if industryEntity == nil {
-		span.LogFields(log.Bool("result.industryFound", false))
+		spans.LogKV("result.industryFound", false)
 		return
 	}
 
-	span.LogFields(log.Bool("result.industryFound", true))
+	spans.LogKV("result.industryFound", true)
 
 	err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetIndustry(ctx, globalOrganization.ID, industryEntity.Code, industryEntity.Name)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error setting industry"))
+		spans.TraceError(errors.Wrap(err, "error setting industry"))
 		return
 	}
 }
@@ -844,9 +833,8 @@ func (s *globalOrganizationService) enrichDescriptions() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.enrichDescriptions")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.enrichDescriptions")
+	defer spans.Finish()
 
 	limit := 30
 	hoursFromPreviousAttempt := 24
@@ -854,7 +842,7 @@ func (s *globalOrganizationService) enrichDescriptions() {
 
 	records, err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetOrganizationsToEnrichDescription(ctx, hoursFromPreviousAttempt, maxAttempts, limit)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting records to process"))
+		spans.TraceError(errors.Wrap(err, "error getting records to process"))
 		s.log.Errorf("Error getting records to process: %s", err.Error())
 		return
 	}
@@ -871,15 +859,14 @@ func (s *globalOrganizationService) enrichDescriptions() {
 }
 
 func (s *globalOrganizationService) enrichDescription(ctx context.Context, globalOrganization *postgresentity.GlobalOrganization) {
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.enrichDescription")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
-	tracing.TagEntity(span, strconv.FormatUint(globalOrganization.ID, 10))
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.enrichDescription")
+	defer spans.Finish()
+	spans.TagEntity(strconv.FormatUint(globalOrganization.ID, 10))
 
 	// mark record as processed initially to not process same record again, even if error occurs
 	err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.MarkDescriptionEnrichRequested(ctx, globalOrganization.ID)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error marking record as processed"))
+		spans.TraceError(errors.Wrap(err, "error marking record as processed"))
 		s.log.Errorf("Error marking record as processed: %s", err.Error())
 		return
 	}
@@ -887,7 +874,7 @@ func (s *globalOrganizationService) enrichDescription(ctx context.Context, globa
 	url := "https://" + globalOrganization.PrimaryDomain
 	pageContent, err := s.commonServices.WebscraperService.Scrape(ctx, url)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	// prepare Anthropic prompt
@@ -927,7 +914,7 @@ func (s *globalOrganizationService) enrichDescription(ctx context.Context, globa
 		OutputFormat:     enum.AIOutputJson,
 	})
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error asking AI"))
+		spans.TraceError(errors.Wrap(err, "error asking AI"))
 		return
 	}
 
@@ -935,11 +922,11 @@ func (s *globalOrganizationService) enrichDescription(ctx context.Context, globa
 		aiOutput.Description = utils.FirstNotEmptyString(globalOrganization.Description, globalOrganization.SourceDescription3, globalOrganization.SourceDescription1, globalOrganization.SourceDescription4, globalOrganization.SourceDescription2)
 	}
 
-	span.LogFields(log.String("result.description", aiOutput.Description))
+	spans.LogKV("result.description", aiOutput.Description)
 
 	err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetDescription(ctx, globalOrganization.ID, aiOutput.Description)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error setting description"))
+		spans.TraceError(errors.Wrap(err, "error setting description"))
 		return
 	}
 }
@@ -948,9 +935,8 @@ func (s *globalOrganizationService) enrichNames() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.enrichNames")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.enrichNames")
+	defer spans.Finish()
 
 	limit := 30
 	hoursFromPreviousAttempt := 24
@@ -958,7 +944,7 @@ func (s *globalOrganizationService) enrichNames() {
 
 	records, err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetOrganizationsToEnrichName(ctx, hoursFromPreviousAttempt, maxAttempts, limit)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting records to process"))
+		spans.TraceError(errors.Wrap(err, "error getting records to process"))
 		s.log.Errorf("Error getting records to process: %s", err.Error())
 		return
 	}
@@ -975,15 +961,14 @@ func (s *globalOrganizationService) enrichNames() {
 }
 
 func (s *globalOrganizationService) enrichName(ctx context.Context, globalOrganization *postgres_entity.GlobalOrganization) {
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.enrichName")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
-	tracing.TagEntity(span, strconv.FormatUint(globalOrganization.ID, 10))
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.enrichName")
+	defer spans.Finish()
+	spans.TagEntity(strconv.FormatUint(globalOrganization.ID, 10))
 
 	// mark record as processed initially to not process same record again, even if error occurs
 	err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.MarkNameEnrichRequested(ctx, globalOrganization.ID)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error marking record as processed"))
+		spans.TraceError(errors.Wrap(err, "error marking record as processed"))
 		s.log.Errorf("Error marking record as processed: %s", err.Error())
 		return
 	}
@@ -1024,19 +1009,19 @@ func (s *globalOrganizationService) enrichName(ctx context.Context, globalOrgani
 		OutputFormat:     enum.AIOutputJson,
 	})
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error asking AI"))
+		spans.TraceError(errors.Wrap(err, "error asking AI"))
 		return
 	}
 
-	span.LogFields(log.String("result.confidence", fmt.Sprintf("%f", aiOutput.Confidence)))
+	spans.LogKV("result.confidence", fmt.Sprintf("%f", aiOutput.Confidence))
 	if aiOutput.Confidence < 0.5 {
 		return
 	}
 
-	span.LogFields(log.String("result.name", aiOutput.Name))
+	spans.LogKV("result.name", aiOutput.Name)
 	err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetName(ctx, globalOrganization.ID, aiOutput.Name)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error setting name"))
+		spans.TraceError(errors.Wrap(err, "error setting name"))
 		return
 	}
 }
@@ -1045,16 +1030,15 @@ func (s *globalOrganizationService) SyncGlobalOrgsToTenantOrganizations() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.SyncGlobalOrgsToTenantOrganizations")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.SyncGlobalOrgsToTenantOrganizations")
+	defer spans.Finish()
 
 	limit := 500
 	daysFromPreviousSync := 1
 
 	records, err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetGlobalOrganizationsToSyncIntoTenantOrganizations(ctx, daysFromPreviousSync, limit)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting records to process"))
+		spans.TraceError(errors.Wrap(err, "error getting records to process"))
 		s.log.Errorf("Error getting records to process: %s", err.Error())
 		return
 	}
@@ -1071,15 +1055,15 @@ func (s *globalOrganizationService) SyncGlobalOrgsToTenantOrganizations() {
 }
 
 func (s *globalOrganizationService) syncGlobalOrganizationToTenantOrganizationRecord(ctx context.Context, globalOrganization *postgresentity.GlobalOrganization) {
-	span, ctx := tracing.StartTracerSpan(ctx, "GlobalOrganizationService.syncGlobalOrganizationToTenantOrganizationRecord")
-	defer span.Finish()
-	span.LogFields(log.Uint64("record.id", globalOrganization.ID), log.String("record.primaryDomain", globalOrganization.PrimaryDomain))
-	tracing.TagEntity(span, globalOrganization.PrimaryDomain)
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.syncGlobalOrganizationToTenantOrganizationRecord")
+	defer spans.Finish()
+	spans.TagEntity(strconv.FormatUint(globalOrganization.ID, 10))
+	spans.LogKV("record.id", globalOrganization.ID, "record.primaryDomain", globalOrganization.PrimaryDomain)
 
 	// mark record as processed initially to not process same record again, even if error occurs
 	err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.MarkGlobalOrganizationSyncedToNeo(ctx, globalOrganization.ID)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error marking record as processed"))
+		spans.TraceError(errors.Wrap(err, "error marking record as processed"))
 		s.log.Errorf("Error marking record as processed: %s", err.Error())
 		return
 	}
@@ -1087,7 +1071,7 @@ func (s *globalOrganizationService) syncGlobalOrganizationToTenantOrganizationRe
 	// Find organizations by domain across all tenants
 	tenantWithOrgId, err := s.commonServices.Neo4jRepositories.OrganizationReadRepository.GetOrganizationsByDomainAcrossAllTenants(ctx, globalOrganization.PrimaryDomain)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting organizations by domain"))
+		spans.TraceError(errors.Wrap(err, "error getting organizations by domain"))
 		s.log.Errorf("Error getting organizations by domain: %s", err.Error())
 		return
 	}
@@ -1102,12 +1086,11 @@ func (s *globalOrganizationService) syncGlobalOrganizationToTenantOrganizationRe
 }
 
 func (s *globalOrganizationService) syncOrganizationToTenant(ctx context.Context, globalOrganization *postgresentity.GlobalOrganization, tenantOrg neo4jrepository.TenantAndOrganizationId) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationService.syncOrganizationToTenant")
-	defer span.Finish()
+	spans, ctx := telemetry.StartCronSpan(ctx, "GlobalOrganizationService.syncOrganizationToTenant")
+	defer spans.Finish()
 	tenant := tenantOrg.Tenant
 	organizationId := tenantOrg.OrganizationId
-	tracing.TagTenant(span, tenant)
-	span.LogKV("industryNaicsCode", globalOrganization.IndustryNaicsCode, "description", globalOrganization.Description, "name", globalOrganization.Name)
+	spans.LogKV("industryNaicsCode", globalOrganization.IndustryNaicsCode, "description", globalOrganization.Description, "name", globalOrganization.Name)
 
 	// sync organization
 	dataFields := data_fields.OrganizationFields{}
@@ -1132,14 +1115,14 @@ func (s *globalOrganizationService) syncOrganizationToTenant(ctx context.Context
 	}
 	_, err := s.commonServices.OrganizationService.Save(ctx, nil, utils.StringPtr(organizationId), dataFields)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error syncing organization"))
+		spans.TraceError(errors.Wrap(err, "error syncing organization"))
 		s.log.Errorf("Error syncing organization: %s", err.Error())
 	}
 
 	// sync Linked In
 	socialEntities, err := s.commonServices.SocialService.GetAllForEntities(ctx, tenant, model.ORGANIZATION, []string{organizationId})
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting social entities"))
+		spans.TraceError(errors.Wrap(err, "error getting social entities"))
 		s.log.Errorf("Error getting social entities: %s", err.Error())
 		return
 	}
@@ -1157,7 +1140,7 @@ func (s *globalOrganizationService) syncOrganizationToTenant(ctx context.Context
 			linkedInIdentifier := neo4jentity.SocialEntity{Url: globalOrganization.LinkedInUrl}.ExtractLinkedinCompanyIdentifierFromUrl()
 			orgsWithLinkedIn, err := s.commonServices.Neo4jRepositories.OrganizationReadRepository.GetOrganizationsByLinkedIn(ctx, tenant, linkedInIdentifier, globalOrganization.LinkedInAlias, linkedInIdentifier)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "error getting organizations by linked in"))
+				spans.TraceError(errors.Wrap(err, "error getting organizations by linked in"))
 				s.log.Errorf("Error getting organizations by linked in: %s", err.Error())
 				return
 			}

--- a/packages/runner/customer-os-data-upkeeper/service/ingest_email_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/ingest_email_service.go
@@ -13,7 +13,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	commonservice "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/agent_listeners"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgresEntity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/opentracing/opentracing-go"
 	"sync"
@@ -42,11 +42,11 @@ func NewIngestEmailService(cfg *config.Config, log logger.Logger, commonServices
 func (s *ingestEmailService) SyncEmailsInState(state postgresEntity.IngestEmailImportStatePeriod) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
-	span, ctx := tracing.StartTracerSpan(ctx, "IngestEmailService.SyncEmailsInState")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
 
-	span.LogKV("state", state)
+	spans, ctx := telemetry.StartCronSpan(ctx, "IngestEmailService.SyncEmailsInState")
+	defer spans.Finish()
+
+	spans.LogKV("state", state)
 
 	runImportFor := []map[string]interface{}{}
 
@@ -54,7 +54,7 @@ func (s *ingestEmailService) SyncEmailsInState(state postgresEntity.IngestEmailI
 
 	agents, err := s.commonServices.PostgresRepositories.AgentRepository.GetAllAgentsByTypesCrossTenant(ctx, []commonenum.AgentType{commonenum.AgentEmailKeeper})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -67,7 +67,7 @@ func (s *ingestEmailService) SyncEmailsInState(state postgresEntity.IngestEmailI
 			var listenerConfig agent_listeners.NewEmailConfig
 			err := json.Unmarshal(listener.Config, &listenerConfig)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				continue
 			}
 
@@ -87,7 +87,7 @@ func (s *ingestEmailService) SyncEmailsInState(state postgresEntity.IngestEmailI
 
 				oAuthTokenEntities, err := s.commonServices.PostgresRepositories.OAuthTokenRepository.GetByEmail(ctx, agent.Tenant, provider, emailAddress)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return
 				}
 
@@ -124,7 +124,7 @@ func (s *ingestEmailService) SyncEmailsInState(state postgresEntity.IngestEmailI
 
 			oAuthTokenEntities, err := s.commonServices.PostgresRepositories.OAuthTokenRepository.GetByEmail(ctx, tenant, provider, email)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				return
 			}
 
@@ -138,18 +138,18 @@ func (s *ingestEmailService) SyncEmailsInState(state postgresEntity.IngestEmailI
 func (s *ingestEmailService) SendIngestedEmailsToAgents() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
-	span, ctx := tracing.StartTracerSpan(ctx, "IngestEmailService.SendIngestedEmailsToAgents")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+
+	spans, ctx := telemetry.StartCronSpan(ctx, "IngestEmailService.SendIngestedEmailsToAgents")
+	defer spans.Finish()
 
 	distinctUsersForImport, err := s.commonServices.PostgresRepositories.IngestEmailMessageRepository.GetDistinctUsersForPendingMessages(ctx)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
 	if len(distinctUsersForImport) == 0 {
-		span.LogKV("result", "no distinct users for import with pending messages")
+		spans.LogKV("result", "no distinct users for import with pending messages")
 		return
 	}
 
@@ -166,56 +166,55 @@ func (s *ingestEmailService) SendIngestedEmailsToAgents() {
 			// Check if agent is enabled to process message
 			agentListener, err := s.commonServices.AgentService.GetListener(dto.NewEmail{}.ListenerEvent())
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				return
 			}
 			agentTypes := agentListener.ExecutingAgents()
 			agents, err := s.commonServices.PostgresRepositories.AgentRepository.GetActiveConfiguredAgentsByTypes(localCtx, agentTypes)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				return
 			}
 			if len(agents) == 0 {
-				span.LogKV("message", "no active agents found for tenant: %s", distinctUser.Tenant)
+				spans.LogKV("message", "no active agents found for tenant: %s", distinctUser.Tenant)
 				return
 			}
 
 			ingestEmailMessages, err := s.commonServices.PostgresRepositories.IngestEmailMessageRepository.GetEmailsForUserForSync(ctx, distinctUser.Tenant, distinctUser.Username)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				return
 			}
 
 			for _, ingestEmailMessage := range ingestEmailMessages {
 				err = s.commonServices.Events.Publisher.PublishFanoutEvent(localCtx, ingestEmailMessage.Id, model.INGEST_EMAIL_MESSAGE, dto.NewEmail{})
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return
 				}
 
 				err := s.commonServices.PostgresRepositories.IngestEmailMessageRepository.UpdateState(localCtx, ingestEmailMessage.Id, postgresEntity.IngestEmailMessageStateSentToAgent)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return
 				}
 
 			}
 
-			span.LogKV("message", "sent emails to agents for user: %s in tenant: %s", distinctUser.Tenant, distinctUser.Username)
+			spans.LogKV("message", "sent emails to agents for user: %s in tenant: %s", distinctUser.Tenant, distinctUser.Username)
 		}(dt)
 	}
 
 	wg.Wait()
-	span.LogKV("message", "sent emails to agents for all users")
+	spans.LogKV("message", "sent emails to agents for all users")
 }
 
 func (s *ingestEmailService) syncEmailsForEmailAddress(ctx context.Context, authTokenEntity *postgresEntity.OAuthTokenEntity, state postgresEntity.IngestEmailImportStatePeriod) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IngestEmailService.syncEmailsForEmailAddress - "+authTokenEntity.TenantName+" - "+authTokenEntity.EmailAddress)
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "IngestEmailService.syncEmailsForEmailAddress - "+authTokenEntity.TenantName+" - "+authTokenEntity.EmailAddress)
+	defer spans.Finish()
 
 	if authTokenEntity == nil {
-		span.LogKV("message", "no oauth token found for tenant: %s and username: %s", authTokenEntity.TenantName, authTokenEntity.EmailAddress)
+		spans.LogKV("message", "no oauth token found for tenant: %s and username: %s", authTokenEntity.TenantName, authTokenEntity.EmailAddress)
 		return
 	}
 
@@ -231,30 +230,30 @@ func (s *ingestEmailService) syncEmailsForEmailAddress(ctx context.Context, auth
 
 		emailImportStateLastWeek, err := s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.LAST_WEEK)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 
 		if emailImportStateLastWeek == nil {
-			span.LogKV("message", "no gmail import state found for tenant: %s and username: %s", tenant, email)
+			spans.LogKV("message", "no gmail import state found for tenant: %s and username: %s", tenant, email)
 			return
 		}
 
 		if emailImportStateLastWeek.Active == true {
-			span.LogKV("message", "gmail import state for tenant: %s and username: %s is active for last week. skipping real time import", tenant, email)
+			spans.LogKV("message", "gmail import state for tenant: %s and username: %s is active for last week. skipping real time import", tenant, email)
 			return
 		}
 
 		emailImportState, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.REAL_TIME)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 
 		if emailImportState.Active == false {
 			importedEmails, err := s.commonServices.PostgresRepositories.IngestEmailMessageRepository.CountForUsername(ctx, tenant, email, provider)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				return
 			}
 
@@ -262,56 +261,56 @@ func (s *ingestEmailService) syncEmailsForEmailAddress(ctx context.Context, auth
 			if importedEmails > 100 {
 				err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.ActivateEmailImportState(ctx, tenant, provider, email, postgresEntity.REAL_TIME)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return
 				}
 
 				emailImportState, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.REAL_TIME)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return
 				}
 			} else {
 
 				lastWeek, err := s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.LAST_WEEK)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return
 				}
 
 				last3Months, err := s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.LAST_3_MONTHS)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return
 				}
 
 				lastYear, err := s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.LAST_YEAR)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return
 				}
 
 				olderThanOneYear, err := s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.OLDER_THAN_ONE_YEAR)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return
 				}
 
 				if lastWeek.Active == false && last3Months.Active == false && lastYear.Active == false && olderThanOneYear.Active == false {
 					err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.ActivateEmailImportState(ctx, tenant, provider, email, postgresEntity.REAL_TIME)
 					if err != nil {
-						tracing.TraceErr(span, err)
+						spans.TraceError(err)
 						return
 					}
 
 					emailImportState, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.REAL_TIME)
 					if err != nil {
-						tracing.TraceErr(span, err)
+						spans.TraceError(err)
 						return
 					}
 				}
 
-				span.LogKV("message", "gmail import state for tenant: %s and username: %s is not active for real time. skipping real time import", tenant, email)
+				spans.LogKV("message", "gmail import state for tenant: %s and username: %s is not active for real time. skipping real time import", tenant, email)
 				return
 			}
 		}
@@ -319,31 +318,31 @@ func (s *ingestEmailService) syncEmailsForEmailAddress(ctx context.Context, auth
 
 		err := s.initializeEmailImportState(ctx, authTokenEntity)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 
 		emailImportState, err = s.getHistoryImportState(ctx, authTokenEntity, postgresEntity.LAST_WEEK)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 		if emailImportState == nil {
-			span.LogKV("message", "no gmail import state found for tenant: %s and username: %s", tenant, email)
+			spans.LogKV("message", "no gmail import state found for tenant: %s and username: %s", tenant, email)
 			return
 		}
 	}
 
 	emailImportState, err := s.syncEmailsForState(ctx, emailImportState)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
 	if state == postgresEntity.HISTORY && emailImportState.Cursor == "" {
 		err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.DeactivateEmailImportState(ctx, tenant, provider, email, emailImportState.Period)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 	}
@@ -351,9 +350,8 @@ func (s *ingestEmailService) syncEmailsForEmailAddress(ctx context.Context, auth
 }
 
 func (s *ingestEmailService) getHistoryImportState(ctx context.Context, authTokenEntity *postgresEntity.OAuthTokenEntity, state postgresEntity.IngestEmailImportStatePeriod) (*postgresEntity.IngestEmailImportState, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IngestEmailService.getHistoryImportState")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "IngestEmailService.getHistoryImportState")
+	defer spans.Finish()
 
 	tenant := authTokenEntity.TenantName
 	provider := authTokenEntity.Provider
@@ -361,12 +359,12 @@ func (s *ingestEmailService) getHistoryImportState(ctx context.Context, authToke
 
 	emailImportState, err := s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, username, state)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if emailImportState == nil {
 		err := fmt.Errorf("failed to get gmail import state for tenant: %s and username: %s and week: %s", tenant, username, state)
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -402,9 +400,8 @@ func (s *ingestEmailService) getNextEmailImportState(state postgresEntity.Ingest
 }
 
 func (s *ingestEmailService) initializeEmailImportState(ctx context.Context, authTokenEntity *postgresEntity.OAuthTokenEntity) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IngestEmailService.initializeEmailImportState")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "IngestEmailService.initializeEmailImportState")
+	defer spans.Finish()
 
 	now := time.Now()
 	tenant := authTokenEntity.TenantName
@@ -413,69 +410,69 @@ func (s *ingestEmailService) initializeEmailImportState(ctx context.Context, aut
 
 	emailImportState, err := s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.REAL_TIME)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	if emailImportState == nil {
 		_, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.CreateEmailImportState(ctx, tenant, provider, email, postgresEntity.REAL_TIME, nil, nil, false, "")
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}
 
 	emailImportState, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.LAST_WEEK)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	if emailImportState == nil {
 		stop := now.AddDate(0, 0, -7)
 		_, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.CreateEmailImportState(ctx, tenant, provider, email, postgresEntity.LAST_WEEK, &now, &stop, true, "")
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}
 
 	emailImportState, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.LAST_3_MONTHS)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	if emailImportState == nil {
 		stop := now.AddDate(0, -3, 0)
 		_, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.CreateEmailImportState(ctx, tenant, provider, email, postgresEntity.LAST_3_MONTHS, &now, &stop, true, "")
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}
 
 	emailImportState, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.LAST_YEAR)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	if emailImportState == nil {
 		stop := now.AddDate(-1, 0, 0)
 		_, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.CreateEmailImportState(ctx, tenant, provider, email, postgresEntity.LAST_YEAR, &now, &stop, true, "")
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}
 
 	emailImportState, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.GetEmailImportState(ctx, tenant, provider, email, postgresEntity.OLDER_THAN_ONE_YEAR)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	if emailImportState == nil {
 		stop := now.AddDate(-50, 0, 0)
 		_, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.CreateEmailImportState(ctx, tenant, provider, email, postgresEntity.OLDER_THAN_ONE_YEAR, &now, &stop, true, "")
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}
@@ -484,9 +481,8 @@ func (s *ingestEmailService) initializeEmailImportState(ctx context.Context, aut
 }
 
 func (s *ingestEmailService) syncEmailsForState(ctx context.Context, importState *postgresEntity.IngestEmailImportState) (*postgresEntity.IngestEmailImportState, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IngestEmailService.syncEmailsForState")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "IngestEmailService.syncEmailsForState")
+	defer spans.Finish()
 
 	batchSize := int64(100)
 	countEmailsExists := int64(0)
@@ -498,13 +494,13 @@ func (s *ingestEmailService) syncEmailsForState(ctx context.Context, importState
 	if importState.Provider == commonenum.SourceGmail.String() {
 		rawEmails, next, err = s.commonServices.GoogleService.ReadEmails(ctx, batchSize, importState)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 	} else if importState.Provider == commonenum.SourceOutlook.String() {
 		rawEmails, next, err = s.commonServices.AzureService.ReadEmailsFromAzureAd(ctx, importState)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 	}
@@ -513,6 +509,7 @@ func (s *ingestEmailService) syncEmailsForState(ctx context.Context, importState
 
 		emailExists, err := s.commonServices.PostgresRepositories.IngestEmailMessageRepository.EmailExistsByMessageId(ctx, importState.Tenant, importState.Username, importState.Provider, emailRawData.MessageId)
 		if err != nil {
+			spans.TraceError(err)
 			return nil, fmt.Errorf("unable to check if email exists: %v", err)
 		}
 
@@ -527,7 +524,7 @@ func (s *ingestEmailService) syncEmailsForState(ctx context.Context, importState
 				if countEmailsExists >= batchSize {
 					importState, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.UpdateEmailImportState(ctx, importState.Tenant, importState.Provider, importState.Username, importState.Period, "")
 					if err != nil {
-						tracing.TraceErr(span, err)
+						spans.TraceError(err)
 						return nil, err
 					}
 					return importState, nil
@@ -540,7 +537,7 @@ func (s *ingestEmailService) syncEmailsForState(ctx context.Context, importState
 			if emailRawData.Sent != zeroTime && importState.StopDate != nil && emailRawData.Sent.Before(*importState.StopDate) {
 				importState, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.UpdateEmailImportState(ctx, importState.Tenant, importState.Provider, importState.Username, importState.Period, "")
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return nil, err
 				}
 				return importState, nil
@@ -550,7 +547,7 @@ func (s *ingestEmailService) syncEmailsForState(ctx context.Context, importState
 
 		headersString, err := JSONMarshal(emailRawData.Headers)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 
@@ -582,14 +579,14 @@ func (s *ingestEmailService) syncEmailsForState(ctx context.Context, importState
 
 		err = s.commonServices.PostgresRepositories.IngestEmailMessageRepository.Store(ctx, importState.Tenant, importState.Username, importState.Provider, emailRawData.MessageId, &ingestEmailMessage)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 	}
 
 	importState, err = s.commonServices.PostgresRepositories.IngestEmailImportStateRepository.UpdateEmailImportState(ctx, importState.Tenant, importState.Provider, importState.Username, importState.Period, next)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 

--- a/packages/runner/customer-os-data-upkeeper/service/ingest_email_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/ingest_email_service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/agent_listeners"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgresEntity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
 	"sync"
 	"time"
 )

--- a/packages/runner/customer-os-data-upkeeper/service/invoice_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/invoice_service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/agent_capability"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -12,7 +11,6 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	commonService "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
@@ -66,9 +64,8 @@ func (s *invoiceService) GenerateNextPreviewInvoices() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "InvoiceService.GenerateNextPreviewInvoices")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "InvoiceService.GenerateNextPreviewInvoices")
+	defer spans.Finish()
 
 	referenceTime := utils.Now()
 	delayFromPreviousScheduleInvoiceRun := 15
@@ -77,7 +74,7 @@ func (s *invoiceService) GenerateNextPreviewInvoices() {
 	// Get all agents for cashflow guardian
 	agents, err := s.repositories.PostgresRepositories.AgentRepository.GetAllAgentsByTypesCrossTenant(ctx, []enum.AgentType{enum.AgentCashflowGuardian})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -97,7 +94,7 @@ func (s *invoiceService) GenerateNextPreviewInvoices() {
 
 		contractRecords, err := s.repositories.Neo4jRepositories.ContractReadRepository.GetContractsToGenerateNextScheduledInvoices(ctx, referenceTime, delayFromPreviousScheduleInvoiceRun, limit)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "Error getting contracts for preview invoicing"))
+			spans.TraceError(errors.Wrap(err, "Error getting contracts for preview invoicing"))
 			s.log.Errorf("Error getting contracts for preview invoicing: %v", err)
 			return
 		}
@@ -114,16 +111,15 @@ func (s *invoiceService) GenerateNextPreviewInvoices() {
 					Tenant:    record.Tenant,
 					AppSource: constants.AppSourceDataUpkeeper,
 				})
-				recordSpan, innerCtx := tracing.StartTracerSpan(innerCtx, "InvoiceService.GenerateNextPreviewInvoices.Record")
-				defer recordSpan.Finish()
-				tracing.TagTenant(recordSpan, record.Tenant)
+				recordSpans, innerCtx := telemetry.StartCronSpan(innerCtx, "InvoiceService.GenerateNextPreviewInvoices.Record")
+				defer recordSpans.Finish()
 
 				contract := neo4jmapper.MapDbNodeToContractEntity(record.Node)
 
 				// mark next preview invoice requested
 				err = s.repositories.Neo4jRepositories.ContractWriteRepository.MarkNextPreviewInvoicingRequested(innerCtx, record.Tenant, contract.Id, utils.Now())
 				if err != nil {
-					tracing.TraceErr(span, err)
+					recordSpans.TraceError(err)
 					s.log.Errorf("Error marking invoicing started for contract %s: %s", contract.Id, err.Error())
 					return
 				}
@@ -161,31 +157,12 @@ func (s *invoiceService) GenerateNextPreviewInvoices() {
 				}
 				_, err = s.commonServices.InvoiceService.InvoiceContract(innerCtx, nil, contract.Id, dataFields)
 				if err != nil {
-					tracing.TraceErr(span, errors.Wrap(err, "Error generating preview invoice"))
+					recordSpans.TraceError(errors.Wrap(err, "Error generating preview invoice"))
 					s.log.Errorf("Error generating preview invoice for contract %s: %s", contract.Id, err.Error())
 				}
 			}(record)
 		}
 	}
-}
-
-func (s *invoiceService) calculateInvoiceCycleEnd(ctx context.Context, start time.Time, tenant string, contractEntity neo4jentity.ContractEntity) time.Time {
-	nextStart := start.AddDate(0, int(contractEntity.BillingCycleInMonths), 0)
-	if start.Day() == 1 {
-		// if previous invoice was generated end of month, we need to substract extra 1 day
-		previousCycleInvoiceDbNode, err := s.repositories.Neo4jRepositories.InvoiceReadRepository.GetPreviousCycleInvoice(ctx, tenant, contractEntity.Id)
-		if err != nil {
-			tracing.TraceErr(nil, errors.Wrap(err, "Error getting previous cycle invoice"))
-		}
-		if previousCycleInvoiceDbNode != nil {
-			previousInvoice := neo4jmapper.MapDbNodeToInvoiceEntity(previousCycleInvoiceDbNode)
-			if previousInvoice.PeriodStartDate.Day() != 1 {
-				nextStart = nextStart.AddDate(0, -1, 0)
-				nextStart = time.Date(nextStart.Year(), nextStart.Month(), previousInvoice.PeriodStartDate.Day(), 0, 0, 0, 0, nextStart.Location())
-			}
-		}
-	}
-	return nextStart.AddDate(0, 0, -1)
 }
 
 func (s *invoiceService) getTenantBaseCurrency(ctx context.Context, tenant string, cachedTenantBaseCurrencies map[string]neo4jenum.Currency) neo4jenum.Currency {
@@ -207,9 +184,8 @@ func (s *invoiceService) GenerateOffCycleInvoices() {
 	// ctx, cancel := context.WithCancel(context.Background())
 	// defer cancel() // Cancel context on exit
 
-	//span, ctx := tracing.StartTracerSpan(ctx, "InvoiceService.GenerateOffCycleInvoices")
-	//defer span.Finish()
-	//tracing.TagComponentCronJob(span)
+	//spans, ctx := telemetry.StartCronSpan(ctx, "InvoiceService.GenerateOffCycleInvoices")
+	//defer spans.Finish()
 	//
 	//if s.cfg.App.ProcessConfig.OffCycleInvoicingEnabled == false {
 	//	s.log.Infof("Off-cycle invoicing is disabled, stopping")
@@ -219,7 +195,7 @@ func (s *invoiceService) GenerateOffCycleInvoices() {
 	//
 	//if s.eventsProcessingClient == nil {
 	//	err := errors.New("eventsProcessingClient is nil")
-	//	tracing.TraceErr(span, err)
+	//	spans.TraceError(err)
 	//	s.log.Error(err.Error())
 	//	return
 	//}
@@ -241,7 +217,7 @@ func (s *invoiceService) GenerateOffCycleInvoices() {
 	//
 	//	records, err := s.repositories.Neo4jRepositories.ContractReadRepository.GetContractsToGenerateOffCycleInvoices(ctx, referenceTime, s.cfg.App.ProcessConfig.DelayGenerateOffCycleInvoiceInMinutes, limit)
 	//	if err != nil {
-	//		tracing.TraceErr(span, err)
+	//		spans.TraceError(err)
 	//		s.log.Errorf("Error getting contracts for off-cycle invoicing: %v", err)
 	//		return
 	//	}
@@ -283,14 +259,14 @@ func (s *invoiceService) GenerateOffCycleInvoices() {
 	//				return s.eventsProcessingClient.InvoiceClient.NewInvoiceForContract(ctx, &newInvoiceRequest)
 	//			})
 	//			if err != nil {
-	//				tracing.TraceErr(span, err)
+	//				spans.TraceError(err)
 	//				s.log.Errorf("Error generating off-cycle invoice for contract %s: %s", contract.Id, err.Error())
 	//			}
 	//		}
 	//		// mark invoicing started
 	//		err = s.repositories.Neo4jRepositories.ContractWriteRepository.MarkOffCycleInvoicingRequested(ctx, tenant, contract.Id, utils.Now())
 	//		if err != nil {
-	//			tracing.TraceErr(span, err)
+	//			spans.TraceError(err)
 	//			s.log.Errorf("Error marking invoicing started for contract %s: %s", contract.Id, err.Error())
 	//		}
 	//	}
@@ -306,9 +282,8 @@ func (s *invoiceService) CleanupInvoices() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "InvoiceService.CleanupInvoices")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "InvoiceService.CleanupInvoices")
+	defer spans.Finish()
 
 	for {
 		select {
@@ -321,7 +296,7 @@ func (s *invoiceService) CleanupInvoices() {
 
 		records, err := s.repositories.Neo4jRepositories.InvoiceReadRepository.GetExpiredDryRunInvoices(ctx)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error getting invoices for cleanup: %v", err)
 			return
 		}
@@ -338,7 +313,7 @@ func (s *invoiceService) CleanupInvoices() {
 
 			err = s.repositories.Neo4jRepositories.InvoiceWriteRepository.DeleteDryRunInvoice(ctx, tenant, invoice.Id)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error deleting dry run invoice %s: %v", invoice.Id, err)
 			}
 		}
@@ -429,14 +404,13 @@ func (s *invoiceService) updateInvoiceStatusToOverdue() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "InvoiceService.updateInvoiceStatusToOverdue")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "InvoiceService.updateInvoiceStatusToOverdue")
+	defer spans.Finish()
 
 	limit := 500
 	records, err := s.repositories.Neo4jRepositories.InvoiceReadRepository.GetInvoicesForOverdue(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error getting invoices for overdue: %v", err)
 		return
 	}
@@ -455,7 +429,7 @@ func (s *invoiceService) updateInvoiceStatusToOverdue() {
 			UpdateStatus: true,
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error updating invoice %s to overdue: %s", invoice.Id, err.Error())
 			return // stop processing
 		}
@@ -466,15 +440,14 @@ func (s *invoiceService) updateInvoiceStatusToOnHold() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "InvoiceService.updateInvoiceStatusToOnHold")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "InvoiceService.updateInvoiceStatusToOnHold")
+	defer spans.Finish()
 
 	limit := 500
 
 	records, err := s.repositories.Neo4jRepositories.InvoiceReadRepository.GetInvoicesForOnHold(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error getting invoices for on hold: %v", err)
 		return
 	}
@@ -493,7 +466,7 @@ func (s *invoiceService) updateInvoiceStatusToOnHold() {
 			UpdateStatus: true,
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error updating invoice %s to on hold: %s", invoice.Id, err.Error())
 			return // stop processing
 		}
@@ -504,14 +477,13 @@ func (s *invoiceService) updateInvoiceStatusScheduled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "InvoiceService.updateInvoiceStatusScheduled")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "InvoiceService.updateInvoiceStatusScheduled")
+	defer spans.Finish()
 
 	limit := 500
 	records, err := s.repositories.Neo4jRepositories.InvoiceReadRepository.GetInvoicesForScheduled(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error getting invoices for scheduled: %v", err)
 		return
 	}
@@ -530,7 +502,7 @@ func (s *invoiceService) updateInvoiceStatusScheduled() {
 			UpdateStatus: true,
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error updating invoice %s to scheduled: %s", invoice.Id, err.Error())
 			return // stop processing
 		}
@@ -541,15 +513,14 @@ func (s *invoiceService) updateInvoiceStatusFromPaymentProcessingToDue() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	span, ctx := tracing.StartTracerSpan(ctx, "InvoiceService.updateInvoiceStatusFromPaymentProcessingToDue")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "InvoiceService.updateInvoiceStatusFromPaymentProcessingToDue")
+	defer spans.Finish()
 
 	limit := 500
 	paymentProcessingMaxDays := 8
 	records, err := s.repositories.Neo4jRepositories.InvoiceReadRepository.GetExpiredPaymentProcessingInvoices(ctx, paymentProcessingMaxDays, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error getting invoices for overdue: %v", err)
 		return
 	}
@@ -568,7 +539,7 @@ func (s *invoiceService) updateInvoiceStatusFromPaymentProcessingToDue() {
 			UpdateStatus: true,
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error updating invoice %s to due: %s", invoice.Id, err.Error())
 			return // stop processing
 		}

--- a/packages/runner/customer-os-data-upkeeper/service/issue_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/issue_service.go
@@ -5,7 +5,7 @@ import (
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/config"
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/logger"
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/repository"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 )
 
@@ -31,13 +31,12 @@ func (s *issueService) LinkUnthreadIssues() {
 	ctx, cancel := utils.GetLongLivedContext(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "IssueService.LinkUnthreadIssues")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "IssueService.LinkUnthreadIssues")
+	defer spans.Finish()
 
 	err := s.repositories.Neo4jRepositories.IssueWriteRepository.LinkUnthreadIssuesToOrganizationByGroupId(ctx)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error linking unthread issues to organization by group id: %s", err.Error())
 		return
 	}

--- a/packages/runner/customer-os-data-upkeeper/service/media_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/media_service.go
@@ -7,14 +7,12 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	service "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgresentity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
 
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/logger"
 )
@@ -64,16 +62,15 @@ func (s *mediaService) FetchAndStoreCompanyLogos() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "MediaService.FetchAndStoreCompanyLogos")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "MediaService.FetchAndStoreCompanyLogos")
+	defer spans.Finish()
 
 	limit := 5
 
 	// get companies
 	orgs, err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetOrganizationsToFetchLogo(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -91,16 +88,15 @@ func (s *mediaService) FetchAndStoreCompanyIcons() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "MediaService.FetchAndStoreCompanyIcons")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "MediaService.FetchAndStoreCompanyIcons")
+	defer spans.Finish()
 
 	limit := 5
 
 	// get companies
 	orgs, err := s.commonServices.PostgresRepositories.GlobalOrganizationRepository.GetOrganizationsToFetchIcon(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -117,16 +113,15 @@ func (s *mediaService) FetchAndStoreContactProfilePhotos() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "MediaService.FetchAndStoreContactProfilePhotos")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "MediaService.FetchAndStoreContactProfilePhotos")
+	defer spans.Finish()
 
 	limit := 10
 
 	// get contacts
 	contacts, err := s.commonServices.PostgresRepositories.GlobalContactRepository.GetContactsToFetchPhoto(ctx, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return
 	}
 
@@ -137,7 +132,7 @@ func (s *mediaService) FetchAndStoreContactProfilePhotos() {
 			if hashPath == "" {
 				// error, this contact has no valid identifier
 				err = errors.New("no valid identifier for contact")
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				continue
 			}
 			photoPath := fmt.Sprintf("%s/%s", hashPath, "profile")
@@ -147,19 +142,20 @@ func (s *mediaService) FetchAndStoreContactProfilePhotos() {
 }
 
 func (s *mediaService) downloadCompanyLogo(ctx context.Context, globalOrgId uint64, imageUrl, imagePath string) bool {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MediaService.downloadCompanyLogo")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
-	span.LogFields(log.String("imageUrl", imageUrl), log.String("imagePath", imagePath), log.Uint64("globalOrgId", globalOrgId))
+	spans, ctx := telemetry.StartCronSpan(ctx, "MediaService.downloadCompanyLogo")
+	defer spans.Finish()
+	spans.LogKV("imageUrl", imageUrl)
+	spans.LogKV("imagePath", imagePath)
+	spans.LogKV("globalOrgId", globalOrgId)
 
 	imagePath, err := s.commonServices.MediaService.DownloadImageToS3(ctx, imageUrl, BUCKET, imagePath)
 	if err != nil {
 		if !errors.Is(err, coserrors.ErrResourceNotFound) && !errors.Is(err, coserrors.ErrResourceForbidden) {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 		}
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetDownloadStatusLogo(ctx, globalOrgId, enum.DownloadError)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to set download status"))
+			spans.TraceError(errors.Wrap(err, "failed to set download status"))
 		}
 		return false
 	}
@@ -167,31 +163,32 @@ func (s *mediaService) downloadCompanyLogo(ctx context.Context, globalOrgId uint
 	if imagePath != "" {
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetLogo(ctx, globalOrgId, imagePath)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to set image path"))
+			spans.TraceError(errors.Wrap(err, "failed to set image path"))
 			return false
 		}
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetDownloadStatusLogo(ctx, globalOrgId, enum.DownloadCompleted)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to set download status"))
+			spans.TraceError(errors.Wrap(err, "failed to set download status"))
 		}
 	}
 	return true
 }
 
 func (s *mediaService) downloadCompanyIcon(ctx context.Context, globalOrgId uint64, imageUrl, imagePath string) bool {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MediaService.downloadCompanyIcon")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
-	span.LogFields(log.String("imageUrl", imageUrl), log.String("imagePath", imagePath), log.Uint64("globalOrgId", globalOrgId))
+	spans, ctx := telemetry.StartCronSpan(ctx, "MediaService.downloadCompanyIcon")
+	defer spans.Finish()
+	spans.LogKV("imageUrl", imageUrl)
+	spans.LogKV("imagePath", imagePath)
+	spans.LogKV("globalOrgId", globalOrgId)
 
 	imagePath, err := s.commonServices.MediaService.DownloadImageToS3(ctx, imageUrl, BUCKET, imagePath)
 	if err != nil {
 		if !errors.Is(err, coserrors.ErrResourceNotFound) && !errors.Is(err, coserrors.ErrResourceForbidden) {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 		}
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetDownloadStatusIcon(ctx, globalOrgId, enum.DownloadError)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to set download status"))
+			spans.TraceError(errors.Wrap(err, "failed to set download status"))
 		}
 		return false
 	}
@@ -199,44 +196,45 @@ func (s *mediaService) downloadCompanyIcon(ctx context.Context, globalOrgId uint
 	if imagePath != "" {
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetIcon(ctx, globalOrgId, imagePath)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to set image path"))
+			spans.TraceError(errors.Wrap(err, "failed to set image path"))
 			return false
 		}
 		err = s.commonServices.PostgresRepositories.GlobalOrganizationRepository.SetDownloadStatusIcon(ctx, globalOrgId, enum.DownloadCompleted)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to set download status"))
+			spans.TraceError(errors.Wrap(err, "failed to set download status"))
 		}
 	}
 	return true
 }
 
 func (s *mediaService) downloadContactPhoto(ctx context.Context, globalContactId uint64, imageUrl, imagePath string) bool {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MediaService.downloadContactPhoto")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
-	span.LogFields(log.String("imageUrl", imageUrl), log.String("imagePath", imagePath), log.Uint64("globalContactId", globalContactId))
+	spans, ctx := telemetry.StartCronSpan(ctx, "MediaService.downloadContactPhoto")
+	defer spans.Finish()
+	spans.LogKV("imageUrl", imageUrl)
+	spans.LogKV("imagePath", imagePath)
+	spans.LogKV("globalContactId", globalContactId)
 
 	imagePath, err := s.commonServices.MediaService.DownloadImageToS3(ctx, imageUrl, BUCKET, imagePath)
 	if err != nil {
 		if !errors.Is(err, coserrors.ErrResourceNotFound) && !errors.Is(err, coserrors.ErrResourceForbidden) {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 		} else {
 			// clear global contact profile photo external url
 			globalContact, err := s.commonServices.PostgresRepositories.GlobalContactRepository.GetById(ctx, globalContactId)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 			}
 			if globalContact != nil {
 				globalContact.ProfilePhotoExternalUrl = ""
 				_, err = s.commonServices.PostgresRepositories.GlobalContactRepository.Update(ctx, globalContact)
 				if err != nil {
-					tracing.TraceErr(span, errors.Wrap(err, "failed to update global contact"))
+					spans.TraceError(errors.Wrap(err, "failed to update global contact"))
 				}
 			}
 		}
 		err = s.commonServices.PostgresRepositories.GlobalContactRepository.SetDownloadStatus(ctx, globalContactId, enum.DownloadError)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to set download status"))
+			spans.TraceError(errors.Wrap(err, "failed to set download status"))
 		}
 		return false
 	}
@@ -244,12 +242,12 @@ func (s *mediaService) downloadContactPhoto(ctx context.Context, globalContactId
 	if imagePath != "" {
 		err = s.commonServices.PostgresRepositories.GlobalContactRepository.SetProfilePhoto(ctx, globalContactId, imagePath)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to set image path"))
+			spans.TraceError(errors.Wrap(err, "failed to set image path"))
 			return false
 		}
 		err = s.commonServices.PostgresRepositories.GlobalContactRepository.SetDownloadStatus(ctx, globalContactId, enum.DownloadCompleted)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to set download status"))
+			spans.TraceError(errors.Wrap(err, "failed to set download status"))
 		}
 	}
 	return true

--- a/packages/runner/customer-os-data-upkeeper/service/organization_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/organization_service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	commonService "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
 	common_srv "github.com/customeros/customeros/packages/server/customer-os-common-module/services/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
@@ -44,9 +44,8 @@ func (s *organizationService) RefreshLastTouchpoint() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "OrganizationService.RefreshLastTouchpoint")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "OrganizationService.RefreshLastTouchpoint")
+	defer spans.Finish()
 
 	limit := 50
 	delayFromPreviousCheckInMinutes := 60 // 60 minutes
@@ -62,7 +61,7 @@ func (s *organizationService) RefreshLastTouchpoint() {
 
 		records, err := s.commonServices.Neo4jRepositories.OrganizationReadRepository.GetOrganizationsForUpdateLastTouchpoint(ctx, limit, delayFromPreviousCheckInMinutes)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error getting organizations for renewals: %v", err)
 			return
 		}
@@ -81,13 +80,13 @@ func (s *organizationService) RefreshLastTouchpoint() {
 
 			err = s.commonServices.OrganizationService.RequestRefreshLastTouchpoint(innerCtx, record.OrganizationId)
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "error refreshing last touchpoint"))
+				spans.TraceError(errors.Wrap(err, "error refreshing last touchpoint"))
 				s.log.Errorf("Error refreshing last touchpoint for organization {%s}: %s", record.OrganizationId, err.Error())
 			}
 
 			err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(innerCtx, record.Tenant, model.NodeLabelOrganization, record.OrganizationId, string(neo4jentity.OrganizationPropertyLastTouchpointRequestedAt), utils.NowPtr())
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "error updating last touchpoint requested at"))
+				spans.TraceError(errors.Wrap(err, "error updating last touchpoint requested at"))
 				s.log.Errorf("Error updating refresh last touchpoint requested at: %s", err.Error())
 			}
 		}
@@ -114,9 +113,8 @@ func (s *organizationService) UpkeepOrganizations() {
 }
 
 func (s *organizationService) updateDerivedNextRenewalDates(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "OrganizationService.updateDerivedNextRenewalDates")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "OrganizationService.updateDerivedNextRenewalDates")
+	defer spans.Finish()
 
 	limit := 1000
 
@@ -131,7 +129,7 @@ func (s *organizationService) updateDerivedNextRenewalDates(ctx context.Context)
 
 		records, err := s.commonServices.Neo4jRepositories.OrganizationReadRepository.GetOrganizationsForUpdateNextRenewalDate(ctx, limit)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error getting organizations for renewals: %v", err)
 			return
 		}
@@ -150,7 +148,7 @@ func (s *organizationService) updateDerivedNextRenewalDates(ctx context.Context)
 
 			err = s.commonServices.OrganizationService.UpdateRenewalSummary(localCtx, record.OrganizationId)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 			}
 		}
 
@@ -168,9 +166,8 @@ func (s *organizationService) updateDerivedNextRenewalDates(ctx context.Context)
 }
 
 func (s *organizationService) linkWithDomain(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "OrganizationService.linkWithDomain")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "OrganizationService.linkWithDomain")
+	defer spans.Finish()
 
 	limit := 100
 	delayMinutesFromLastCheck := 60 * 24 * 3 // 3 days
@@ -186,7 +183,7 @@ func (s *organizationService) linkWithDomain(ctx context.Context) {
 
 		records, err := s.commonServices.Neo4jRepositories.OrganizationReadRepository.GetOrganizationsWithWebsiteAndWithoutDomains(ctx, limit, delayMinutesFromLastCheck)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error getting organizations: %v", err)
 			return
 		}
@@ -205,7 +202,7 @@ func (s *organizationService) linkWithDomain(ctx context.Context) {
 
 			organizationEntity, err := s.commonServices.OrganizationService.GetById(innerCtx, record.Tenant, record.OrganizationId)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error getting organization {%s}: %s", record.OrganizationId, err.Error())
 			}
 
@@ -217,13 +214,13 @@ func (s *organizationService) linkWithDomain(ctx context.Context) {
 			if primaryDomain != "" {
 				_, err = s.commonServices.OrganizationService.LinkWithDomain(innerCtx, nil, record.OrganizationId, primaryDomain)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					s.log.Errorf("Error linking with domain {%s}: %s", record.OrganizationId, err.Error())
 				}
 			}
 			err = s.commonServices.Neo4jRepositories.CommonWriteRepository.UpdateTimeProperty(innerCtx, record.Tenant, model.NodeLabelOrganization, record.OrganizationId, string(neo4jentity.OrganizationPropertyDomainCheckedAt), utils.NowPtr())
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error updating domain checked at: %s", err.Error())
 			}
 		}
@@ -239,9 +236,8 @@ func (s *organizationService) linkWithDomain(ctx context.Context) {
 }
 
 func (s *organizationService) enrichOrganization(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "OrganizationService.enrichOrganization")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "OrganizationService.enrichOrganization")
+	defer spans.Finish()
 
 	limit := 250
 	delayFromPreviousAttemptInMinutes := 60 * 24 * 10 // 10 days
@@ -257,7 +253,7 @@ func (s *organizationService) enrichOrganization(ctx context.Context) {
 
 		records, err := s.commonServices.Neo4jRepositories.OrganizationReadRepository.GetOrganizationsForEnrichByDomain(ctx, limit, delayFromPreviousAttemptInMinutes)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error getting organizations: %v", err)
 			return
 		}
@@ -275,19 +271,19 @@ func (s *organizationService) enrichOrganization(ctx context.Context) {
 			})
 			err = s.commonServices.Events.Publisher.PublishFanoutEvent(innerCtx, record.OrganizationId, model.ORGANIZATION, dto.RequestEnrichOrganization{Url: record.Param1})
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error enriching organization {%s}: %s", record.OrganizationId, err.Error())
 			}
 			err = s.commonServices.Neo4jRepositories.OrganizationWriteRepository.UpdateTimeProperty(innerCtx, record.Tenant, record.OrganizationId, string(neo4jentity.OrganizationPropertyEnrichRequestedAt), utils.NowPtr())
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error updating domain checked at: %s", err.Error())
 			}
 
 			// increment enrich attempts
 			err = s.commonServices.Neo4jRepositories.CommonWriteRepository.IncrementProperty(innerCtx, record.Tenant, model.NodeLabelOrganization, record.OrganizationId, string(neo4jentity.OrganizationPropertyEnrichAttempts))
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error incrementing contact' enrich attempts: %s", err.Error())
 			}
 		}
@@ -303,16 +299,15 @@ func (s *organizationService) enrichOrganization(ctx context.Context) {
 }
 
 func (s *organizationService) removeEmptySocials(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "OrganizationService.removeEmptySocials")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "OrganizationService.removeEmptySocials")
+	defer spans.Finish()
 
 	limit := 100
 	minutesSinceLastUpdate := 180
 
 	records, err := s.commonServices.Neo4jRepositories.SocialReadRepository.GetEmptySocialsForEntityType(ctx, model.NodeLabelOrganization, minutesSinceLastUpdate, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error getting socials: %v", err)
 		return
 	}
@@ -335,23 +330,22 @@ func (s *organizationService) removeEmptySocials(ctx context.Context) {
 			},
 			record.SocialId)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error removing social {%s}: %s", record.SocialId, err.Error())
 		}
 	}
 }
 
 func (s *organizationService) removeDuplicatedSocials(ctx context.Context) {
-	span, ctx := tracing.StartTracerSpan(ctx, "OrganizationService.removeDuplicatedSocials")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "OrganizationService.removeDuplicatedSocials")
+	defer spans.Finish()
 
 	limit := 100
 	minutesSinceLastUpdate := 5
 
 	records, err := s.commonServices.Neo4jRepositories.SocialReadRepository.GetDuplicatedSocialsForEntityType(ctx, model.NodeLabelOrganization, minutesSinceLastUpdate, limit)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error getting socials: %v", err)
 		return
 	}
@@ -376,7 +370,7 @@ func (s *organizationService) removeDuplicatedSocials(ctx context.Context) {
 			},
 			record.SocialId)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error removing social {%s}: %s", record.SocialId, err.Error())
 		}
 	}
@@ -386,13 +380,12 @@ func (s *organizationService) SendReminders() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "OrganizationService.SendReminders")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "OrganizationService.SendReminders")
+	defer spans.Finish()
 
 	readyToSendNodes, err := s.commonServices.Neo4jRepositories.ReminderReadRepository.GetReadyToSend(ctx, utils.Now())
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error getting reminders to send: %v", err)
 		return
 	}
@@ -407,14 +400,14 @@ func (s *organizationService) SendReminders() {
 		reminder := neo4jmapper.MapDbNodeToReminderEntity(reminderNode)
 		err := s.commonServices.ReminderService.SendNotification(innerCtx, reminder.Id, s.cfg.Common.External.NovuConfig.FronteraUrl)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error sending reminder {%s}: %s", reminder.Id, err.Error())
 			return
 		}
 
 		err = s.commonServices.ReminderService.UpdateReminder(ctx, tenant, reminder.Id, nil, nil, nil, utils.BoolPtr(true))
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return
 		}
 	}

--- a/packages/runner/customer-os-data-upkeeper/service/task_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/task_service.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/logger"
 	commonservice "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 )
 
 type TaskService interface {
@@ -28,9 +28,8 @@ func (s *taskService) DeleteArchivedTasks() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "TaskService.DeleteArchivedTasks")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "TaskService.DeleteArchivedTasks")
+	defer spans.Finish()
 
 	delitionDelayDays := 30
 
@@ -41,14 +40,14 @@ func (s *taskService) DeleteArchivedTasks() {
 		return
 	}
 
-	span.LogKV("taskIds.count", len(taskIds))
-	tracing.LogObjectAsJson(span, "taskIds", taskIds)
+	spans.LogKV("taskIds.count", len(taskIds))
+	spans.LogObjectAsJson("taskIds", taskIds)
 	s.log.Infof("Deleting %d archived tasks: %v", len(taskIds), taskIds)
 
 	// Delete tasks
 	err = s.commonServices.Neo4jRepositories.TaskWriteRepository.PermanentDeleteHiddenTasks(ctx, nil, taskIds)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Error("Error deleting tasks", "error", err)
 		return
 	}

--- a/packages/runner/customer-os-data-upkeeper/service/tenant_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/tenant_service.go
@@ -12,10 +12,8 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	commonService "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/mailstack"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/config"
@@ -45,16 +43,15 @@ func (s *tenantService) CheckOnboarding() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	span, ctx := tracing.StartTracerSpan(ctx, "TenantService.CheckOnboarding")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
+	spans, ctx := telemetry.StartCronSpan(ctx, "TenantService.CheckOnboarding")
+	defer spans.Finish()
 
 	limit := 50
 	delayFromLastCheckHours := 24
 
 	tenantDbNodes, err := s.commonServices.Neo4jRepositories.TenantReadRepository.GetTenantsForOnboardingCheck(ctx, limit, delayFromLastCheckHours)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting tenants for onboarding check"))
+		spans.TraceError(errors.Wrap(err, "error getting tenants for onboarding check"))
 		s.log.Errorf("Error getting tenants for onboarding check: %s", err.Error())
 		return
 	}
@@ -65,20 +62,20 @@ func (s *tenantService) CheckOnboarding() {
 
 	for _, tenantDbNode := range tenantDbNodes {
 		func(tenantDbNode *dbtype.Node) {
-			recordSpan, ctx := tracing.StartTracerSpan(ctx, "TenantService.CheckOnboarding.Record")
-			defer recordSpan.Finish()
+			recordSpans, ctx := telemetry.StartCronSpan(ctx, "TenantService.CheckOnboarding.Record")
+			defer recordSpans.Finish()
 
 			tenantEntity := neo4jmapper.MapDbNodeToTenantEntity(tenantDbNode)
 			innerCtx := common.WithCustomContext(ctx, &common.CustomContext{
 				Tenant:    tenantEntity.Name,
 				AppSource: constants.AppSourceDataUpkeeper,
 			})
-			tracing.TagTenant(recordSpan, tenantEntity.Name)
+			recordSpans.TagTenant(tenantEntity.Name)
 
 			// mark tenant as checked
 			err = s.commonServices.Neo4jRepositories.TenantWriteRepository.MarkOnboardingChecked(innerCtx, tenantEntity.Name)
 			if err != nil {
-				tracing.TraceErr(recordSpan, errors.Wrap(err, "error marking tenant as checked"))
+				recordSpans.TraceError(errors.Wrap(err, "error marking tenant as checked"))
 				s.log.Errorf("Error marking tenant as checked: %s", err.Error())
 				return
 			}
@@ -91,68 +88,65 @@ func (s *tenantService) CheckOnboarding() {
 }
 
 func (s *tenantService) checkWebVisitorAgents(ctx context.Context, tenant string) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantService.checkWebVisitorAgents")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartCronSpan(ctx, "TenantService.checkWebVisitorAgents")
+	defer spans.Finish()
 
 	// get web visitor agents
 	webVisitorAgents, err := s.commonServices.PostgresRepositories.AgentRepository.GetAllAgentsByTypes(ctx, []enum.AgentType{enum.AgentWebVisitorIdentifier})
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting web visitor agents"))
+		spans.TraceError(errors.Wrap(err, "error getting web visitor agents"))
 		s.log.Errorf("Error getting web visitor agents: %s", err.Error())
 		return
 	}
 
 	if len(webVisitorAgents) > 0 {
-		span.LogFields(log.Bool("result.onboarded", true))
+		spans.LogKV("result.onboarded", true)
 		return
 	}
 
 	// create web visitor agents
 	_, err = s.commonServices.AgentService.CreateAgent(ctx, enum.AgentWebVisitorIdentifier)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error creating web visitor agent"))
+		spans.TraceError(errors.Wrap(err, "error creating web visitor agent"))
 		s.log.Errorf("Error creating web visitor agents: %s", err.Error())
 	}
 }
 
 func (s *tenantService) checkIcpQualificationAgents(ctx context.Context, tenant string) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantService.checkIcpQualificationAgents")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartCronSpan(ctx, "TenantService.checkIcpQualificationAgents")
+	defer spans.Finish()
 
 	// get icp qualification agents
 	icpQualificationAgents, err := s.commonServices.PostgresRepositories.AgentRepository.GetAllAgentsByTypes(ctx, []enum.AgentType{enum.AgentICPQualifier})
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error getting icp qualification agents"))
+		spans.TraceError(errors.Wrap(err, "error getting icp qualification agents"))
 		s.log.Errorf("Error getting icp qualification agents: %s", err.Error())
 		return
 	}
 
 	if len(icpQualificationAgents) > 0 {
-		span.LogFields(log.Bool("result.onboarded", true))
+		spans.LogKV("result.onboarded", true)
 		return
 	}
 
 	// create icp qualification agents
 	_, err = s.commonServices.AgentService.CreateAgent(ctx, enum.AgentICPQualifier)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error creating icp qualification agent"))
+		spans.TraceError(errors.Wrap(err, "error creating icp qualification agent"))
 		s.log.Errorf("Error creating icp qualification agents: %s", err.Error())
 	}
 }
 
 func (s *tenantService) checkTestMailbox(ctx context.Context, tenant string) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantService.checkTestMailbox")
-	defer span.Finish()
-	tracing.TagComponentCronJob(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartCronSpan(ctx, "TenantService.checkTestMailbox")
+	defer spans.Finish()
+
+	// Skip if tenant has uppercase letters
 
 	// Skip if tenant has uppercase letters
 	if tenant != strings.ToLower(tenant) {
-		span.LogFields(log.Bool("result.skipped", true), log.String("reason", "tenant name was auto generated"))
+		spans.LogKV("result.skipped", true)
+		spans.LogKV("reason", "tenant name was auto generated")
 		return
 	}
 
@@ -161,7 +155,7 @@ func (s *tenantService) checkTestMailbox(ctx context.Context, tenant string) {
 	// Check if mailbox exists using GetMailboxes from mailstack service
 	statusCode, errMsg, mailboxes, err := s.commonServices.MailstackService.GetMailboxes(ctx, tenant, mailstack.TEST_MAILBOX_DOMAIN, "")
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to get mailboxes"))
+		spans.TraceError(errors.Wrap(err, "failed to get mailboxes"))
 		s.log.Errorf("Error checking test mailbox: %s", err.Error())
 		return
 	}
@@ -169,7 +163,7 @@ func (s *tenantService) checkTestMailbox(ctx context.Context, tenant string) {
 	// Handle non-200 responses
 	if statusCode != http.StatusOK {
 		err = errors.New(errMsg)
-		tracing.TraceErr(span, errors.Wrap(err, "failed to get mailboxes"))
+		spans.TraceError(errors.Wrap(err, "failed to get mailboxes"))
 		s.log.Errorf("Error checking test mailbox: %s", err.Error())
 		return
 	}
@@ -184,21 +178,21 @@ func (s *tenantService) checkTestMailbox(ctx context.Context, tenant string) {
 	}
 
 	if mailboxExists {
-		span.LogFields(log.Bool("result.exists", true))
+		spans.LogKV("result.exists", true)
 		return
 	}
 
 	testUserSetup, err := s.commonServices.RegistrationService.ConfigureTestMailbox(ctx)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to configure test mailbox"))
+		spans.TraceError(errors.Wrap(err, "failed to configure test mailbox"))
 		s.log.Errorf("Error configuring test mailbox: %s", err.Error())
 		return
 	}
 
 	if testUserSetup == nil {
-		span.LogFields(log.Bool("result.created", false))
+		spans.LogKV("result.created", false)
 		return
 	}
 
-	span.LogFields(log.Bool("result.created", true))
+	spans.LogKV("result.created", true)
 }

--- a/packages/server/customer-os-common-module/telemetry/helpers.go
+++ b/packages/server/customer-os-common-module/telemetry/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"runtime/debug"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -780,4 +782,34 @@ func SetDefaultServiceSpanAttributes(ctx context.Context, span trace.Span) {
 		return
 	}
 	span.SetAttributes(GetDefaultServiceSpanAttributes(ctx)...)
+}
+
+// InjectSpanContextIntoHTTPRequest injects both Jaeger and OpenTelemetry span contexts into an HTTP request
+func InjectSpanContextIntoHTTPRequest(req *http.Request, spans *Spans) *http.Request {
+	if spans == nil {
+		return req
+	}
+
+	// Inject Jaeger span context
+	if spans.Jaeger != nil {
+		// Use existing tracing package's function for Jaeger
+		req = tracing.InjectSpanContextIntoHTTPRequest(req, spans.Jaeger)
+	}
+
+	// Inject OpenTelemetry span context
+	if spans.OTel != nil {
+		// Get the propagator from the global tracer provider
+		propagator := otel.GetTextMapPropagator()
+
+		// Create a carrier for the headers
+		carrier := propagation.HeaderCarrier(req.Header)
+
+		// Create a context with the span context
+		ctx := trace.ContextWithSpanContext(context.Background(), spans.OTel.SpanContext())
+
+		// Inject the span context into the carrier
+		propagator.Inject(ctx, carrier)
+	}
+
+	return req
 }

--- a/packages/server/customer-os-common-module/telemetry/helpers.go
+++ b/packages/server/customer-os-common-module/telemetry/helpers.go
@@ -412,6 +412,18 @@ func (s *Spans) TagEntity(entityId string) {
 	}
 }
 
+func (s *Spans) TagTenant(tenant string) {
+	if s == nil || tenant == "" {
+		return
+	}
+	if s.Jaeger != nil {
+		tracing.TagTenant(s.Jaeger, tenant)
+	}
+	if s.OTel != nil {
+		s.OTel.SetAttributes(attribute.String("tenant", tenant))
+	}
+}
+
 // Logging Methods
 func (s *Spans) LogFields(fields ...log.Field) {
 	if s == nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `tracing` with `telemetry` for span management and error logging across multiple services in `customer-os-data-upkeeper`.
> 
>   - **Telemetry Integration**:
>     - Replace `tracing` with `telemetry` in services like `contact_service.go`, `contract_service.go`, and `currency_service.go`.
>     - Update span creation and error logging to use `telemetry` methods.
>   - **Error Handling**:
>     - Replace `tracing.TraceErr` with `spans.TraceError` in multiple functions for error logging.
>   - **Span Management**:
>     - Use `telemetry.StartCronSpan` for starting spans in cron jobs.
>     - Use `spans.Finish()` to end spans consistently.
>   - **Miscellaneous**:
>     - Remove unused imports related to `opentracing` in several files.
>     - Update `helpers.go` to include new telemetry functions for span context injection and error tracing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 886a92ec240be9f1b81c35dcfb59225267ec98d9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->