### PR TITLE
Comment out internal API key validation in validate_headers.ex

### DIFF
--- a/packages/server/realtime/lib/realtime_web/plugs/validate_headers.ex
+++ b/packages/server/realtime/lib/realtime_web/plugs/validate_headers.ex
@@ -20,17 +20,17 @@ defmodule RealtimeWeb.Plugs.ValidateHeaders do
 
     api_token = System.get_env("API_TOKEN")
 
-    if internal_api_key && internal_api_key != api_token do
-      conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(
-        401,
-        Jason.encode!(%{error: "Unauthorized", message: "Invalid internal app token"})
-      )
-      |> halt()
-    else
-      conn
-    end
+    # if internal_api_key && internal_api_key != api_token do
+    #   conn
+    #   |> put_resp_content_type("application/json")
+    #   |> send_resp(
+    #     401,
+    #     Jason.encode!(%{error: "Unauthorized", message: "Invalid internal app token"})
+    #   )
+    #   |> halt()
+    # else
+    #   conn
+    # end
 
     if !tenant do
       conn

--- a/packages/server/realtime/lib/realtime_web/plugs/validate_headers.ex
+++ b/packages/server/realtime/lib/realtime_web/plugs/validate_headers.ex
@@ -16,9 +16,9 @@ defmodule RealtimeWeb.Plugs.ValidateHeaders do
         [value] -> value
       end
 
-    internal_api_key = get_req_header(conn, "x-openline-api-key") |> List.first()
+    # internal_api_key = get_req_header(conn, "x-openline-api-key") |> List.first()
 
-    api_token = System.get_env("API_TOKEN")
+    # api_token = System.get_env("API_TOKEN")
 
     # if internal_api_key && internal_api_key != api_token do
     #   conn


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Commented out internal API key validation in `validate_headers.ex`, removing check for `x-openline-api-key`.
> 
>   - **Behavior**:
>     - Commented out internal API key validation logic in `call` function of `RealtimeWeb.Plugs.ValidateHeaders`.
>     - No longer checks `x-openline-api-key` header against `API_TOKEN` environment variable.
>   - **Code**:
>     - Lines 19-33 in `validate_headers.ex` are commented out, removing the unauthorized response for invalid internal app token.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 1e7e6fa0b3546fea7108109a7ea83e9f1ad509ad. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->