### PR TITLE
be spans rework part1 + domain ignore space

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/config/config.go
+++ b/packages/runner/customer-os-data-upkeeper/config/config.go
@@ -7,7 +7,6 @@ import (
 	commonconf "github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/joho/godotenv"
 
 	cronconf "github.com/customeros/customeros/packages/runner/customer-os-data-upkeeper/cron/config"
@@ -16,7 +15,7 @@ import (
 type CommonConfig struct {
 	Enrow             commonconf.EnrowConfig
 	Logger            logger.Config
-	Jaeger            tracing.JaegerConfig
+	Jaeger            telemetry.JaegerConfig
 	OpenTelemetry     telemetry.OpenTelemetryConfig
 	RabbitMQConfig    commonconf.RabbitMQConfig
 	ScrubbyIo         commonconf.ScrubbyIoConfig

--- a/packages/runner/customer-os-data-upkeeper/customer_os_data_upkeeper_main.go
+++ b/packages/runner/customer-os-data-upkeeper/customer_os_data_upkeeper_main.go
@@ -14,7 +14,6 @@ import (
 	commonService "github.com/customeros/customeros/packages/server/customer-os-common-module/services"
 	agent_producers "github.com/customeros/customeros/packages/server/customer-os-common-module/services/agent_event_producers"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/opentracing/opentracing-go"
 	"github.com/robfig/cron"
 	"github.com/sirupsen/logrus"
@@ -134,7 +133,7 @@ func initTracing(cfg *config.Config, appLogger logger.Logger) io.Closer {
 
 	// Initialize Jaeger if enabled
 	if cfg.Common.Infrastructure.JaegerConfig.Enabled {
-		tracer, jaegerCloser, err := tracing.NewJaegerTracer(&cfg.Common.Infrastructure.JaegerConfig, appLogger)
+		tracer, jaegerCloser, err := telemetry.NewJaegerTracer(&cfg.Common.Infrastructure.JaegerConfig, appLogger)
 		if err != nil {
 			appLogger.Fatalf("Could not initialize jaeger tracer: %v", err.Error())
 		}

--- a/packages/runner/integrity-checker/config/config.go
+++ b/packages/runner/integrity-checker/config/config.go
@@ -8,14 +8,13 @@ import (
 	commonConfig "github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/joho/godotenv"
 )
 
 type Config struct {
 	Neo4j         commonConfig.Neo4jConfig
 	Logger        logger.Config
-	Jaeger        tracing.JaegerConfig
+	Jaeger        telemetry.JaegerConfig
 	OpenTelemetry telemetry.OpenTelemetryConfig
 	Cron          cronconfig.Config
 

--- a/packages/runner/integrity-checker/integrity_checker_main.go
+++ b/packages/runner/integrity-checker/integrity_checker_main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/customeros/customeros/packages/runner/integrity-checker/repository"
 	commonConfig "github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/opentracing/opentracing-go"
 	"github.com/robfig/cron"
 )
@@ -92,7 +91,7 @@ func initTracing(cfg *config.Config, appLogger logger.Logger) io.Closer {
 
 	// Initialize Jaeger if enabled
 	if cfg.Jaeger.Enabled {
-		tracer, jaegerCloser, err := tracing.NewJaegerTracer(&cfg.Jaeger, appLogger)
+		tracer, jaegerCloser, err := telemetry.NewJaegerTracer(&cfg.Jaeger, appLogger)
 		if err != nil {
 			appLogger.Fatalf("Could not initialize jaeger tracer: %v", err.Error())
 		}

--- a/packages/runner/sync-slack/config/config.go
+++ b/packages/runner/sync-slack/config/config.go
@@ -2,11 +2,11 @@ package config
 
 import (
 	"github.com/caarlos0/env/v6"
-	"github.com/joho/godotenv"
 	cronConfig "github.com/customeros/customeros/packages/runner/sync-slack/cron/config"
 	commonConfig "github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/joho/godotenv"
 	"log"
 )
 
@@ -14,7 +14,7 @@ type Config struct {
 	CommonConfig commonConfig.CommonConfig
 
 	Logger             logger.Config
-	Jaeger             tracing.JaegerConfig
+	Jaeger             telemetry.JaegerConfig
 	Cron               cronConfig.Config
 	RawDataStoreDBName string `env:"RAW_DATA_STORE_DB_NAME,required" envDefault:"destination"`
 }

--- a/packages/runner/sync-slack/sync_slack_main.go
+++ b/packages/runner/sync-slack/sync_slack_main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/customeros/customeros/packages/runner/sync-slack/logger"
 	"github.com/customeros/customeros/packages/runner/sync-slack/repository"
 	commonConfig "github.com/customeros/customeros/packages/server/customer-os-common-module/config"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/opentracing/opentracing-go"
 	"github.com/robfig/cron"
@@ -97,7 +98,7 @@ func initLogger(cfg *config.Config) logger.Logger {
 
 func initTracing(cfg *config.Config, appLogger logger.Logger) io.Closer {
 	if cfg.Jaeger.Enabled {
-		tracer, closer, err := tracing.NewJaegerTracer(&cfg.Jaeger, appLogger)
+		tracer, closer, err := telemetry.NewJaegerTracer(&cfg.Jaeger, appLogger)
 		if err != nil {
 			appLogger.Fatalf("Could not initialize jaeger tracer: %v", err.Error())
 		}

--- a/packages/server/apigator/config/config.go
+++ b/packages/server/apigator/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 )
 
 type Config struct {
@@ -13,6 +13,6 @@ type Config struct {
 	PostgresConfig      config.PostgresConfig
 	PostgresAsyncConfig config.PostgresAsyncConfig
 	Neo4jConfig         config.Neo4jConfig
-	Jaeger              tracing.JaegerConfig
+	Jaeger              telemetry.JaegerConfig
 	Logger              logger.Config
 }

--- a/packages/server/apigator/main.go
+++ b/packages/server/apigator/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"io"
 	"log"
 	"net/http"
@@ -98,7 +99,7 @@ func initLogger(cfg *config.Config) logger.Logger {
 
 func initTracing(cfg *config.Config, appLogger logger.Logger) io.Closer {
 	if cfg.Jaeger.Enabled {
-		tracer, closer, err := tracing.NewJaegerTracer(&cfg.Jaeger, appLogger)
+		tracer, closer, err := telemetry.NewJaegerTracer(&cfg.Jaeger, appLogger)
 		if err != nil {
 			appLogger.Fatalf("Could not initialize jaeger tracer: %v", err.Error())
 		}

--- a/packages/server/customer-os-api/config/config.go
+++ b/packages/server/customer-os-api/config/config.go
@@ -7,7 +7,6 @@ import (
 	commonconf "github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/validator"
 	"github.com/joho/godotenv"
 
@@ -21,7 +20,7 @@ type Config struct {
 
 type CommonConfig struct {
 	Logger         logger.Config
-	Jaeger         tracing.JaegerConfig
+	Jaeger         telemetry.JaegerConfig
 	OpenTelemetry  telemetry.OpenTelemetryConfig
 	RabbitMQConfig commonconf.RabbitMQConfig
 	Postgres       commonconf.PostgresConfig
@@ -83,7 +82,7 @@ type GraphQLConfig struct {
 }
 
 type ObservabilityConfig struct {
-	Jaeger        tracing.JaegerConfig
+	Jaeger        telemetry.JaegerConfig
 	Metrics       metrics.Config
 	OpenTelemetry telemetry.OpenTelemetryConfig
 }

--- a/packages/server/customer-os-api/graphql/resolver/mailstack.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/mailstack.resolvers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
 	"github.com/customeros/customeros/packages/server/customer-os-api/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	opentracing "github.com/opentracing/opentracing-go"
 	tracingLog "github.com/opentracing/opentracing-go/log"
@@ -65,12 +66,14 @@ func (r *mutationResolver) MailstackRegisterBuyDomainsWithMailboxes(ctx context.
 
 // MailstackDomainPurchaseSuggestions is the resolver for the mailstack_DomainPurchaseSuggestions field.
 func (r *queryResolver) MailstackDomainPurchaseSuggestions(ctx context.Context, domain string) ([]string, error) {
-	ctx, span := tracing.StartGraphQLTracerSpan(ctx, "QueryResolver.MailstackDomainPurchaseSuggestions", graphql.GetOperationContext(ctx))
-	defer span.Finish()
-	tracing.SetDefaultResolverSpanTags(ctx, span)
-	span.LogKV("request.domain", domain)
+	spans, ctx := telemetry.StartGraphQLSpan(ctx, "QueryResolver.MailstackDomainPurchaseSuggestions", graphql.GetOperationContext(ctx))
+	defer spans.Finish()
+	spans.LogKV("request.domain", domain)
 
 	tenant := common.GetTenantFromContext(ctx)
+
+	// remove all spaces from domain
+	domain = strings.ReplaceAll(domain, " ", "")
 
 	// Strip TLD if present
 	if strings.Contains(domain, ".") {
@@ -79,10 +82,14 @@ func (r *queryResolver) MailstackDomainPurchaseSuggestions(ctx context.Context, 
 
 	// Call service to get domain recommendations
 	statusCode, errorMsg, recommendations, err := r.Services.CommonServices.MailstackService.RecommendDomain(ctx, tenant, domain)
+	if err != nil {
+		spans.TraceError(err)
+	}
 	if err != nil || statusCode != http.StatusOK {
 		if errorMsg != "" {
 			graphql.AddErrorf(ctx, errorMsg)
 		} else {
+			spans.TraceError(errors.New("Failed to get domain recommendations"))
 			graphql.AddErrorf(ctx, "Failed to get domain recommendations")
 		}
 		return nil, nil

--- a/packages/server/customer-os-api/server/server.go
+++ b/packages/server/customer-os-api/server/server.go
@@ -78,7 +78,7 @@ func (server *server) Run(parentCtx context.Context) error {
 	}
 
 	// Setting up tracing
-	tracer, closer, err := tracing.NewJaegerTracer(&server.cfg.App.Observability.Jaeger, server.log)
+	tracer, closer, err := telemetry.NewJaegerTracer(&server.cfg.App.Observability.Jaeger, server.log)
 	if err != nil {
 		server.log.Fatalf("Could not initialize jaeger tracer: %s", err.Error())
 	}

--- a/packages/server/customer-os-common-module/config/common_config.go
+++ b/packages/server/customer-os-common-module/config/common_config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 )
 
 type CommonConfig struct {
@@ -20,7 +19,7 @@ type InfrastructureConfig struct {
 	AzureOAuthConfig    AzureOAuthConfig
 	RabbitMQConfig      RabbitMQConfig
 	OpensearchConfig    OpensearchConfig
-	JaegerConfig        tracing.JaegerConfig
+	JaegerConfig        telemetry.JaegerConfig
 	OpenTelemetryConfig telemetry.OpenTelemetryConfig
 	LoggerConfig        logger.Config
 }

--- a/packages/server/customer-os-common-module/telemetry/jaeger.go
+++ b/packages/server/customer-os-common-module/telemetry/jaeger.go
@@ -1,11 +1,12 @@
-package tracing
+package telemetry
 
 import (
+	"io"
+
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/jaeger-client-go/config"
 	"github.com/uber/jaeger-client-go/log/zap"
-	"io"
 )
 
 type JaegerConfig struct {

--- a/packages/server/customer-os-webhooks/server/server.go
+++ b/packages/server/customer-os-webhooks/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"os"
 	"os/signal"
 	"syscall"
@@ -48,7 +49,7 @@ func (server *server) Run(parentCtx context.Context) error {
 	}
 
 	// Setting up tracing
-	tracer, closer, err := tracing.NewJaegerTracer(&server.cfg.Common.Infrastructure.JaegerConfig, server.log)
+	tracer, closer, err := telemetry.NewJaegerTracer(&server.cfg.Common.Infrastructure.JaegerConfig, server.log)
 	if err != nil {
 		server.log.Fatalf("Could not initialize jaeger tracer: %s", err.Error())
 	}

--- a/packages/server/events-subscribers/config/config.go
+++ b/packages/server/events-subscribers/config/config.go
@@ -7,7 +7,6 @@ import (
 	commonconf "github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/joho/godotenv"
 )
 
@@ -22,7 +21,7 @@ type AppConfig struct {
 
 type CommonConfig struct {
 	Logger           logger.Config
-	Jaeger           tracing.JaegerConfig
+	Jaeger           telemetry.JaegerConfig
 	OpenTelemetry    telemetry.OpenTelemetryConfig
 	Postgres         commonconf.PostgresConfig
 	PostgresAsync    commonconf.PostgresAsyncConfig

--- a/packages/server/events-subscribers/events_subscribers_main.go
+++ b/packages/server/events-subscribers/events_subscribers_main.go
@@ -14,7 +14,6 @@ import (
 	common_agent_listeners "github.com/customeros/customeros/packages/server/customer-os-common-module/services/agent_listeners"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/events"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	neo4j_repository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
@@ -82,7 +81,7 @@ func (a *App) Initialize() error {
 
 func (a *App) initTracing() error {
 	if a.config.Common.Infrastructure.JaegerConfig.Enabled {
-		tracer, closer, err := tracing.NewJaegerTracer(&a.config.Common.Infrastructure.JaegerConfig, a.logger)
+		tracer, closer, err := telemetry.NewJaegerTracer(&a.config.Common.Infrastructure.JaegerConfig, a.logger)
 		if err != nil {
 			return fmt.Errorf("could not initialize jaeger tracer: %w", err)
 		}

--- a/packages/server/mailsherpa-api/config/config.go
+++ b/packages/server/mailsherpa-api/config/config.go
@@ -4,7 +4,6 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 )
 
 type Config struct {
@@ -12,7 +11,7 @@ type Config struct {
 	AppKey              string `env:"APP_KEY" envDefault:"" validate:"required"`
 	PostgresConfig      config.PostgresConfig
 	PostgresAsyncConfig config.PostgresAsyncConfig
-	Jaeger              tracing.JaegerConfig
+	Jaeger              telemetry.JaegerConfig
 	OpenTelemetry       telemetry.OpenTelemetryConfig
 	Logger              logger.Config
 	EmailConfig         EmailConfig

--- a/packages/server/mailsherpa-api/mailsherpa_api_main.go
+++ b/packages/server/mailsherpa-api/mailsherpa_api_main.go
@@ -98,7 +98,7 @@ func initLogger(cfg *config.Config) logger.Logger {
 
 func initTracing(cfg *config.Config, appLogger logger.Logger) io.Closer {
 	if cfg.Jaeger.Enabled {
-		tracer, closer, err := tracing.NewJaegerTracer(&cfg.Jaeger, appLogger)
+		tracer, closer, err := telemetry.NewJaegerTracer(&cfg.Jaeger, appLogger)
 		if err != nil {
 			appLogger.Fatalf("Could not initialize jaeger tracer: %v", err.Error())
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor Jaeger tracing configuration by moving it to the `telemetry` package and update related imports and function calls across the codebase.
> 
>   - **Refactoring**:
>     - Move `JaegerConfig` from `tracing` to `telemetry` package.
>     - Update imports from `tracing` to `telemetry` in `config.go`, `main.go`, and other files across multiple packages.
>     - Rename `tracing.NewJaegerTracer` to `telemetry.NewJaegerTracer` in `customer_os_data_upkeeper_main.go`, `integrity_checker_main.go`, `sync_slack_main.go`, `apigator/main.go`, `server.go`, and other files.
>   - **Enhancements**:
>     - In `mailstack.resolvers.go`, `MailstackDomainPurchaseSuggestions` now removes spaces from domain names before processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 0ae19c2dbc7f68b2a15977452e540b9b4c84d318. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->