### PR TITLE
move to new tracing p1

### DIFF
--- a/packages/server/customer-os-common-module/telemetry/helpers.go
+++ b/packages/server/customer-os-common-module/telemetry/helpers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -903,4 +904,20 @@ func GraphQLTracingEnhancer(ctx context.Context) func(c *gin.Context) {
 			spans.TraceError(nil)
 		}
 	}
+}
+
+func GetTraceIds(spans *Spans) (string, string) {
+	if spans == nil {
+		return "", ""
+	}
+	jaegerTraceId := ""
+	otelTraceId := ""
+	if spans.Jaeger != nil {
+		tracingData := ExtractTextMapCarrier((spans.Jaeger).Context())
+		jaegerTraceId = strings.Split(tracingData["uber-trace-id"], ":")[0]
+	}
+	if spans.OTel != nil {
+		otelTraceId = spans.OTel.SpanContext().TraceID().String()
+	}
+	return jaegerTraceId, otelTraceId
 }

--- a/packages/server/customer-os-common-module/telemetry/jaeger.go
+++ b/packages/server/customer-os-common-module/telemetry/jaeger.go
@@ -44,3 +44,19 @@ func initJaeger(jaegerConfig *JaegerConfig) *config.Configuration {
 	}
 	return cfg
 }
+
+func ExtractTextMapCarrier(spanCtx opentracing.SpanContext) opentracing.TextMapCarrier {
+	textMapCarrier, err := InjectTextMapCarrier(spanCtx)
+	if err != nil {
+		return make(opentracing.TextMapCarrier)
+	}
+	return textMapCarrier
+}
+
+func InjectTextMapCarrier(spanCtx opentracing.SpanContext) (opentracing.TextMapCarrier, error) {
+	m := make(opentracing.TextMapCarrier)
+	if err := opentracing.GlobalTracer().Inject(spanCtx, opentracing.TextMap, m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/packages/server/customer-os-postgres-repository/repository/agent_execution_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agent_execution_repository.go
@@ -3,14 +3,13 @@ package postgres_repository
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"gorm.io/gorm"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -42,14 +41,13 @@ func NewAgentExecutionRepository(gormDb *gorm.DB) AgentExecutionRepository {
 }
 
 func (f *agentExecutionRepository) Create(ctx context.Context, executionRecord postgres_entity.AgentExecution) (*postgres_entity.AgentExecution, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.Create")
+	defer spans.Finish()
 
 	if executionRecord.AgentID == nil {
-		span.LogFields(log.Object("executionRecord", executionRecord))
+		spans.LogObjectAsJson("executionRecord", executionRecord)
 		err := errors.New("agent or executionID missing")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if executionRecord.Tenant == "" {
@@ -58,7 +56,7 @@ func (f *agentExecutionRepository) Create(ctx context.Context, executionRecord p
 
 	err := f.gormDb.Create(&executionRecord).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -66,18 +64,16 @@ func (f *agentExecutionRepository) Create(ctx context.Context, executionRecord p
 }
 
 func (f *agentExecutionRepository) Completed(ctx context.Context, executionID string, goalAchieved *bool) (*postgres_entity.AgentExecution, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.Completed")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, executionID)
-	span.LogFields(log.String("executionID", executionID))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.Completed")
+	defer spans.Finish()
+	spans.TagEntity(executionID)
 	if goalAchieved != nil {
-		span.LogFields(log.Bool("goalAchieved", *goalAchieved))
+		spans.LogKV("goalAchieved", *goalAchieved)
 	}
 
 	if executionID == "" {
 		err := errors.New("ID is missing")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -98,7 +94,7 @@ func (f *agentExecutionRepository) Completed(ctx context.Context, executionID st
 		First(&updatedRecord, "id = ?", executionID).
 		Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -106,10 +102,9 @@ func (f *agentExecutionRepository) Completed(ctx context.Context, executionID st
 }
 
 func (f *agentExecutionRepository) Finish(ctx context.Context, executionID string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.Finish")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("executionID", executionID))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.Finish")
+	defer spans.Finish()
+	spans.TagEntity(executionID)
 
 	err := f.gormDb.
 		Model(&postgres_entity.AgentExecution{}).
@@ -121,17 +116,16 @@ func (f *agentExecutionRepository) Finish(ctx context.Context, executionID strin
 		}).
 		Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (f *agentExecutionRepository) Fail(ctx context.Context, executionID, errorMessage string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.Fail")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("executionID", executionID))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.Fail")
+	defer spans.Finish()
+	spans.TagEntity(executionID)
 
 	err := f.gormDb.
 		Model(&postgres_entity.AgentExecution{}).
@@ -143,21 +137,20 @@ func (f *agentExecutionRepository) Fail(ctx context.Context, executionID, errorM
 		}).
 		Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (f *agentExecutionRepository) Pending(ctx context.Context, executionID string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.Pending")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("executionID", executionID))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.Pending")
+	defer spans.Finish()
+	spans.TagEntity(executionID)
 
 	if executionID == "" {
 		err := errors.New("executionID is missing")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -172,39 +165,37 @@ func (f *agentExecutionRepository) Pending(ctx context.Context, executionID stri
 		}).
 		Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (f *agentExecutionRepository) Find(ctx context.Context, executionRecord postgres_entity.AgentExecution) (*postgres_entity.AgentExecution, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.Find")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.Find")
+	defer spans.Finish()
+	spans.TagEntity(executionRecord.ID)
 
 	var agentExecution postgres_entity.AgentExecution
 	err := f.gormDb.
 		Where(&executionRecord).
 		First(&agentExecution).Error
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return &agentExecution, nil
 }
 
 func (f *agentExecutionRepository) GetById(ctx context.Context, executionID string) (*postgres_entity.AgentExecution, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("executionID", executionID))
-	tracing.TagEntity(span, executionID)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.GetById")
+	defer spans.Finish()
+	spans.TagEntity(executionID)
 
 	var agentExecution postgres_entity.AgentExecution
 	err := f.gormDb.
@@ -212,27 +203,27 @@ func (f *agentExecutionRepository) GetById(ctx context.Context, executionID stri
 		First(&agentExecution).
 		Error
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return &agentExecution, nil
 }
 
 func (f *agentExecutionRepository) ScheduleRetry(ctx context.Context, executionID string, inputError error, stateData map[string]any) (*time.Time, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.ScheduleRetry")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("executionID", executionID))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.ScheduleRetry")
+	defer spans.Finish()
+	spans.TagEntity(executionID)
+
 	if inputError == nil {
-		span.LogFields(log.String("inputError", "nil"))
+		spans.LogKV("inputError", "nil")
 	} else {
-		span.LogFields(log.String("inputError", inputError.Error()))
+		spans.LogKV("inputError", inputError.Error())
 	}
 
 	execution := &postgres_entity.AgentExecution{}
@@ -242,9 +233,10 @@ func (f *agentExecutionRepository) ScheduleRetry(ctx context.Context, executionI
 	}
 
 	// Prepare update fields
+	jaegerTraceId, otelTraceId := telemetry.GetTraceIds(spans)
 	updateFields := map[string]any{
 		"state_data":      stateData,
-		"trace_id_latest": tracing.GetTraceId(span),
+		"trace_id_latest": fmt.Sprintf("jaeger: %s , otel: %s", jaegerTraceId, otelTraceId),
 	}
 
 	// Increment retry count and set next retry time if it's not the first scheduling
@@ -292,10 +284,9 @@ func (f *agentExecutionRepository) ScheduleRetry(ctx context.Context, executionI
 }
 
 func (f *agentExecutionRepository) SaveAsyncState(ctx context.Context, executionID string, currentStep string, stateData map[string]any) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.SaveAsyncState")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("executionID", executionID))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.SaveAsyncState")
+	defer spans.Finish()
+	spans.TagEntity(executionID)
 
 	return f.gormDb.Model(&postgres_entity.AgentExecution{}).
 		Where("id = ?", executionID).
@@ -307,10 +298,9 @@ func (f *agentExecutionRepository) SaveAsyncState(ctx context.Context, execution
 }
 
 func (f *agentExecutionRepository) CompleteStep(ctx context.Context, executionID string, step string, result map[string]any) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.CompleteStep")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("executionID", executionID))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.CompleteStep")
+	defer spans.Finish()
+	spans.TagEntity(executionID)
 
 	// First get the current execution to check/initialize checkpoints
 	execution := &postgres_entity.AgentExecution{}
@@ -337,15 +327,14 @@ func (f *agentExecutionRepository) CompleteStep(ctx context.Context, executionID
 }
 
 func (f *agentExecutionRepository) GoalAchieved(ctx context.Context, executionID string, goalAchieved bool, impactedId *string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.GoalAchieved")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, executionID)
-	span.LogFields(log.Bool("goalAchieved", goalAchieved))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.GoalAchieved")
+	defer spans.Finish()
+	spans.TagEntity(executionID)
+	spans.LogKV("goalAchieved", goalAchieved)
 
 	if executionID == "" {
 		err := errors.New("ID is missing")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -363,7 +352,7 @@ func (f *agentExecutionRepository) GoalAchieved(ctx context.Context, executionID
 		Updates(fieldsToUpdate).
 		Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -371,9 +360,9 @@ func (f *agentExecutionRepository) GoalAchieved(ctx context.Context, executionID
 }
 
 func (r *agentExecutionRepository) GetGoalAchievedCountLast30Days(ctx context.Context, agentID string) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.GetGoalAchievedCountLast30Days")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.GetGoalAchievedCountLast30Days")
+	defer spans.Finish()
+	spans.TagEntity(agentID)
 
 	var count int64
 	thirtyDaysAgo := time.Now().AddDate(0, 0, -30)
@@ -382,7 +371,7 @@ func (r *agentExecutionRepository) GetGoalAchievedCountLast30Days(ctx context.Co
 		Where("agent_id = ? AND goal_achieved = true AND updated_at >= ?", agentID, thirtyDaysAgo).
 		Count(&count).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return 0, err
 	}
 
@@ -390,10 +379,9 @@ func (r *agentExecutionRepository) GetGoalAchievedCountLast30Days(ctx context.Co
 }
 
 func (f *agentExecutionRepository) GetExecutionsForRetry(ctx context.Context, limit int) ([]postgres_entity.AgentExecution, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.GetExecutionsForRetry")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.GetExecutionsForRetry")
+	defer spans.Finish()
+	spans.LogKV("limit", limit)
 
 	var executions []postgres_entity.AgentExecution
 	err := f.gormDb.
@@ -404,18 +392,18 @@ func (f *agentExecutionRepository) GetExecutionsForRetry(ctx context.Context, li
 		Find(&executions).
 		Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogKV("result.count", len(executions))
+	spans.LogKV("result.count", len(executions))
 	return executions, nil
 }
 
 func (f *agentExecutionRepository) GetGoalAchievedImpactedIdsLast30Days(ctx context.Context, agentID string) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentExecutionRepository.GetGoalAchievedImpactedIdsLast30Days")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentExecutionRepository.GetGoalAchievedImpactedIdsLast30Days")
+	defer spans.Finish()
+	spans.TagEntity(agentID)
 
 	var impactedIds []string
 	thirtyDaysAgo := time.Now().AddDate(0, 0, -30)
@@ -425,13 +413,13 @@ func (f *agentExecutionRepository) GetGoalAchievedImpactedIdsLast30Days(ctx cont
 		Pluck("impacted_id", &impactedIds).
 		Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	impactedIds = utils.RemoveEmpties(impactedIds)
 	impactedIds = utils.RemoveDuplicates(impactedIds)
 
-	span.LogFields(log.Int("result.count", len(impactedIds)))
+	spans.LogKV("result.count", len(impactedIds))
 	return impactedIds, nil
 }

--- a/packages/server/customer-os-postgres-repository/repository/agent_registry_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agent_registry_repository.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/opentracing/opentracing-go/log"
 	"strings"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/opentracing/opentracing-go"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"gorm.io/gorm"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -41,77 +39,72 @@ func NewAgentRegistryRepository(gormDb *gorm.DB) AgentRegistryRepository {
 }
 
 func (r *agentRegistryRepository) FindAll(ctx context.Context) ([]postgres_entity.AgentRegistry, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRegistryRepository.FindAll")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRegistryRepository.FindAll")
+	defer spans.Finish()
 
 	var agents []postgres_entity.AgentRegistry
 	err := r.gormDb.WithContext(ctx).
 		Where("is_active = ?", true).
 		Find(&agents).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to find agents: %w", err)
 	}
 
-	span.LogFields(log.Int("result.count", len(agents)))
+	spans.LogKV("result.count", len(agents))
 	return agents, nil
 }
 
 func (r *agentRegistryRepository) FindPlay(ctx context.Context, agentType enum.AgentType, triggerEvent enum.AgentListenerEvent) (*postgres_entity.AgentPlay, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRegistryRepository.FindPlay")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(
-		log.String("agentType", agentType.String()),
-		log.String("triggerEvent", triggerEvent.String()))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRegistryRepository.FindPlay")
+	defer spans.Finish()
+	spans.LogKV("agentType", agentType.String())
+	spans.LogKV("triggerEvent", triggerEvent.String())
 
 	var play postgres_entity.AgentPlay
 	err := r.gormDb.WithContext(ctx).
 		Where("agent_type = ? AND trigger_event = ?", agentType.String(), triggerEvent.String()).
 		First(&play).Error
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to find play for agent type %s and trigger %s: %w",
 			agentType.String(), triggerEvent.String(), err)
 	}
 
-	span.LogFields(log.Bool("result.found", true))
-	span.LogFields(log.String("play.capabilities", strings.Join(play.Capabilities, ",")))
+	spans.LogKV("result.found", true)
+	spans.LogKV("play.capabilities", strings.Join(play.Capabilities, ","))
 	return &play, nil
 }
 
 func (r *agentRegistryRepository) FindByType(ctx context.Context, agentType enum.AgentType) (*postgres_entity.AgentRegistry, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRegistryRepository.FindByType")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("agentType", agentType.String()))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRegistryRepository.FindByType")
+	defer spans.Finish()
+	spans.LogKV("agentType", agentType.String())
 
 	var agent postgres_entity.AgentRegistry
 	err := r.gormDb.WithContext(ctx).
 		Where("is_active = ? AND type = ?", true, agentType.String()).
 		First(&agent).Error
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to find agent: %w", err)
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return &agent, nil
 }
 
 func (r *agentRegistryRepository) Create(ctx context.Context, agent postgres_entity.AgentRegistry, plays []postgres_entity.AgentPlay) (*postgres_entity.AgentRegistry, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRegistryRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRegistryRepository.Create")
+	defer spans.Finish()
 
 	err := r.gormDb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Check for existing agent with same type
@@ -144,7 +137,7 @@ func (r *agentRegistryRepository) Create(ctx context.Context, agent postgres_ent
 		return nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, fmt.Errorf("%w: %v", ErrAgentCreateFailed, err)
 	}
 
@@ -152,9 +145,8 @@ func (r *agentRegistryRepository) Create(ctx context.Context, agent postgres_ent
 }
 
 func (r *agentRegistryRepository) Update(ctx context.Context, agent postgres_entity.AgentRegistry, plays []postgres_entity.AgentPlay) (*postgres_entity.AgentRegistry, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRegistryRepository.Update")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRegistryRepository.Update")
+	defer spans.Finish()
 
 	if agent.ID == "" {
 		return nil, ErrAgentIDMissing
@@ -202,7 +194,7 @@ func (r *agentRegistryRepository) Update(ctx context.Context, agent postgres_ent
 		return tx.First(&updatedAgent, "id = ?", agent.ID).Error
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to update agent: %w", err)
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/agents_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/agents_repository.go
@@ -7,9 +7,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"gorm.io/gorm"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -40,10 +38,9 @@ func NewAgentRepository(gormDb *gorm.DB) AgentRepository {
 }
 
 func (f *agentsRepository) GetById(ctx context.Context, id string) (*postgres_entity.Agent, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("id", id))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.GetById")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	var agent postgres_entity.Agent
 	err := f.gormDb.
@@ -57,28 +54,27 @@ func (f *agentsRepository) GetById(ctx context.Context, id string) (*postgres_en
 		First(&agent).
 		Error
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return &agent, nil
 }
 
 func (f *agentsRepository) Create(ctx context.Context, agent postgres_entity.Agent) (*postgres_entity.Agent, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.Create")
+	defer spans.Finish()
 
 	if agent.Scope == enum.AgentScopePersonal {
 		agent.Owner = common.GetUserIdFromContext(ctx)
 		if agent.Owner == "" {
 			err := errors.New("UserID not set on context")
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 	}
@@ -86,7 +82,7 @@ func (f *agentsRepository) Create(ctx context.Context, agent postgres_entity.Age
 	agent.Tenant = common.GetTenantFromContext(ctx)
 	if agent.Tenant == "" {
 		err := errors.New("tenant not set on context")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -98,7 +94,7 @@ func (f *agentsRepository) Create(ctx context.Context, agent postgres_entity.Age
 		return nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -109,7 +105,7 @@ func (f *agentsRepository) Create(ctx context.Context, agent postgres_entity.Age
 	}).Preload("Listeners", func(db *gorm.DB) *gorm.DB {
 		return db.Order("position ASC")
 	}).First(&created, "id = ?", agent.ID).Error; err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -117,14 +113,13 @@ func (f *agentsRepository) Create(ctx context.Context, agent postgres_entity.Age
 }
 
 func (f *agentsRepository) GetAll(ctx context.Context) ([]*postgres_entity.Agent, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.GetAll")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.GetAll")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {
 		err := errors.New("tenant not set")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -145,23 +140,22 @@ func (f *agentsRepository) GetAll(ctx context.Context) ([]*postgres_entity.Agent
 
 	err := query.Find(&agents).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(agents)))
+	spans.LogKV("result.count", len(agents))
 	return agents, nil
 }
 
 func (f *agentsRepository) GetAllAgentsByTypes(ctx context.Context, agentTypes []enum.AgentType) ([]postgres_entity.Agent, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.GetAllAgentsByTypes")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.GetAllAgentsByTypes")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {
 		err := errors.New("tenant not set")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -185,17 +179,16 @@ func (f *agentsRepository) GetAllAgentsByTypes(ctx context.Context, agentTypes [
 
 	err := query.Find(&records).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	return records, nil
 }
 
 func (f *agentsRepository) GetAllAgentsByTypesCrossTenant(ctx context.Context, agentTypes []enum.AgentType) ([]postgres_entity.Agent, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.GetAllAgentsByTypesCrossTenant")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("agentTypes", agentTypes))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.GetAllAgentsByTypesCrossTenant")
+	defer spans.Finish()
+	spans.LogKV("agentTypes", agentTypes)
 
 	var records []postgres_entity.Agent
 	types := make([]string, len(agentTypes))
@@ -216,22 +209,21 @@ func (f *agentsRepository) GetAllAgentsByTypesCrossTenant(ctx context.Context, a
 
 	err := query.Find(&records).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(records)))
+	spans.LogKV("result.count", len(records))
 	return records, nil
 }
 
 func (f *agentsRepository) GetActiveConfiguredAgentsByTypes(ctx context.Context, agentTypes []enum.AgentType) ([]postgres_entity.Agent, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.GetActiveConfiguredAgentsByTypes")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.GetActiveConfiguredAgentsByTypes")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {
 		err := errors.New("tenant not set")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -255,26 +247,25 @@ func (f *agentsRepository) GetActiveConfiguredAgentsByTypes(ctx context.Context,
 
 	err := query.Find(&records).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(records)))
+	spans.LogKV("result.count", len(records))
 	return records, nil
 }
 
 func (f *agentsRepository) GetActiveConfiguredAgentsByUserAndType(ctx context.Context, agentTypes []enum.AgentType) ([]postgres_entity.Agent, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.GetActiveConfiguredAgentsByUserAndType")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.GetActiveConfiguredAgentsByUserAndType")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {
-		tracing.TraceErr(span, coserrors.ErrTenantNotSet)
+		spans.TraceError(coserrors.ErrTenantNotSet)
 		return nil, coserrors.ErrTenantNotSet
 	}
 	user := common.GetUserIdFromContext(ctx)
 	if user == "" {
-		tracing.TraceErr(span, coserrors.ErrUserIDNotSet)
+		spans.TraceError(coserrors.ErrUserIDNotSet)
 		return nil, coserrors.ErrUserIDNotSet
 	}
 
@@ -298,17 +289,16 @@ func (f *agentsRepository) GetActiveConfiguredAgentsByUserAndType(ctx context.Co
 
 	err := query.Find(&records).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	return records, nil
 }
 
 func (f *agentsRepository) GetActiveConfiguredAgentsByTypesCrossTenant(ctx context.Context, agentTypes []enum.AgentType) ([]postgres_entity.Agent, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.GetActiveConfiguredAgentsByTypesCrossTenant")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "agentTypes", agentTypes)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.GetActiveConfiguredAgentsByTypesCrossTenant")
+	defer spans.Finish()
+	spans.LogKV("agentTypes", agentTypes)
 
 	var records []postgres_entity.Agent
 	types := make([]string, len(agentTypes))
@@ -330,22 +320,21 @@ func (f *agentsRepository) GetActiveConfiguredAgentsByTypesCrossTenant(ctx conte
 
 	err := query.Find(&records).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(records)))
+	spans.LogKV("result.count", len(records))
 	return records, nil
 }
 
 func (f *agentsRepository) Update(ctx context.Context, agent postgres_entity.Agent) (*postgres_entity.Agent, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.Update")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "agentEntity", agent)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.Update")
+	defer spans.Finish()
+	spans.LogObjectAsJson("agentEntity", agent)
 
 	if agent.ID == "" {
 		err := errors.New("agent ID is missing")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -357,7 +346,7 @@ func (f *agentsRepository) Update(ctx context.Context, agent postgres_entity.Age
 		return nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -371,7 +360,7 @@ func (f *agentsRepository) Update(ctx context.Context, agent postgres_entity.Age
 			return db.Order("position ASC")
 		}).
 		First(&updatedAgent, "id = ?", agent.ID).Error; err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -379,9 +368,9 @@ func (f *agentsRepository) Update(ctx context.Context, agent postgres_entity.Age
 }
 
 func (f *agentsRepository) UpdateCapabilities(ctx context.Context, capabilities []postgres_entity.Capability) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.UpdateCapabilities")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.UpdateCapabilities")
+	defer spans.Finish()
+	spans.LogKV("capabilities", capabilities)
 
 	return f.gormDb.Transaction(func(tx *gorm.DB) error {
 		for _, capability := range capabilities {
@@ -391,7 +380,7 @@ func (f *agentsRepository) UpdateCapabilities(ctx context.Context, capabilities 
 			}
 			// Save() will update the record with the primary key cap.ID.
 			if err := tx.Save(&capability).Error; err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				return err
 			}
 		}
@@ -400,9 +389,9 @@ func (f *agentsRepository) UpdateCapabilities(ctx context.Context, capabilities 
 }
 
 func (f *agentsRepository) UpdateListeners(ctx context.Context, listeners []postgres_entity.Listener) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.UpdateListeners")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.UpdateListeners")
+	defer spans.Finish()
+	spans.LogKV("listeners", listeners)
 
 	return f.gormDb.Transaction(func(tx *gorm.DB) error {
 		for _, listener := range listeners {
@@ -412,7 +401,7 @@ func (f *agentsRepository) UpdateListeners(ctx context.Context, listeners []post
 			}
 			// Save() will update the record with the primary key listener.ID.
 			if err := tx.Save(&listener).Error; err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				return err
 			}
 		}
@@ -421,13 +410,10 @@ func (f *agentsRepository) UpdateListeners(ctx context.Context, listeners []post
 }
 
 func (f *agentsRepository) FindCapability(ctx context.Context, agentID string, capabilityType enum.AgentCapability) (*postgres_entity.Capability, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.FindActiveCapability")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(
-		log.String("agentID", agentID),
-		log.String("capabilityType", capabilityType.String()),
-	)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.FindActiveCapability")
+	defer spans.Finish()
+	spans.LogKV("agentID", agentID)
+	spans.LogKV("capabilityType", capabilityType.String())
 
 	var capability postgres_entity.Capability
 	err := f.gormDb.
@@ -435,29 +421,28 @@ func (f *agentsRepository) FindCapability(ctx context.Context, agentID string, c
 		First(&capability).
 		Error
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", true))
-	span.LogFields(log.String("result.capabilityId", capability.ID))
+	spans.LogKV("result.found", true)
+	spans.LogKV("result.capabilityId", capability.ID)
 	return &capability, nil
 }
 
 func (f *agentsRepository) Delete(ctx context.Context, id string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AgentRepository.Delete")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("id", id))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "AgentRepository.Delete")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {
 		err := errors.New("tenant not set")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -468,25 +453,25 @@ func (f *agentsRepository) Delete(ctx context.Context, id string) error {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return errors.New("agent not found or access denied")
 			}
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 
 		// Delete capabilities
 		if err := tx.Where("agent_id = ?", id).Delete(&postgres_entity.Capability{}).Error; err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 
 		// Delete listeners
 		if err := tx.Where("agent_id = ?", id).Delete(&postgres_entity.Listener{}).Error; err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 
 		// Delete the agent
 		if err := tx.Delete(&postgres_entity.Agent{}, "id = ?", id).Error; err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 

--- a/packages/server/customer-os-postgres-repository/repository/ai_location_mapping_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/ai_location_mapping_repository.go
@@ -1,8 +1,7 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/opentracing/opentracing-go"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 
@@ -23,13 +22,12 @@ func NewAiLocationMappingRepository(gormDb *gorm.DB) AiLocationMappingRepository
 }
 
 func (r aiLocationMappingRepository) AddLocationMapping(ctx context.Context, aiLocationMapping postgres_entity.AiLocationMapping) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "AiLocationMappingRepository.AddLocationMapping")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "AiLocationMappingRepository.AddLocationMapping")
+	defer spans.Finish()
 
 	err := r.gormDb.Create(&aiLocationMapping).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -37,9 +35,8 @@ func (r aiLocationMappingRepository) AddLocationMapping(ctx context.Context, aiL
 }
 
 func (r aiLocationMappingRepository) GetLatestLocationMappingByInput(ctx context.Context, input string) (*postgres_entity.AiLocationMapping, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "AiLocationMappingRepository.GetLatestLocationMappingByInput")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "AiLocationMappingRepository.GetLatestLocationMappingByInput")
+	defer spans.Finish()
 
 	var aiLocationMapping postgres_entity.AiLocationMapping
 	err := r.gormDb.Where("input = ?", input).Order("created_at desc").First(&aiLocationMapping).Error
@@ -47,7 +44,7 @@ func (r aiLocationMappingRepository) GetLatestLocationMappingByInput(ctx context
 		if err == gorm.ErrRecordNotFound {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/api_billable_event_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/api_billable_event_repository.go
@@ -3,9 +3,8 @@ package postgres_repository
 import (
 	"context"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 
@@ -33,14 +32,14 @@ func NewApiBillableEventRepository(db *gorm.DB) ApiBillableEventRepository {
 
 // Register creates a new ApiBillableEvent and stores it in the database
 func (r *apiBillableEventRepository) RegisterEvent(ctx context.Context, tenant string, event postgres_entity.BillableEvent, details BillableEventDetails) (*postgres_entity.ApiBillableEvent, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "BillableEventRepository.RegisterEvent")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("event", event)
-	span.LogKV("externalID", details.ExternalID)
-	span.LogKV("referenceData", details.ReferenceData)
-	span.LogKV("subtype", details.Subtype)
-	span.LogKV("source", details.Source)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "BillableEventRepository.RegisterEvent")
+	defer spans.Finish()
+
+	spans.LogKV("event", event)
+	spans.LogKV("externalID", details.ExternalID)
+	spans.LogKV("referenceData", details.ReferenceData)
+	spans.LogKV("subtype", details.Subtype)
+	spans.LogKV("source", details.Source)
 
 	// Construct the ApiBillableEvent postgres_entity
 	billableEvent := postgres_entity.ApiBillableEvent{
@@ -55,7 +54,7 @@ func (r *apiBillableEventRepository) RegisterEvent(ctx context.Context, tenant s
 
 	err := r.gormDb.Create(&billableEvent).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, errors.Wrap(err, "failed to store billable event")
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/browser_automation_run_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/browser_automation_run_repository.go
@@ -1,9 +1,7 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 
@@ -25,30 +23,28 @@ func NewBrowserAutomationRunRepository(gormDb *gorm.DB) BrowserAutomationRunRepo
 }
 
 func (r *browserAutomationRunRepositoryImpl) Get(ctx context.Context, automationType, status string) ([]postgres_entity.BrowserAutomationsRun, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "BrowserAutomationRunRepository.Get")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "BrowserAutomationRunRepository.Get")
+	defer spans.Finish()
 
 	var result []postgres_entity.BrowserAutomationsRun
 	err := r.gormDb.Where("type = ? and status = ? ", automationType, status).Find(&result).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result)))
+	spans.LogKV("result.count", len(result))
 
 	return result, nil
 }
 
 func (r *browserAutomationRunRepositoryImpl) Add(ctx context.Context, input *postgres_entity.BrowserAutomationsRun) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "BrowserAutomationRunRepository.Add")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "BrowserAutomationRunRepository.Add")
+	defer spans.Finish()
 
 	err := r.gormDb.Create(input).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -56,13 +52,12 @@ func (r *browserAutomationRunRepositoryImpl) Add(ctx context.Context, input *pos
 }
 
 func (r *browserAutomationRunRepositoryImpl) MarkAsProcessed(ctx context.Context, id int) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "BrowserAutomationRunRepository.MarkAsProcessed")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "BrowserAutomationRunRepository.MarkAsProcessed")
+	defer spans.Finish()
 
 	err := r.gormDb.Model(&postgres_entity.BrowserAutomationsRun{}).Where("id = ?", id).Update("status", "PROCESSED").Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/browser_automation_run_result_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/browser_automation_run_result_repository.go
@@ -1,9 +1,8 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -21,15 +20,14 @@ func NewBrowserAutomationRunResultRepository(gormDb *gorm.DB) BrowserAutomationR
 }
 
 func (repo *browserAutomationRunResultRepositoryImpl) Get(ctx context.Context, runId int) (*postgres_entity.BrowserAutomationsRunResult, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "BrowserAutomationRunRepository.Get")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "BrowserAutomationRunRepository.Get")
+	defer spans.Finish()
 
 	var result *postgres_entity.BrowserAutomationsRunResult
 	err := repo.gormDb.Where("run_id = ? ", runId).Find(&result).Error
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/browser_config_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/browser_config_repository.go
@@ -2,10 +2,8 @@ package postgres_repository
 
 import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
@@ -27,15 +25,14 @@ func NewBrowserConfigRepository(gormDb *gorm.DB) BrowserConfigRepository {
 }
 
 func (repo *browserConfigRepositoryImpl) Get(ctx context.Context) ([]postgres_entity.BrowserConfig, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "BrowserConfigRepository.Get")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "BrowserConfigRepository.Get")
+	defer spans.Finish()
 
 	var result []postgres_entity.BrowserConfig
 	err := repo.gormDb.Where("session_status = 'VALID'").Find(&result).Error
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -43,9 +40,8 @@ func (repo *browserConfigRepositoryImpl) Get(ctx context.Context) ([]postgres_en
 }
 
 func (repo *browserConfigRepositoryImpl) GetForUser(ctx context.Context, userId string) (*postgres_entity.BrowserConfig, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "BrowserConfigRepository.Get")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "BrowserConfigRepository.Get")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -57,7 +53,7 @@ func (repo *browserConfigRepositoryImpl) GetForUser(ctx context.Context, userId 
 	}
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -65,13 +61,11 @@ func (repo *browserConfigRepositoryImpl) GetForUser(ctx context.Context, userId 
 }
 
 func (r *browserConfigRepositoryImpl) Merge(ctx context.Context, input *postgres_entity.BrowserConfig) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "BrowserConfigRepository.Merge")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "BrowserConfigRepository.Merge")
+	defer spans.Finish()
+	spans.LogObjectAsJson("input", input)
 
 	tenant := common.GetTenantFromContext(ctx)
-
-	span.LogFields(tracingLog.Object("input", input))
 
 	// Check if the browserConfig already exists
 	var browserConfig postgres_entity.BrowserConfig
@@ -80,7 +74,7 @@ func (r *browserConfigRepositoryImpl) Merge(ctx context.Context, input *postgres
 		First(&browserConfig).Error
 
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -93,7 +87,7 @@ func (r *browserConfigRepositoryImpl) Merge(ctx context.Context, input *postgres
 
 		err = r.gormDb.Create(&browserConfig).Error
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	} else {
@@ -102,7 +96,7 @@ func (r *browserConfigRepositoryImpl) Merge(ctx context.Context, input *postgres
 
 		err = r.gormDb.Save(&browserConfig).Error
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}

--- a/packages/server/customer-os-postgres-repository/repository/cache_crust_data_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/cache_crust_data_repository.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -30,12 +29,11 @@ func NewCacheCrustDataRepository(db *gorm.DB) CacheCrustDataRepository {
 }
 
 func (r *cacheCrustDataRepository) Create(ctx context.Context, data postgres_entity.CacheCrustData) (*postgres_entity.CacheCrustData, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CrustDataCacheRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "CrustDataCacheRepository.Create")
+	defer spans.Finish()
 
 	if err := r.db.WithContext(ctx).Create(&data).Error; err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to create crust data cache"))
+		spans.TraceError(errors.Wrap(err, "failed to create crust data cache"))
 		return nil, err
 	}
 
@@ -43,16 +41,15 @@ func (r *cacheCrustDataRepository) Create(ctx context.Context, data postgres_ent
 }
 
 func (r *cacheCrustDataRepository) GetByCompanyAndTitle(ctx context.Context, company string, jobTitle string, ttl time.Duration) ([]*postgres_entity.CacheCrustData, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CrustDataCacheRepository.GetByCompanyAndTitle")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "CrustDataCacheRepository.GetByCompanyAndTitle")
+	defer spans.Finish()
 
 	var result []*postgres_entity.CacheCrustData
 	if err := r.db.WithContext(ctx).
 		Where("request_company_domain = ? AND request_job_title = ?", company, jobTitle).
 		Where("created_at > ?", time.Now().Add(-ttl)).
 		Find(&result).Error; err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to get crust data cache"))
+		spans.TraceError(errors.Wrap(err, "failed to get crust data cache"))
 		return nil, err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/cache_email_enrow_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/cache_email_enrow_repository.go
@@ -3,10 +3,8 @@ package postgres_repository
 import (
 	"time"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
@@ -31,10 +29,9 @@ func NewCacheEmailEnrowRepository(gormDb *gorm.DB) CacheEmailEnrowRepository {
 }
 
 func (r cacheEmailEnrowRepository) RegisterRequest(ctx context.Context, record postgres_entity.CacheEmailEnrow) (*postgres_entity.CacheEmailEnrow, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailEnrowRepository.RegisterRequest")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "record", record)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailEnrowRepository.RegisterRequest")
+	defer spans.Finish()
+	spans.LogObjectAsJson("record", record)
 
 	now := utils.Now()
 	record.CreatedAt = now
@@ -47,12 +44,11 @@ func (r cacheEmailEnrowRepository) RegisterRequest(ctx context.Context, record p
 }
 
 func (r cacheEmailEnrowRepository) AddResponse(ctx context.Context, requestId, qualification, response string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailEnrowRepository.AddResponse")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("requestId", requestId)
-	span.LogKV("qualification", qualification)
-	span.LogKV("response", response)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailEnrowRepository.AddResponse")
+	defer spans.Finish()
+	spans.LogKV("requestId", requestId)
+	spans.LogKV("qualification", qualification)
+	spans.LogKV("response", response)
 
 	// Add response to the request with the given requestId, empty response and latest by created_at
 	err := r.db.
@@ -67,6 +63,7 @@ func (r cacheEmailEnrowRepository) AddResponse(ctx context.Context, requestId, q
 			"updated_at":    utils.Now(),
 		}).Error
 	if err != nil {
+		spans.TraceError(err)
 		return err
 	}
 
@@ -74,10 +71,9 @@ func (r cacheEmailEnrowRepository) AddResponse(ctx context.Context, requestId, q
 }
 
 func (r cacheEmailEnrowRepository) GetAllByEmail(ctx context.Context, email string) ([]postgres_entity.CacheEmailEnrow, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailEnrowRepository.GetAllByEmail")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("email", email)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailEnrowRepository.GetAllByEmail")
+	defer spans.Finish()
+	spans.LogKV("email", email)
 
 	var records []postgres_entity.CacheEmailEnrow
 	err := r.db.Where("email = ?", email).Order("created_at desc").Find(&records).Error
@@ -85,16 +81,15 @@ func (r cacheEmailEnrowRepository) GetAllByEmail(ctx context.Context, email stri
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.Int("result.count", len(records)))
+	spans.LogKV("result.count", len(records))
 
 	return records, nil
 }
 
 func (r cacheEmailEnrowRepository) GetLatestByEmail(ctx context.Context, email string) (*postgres_entity.CacheEmailEnrow, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailEnrowRepository.GetLatestByEmail")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("email", email)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailEnrowRepository.GetLatestByEmail")
+	defer spans.Finish()
+	spans.LogKV("email", email)
 
 	var data postgres_entity.CacheEmailEnrow
 	err := r.db.Where("email = ?", email).Order("created_at desc").First(&data).Error
@@ -102,6 +97,7 @@ func (r cacheEmailEnrowRepository) GetLatestByEmail(ctx context.Context, email s
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil // Return nil if no record found
 		}
+		spans.TraceError(err)
 		return nil, err // Return other errors as usual
 	}
 
@@ -109,9 +105,8 @@ func (r cacheEmailEnrowRepository) GetLatestByEmail(ctx context.Context, email s
 }
 
 func (r cacheEmailEnrowRepository) GetWithoutResponses(ctx context.Context) ([]*postgres_entity.CacheEmailEnrow, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsBetterContactRepository.GetWithoutResponses")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsBetterContactRepository.GetWithoutResponses")
+	defer spans.Finish()
 
 	var postgres_entity []*postgres_entity.CacheEmailEnrow
 	err := r.db.
@@ -119,6 +114,10 @@ func (r cacheEmailEnrowRepository) GetWithoutResponses(ctx context.Context) ([]*
 		Where("created_at < ?", utils.Now().Add(-10*time.Minute)).
 		Limit(50).
 		Find(&postgres_entity).Error
+	if err != nil {
+		spans.TraceError(err)
+		return nil, err
+	}
 
-	return postgres_entity, err
+	return postgres_entity, nil
 }

--- a/packages/server/customer-os-postgres-repository/repository/cache_email_scrubby_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/cache_email_scrubby_repository.go
@@ -3,11 +3,9 @@ package postgres_repository
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"gorm.io/gorm"
 	"time"
 )
@@ -30,10 +28,9 @@ func NewCacheEmailScrubbyRepository(gormDb *gorm.DB) CacheEmailScrubbyRepository
 }
 
 func (r *cacheEmailScrubbyRepository) Save(ctx context.Context, cacheEmailScrubby postgres_entity.CacheEmailScrubby) (*postgres_entity.CacheEmailScrubby, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailScrubbyRepository.Save")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "cacheEmailScrubby", cacheEmailScrubby)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailScrubbyRepository.Save")
+	defer spans.Finish()
+	spans.LogObjectAsJson("cacheEmailScrubby", cacheEmailScrubby)
 
 	now := utils.Now()
 	cacheEmailScrubby.CreatedAt = now
@@ -47,10 +44,9 @@ func (r *cacheEmailScrubbyRepository) Save(ctx context.Context, cacheEmailScrubb
 }
 
 func (r *cacheEmailScrubbyRepository) GetAllByEmail(ctx context.Context, email string) ([]postgres_entity.CacheEmailScrubby, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailScrubbyRepository.GetAllByEmail")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("email", email))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailScrubbyRepository.GetAllByEmail")
+	defer spans.Finish()
+	spans.LogKV("email", email)
 
 	var cacheEmailScrubbys []postgres_entity.CacheEmailScrubby
 	result := r.db.WithContext(ctx).Where("email = ?", email).Order("created_at desc").Find(&cacheEmailScrubbys)
@@ -63,10 +59,9 @@ func (r *cacheEmailScrubbyRepository) GetAllByEmail(ctx context.Context, email s
 }
 
 func (r *cacheEmailScrubbyRepository) GetLatestByEmail(ctx context.Context, email string) (*postgres_entity.CacheEmailScrubby, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailScrubbyRepository.GetLatestByEmail")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("email", email))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailScrubbyRepository.GetLatestByEmail")
+	defer spans.Finish()
+	spans.LogKV("email", email)
 
 	var cacheEmailScrubby postgres_entity.CacheEmailScrubby
 	result := r.db.WithContext(ctx).Where("email = ?", email).Order("created_at desc").First(&cacheEmailScrubby)
@@ -75,6 +70,7 @@ func (r *cacheEmailScrubbyRepository) GetLatestByEmail(ctx context.Context, emai
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		} else {
+			spans.TraceError(result.Error)
 			return nil, result.Error
 		}
 	}
@@ -83,10 +79,10 @@ func (r *cacheEmailScrubbyRepository) GetLatestByEmail(ctx context.Context, emai
 }
 
 func (r *cacheEmailScrubbyRepository) SetStatus(ctx context.Context, email, status string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailScrubbyRepository.SetStatus")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("email", email), log.String("status", status))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailScrubbyRepository.SetStatus")
+	defer spans.Finish()
+	spans.LogKV("email", email)
+	spans.LogKV("status", status)
 
 	result := r.db.WithContext(ctx).
 		Model(&postgres_entity.CacheEmailScrubby{}).
@@ -102,17 +98,16 @@ func (r *cacheEmailScrubbyRepository) SetStatus(ctx context.Context, email, stat
 
 	// If no records were affected, it's not considered an error
 	if result.RowsAffected == 0 {
-		span.LogFields(log.String("message", "No records found for the given email"))
+		spans.LogKV("message", "No records found for the given email")
 	}
 
 	return nil
 }
 
 func (r *cacheEmailScrubbyRepository) SetJustChecked(ctx context.Context, id string) (*postgres_entity.CacheEmailScrubby, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailScrubbyRepository.SetJustChecked")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("id", id))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailScrubbyRepository.SetJustChecked")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	var cacheEmailScrubby postgres_entity.CacheEmailScrubby
 	result := r.db.WithContext(ctx).Where("id = ?", id).First(&cacheEmailScrubby)
@@ -131,10 +126,10 @@ func (r *cacheEmailScrubbyRepository) SetJustChecked(ctx context.Context, id str
 }
 
 func (r *cacheEmailScrubbyRepository) GetToCheck(ctx context.Context, delayFromPreviousCheckInHours, limit int) ([]postgres_entity.CacheEmailScrubby, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailScrubbyRepository.GetToCheck")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.Int("delayFromPreviousCheckInHours", delayFromPreviousCheckInHours), log.Int("limit", limit))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailScrubbyRepository.GetToCheck")
+	defer spans.Finish()
+	spans.LogKV("delayFromPreviousCheckInHours", delayFromPreviousCheckInHours)
+	spans.LogKV("limit", limit)
 
 	var cacheEmailScrubbys []postgres_entity.CacheEmailScrubby
 
@@ -148,6 +143,7 @@ func (r *cacheEmailScrubbyRepository) GetToCheck(ctx context.Context, delayFromP
 		Find(&cacheEmailScrubbys)
 
 	if result.Error != nil {
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/cache_email_trueinbox_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/cache_email_trueinbox_repository.go
@@ -1,11 +1,9 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
@@ -26,10 +24,9 @@ func NewCacheEmailTrueinboxRepository(gormDb *gorm.DB) CacheEmailTrueinboxReposi
 }
 
 func (r cacheEmailTrueinboxRepository) GetAllByEmail(ctx context.Context, email string) ([]postgres_entity.CacheEmailTrueinbox, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailTrueinboxRepository.GetAllByEmail")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(tracingLog.String("email", email))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailTrueinboxRepository.GetAllByEmail")
+	defer spans.Finish()
+	spans.LogKV("email", email)
 
 	var records []postgres_entity.CacheEmailTrueinbox
 	err := r.db.Where("email = ?", email).Order("created_at desc").Find(&records).Error
@@ -37,16 +34,15 @@ func (r cacheEmailTrueinboxRepository) GetAllByEmail(ctx context.Context, email 
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.Int("result.count", len(records)))
+	spans.LogKV("result.count", len(records))
 
 	return records, nil
 }
 
 func (r cacheEmailTrueinboxRepository) GetLatestByEmail(ctx context.Context, email string) (*postgres_entity.CacheEmailTrueinbox, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailTrueinboxRepository.GetLatestByEmail")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(tracingLog.String("email", email))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailTrueinboxRepository.GetLatestByEmail")
+	defer spans.Finish()
+	spans.LogKV("email", email)
 
 	var data postgres_entity.CacheEmailTrueinbox
 	err := r.db.Where("email = ?", email).Order("created_at desc").First(&data).Error
@@ -54,6 +50,7 @@ func (r cacheEmailTrueinboxRepository) GetLatestByEmail(ctx context.Context, ema
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil // Return nil if no record found
 		}
+		spans.TraceError(err)
 		return nil, err // Return other errors as usual
 	}
 
@@ -61,13 +58,13 @@ func (r cacheEmailTrueinboxRepository) GetLatestByEmail(ctx context.Context, ema
 }
 
 func (r cacheEmailTrueinboxRepository) Create(ctx context.Context, record postgres_entity.CacheEmailTrueinbox) (*postgres_entity.CacheEmailTrueinbox, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailTrueinboxRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "record", record)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailTrueinboxRepository.Create")
+	defer spans.Finish()
+	spans.LogObjectAsJson("record", record)
 
 	record.CreatedAt = utils.Now()
 	if err := r.db.WithContext(ctx).Create(&record).Error; err != nil {
+		spans.TraceError(err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/cache_email_validation_domain_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/cache_email_validation_domain_repository.go
@@ -3,11 +3,9 @@ package postgres_repository
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"gorm.io/gorm"
 )
 
@@ -25,10 +23,9 @@ func NewCacheEmailValidationDomainRepository(gormDb *gorm.DB) CacheEmailValidati
 }
 
 func (r cacheEmailValidationDomainRepository) Get(ctx context.Context, domain string) (*postgres_entity.CacheEmailValidationDomain, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailValidationDomainRepository.Get")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("domain", domain))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailValidationDomainRepository.Get")
+	defer spans.Finish()
+	spans.LogKV("domain", domain)
 
 	var cacheEmailValidationDomain postgres_entity.CacheEmailValidationDomain
 	result := r.db.WithContext(ctx).Where("domain = ?", domain).First(&cacheEmailValidationDomain)
@@ -45,10 +42,9 @@ func (r cacheEmailValidationDomainRepository) Get(ctx context.Context, domain st
 }
 
 func (r cacheEmailValidationDomainRepository) Save(ctx context.Context, cacheEmailValidationDomain postgres_entity.CacheEmailValidationDomain) (*postgres_entity.CacheEmailValidationDomain, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailValidationDomainRepository.Save")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "cacheEmailValidationDomain", cacheEmailValidationDomain)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailValidationDomainRepository.Save")
+	defer spans.Finish()
+	spans.LogObjectAsJson("cacheEmailValidationDomain", cacheEmailValidationDomain)
 
 	query := `
         INSERT INTO cache_email_validation_domain (

--- a/packages/server/customer-os-postgres-repository/repository/cache_email_validation_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/cache_email_validation_repository.go
@@ -2,11 +2,9 @@ package postgres_repository
 
 import (
 	"context"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -25,10 +23,9 @@ func NewCacheEmailValidationRepository(gormDb *gorm.DB) CacheEmailValidationRepo
 }
 
 func (r cacheEmailValidationRepository) Get(ctx context.Context, email string) (*postgres_entity.CacheEmailValidation, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailValidationRepository.Get")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("email", email))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailValidationRepository.Get")
+	defer spans.Finish()
+	spans.LogKV("email", email)
 
 	var cacheEmailValidation postgres_entity.CacheEmailValidation
 	result := r.db.WithContext(ctx).Where("email = ?", email).First(&cacheEmailValidation)
@@ -37,6 +34,7 @@ func (r cacheEmailValidationRepository) Get(ctx context.Context, email string) (
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		} else {
+			spans.TraceError(result.Error)
 			return nil, result.Error
 		}
 	}
@@ -45,10 +43,9 @@ func (r cacheEmailValidationRepository) Get(ctx context.Context, email string) (
 }
 
 func (r cacheEmailValidationRepository) Save(ctx context.Context, cacheEmailValidation postgres_entity.CacheEmailValidation) (*postgres_entity.CacheEmailValidation, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheEmailValidationRepository.Save")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "cacheEmailValidation", cacheEmailValidation)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheEmailValidationRepository.Save")
+	defer spans.Finish()
+	spans.LogObjectAsJson("cacheEmailValidation", cacheEmailValidation)
 
 	var existingData postgres_entity.CacheEmailValidation
 	result := r.db.WithContext(ctx).Where("email = ?", cacheEmailValidation.Email).First(&existingData)
@@ -60,12 +57,12 @@ func (r cacheEmailValidationRepository) Save(ctx context.Context, cacheEmailVali
 			cacheEmailValidation.CreatedAt = now
 			cacheEmailValidation.UpdatedAt = now
 			if err := r.db.WithContext(ctx).Save(&cacheEmailValidation).Error; err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "failed to save cache email validation"))
+				spans.TraceError(errors.Wrap(err, "failed to save cache email validation"))
 				return nil, err
 			}
 		} else {
 			// Some other error occurred
-			tracing.TraceErr(span, result.Error)
+			spans.TraceError(result.Error)
 			return nil, result.Error
 		}
 	} else {
@@ -96,7 +93,7 @@ func (r cacheEmailValidationRepository) Save(ctx context.Context, cacheEmailVali
 			"data":                  cacheEmailValidation.Data,
 		}
 		if err := r.db.WithContext(ctx).Model(&existingData).Updates(updates).Error; err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to update cache email validation"))
+			spans.TraceError(errors.Wrap(err, "failed to update cache email validation"))
 			return nil, err
 		}
 		cacheEmailValidation = existingData

--- a/packages/server/customer-os-postgres-repository/repository/cache_ip_data_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/cache_ip_data_repository.go
@@ -3,11 +3,9 @@ package postgres_repository
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"gorm.io/gorm"
 )
 
@@ -25,10 +23,9 @@ func NewCacheIpDataRepository(gormDb *gorm.DB) CacheIpDataRepository {
 }
 
 func (r cacheIpDataRepository) Get(ctx context.Context, ip string) (*postgres_entity.CacheIpData, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheIpDataRepository.Get")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("ip", ip))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheIpDataRepository.Get")
+	defer spans.Finish()
+	spans.LogKV("ip", ip)
 
 	var cacheIpData postgres_entity.CacheIpData
 	result := r.db.WithContext(ctx).Where("ip = ?", ip).First(&cacheIpData)
@@ -45,10 +42,9 @@ func (r cacheIpDataRepository) Get(ctx context.Context, ip string) (*postgres_en
 }
 
 func (r cacheIpDataRepository) Save(ctx context.Context, cacheIpData postgres_entity.CacheIpData) (*postgres_entity.CacheIpData, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheIpDataRepository.Save")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "cacheIpData", cacheIpData)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheIpDataRepository.Save")
+	defer spans.Finish()
+	spans.LogObjectAsJson("cacheIpData", cacheIpData)
 
 	var existingData postgres_entity.CacheIpData
 	result := r.db.WithContext(ctx).Where("ip = ?", cacheIpData.Ip).First(&existingData)
@@ -72,6 +68,7 @@ func (r cacheIpDataRepository) Save(ctx context.Context, cacheIpData postgres_en
 			"data":       cacheIpData.Data,
 		}
 		if err := r.db.WithContext(ctx).Model(&existingData).Updates(updates).Error; err != nil {
+			spans.TraceError(err)
 			return nil, err
 		}
 		cacheIpData = existingData

--- a/packages/server/customer-os-postgres-repository/repository/cache_ip_hunter_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/cache_ip_hunter_repository.go
@@ -3,11 +3,9 @@ package postgres_repository
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"gorm.io/gorm"
 )
 
@@ -25,10 +23,9 @@ func NewCacheIpHunterRepository(gormDb *gorm.DB) CacheIpHunterRepository {
 }
 
 func (r cacheIpHunterRepository) Get(ctx context.Context, ip string) (*postgres_entity.CacheIpHunter, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheIpHunterRepository.Register")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("ip", ip))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheIpHunterRepository.Register")
+	defer spans.Finish()
+	spans.LogKV("ip", ip)
 
 	var cacheIpHunter postgres_entity.CacheIpHunter
 	result := r.db.WithContext(ctx).Where("ip = ?", ip).First(&cacheIpHunter)
@@ -45,10 +42,9 @@ func (r cacheIpHunterRepository) Get(ctx context.Context, ip string) (*postgres_
 }
 
 func (r cacheIpHunterRepository) Save(ctx context.Context, cacheIpHunter postgres_entity.CacheIpHunter) (*postgres_entity.CacheIpHunter, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CacheIpHunterRepository.Register")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "cacheIpHunter", cacheIpHunter)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CacheIpHunterRepository.Register")
+	defer spans.Finish()
+	spans.LogObjectAsJson("cacheIpHunter", cacheIpHunter)
 
 	var existingHunter postgres_entity.CacheIpHunter
 	result := r.db.WithContext(ctx).Where("ip = ?", cacheIpHunter.Ip).First(&existingHunter)
@@ -72,6 +68,7 @@ func (r cacheIpHunterRepository) Save(ctx context.Context, cacheIpHunter postgre
 			"data":       cacheIpHunter.Data,
 		}
 		if err := r.db.WithContext(ctx).Model(&existingHunter).Updates(updates).Error; err != nil {
+			spans.TraceError(err)
 			return nil, err
 		}
 		cacheIpHunter = existingHunter

--- a/packages/server/customer-os-postgres-repository/repository/cache_ip_identify.go
+++ b/packages/server/customer-os-postgres-repository/repository/cache_ip_identify.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/opentracing/opentracing-go"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 
@@ -26,20 +25,19 @@ func NewCacheIPIdentifyRepository(gormDb *gorm.DB) CacheIPIdentifyRepository {
 }
 
 func (r *cacheIPIdentifyRepository) Create(ctx context.Context, ipData postgres_entity.CacheIPIdentify) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CacheSnitcherRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "ipData", ipData)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "CacheSnitcherRepository.Create")
+	defer spans.Finish()
+	spans.LogObjectAsJson("ipData", ipData)
 
 	if ipData.IPAddress == "" {
 		err := errors.New("IP address missing")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	err := r.db.Create(&ipData).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -47,10 +45,9 @@ func (r *cacheIPIdentifyRepository) Create(ctx context.Context, ipData postgres_
 }
 
 func (r *cacheIPIdentifyRepository) FindByIP(ctx context.Context, ip string, cacheLookBackInDays int) (*postgres_entity.CacheIPIdentify, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CacheSnitcherRepository.FindByIP")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("ip", ip, "cacheLookBackInDays", cacheLookBackInDays)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "CacheSnitcherRepository.FindByIP")
+	defer spans.Finish()
+	spans.LogKV("ip", ip, "cacheLookBackInDays", cacheLookBackInDays)
 
 	lookBackDate := time.Now().AddDate(0, 0, -cacheLookBackInDays)
 
@@ -62,12 +59,12 @@ func (r *cacheIPIdentifyRepository) FindByIP(ctx context.Context, ip string, cac
 		First(&result).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			span.LogKV("result.found", false)
+			spans.LogKV("result.found", false)
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogKV("result.found", true)
+	spans.LogKV("result.found", true)
 	return &result, nil
 }

--- a/packages/server/customer-os-postgres-repository/repository/common_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/common_repository.go
@@ -6,9 +6,7 @@ import (
 	"reflect"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/config"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"gorm.io/gorm"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -28,14 +26,14 @@ func NewCommonRepository(postgresDB *config.PostgresDB) CommonRepository {
 }
 
 func (r *commonRepository) UpdateProperty(ctx context.Context, tenant string, postgres_entityType interface{}, id any, propertyName string, newValue interface{}) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonRepository.UpdateProperty")
-	defer span.Finish()
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "CommonRepository.UpdateProperty")
+	defer spans.Finish()
 
-	span.LogFields(log.String("tenant", tenant))
-	span.LogFields(log.String("postgres_entityType", reflect.TypeOf(postgres_entityType).String()))
-	span.LogFields(log.String("id", fmt.Sprintf("%v", id)))
-	span.LogFields(log.String("propertyName", propertyName))
-	span.LogFields(log.String("newValue", fmt.Sprintf("%v", newValue)))
+	spans.LogKV("tenant", tenant)
+	spans.LogKV("postgres_entityType", reflect.TypeOf(postgres_entityType).String())
+	spans.LogKV("id", fmt.Sprintf("%v", id))
+	spans.LogKV("propertyName", propertyName)
+	spans.LogKV("newValue", fmt.Sprintf("%v", newValue))
 
 	// Create a new instance of the postgres_entity type
 	postgres_entity := reflect.New(reflect.TypeOf(postgres_entityType)).Interface()
@@ -43,7 +41,7 @@ func (r *commonRepository) UpdateProperty(ctx context.Context, tenant string, po
 	// Fetch the postgres_entity by ID and tenant using context
 	query := r.postgresDB.GormDB.WithContext(ctx).Where("tenant = ? and id = ?", tenant, id).First(postgres_entity)
 	if err := query.Error; err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		if err == gorm.ErrRecordNotFound {
 			return fmt.Errorf("postgres_entity not found for tenant %s with id %v", tenant, id)
 		}
@@ -56,13 +54,13 @@ func (r *commonRepository) UpdateProperty(ctx context.Context, tenant string, po
 
 	if !field.IsValid() {
 		err := fmt.Errorf("property %s does not exist on postgres_entity", propertyName)
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	if !field.CanSet() {
 		err := fmt.Errorf("property %s cannot be set", propertyName)
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -72,7 +70,7 @@ func (r *commonRepository) UpdateProperty(ctx context.Context, tenant string, po
 	// Save the updated postgres_entity with context
 	if err := r.postgresDB.GormDB.WithContext(ctx).Save(postgres_entity).Error; err != nil {
 		err := fmt.Errorf("failed to save updated postgres_entity: %w", err)
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -80,9 +78,8 @@ func (r *commonRepository) UpdateProperty(ctx context.Context, tenant string, po
 }
 
 func (r *commonRepository) PermanentlyDelete(ctx context.Context, tenant string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonRepository.PermanentlyDelete")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "CommonRepository.PermanentlyDelete")
+	defer spans.Finish()
 	asyncTablesWithTenantNameColumn := []string{
 		postgres_entity.OAuthTokenEntity{}.TableName(),
 	}
@@ -128,28 +125,28 @@ func (r *commonRepository) PermanentlyDelete(ctx context.Context, tenant string)
 
 	for _, tableName := range asyncTablesWithTenantNameColumn {
 		if err := r.postgresDB.AsyncGormDB.Exec("DELETE FROM "+tableName+" WHERE tenant_name = ?", tenant).Error; err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}
 
 	for _, tableName := range asyncTablesWithTenantColumn {
 		if err := r.postgresDB.AsyncGormDB.Exec("DELETE FROM "+tableName+" WHERE tenant = ?", tenant).Error; err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}
 
 	for _, tableName := range tableNamesWithTenantNameColumn {
 		if err := r.postgresDB.GormDB.Exec("DELETE FROM "+tableName+" WHERE tenant_name = ?", tenant).Error; err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}
 
 	for _, tableName := range tableNamesWithTenantColumn {
 		if err := r.postgresDB.GormDB.Exec("DELETE FROM "+tableName+" WHERE tenant = ?", tenant).Error; err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}

--- a/packages/server/customer-os-postgres-repository/repository/cos_api_enrich_person_temp_result_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/cos_api_enrich_person_temp_result_repository.go
@@ -1,10 +1,9 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
@@ -25,9 +24,8 @@ func NewCosApiEnrichPersonTempResultRepository(gormDb *gorm.DB) CosApiEnrichPers
 }
 
 func (r cosApiEnrichPersonTempResultRepository) GetById(ctx context.Context, id, tenant string) (*postgres_entity.CosApiEnrichPersonTempResult, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CosApiEnrichPersonTempResultRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CosApiEnrichPersonTempResultRepository.GetById")
+	defer spans.Finish()
 
 	var data postgres_entity.CosApiEnrichPersonTempResult
 	err := r.db.Where("id = ? AND tenant = ?", id, tenant).First(&data).Error
@@ -42,10 +40,9 @@ func (r cosApiEnrichPersonTempResultRepository) GetById(ctx context.Context, id,
 }
 
 func (r cosApiEnrichPersonTempResultRepository) Create(ctx context.Context, data postgres_entity.CosApiEnrichPersonTempResult) (*postgres_entity.CosApiEnrichPersonTempResult, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CosApiEnrichPersonTempResultRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CosApiEnrichPersonTempResultRepository.Create")
+	defer spans.Finish()
+	spans.LogObjectAsJson("data", data)
 
 	data.CreatedAt = utils.Now()
 	if err := r.db.WithContext(ctx).Create(&data).Error; err != nil {
@@ -56,9 +53,8 @@ func (r cosApiEnrichPersonTempResultRepository) Create(ctx context.Context, data
 }
 
 func (r cosApiEnrichPersonTempResultRepository) GetByBettercontactRecordId(ctx context.Context, bettercontactRecordId string) (*postgres_entity.CosApiEnrichPersonTempResult, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CosApiEnrichPersonTempResultRepository.GetByBettercontactRecordId")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CosApiEnrichPersonTempResultRepository.GetByBettercontactRecordId")
+	defer spans.Finish()
 
 	var data postgres_entity.CosApiEnrichPersonTempResult
 	err := r.db.Where("bettercontact_record_id = ?", bettercontactRecordId).First(&data).Error
@@ -66,6 +62,7 @@ func (r cosApiEnrichPersonTempResultRepository) GetByBettercontactRecordId(ctx c
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
+		spans.TraceError(err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/currency_rates_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/currency_rates_repository.go
@@ -2,10 +2,9 @@ package postgres_repository
 
 import (
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 	"time"
@@ -25,9 +24,8 @@ func NewCurrencyRateRepository(db *gorm.DB) CurrencyRateRepository {
 }
 
 func (r *currencyRateRepo) GetLatestCurrencyRate(ctx context.Context, currency string) (*postgres_entity.CurrencyRate, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CurrencyRateRepository.GetLatestCurrencyRate")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CurrencyRateRepository.GetLatestCurrencyRate")
+	defer spans.Finish()
 
 	var rate postgres_entity.CurrencyRate
 	err := r.db.
@@ -46,9 +44,8 @@ func (r *currencyRateRepo) GetLatestCurrencyRate(ctx context.Context, currency s
 }
 
 func (r *currencyRateRepo) SaveCurrencyRate(ctx context.Context, currency string, rate float64, date time.Time, source string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CurrencyRateRepository.SaveCurrencyRate")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CurrencyRateRepository.SaveCurrencyRate")
+	defer spans.Finish()
 
 	// Check if the currency rate already exists for the given currency and date
 	var existingRate postgres_entity.CurrencyRate
@@ -59,6 +56,7 @@ func (r *currencyRateRepo) SaveCurrencyRate(ctx context.Context, currency string
 		First(&existingRate).Error
 
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		spans.TraceError(err)
 		return err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/customer_os_ids_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/customer_os_ids_repository.go
@@ -1,9 +1,8 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -21,9 +20,8 @@ func NewCustomerOsIdsRepository(gormDb *gorm.DB) CustomerOsIdsRepository {
 }
 
 func (repo *customerOsIdsRepository) Reserve(ctx context.Context, customerOsIds postgres_entity.CustomerOsIds) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "CustomerOsIdsRepository.Reserve")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "CustomerOsIdsRepository.Reserve")
+	defer spans.Finish()
 
 	err := repo.gormDb.Save(&customerOsIds).Error
 	return err

--- a/packages/server/customer-os-postgres-repository/repository/enrich_details_brandfetch_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/enrich_details_brandfetch_repository.go
@@ -1,11 +1,9 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
@@ -28,10 +26,9 @@ func NewEnrichDetailsBrandfetchRepository(gormDb *gorm.DB) EnrichDetailsBrandfet
 }
 
 func (r enrichDetailsBrandfetchRepository) GetAllSuccessByDomain(ctx context.Context, domain string) ([]postgres_entity.EnrichDetailsBrandfetch, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "enrichDetailsBrandfetchRepository.GetAllSuccessByDomain")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("domain", domain)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "enrichDetailsBrandfetchRepository.GetAllSuccessByDomain")
+	defer spans.Finish()
+	spans.LogKV("domain", domain)
 
 	var data []postgres_entity.EnrichDetailsBrandfetch
 	err := r.db.Where("domain = ? AND success = ?", domain, true).Order("created_at desc").Find(&data).Error
@@ -39,36 +36,34 @@ func (r enrichDetailsBrandfetchRepository) GetAllSuccessByDomain(ctx context.Con
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.Int("result.count", len(data)))
+	spans.LogKV("result.count", len(data))
 
 	return data, nil
 }
 
 func (r enrichDetailsBrandfetchRepository) GetLatestByDomain(ctx context.Context, domain string) (*postgres_entity.EnrichDetailsBrandfetch, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "enrichDetailsBrandfetchRepository.GetLatestByDomain")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("domain", domain)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "enrichDetailsBrandfetchRepository.GetLatestByDomain")
+	defer spans.Finish()
+	spans.LogKV("domain", domain)
 
 	var data postgres_entity.EnrichDetailsBrandfetch
 	err := r.db.Where("domain = ?", domain).Order("created_at desc").First(&data).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			span.LogFields(tracingLog.Bool("result.found", false))
+			spans.LogKV("result.found", false)
 			return nil, nil // Return nil if no record found
 		}
 		return nil, err // Return other errors as usual
 	}
 
-	span.LogFields(tracingLog.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return &data, nil
 }
 
 func (r enrichDetailsBrandfetchRepository) Create(ctx context.Context, data postgres_entity.EnrichDetailsBrandfetch) (*postgres_entity.EnrichDetailsBrandfetch, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "enrichDetailsBrandfetchRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "enrichDetailsBrandfetchRepository.Create")
+	defer spans.Finish()
+	spans.LogObjectAsJson("data", data)
 
 	data.CreatedAt = utils.Now()
 	data.UpdatedAt = utils.Now()
@@ -80,9 +75,8 @@ func (r enrichDetailsBrandfetchRepository) Create(ctx context.Context, data post
 }
 
 func (r enrichDetailsBrandfetchRepository) GetToSyncIntoGlobalOrganizations(ctx context.Context, limit int) ([]*postgres_entity.EnrichDetailsBrandfetch, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsBrandfetchRepository.GetToSyncIntoGlobalOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsBrandfetchRepository.GetToSyncIntoGlobalOrganizations")
+	defer spans.Finish()
 
 	var data []*postgres_entity.EnrichDetailsBrandfetch
 	err := r.db.
@@ -94,19 +88,18 @@ func (r enrichDetailsBrandfetchRepository) GetToSyncIntoGlobalOrganizations(ctx 
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.Int("result.count", len(data)))
+	spans.LogKV("result.count", len(data))
 
 	return data, nil
 }
 
 func (r enrichDetailsBrandfetchRepository) MarkSyncedToGlobalOrganizations(ctx context.Context, id uint64) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsBrandfetchRepository.MarkSyncedToGlobalOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsBrandfetchRepository.MarkSyncedToGlobalOrganizations")
+	defer spans.Finish()
 
 	err := r.db.Model(&postgres_entity.EnrichDetailsBrandfetch{}).Where("id = ?", id).Update("synced_to_global_orgs", true).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		return err
 	}
-	return err
+	return nil
 }

--- a/packages/server/customer-os-postgres-repository/repository/enrich_details_scrapin_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/enrich_details_scrapin_repository.go
@@ -1,11 +1,9 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
@@ -35,50 +33,53 @@ func NewEnrichDetailsScrapInRepository(gormDb *gorm.DB) EnrichDetailsScrapInRepo
 }
 
 func (r enrichDetailsScrapInRepository) GetAllByParam1AndFlow(ctx context.Context, param string, flow postgres_entity.ScrapInFlow) ([]postgres_entity.EnrichDetailsScrapIn, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.GetAllByParam1AndFlow")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.GetAllByParam1AndFlow")
+	defer spans.Finish()
+	spans.LogKV("param", param)
+	spans.LogKV("flow", flow)
 
 	var data []postgres_entity.EnrichDetailsScrapIn
 	err := r.db.Where("param1 = ? AND flow = ?", param, flow).Find(&data).Error
 	if err != nil {
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.Int("result.count", len(data)))
+	spans.LogKV("result.count", len(data))
 
 	return data, nil
 }
 
 func (r enrichDetailsScrapInRepository) GetLatestByParam1AndFlow(ctx context.Context, param string, flow postgres_entity.ScrapInFlow) (*postgres_entity.EnrichDetailsScrapIn, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlow")
+	defer spans.Finish()
+	spans.LogKV("param", param)
+	spans.LogKV("flow", flow)
 
 	var data postgres_entity.EnrichDetailsScrapIn
 	err := r.db.Where("param1 = ? AND flow = ?", param, flow).Order("created_at desc").First(&data).Error
 	if err != nil {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil // Return nil if no record found
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err // Return other errors as usual
 	}
 
-	span.LogFields(tracingLog.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return &data, nil
 }
 
 func (r enrichDetailsScrapInRepository) Create(ctx context.Context, data postgres_entity.EnrichDetailsScrapIn) (*postgres_entity.EnrichDetailsScrapIn, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.Create")
+	defer spans.Finish()
+	spans.LogObjectAsJson("data", data)
 
 	data.CreatedAt = utils.Now()
 	data.UpdatedAt = utils.Now()
 	if err := r.db.WithContext(ctx).Create(&data).Error; err != nil {
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -86,9 +87,9 @@ func (r enrichDetailsScrapInRepository) Create(ctx context.Context, data postgre
 }
 
 func (r enrichDetailsScrapInRepository) GetById(ctx context.Context, id uint64) (*postgres_entity.EnrichDetailsScrapIn, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.GetById")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	var data postgres_entity.EnrichDetailsScrapIn
 	err := r.db.Where("id = ?", id).First(&data).Error
@@ -96,6 +97,7 @@ func (r enrichDetailsScrapInRepository) GetById(ctx context.Context, id uint64) 
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil // Return nil if no record found
 		}
+		spans.TraceError(err)
 		return nil, err // Return other errors as usual
 	}
 
@@ -103,9 +105,14 @@ func (r enrichDetailsScrapInRepository) GetById(ctx context.Context, id uint64) 
 }
 
 func (r enrichDetailsScrapInRepository) GetLatestByAllParamsAndFlow(ctx context.Context, param1, param2, param3, param4, param5 string, flow postgres_entity.ScrapInFlow) (*postgres_entity.EnrichDetailsScrapIn, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.GetLatestByAllParamsAndFlow")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.GetLatestByAllParamsAndFlow")
+	defer spans.Finish()
+	spans.LogKV("param1", param1)
+	spans.LogKV("param2", param2)
+	spans.LogKV("param3", param3)
+	spans.LogKV("param4", param4)
+	spans.LogKV("param5", param5)
+	spans.LogKV("flow", flow)
 
 	var data postgres_entity.EnrichDetailsScrapIn
 	err := r.db.Where("param1 = ? AND param2 = ? AND param3 = ? AND param4 = ? AND param5 = ? AND flow = ?", param1, param2, param3, param4, param5, flow).Order("created_at desc").First(&data).Error
@@ -113,6 +120,7 @@ func (r enrichDetailsScrapInRepository) GetLatestByAllParamsAndFlow(ctx context.
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil // Return nil if no record found
 		}
+		spans.TraceError(err)
 		return nil, err // Return other errors as usual
 	}
 
@@ -120,9 +128,10 @@ func (r enrichDetailsScrapInRepository) GetLatestByAllParamsAndFlow(ctx context.
 }
 
 func (r enrichDetailsScrapInRepository) GetLatestByParam1AndFlowWithPersonFound(ctx context.Context, param string, flow postgres_entity.ScrapInFlow) (*postgres_entity.EnrichDetailsScrapIn, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlowWithPersonFound")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlowWithPersonFound")
+	defer spans.Finish()
+	spans.LogKV("param", param)
+	spans.LogKV("flow", flow)
 
 	var data postgres_entity.EnrichDetailsScrapIn
 	err := r.db.Where("param1 = ? AND flow = ? AND person_found = ?", param, flow, true).Order("created_at desc").First(&data).Error
@@ -130,6 +139,7 @@ func (r enrichDetailsScrapInRepository) GetLatestByParam1AndFlowWithPersonFound(
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil // Return nil if no record found
 		}
+		spans.TraceError(err)
 		return nil, err // Return other errors as usual
 	}
 
@@ -137,9 +147,10 @@ func (r enrichDetailsScrapInRepository) GetLatestByParam1AndFlowWithPersonFound(
 }
 
 func (r enrichDetailsScrapInRepository) GetLatestByParam1AndFlowWithCompanyFound(ctx context.Context, param string, flow postgres_entity.ScrapInFlow) (*postgres_entity.EnrichDetailsScrapIn, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlowWithCompanyFound")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.GetLatestByParam1AndFlowWithCompanyFound")
+	defer spans.Finish()
+	spans.LogKV("param", param)
+	spans.LogKV("flow", flow)
 
 	var data postgres_entity.EnrichDetailsScrapIn
 	err := r.db.Where("param1 = ? AND flow = ? AND person_found = ?", param, flow, true).Order("created_at desc").First(&data).Error
@@ -147,6 +158,7 @@ func (r enrichDetailsScrapInRepository) GetLatestByParam1AndFlowWithCompanyFound
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil // Return nil if no record found
 		}
+		spans.TraceError(err)
 		return nil, err // Return other errors as usual
 	}
 
@@ -154,9 +166,14 @@ func (r enrichDetailsScrapInRepository) GetLatestByParam1AndFlowWithCompanyFound
 }
 
 func (r enrichDetailsScrapInRepository) GetLatestByAllParamsAndFlowWithPersonFound(ctx context.Context, param1, param2, param3, param4, param5 string, flow postgres_entity.ScrapInFlow) (*postgres_entity.EnrichDetailsScrapIn, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.GetLatestByAllParamsAndFlowWithPersonFound")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.GetLatestByAllParamsAndFlowWithPersonFound")
+	defer spans.Finish()
+	spans.LogKV("param1", param1)
+	spans.LogKV("param2", param2)
+	spans.LogKV("param3", param3)
+	spans.LogKV("param4", param4)
+	spans.LogKV("param5", param5)
+	spans.LogKV("flow", flow)
 
 	var data postgres_entity.EnrichDetailsScrapIn
 	err := r.db.Where("param1 = ? AND param2 = ? AND param3 = ? AND param4 = ? AND param5 = ? AND flow = ? AND person_found = ?", param1, param2, param3, param4, param5, flow, true).Order("created_at desc").First(&data).Error
@@ -164,6 +181,7 @@ func (r enrichDetailsScrapInRepository) GetLatestByAllParamsAndFlowWithPersonFou
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil // Return nil if no record found
 		}
+		spans.TraceError(err)
 		return nil, err // Return other errors as usual
 	}
 
@@ -171,9 +189,9 @@ func (r enrichDetailsScrapInRepository) GetLatestByAllParamsAndFlowWithPersonFou
 }
 
 func (r enrichDetailsScrapInRepository) GetToSyncIntoGlobalOrganizations(ctx context.Context, limit int) ([]*postgres_entity.EnrichDetailsScrapIn, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.GetToSyncIntoGlobalOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.GetToSyncIntoGlobalOrganizations")
+	defer spans.Finish()
+	spans.LogKV("limit", limit)
 
 	// get records that has SyncedToGlobalOrgs = false or NULL, flow = ScrapInFlowCompanySearch or ScrapInFlowCompanyProfile, and CompanyFound = true
 	// ordered by created date ascending, limit by limit
@@ -184,30 +202,31 @@ func (r enrichDetailsScrapInRepository) GetToSyncIntoGlobalOrganizations(ctx con
 		Limit(limit).
 		Find(&data).Error
 	if err != nil {
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.Int("result.count", len(data)))
+	spans.LogKV("result.count", len(data))
 
 	return data, nil
 }
 
 func (r enrichDetailsScrapInRepository) MarkSyncedToGlobalOrganizations(ctx context.Context, id uint64) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.MarkSyncedToGlobalOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.MarkSyncedToGlobalOrganizations")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	err := r.db.Model(&postgres_entity.EnrichDetailsScrapIn{}).Where("id = ?", id).Update("synced_to_global_orgs", true).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r enrichDetailsScrapInRepository) GetToSyncIntoGlobalContacts(ctx context.Context, limit int) ([]*postgres_entity.EnrichDetailsScrapIn, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.GetToSyncIntoGlobalContacts")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.GetToSyncIntoGlobalContacts")
+	defer spans.Finish()
+	spans.LogKV("limit", limit)
 
 	var data []*postgres_entity.EnrichDetailsScrapIn
 
@@ -218,23 +237,23 @@ func (r enrichDetailsScrapInRepository) GetToSyncIntoGlobalContacts(ctx context.
 		Limit(limit).
 		Find(&data).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.Int("result.count", len(data)))
+	spans.LogKV("result.count", len(data))
 
 	return data, nil
 }
 
 func (r enrichDetailsScrapInRepository) MarkSyncedToGlobalContacts(ctx context.Context, id uint64) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "EnrichDetailsScrapInRepository.MarkSyncedToGlobalContacts")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "EnrichDetailsScrapInRepository.MarkSyncedToGlobalContacts")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	err := r.db.Model(&postgres_entity.EnrichDetailsScrapIn{}).Where("id = ?", id).Update("synced_to_global_contacts", true).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-postgres-repository/repository/global_organization_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/global_organization_repository.go
@@ -8,10 +8,8 @@ import (
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"gorm.io/gorm"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -58,89 +56,84 @@ func NewGlobalOrganizationRepository(gormDb *gorm.DB) GlobalOrganizationReposito
 }
 
 func (r *globalOrganizationRepository) GetById(ctx context.Context, id uint64) (*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("id", id)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.GetById")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	organization := &postgres_entity.GlobalOrganization{}
 	result := r.db.WithContext(ctx).Where("id = ?", id).First(organization)
 	if result.Error != nil {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-	span.LogFields(tracingLog.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return organization, nil
 }
 
 func (r *globalOrganizationRepository) GetByPrimaryDomains(ctx context.Context, domains []string) ([]*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetByPrimaryDomains")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(tracingLog.Object("domains", domains))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.GetByPrimaryDomains")
+	defer spans.Finish()
+	spans.LogKV("domains", domains)
 
 	organizations := make([]*postgres_entity.GlobalOrganization, 0)
 	result := r.db.WithContext(ctx).Where("primary_domain IN ?", domains).Find(&organizations)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-	span.LogFields(tracingLog.Int("result.count", len(organizations)))
+	spans.LogKV("result.count", len(organizations))
 	return organizations, nil
 }
 
 func (r *globalOrganizationRepository) GetByPrimaryDomain(ctx context.Context, domain string) (*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetByPrimaryDomain")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("domain", domain)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.GetByPrimaryDomain")
+	defer spans.Finish()
+	spans.LogKV("domain", domain)
 
 	organization := &postgres_entity.GlobalOrganization{}
 	result := r.db.WithContext(ctx).Where("primary_domain = ?", domain).First(organization)
 	if result.Error != nil {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-	span.LogFields(tracingLog.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return organization, nil
 }
 
 func (r *globalOrganizationRepository) Create(ctx context.Context, organization *postgres_entity.GlobalOrganization) (*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "organization", organization)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.Create")
+	defer spans.Finish()
+	spans.LogObjectAsJson("organization", organization)
 
 	result := r.db.WithContext(ctx).Create(&organization)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
 	return organization, nil
 }
 
 func (r *globalOrganizationRepository) CreateIfNotExists(ctx context.Context, primaryDomain string) (*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.CreateIfNotExists")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("primaryDomain", primaryDomain)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.CreateIfNotExists")
+	defer spans.Finish()
+	spans.LogKV("primaryDomain", primaryDomain)
 
 	// Check if organization exists
 	existing, err := r.GetByPrimaryDomain(ctx, primaryDomain)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if existing != nil {
-		span.LogFields(tracingLog.Bool("result.created", false))
+		spans.LogKV("result.created", false)
 		return existing, nil
 	}
 
@@ -153,34 +146,32 @@ func (r *globalOrganizationRepository) CreateIfNotExists(ctx context.Context, pr
 
 	result := r.db.WithContext(ctx).Create(organization)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
 
-	span.LogFields(tracingLog.Bool("result.created", true))
+	spans.LogKV("result.created", true)
 	return organization, nil
 }
 
 func (r *globalOrganizationRepository) Update(ctx context.Context, organization *postgres_entity.GlobalOrganization) (*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.Update")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "organization", organization)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.Update")
+	defer spans.Finish()
+	spans.LogObjectAsJson("organization", organization)
 
 	organization.UpdatedAt = utils.Now()
 	result := r.db.WithContext(ctx).Save(organization)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
 	return organization, nil
 }
 
 func (r *globalOrganizationRepository) Search(ctx context.Context, searchTerm string, limit int) ([]*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.SearchOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("searchTerm", searchTerm)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.SearchOrganizations")
+	defer spans.Finish()
+	spans.LogKV("searchTerm", searchTerm)
 
 	organizations := make([]*postgres_entity.GlobalOrganization, 0)
 	result := r.db.WithContext(ctx).
@@ -189,18 +180,17 @@ func (r *globalOrganizationRepository) Search(ctx context.Context, searchTerm st
 		Limit(limit).
 		Find(&organizations)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-	span.LogFields(tracingLog.Int("found", len(organizations)))
+	spans.LogKV("found", len(organizations))
 	return organizations, nil
 }
 
 func (r *globalOrganizationRepository) GetOrganizationsToEnrichIndustry(ctx context.Context, hoursFromPreviousAttempt, maxAttempts, limit int) ([]*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetOrganizationsToEnrichIndustry")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(tracingLog.Int("hoursFromPreviousAttempt", hoursFromPreviousAttempt), tracingLog.Int("limit", limit), tracingLog.Int("maxAttempts", maxAttempts))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.GetOrganizationsToEnrichIndustry")
+	defer spans.Finish()
+	spans.LogKV("hoursFromPreviousAttempt", hoursFromPreviousAttempt, "limit", limit, "maxAttempts", maxAttempts)
 
 	organizations := make([]*postgres_entity.GlobalOrganization, 0)
 	result := r.db.WithContext(ctx).
@@ -214,17 +204,17 @@ func (r *globalOrganizationRepository) GetOrganizationsToEnrichIndustry(ctx cont
 		Limit(limit).
 		Find(&organizations)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-	span.LogFields(tracingLog.Int("found", len(organizations)))
+	spans.LogKV("found", len(organizations))
 	return organizations, nil
 }
 
 func (r *globalOrganizationRepository) GetOrganizationsToScrape(ctx context.Context, limit int) ([]*postgres_entity.GlobalOrganization, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetOrganizationsToScrape")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.GetOrganizationsToScrape")
+	defer spans.Finish()
+	spans.LogKV("limit", limit)
 
 	organizations := make([]*postgres_entity.GlobalOrganization, 0)
 	result := r.db.WithContext(ctx).
@@ -236,18 +226,17 @@ func (r *globalOrganizationRepository) GetOrganizationsToScrape(ctx context.Cont
 		Limit(limit).
 		Find(&organizations)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-	span.LogFields(tracingLog.Int("found", len(organizations)))
+	spans.LogKV("found", len(organizations))
 	return organizations, nil
 }
 
 func (r *globalOrganizationRepository) GetOrganizationsToFetchLogo(ctx context.Context, limit int) ([]*postgres_entity.GlobalOrganization, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetOrganizationsToFetchLogo")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("limit", limit)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.GetOrganizationsToFetchLogo")
+	defer spans.Finish()
+	spans.LogKV("limit", limit)
 
 	organizations := make([]*postgres_entity.GlobalOrganization, 0)
 	result := r.db.WithContext(ctx).
@@ -257,18 +246,17 @@ func (r *globalOrganizationRepository) GetOrganizationsToFetchLogo(ctx context.C
 		Limit(limit).
 		Find(&organizations)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-	span.LogKV("result.count", len(organizations))
+	spans.LogKV("result.count", len(organizations))
 	return organizations, nil
 }
 
 func (r *globalOrganizationRepository) GetOrganizationsToFetchIcon(ctx context.Context, limit int) ([]*postgres_entity.GlobalOrganization, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetOrganizationsToFetchIcon")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("limit", limit)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.GetOrganizationsToFetchIcon")
+	defer spans.Finish()
+	spans.LogKV("limit", limit)
 
 	organizations := make([]*postgres_entity.GlobalOrganization, 0)
 	result := r.db.WithContext(ctx).
@@ -278,19 +266,17 @@ func (r *globalOrganizationRepository) GetOrganizationsToFetchIcon(ctx context.C
 		Limit(limit).
 		Find(&organizations)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-
-	span.LogKV("result.count", len(organizations))
+	spans.LogKV("result.count", len(organizations))
 	return organizations, nil
 }
 
 func (r *globalOrganizationRepository) GetOrganizationsToEnrichDescription(ctx context.Context, hoursFromPreviousAttempt, maxAttempts, limit int) ([]*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetOrganizationsToEnrichDescription")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(tracingLog.Int("hoursFromPreviousAttempt", hoursFromPreviousAttempt), tracingLog.Int("limit", limit), tracingLog.Int("maxAttempts", maxAttempts))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.GetOrganizationsToEnrichDescription")
+	defer spans.Finish()
+	spans.LogKV("hoursFromPreviousAttempt", hoursFromPreviousAttempt, "limit", limit, "maxAttempts", maxAttempts)
 
 	organizations := make([]*postgres_entity.GlobalOrganization, 0)
 	result := r.db.WithContext(ctx).
@@ -304,20 +290,17 @@ func (r *globalOrganizationRepository) GetOrganizationsToEnrichDescription(ctx c
 		Limit(limit).
 		Find(&organizations)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-	span.LogFields(tracingLog.Int("found", len(organizations)))
+	spans.LogKV("found", len(organizations))
 	return organizations, nil
 }
 
 func (r *globalOrganizationRepository) GetOrganizationsToEnrichName(ctx context.Context, hoursFromPreviousAttempt, maxAttempts, limit int) ([]*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetOrganizationsToEnrichName")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(tracingLog.Int("hoursFromPreviousAttempt", hoursFromPreviousAttempt),
-		tracingLog.Int("limit", limit),
-		tracingLog.Int("maxAttempts", maxAttempts))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.GetOrganizationsToEnrichName")
+	defer spans.Finish()
+	spans.LogKV("hoursFromPreviousAttempt", hoursFromPreviousAttempt, "limit", limit, "maxAttempts", maxAttempts)
 
 	// Condition to flag "suspicious" or missing name
 	// 1) Name is NULL or empty
@@ -354,10 +337,10 @@ func (r *globalOrganizationRepository) GetOrganizationsToEnrichName(ctx context.
 		Limit(limit).
 		Find(&organizations)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-	span.LogFields(tracingLog.Int("found", len(organizations)))
+	spans.LogKV("found", len(organizations))
 	return organizations, nil
 }
 
@@ -374,10 +357,9 @@ func (r *globalOrganizationRepository) MarkNameEnrichRequested(ctx context.Conte
 }
 
 func (r *globalOrganizationRepository) SetIndustry(ctx context.Context, id uint64, industryNaicsCode, industryNaicsName string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.SetIndustry")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("id", id, "industryNaicsCode", industryNaicsCode, "industryNaicsName", industryNaicsName)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.SetIndustry")
+	defer spans.Finish()
+	spans.LogKV("id", id, "industryNaicsCode", industryNaicsCode, "industryNaicsName", industryNaicsName)
 
 	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalOrganization{}).
 		Where("id = ?", id).
@@ -387,17 +369,16 @@ func (r *globalOrganizationRepository) SetIndustry(ctx context.Context, id uint6
 			"industry_set_at":     utils.Now(),
 		})
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 	return nil
 }
 
 func (r *globalOrganizationRepository) SetDescription(ctx context.Context, id uint64, description string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.SetDescription")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("id", id, "description", description)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.SetDescription")
+	defer spans.Finish()
+	spans.LogKV("id", id, "description", description)
 
 	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalOrganization{}).
 		Where("id = ?", id).
@@ -406,17 +387,16 @@ func (r *globalOrganizationRepository) SetDescription(ctx context.Context, id ui
 			"description_set_at": utils.Now(),
 		})
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 	return nil
 }
 
 func (r *globalOrganizationRepository) SetName(ctx context.Context, id uint64, name string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.SetName")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("id", id, "name", name)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.SetName")
+	defer spans.Finish()
+	spans.LogKV("id", id, "name", name)
 
 	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalOrganization{}).
 		Where("id = ?", id).
@@ -425,17 +405,16 @@ func (r *globalOrganizationRepository) SetName(ctx context.Context, id uint64, n
 			"name_set_at": utils.Now(),
 		})
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 	return nil
 }
 
 func (r *globalOrganizationRepository) GetGlobalOrganizationsToSyncIntoTenantOrganizations(ctx context.Context, daysFromPreviousSync, limit int) ([]*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetGlobalOrganizationsToSyncIntoTenantOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(tracingLog.Int("daysFromPreviousSync", daysFromPreviousSync), tracingLog.Int("limit", limit))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.GetGlobalOrganizationsToSyncIntoTenantOrganizations")
+	defer spans.Finish()
+	spans.LogKV("daysFromPreviousSync", daysFromPreviousSync, "limit", limit)
 
 	organizations := make([]*postgres_entity.GlobalOrganization, 0)
 	result := r.db.WithContext(ctx).
@@ -445,33 +424,32 @@ func (r *globalOrganizationRepository) GetGlobalOrganizationsToSyncIntoTenantOrg
 		Limit(limit).
 		Find(&organizations)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-	span.LogFields(tracingLog.Int("found", len(organizations)))
+	spans.LogKV("found", len(organizations))
 	return organizations, nil
 }
 
 func (r *globalOrganizationRepository) MarkGlobalOrganizationSyncedToNeo(ctx context.Context, id uint64) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.MarkGlobalOrganizationSyncedToNeo")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("id", id)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.MarkGlobalOrganizationSyncedToNeo")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalOrganization{}).
 		Where("id = ?", id).
 		UpdateColumn("synced_to_neo_at", utils.Now().Add(10*time.Second))
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 	return nil
 }
 
 func (r *globalOrganizationRepository) markEnrichRequested(ctx context.Context, id uint64, fieldBase string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.markEnrichRequested")
-	defer span.Finish()
-	span.LogFields(tracingLog.Uint64("id", id), tracingLog.String("fieldBase", fieldBase))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.markEnrichRequested")
+	defer spans.Finish()
+	spans.LogKV("id", id, "fieldBase", fieldBase)
 
 	countField := fieldBase + "_request_count" // e.g., "industry_request_count"
 	timeField := fieldBase + "_requested_at"   // e.g., "industry_requested_at"
@@ -487,10 +465,9 @@ func (r *globalOrganizationRepository) markEnrichRequested(ctx context.Context, 
 }
 
 func (r *globalOrganizationRepository) SetScrapeStatus(ctx context.Context, id uint64, status enum.ScrapeStatus) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.SetScrapeStatus")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("id", id, "status", status.String())
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.SetScrapeStatus")
+	defer spans.Finish()
+	spans.LogKV("id", id, "status", status.String())
 
 	active := status == enum.ScrapeCompleted
 	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalOrganization{}).
@@ -503,13 +480,13 @@ func (r *globalOrganizationRepository) SetScrapeStatus(ctx context.Context, id u
 		})
 
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 
 	if result.RowsAffected == 0 {
 		err := errors.New("no organization found with provided ID")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -517,9 +494,9 @@ func (r *globalOrganizationRepository) SetScrapeStatus(ctx context.Context, id u
 }
 
 func (r *globalOrganizationRepository) SetLogo(ctx context.Context, id uint64, logoPath string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.SetLogo")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.SetLogo")
+	defer spans.Finish()
+	spans.LogKV("id", id, "logoPath", logoPath)
 
 	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalOrganization{}).
 		Where("id = ?", id).
@@ -529,24 +506,24 @@ func (r *globalOrganizationRepository) SetLogo(ctx context.Context, id uint64, l
 		})
 
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 
 	if result.RowsAffected == 0 {
 		err := errors.New("no organization found with provided ID")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
-	span.LogFields(tracingLog.Int64("rows_affected", result.RowsAffected))
+	spans.LogKV("rows_affected", result.RowsAffected)
 	return nil
 }
 
 func (r *globalOrganizationRepository) SetIcon(ctx context.Context, id uint64, iconPath string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.SetIcon")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.SetIcon")
+	defer spans.Finish()
+	spans.LogKV("id", id, "iconPath", iconPath)
 
 	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalOrganization{}).
 		Where("id = ?", id).
@@ -556,24 +533,24 @@ func (r *globalOrganizationRepository) SetIcon(ctx context.Context, id uint64, i
 		})
 
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 
 	if result.RowsAffected == 0 {
 		err := errors.New("no organization found with provided ID")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
-	span.LogFields(tracingLog.Int64("rows_affected", result.RowsAffected))
+	spans.LogKV("rows_affected", result.RowsAffected)
 	return nil
 }
 
 func (r *globalOrganizationRepository) SetDownloadStatusLogo(ctx context.Context, id uint64, status enum.DownloadStatus) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.SetDownloadStatusLogo")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.SetDownloadStatusLogo")
+	defer spans.Finish()
+	spans.LogKV("id", id, "status", status.String())
 
 	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalOrganization{}).
 		Where("id = ?", id).
@@ -582,7 +559,7 @@ func (r *globalOrganizationRepository) SetDownloadStatusLogo(ctx context.Context
 		})
 
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 
@@ -590,9 +567,9 @@ func (r *globalOrganizationRepository) SetDownloadStatusLogo(ctx context.Context
 }
 
 func (r *globalOrganizationRepository) SetDownloadStatusIcon(ctx context.Context, id uint64, status enum.DownloadStatus) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.SetDownloadStatusIcon")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.SetDownloadStatusIcon")
+	defer spans.Finish()
+	spans.LogKV("id", id, "status", status.String())
 
 	result := r.db.WithContext(ctx).Model(&postgres_entity.GlobalOrganization{}).
 		Where("id = ?", id).
@@ -601,7 +578,7 @@ func (r *globalOrganizationRepository) SetDownloadStatusIcon(ctx context.Context
 		})
 
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 
@@ -609,35 +586,33 @@ func (r *globalOrganizationRepository) SetDownloadStatusIcon(ctx context.Context
 }
 
 func (r *globalOrganizationRepository) GetByLinkedInUrl(ctx context.Context, linkedInUrl string) (*postgres_entity.GlobalOrganization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.GetByLinkedInUrl")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("linkedInUrl", linkedInUrl)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.GetByLinkedInUrl")
+	defer spans.Finish()
+	spans.LogKV("linkedInUrl", linkedInUrl)
 
 	organization := &postgres_entity.GlobalOrganization{}
 	result := r.db.WithContext(ctx).Where("linkedin = ?", linkedInUrl).First(organization)
 	if result.Error != nil {
-		span.LogFields(tracingLog.Bool("found", false))
+		spans.LogKV("found", false)
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
-	span.LogFields(tracingLog.Bool("found", true))
+	spans.LogKV("found", true)
 	return organization, nil
 }
 
 func (r *globalOrganizationRepository) AddOtherSocials(ctx context.Context, primaryDomain string, otherSocials []string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.AddOtherSocials")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("primaryDomain", primaryDomain, "otherSocials", otherSocials)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.AddOtherSocials")
+	defer spans.Finish()
+	spans.LogKV("primaryDomain", primaryDomain, "otherSocials", otherSocials)
 
 	// Get existing organization or create new one
 	org, err := r.CreateIfNotExists(ctx, primaryDomain)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -669,7 +644,7 @@ func (r *globalOrganizationRepository) AddOtherSocials(ctx context.Context, prim
 				"other_socials": org.OtherSocials,
 			})
 		if result.Error != nil {
-			tracing.TraceErr(span, result.Error)
+			spans.TraceError(result.Error)
 			return result.Error
 		}
 	}
@@ -678,14 +653,13 @@ func (r *globalOrganizationRepository) AddOtherSocials(ctx context.Context, prim
 }
 
 func (r *globalOrganizationRepository) Delete(ctx context.Context, id uint64) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationRepository.Delete")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, fmt.Sprintf("%d", id))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationRepository.Delete")
+	defer spans.Finish()
+	spans.TagEntity(fmt.Sprintf("%d", id))
 
 	result := r.db.WithContext(ctx).Delete(&postgres_entity.GlobalOrganization{}, id)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/global_organization_website_to_process_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/global_organization_website_to_process_repository.go
@@ -2,11 +2,9 @@ package postgres_repository
 
 import (
 	"context"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"gorm.io/gorm"
 )
 
@@ -25,10 +23,9 @@ func NewGlobalOrganizationWebsiteToProcessRepository(gormDb *gorm.DB) GlobalOrga
 }
 
 func (r globalOrganizationWebsiteToProcessRepository) GetWebsitesToProcess(ctx context.Context, limit int) ([]*postgres_entity.GlobalOrganizationWebsiteToProcess, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationWebsiteToProcessRepository.GetWebsitesToProcess")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("limit", limit)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationWebsiteToProcessRepository.GetWebsitesToProcess")
+	defer spans.Finish()
+	spans.LogKV("limit", limit)
 
 	var data []*postgres_entity.GlobalOrganizationWebsiteToProcess
 	err := r.db.
@@ -40,16 +37,15 @@ func (r globalOrganizationWebsiteToProcessRepository) GetWebsitesToProcess(ctx c
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.Int("result.count", len(data)))
+	spans.LogKV("result.count", len(data))
 
 	return data, nil
 }
 
 func (r globalOrganizationWebsiteToProcessRepository) MarkAsProcessed(ctx context.Context, id uint64, notes string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationWebsiteToProcessRepository.MarkAsProcessed")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("id", id, "notes", notes)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationWebsiteToProcessRepository.MarkAsProcessed")
+	defer spans.Finish()
+	spans.LogKV("id", id, "notes", notes)
 
 	err := r.db.Model(&postgres_entity.GlobalOrganizationWebsiteToProcess{}).
 		Where("id = ?", id).
@@ -66,10 +62,9 @@ func (r globalOrganizationWebsiteToProcessRepository) MarkAsProcessed(ctx contex
 }
 
 func (r globalOrganizationWebsiteToProcessRepository) AddWebsiteToProcess(ctx context.Context, website string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "GlobalOrganizationWebsiteToProcessRepository.AddWebsiteToProcess")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("website", website)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "GlobalOrganizationWebsiteToProcessRepository.AddWebsiteToProcess")
+	defer spans.Finish()
+	spans.LogKV("website", website)
 
 	err := r.db.Create(&postgres_entity.GlobalOrganizationWebsiteToProcess{
 		Website: website,

--- a/packages/server/customer-os-postgres-repository/repository/ingest_email_import_state_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/ingest_email_import_state_repository.go
@@ -3,9 +3,8 @@ package postgres_repository
 import (
 	"errors"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 	"time"
@@ -28,10 +27,9 @@ func NewIngestEmailImportStateRepository(gormDb *gorm.DB) IngestEmailImportState
 }
 
 func (repo *ingestEmailImportStateImpl) GetEmailImportState(ctx context.Context, tenantName, provider, username string, period postgres_entity.IngestEmailImportStatePeriod) (*postgres_entity.IngestEmailImportState, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IngestEmailImportStateRepository.GetEmailImportState")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("provider", provider, "username", username, "period", period)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "IngestEmailImportStateRepository.GetEmailImportState")
+	defer spans.Finish()
+	spans.LogKV("provider", provider, "username", username, "period", period)
 
 	result := postgres_entity.IngestEmailImportState{}
 	err := repo.gormDb.First(&result, "tenant = ? AND provider = ? AND username = ? AND period = ?", tenantName, provider, username, period).Error
@@ -48,10 +46,9 @@ func (repo *ingestEmailImportStateImpl) GetEmailImportState(ctx context.Context,
 }
 
 func (repo *ingestEmailImportStateImpl) CreateEmailImportState(ctx context.Context, tenantName, provider, username string, period postgres_entity.IngestEmailImportStatePeriod, startDate, stopDate *time.Time, active bool, cursor string) (*postgres_entity.IngestEmailImportState, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IngestEmailImportStateRepository.CreateEmailImportState")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("provider", provider, "username", username, "period", period)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "IngestEmailImportStateRepository.CreateEmailImportState")
+	defer spans.Finish()
+	spans.LogKV("provider", provider, "username", username, "period", period)
 
 	result := postgres_entity.IngestEmailImportState{}
 	err := repo.gormDb.Find(&result, "tenant = ? AND provider = ? AND username = ? AND period = ?", tenantName, provider, username, period).Error
@@ -75,6 +72,7 @@ func (repo *ingestEmailImportStateImpl) CreateEmailImportState(ctx context.Conte
 	result.Cursor = cursor
 	err = repo.gormDb.Save(&result).Error
 	if err != nil {
+		spans.TraceError(err)
 		return nil, fmt.Errorf("UpdateEmailImportState - insert: %s", err.Error())
 	}
 
@@ -82,14 +80,13 @@ func (repo *ingestEmailImportStateImpl) CreateEmailImportState(ctx context.Conte
 }
 
 func (repo *ingestEmailImportStateImpl) UpdateEmailImportState(ctx context.Context, tenantName, provider, username string, period postgres_entity.IngestEmailImportStatePeriod, cursor string) (*postgres_entity.IngestEmailImportState, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IngestEmailImportStateRepository.UpdateEmailImportState")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("provider", provider, "username", username, "period", period)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "IngestEmailImportStateRepository.UpdateEmailImportState")
+	defer spans.Finish()
+	spans.LogKV("provider", provider, "username", username, "period", period)
 
 	gmailImportState, err := repo.GetEmailImportState(ctx, tenantName, provider, username, period)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if gmailImportState == nil {
@@ -99,7 +96,7 @@ func (repo *ingestEmailImportStateImpl) UpdateEmailImportState(ctx context.Conte
 	gmailImportState.Cursor = cursor
 	err = repo.gormDb.Save(&gmailImportState).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, fmt.Errorf("UpdateEmailImportState - insert: %s", err.Error())
 	}
 
@@ -107,14 +104,13 @@ func (repo *ingestEmailImportStateImpl) UpdateEmailImportState(ctx context.Conte
 }
 
 func (repo *ingestEmailImportStateImpl) ActivateEmailImportState(ctx context.Context, tenantName, provider, username string, period postgres_entity.IngestEmailImportStatePeriod) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IngestEmailImportStateRepository.ActivateEmailImportState")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("provider", provider, "username", username, "period", period)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "IngestEmailImportStateRepository.ActivateEmailImportState")
+	defer spans.Finish()
+	spans.LogKV("provider", provider, "username", username, "period", period)
 
 	gmailImportState, err := repo.GetEmailImportState(ctx, tenantName, provider, username, period)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	if gmailImportState == nil {
@@ -124,7 +120,7 @@ func (repo *ingestEmailImportStateImpl) ActivateEmailImportState(ctx context.Con
 	gmailImportState.Active = true
 	err = repo.gormDb.Save(&gmailImportState).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return fmt.Errorf("DeactivateEmailImportState - update: %s", err.Error())
 	}
 
@@ -132,10 +128,9 @@ func (repo *ingestEmailImportStateImpl) ActivateEmailImportState(ctx context.Con
 }
 
 func (repo *ingestEmailImportStateImpl) DeactivateEmailImportState(ctx context.Context, tenantName, provider, username string, period postgres_entity.IngestEmailImportStatePeriod) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IngestEmailImportStateRepository.DeactivateEmailImportState")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("provider", provider, "username", username, "period", period)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "IngestEmailImportStateRepository.DeactivateEmailImportState")
+	defer spans.Finish()
+	spans.LogKV("provider", provider, "username", username, "period", period)
 
 	emailImportState, err := repo.GetEmailImportState(ctx, tenantName, provider, username, period)
 	if emailImportState == nil {
@@ -145,6 +140,7 @@ func (repo *ingestEmailImportStateImpl) DeactivateEmailImportState(ctx context.C
 	emailImportState.Active = false
 	err = repo.gormDb.Save(&emailImportState).Error
 	if err != nil {
+		spans.TraceError(err)
 		return fmt.Errorf("DeactivateEmailImportState - update: %s", err.Error())
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/magic_link_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/magic_link_repository.go
@@ -2,10 +2,8 @@ package postgres_repository
 
 import (
 	"context"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -26,11 +24,9 @@ func NewMagicLinkRepository(db *gorm.DB) MagicLinkRepository {
 }
 
 func (r *magicLinkRepository) GetByEmail(ctx context.Context, email string) (*postgres_entity.MagicLink, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "MagicLinkRepository.GetByEmail")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-
-	span.LogFields(tracingLog.String("email", email))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "MagicLinkRepository.GetByEmail")
+	defer spans.Finish()
+	spans.LogKV("email", email)
 
 	var result *postgres_entity.MagicLink
 	err := r.gormDb.
@@ -40,24 +36,22 @@ func (r *magicLinkRepository) GetByEmail(ctx context.Context, email string) (*po
 
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			span.LogFields(tracingLog.Bool("result.found", false))
+			spans.LogKV("result.found", false)
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 
 	return result, nil
 }
 
 func (r *magicLinkRepository) GetByCode(ctx context.Context, code string) (*postgres_entity.MagicLink, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "MagicLinkRepository.GetByCode")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-
-	span.LogFields(tracingLog.String("code", code))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "MagicLinkRepository.GetByCode")
+	defer spans.Finish()
+	spans.LogKV("code", code)
 
 	var result *postgres_entity.MagicLink
 	err := r.gormDb.
@@ -67,24 +61,22 @@ func (r *magicLinkRepository) GetByCode(ctx context.Context, code string) (*post
 
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			span.LogFields(tracingLog.Bool("result.found", false))
+			spans.LogKV("result.found", false)
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 
 	return result, nil
 }
 
 func (r *magicLinkRepository) Create(ctx context.Context, input *postgres_entity.MagicLink) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "MagicLinkRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-
-	span.LogFields(tracingLog.Object("magicLink", input))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "MagicLinkRepository.Create")
+	defer spans.Finish()
+	spans.LogObjectAsJson("magicLink", input)
 
 	// Check if the mailbox already exists
 	var magicLink postgres_entity.MagicLink
@@ -93,7 +85,7 @@ func (r *magicLinkRepository) Create(ctx context.Context, input *postgres_entity
 		First(&magicLink).Error
 
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -107,12 +99,12 @@ func (r *magicLinkRepository) Create(ctx context.Context, input *postgres_entity
 
 		err = r.gormDb.Create(&magicLink).Error
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	} else {
 		e := errors.New("magic link already exists by code")
-		tracing.TraceErr(span, e)
+		spans.TraceError(e)
 		return e
 	}
 
@@ -120,11 +112,9 @@ func (r *magicLinkRepository) Create(ctx context.Context, input *postgres_entity
 }
 
 func (r *magicLinkRepository) Delete(ctx context.Context, id string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "MagicLinkRepository.Delete")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-
-	span.LogFields(tracingLog.Object("id", id))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "MagicLinkRepository.Delete")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	// Check if the mailbox already exists
 	var magicLink postgres_entity.MagicLink
@@ -133,19 +123,19 @@ func (r *magicLinkRepository) Delete(ctx context.Context, id string) error {
 		First(&magicLink).Error
 
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	if magicLink.ID == "" {
 		e := errors.New("magic link not found")
-		tracing.TraceErr(span, e)
+		spans.TraceError(e)
 		return e
 	}
 
 	err = r.gormDb.Delete(magicLink).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/mailstack_buy_request_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/mailstack_buy_request_repository.go
@@ -2,12 +2,11 @@ package postgres_repository
 
 import (
 	"errors"
+
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -30,16 +29,15 @@ func NewMailstackBuyRequestRepository(gormDb *gorm.DB) MailstackBuyRequestReposi
 }
 
 func (repo *mailstackBuyRequestRepositoryRepositoryImpl) GetList(ctx context.Context) ([]*postgres_entity.MailstackBuyRequest, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MailstackBuyRequestRepository.GetList")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "MailstackBuyRequestRepository.GetList")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
 	var e []*postgres_entity.MailstackBuyRequest
 	err := repo.gormDb.Where("tenant = ?", tenant).Find(&e).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -47,11 +45,9 @@ func (repo *mailstackBuyRequestRepositoryRepositoryImpl) GetList(ctx context.Con
 }
 
 func (repo *mailstackBuyRequestRepositoryRepositoryImpl) GetById(ctx context.Context, id string) (*postgres_entity.MailstackBuyRequest, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MailstackBuyRequestRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-
-	span.LogFields(log.String("id", id))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "MailstackBuyRequestRepository.GetById")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -59,10 +55,10 @@ func (repo *mailstackBuyRequestRepositoryRepositoryImpl) GetById(ctx context.Con
 	err := repo.gormDb.Where("tenant = ? and id = ?", tenant, id).First(&e).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			span.LogFields(log.Bool("result.found", false))
+			spans.LogKV("result.found", false)
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -70,18 +66,16 @@ func (repo *mailstackBuyRequestRepositoryRepositoryImpl) GetById(ctx context.Con
 }
 
 func (repo *mailstackBuyRequestRepositoryRepositoryImpl) Store(ctx context.Context, tx *gorm.DB, input *postgres_entity.MailstackBuyRequest) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MailstackBuyRequestRepository.Store")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "MailstackBuyRequestRepository.Store")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
-	span.LogFields(log.String("input.domains", input.Domains), log.String("input.usernames", input.Usernames))
+	spans.LogObjectAsJson("input", input)
 
 	if input.Domains == "" || input.Usernames == "" {
-		span.LogFields(log.Object("input", input))
 		err := errors.New("params missing")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
 
@@ -94,7 +88,7 @@ func (repo *mailstackBuyRequestRepositoryRepositoryImpl) Store(ctx context.Conte
 
 	err := repo.gormDb.Save(&input).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
 
@@ -102,18 +96,16 @@ func (repo *mailstackBuyRequestRepositoryRepositoryImpl) Store(ctx context.Conte
 }
 
 func (repo *mailstackBuyRequestRepositoryRepositoryImpl) GetDomains(ctx context.Context, mailstackBuyRequestId string) ([]*postgres_entity.MailstackBuyRequestDomain, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MailstackBuyRequestRepository.GetDomains")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-
-	span.LogFields(log.String("mailstackBuyRequestId", mailstackBuyRequestId))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "MailstackBuyRequestRepository.GetDomains")
+	defer spans.Finish()
+	spans.LogKV("mailstackBuyRequestId", mailstackBuyRequestId)
 
 	tenant := common.GetTenantFromContext(ctx)
 
 	var e []*postgres_entity.MailstackBuyRequestDomain
 	err := repo.gormDb.Where("tenant = ? and mailstack_buy_request_id = ?", tenant, mailstackBuyRequestId).Find(&e).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -121,18 +113,15 @@ func (repo *mailstackBuyRequestRepositoryRepositoryImpl) GetDomains(ctx context.
 }
 
 func (repo *mailstackBuyRequestRepositoryRepositoryImpl) StoreDomain(ctx context.Context, tx *gorm.DB, input *postgres_entity.MailstackBuyRequestDomain) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MailstackBuyRequestRepository.StoreDomain")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "MailstackBuyRequestRepository.StoreDomain")
+	defer spans.Finish()
+	spans.LogObjectAsJson("input", input)
 
 	tenant := common.GetTenantFromContext(ctx)
 
-	span.LogKV("input.domain", input.Domain, "input.redirectWebsite", input.RedirectWebsite)
-
 	if input.Domain == "" || input.MailstackBuyRequestId == "" {
-		span.LogFields(log.Object("input", input))
 		err := errors.New("params missing")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -145,7 +134,7 @@ func (repo *mailstackBuyRequestRepositoryRepositoryImpl) StoreDomain(ctx context
 
 	err := repo.gormDb.Save(&input).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/personal_email_provider_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/personal_email_provider_repository.go
@@ -1,9 +1,8 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -21,15 +20,14 @@ func NewPersonalEmailProviderRepository(gormDb *gorm.DB) PersonalEmailProviderRe
 }
 
 func (repo *personalEmailProviderRepositoryImpl) GetPersonalEmailProviders(ctx context.Context) ([]postgres_entity.PersonalEmailProvider, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PersonalEmailProviderRepository.GetPersonalEmailProviders")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "PersonalEmailProviderRepository.GetPersonalEmailProviders")
+	defer spans.Finish()
 
 	var result []postgres_entity.PersonalEmailProvider
 	err := repo.gormDb.Find(&result).Error
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/postmark_api_key_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/postmark_api_key_repository.go
@@ -1,10 +1,9 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository/helper"
-	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -23,9 +22,8 @@ func NewPostmarkApiKeyRepo(db *gorm.DB) *PostmarkApiKeyRepo {
 }
 
 func (r *PostmarkApiKeyRepo) GetPostmarkApiKey(ctx context.Context, tenant string) helper.QueryResult {
-	span, _ := opentracing.StartSpanFromContext(ctx, "PostmarkApiKeyRepo.GetPostmarkApiKey")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "PostmarkApiKeyRepo.GetPostmarkApiKey")
+	defer spans.Finish()
 
 	var postmarkApiKeyEntity postgres_entity.PostmarkApiKey
 	err := r.db.
@@ -40,9 +38,8 @@ func (r *PostmarkApiKeyRepo) GetPostmarkApiKey(ctx context.Context, tenant strin
 }
 
 func (r *PostmarkApiKeyRepo) CreateApiKey(ctx context.Context, apiKey postgres_entity.PostmarkApiKey) helper.QueryResult {
-	span, _ := opentracing.StartSpanFromContext(ctx, "PostmarkApiKeyRepo.CreateApiKey")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "PostmarkApiKeyRepo.CreateApiKey")
+	defer spans.Finish()
 
 	postmarkApiKeyEntity := postgres_entity.PostmarkApiKey{
 		TenantName: apiKey.TenantName,

--- a/packages/server/customer-os-postgres-repository/repository/quickbook_settings_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/quickbook_settings_repository.go
@@ -2,11 +2,9 @@ package postgres_repository
 
 import (
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -28,61 +26,61 @@ func NewQuickbooksSettingsRepository(db *gorm.DB) QuickbooksSettingsRepository {
 }
 
 func (repo *quickbooksSettingsRepository) Get(ctx context.Context, tenant string) (*postgres_entity.QuickbooksSettingsEntity, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "QuickbooksSettingsRepository.Get")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "QuickbooksSettingsRepository.Get")
+	defer spans.Finish()
+	spans.LogKV("tenant", tenant)
 
 	var existing *postgres_entity.QuickbooksSettingsEntity
 	err := repo.db.Find(&existing, "tenant = ?", tenant).Error
 
 	if err != nil {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	if existing == nil {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	} else if existing.Tenant == "" {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(tracingLog.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return existing, nil
 }
 
 func (repo *quickbooksSettingsRepository) Save(ctx context.Context, quickbooksSettings postgres_entity.QuickbooksSettingsEntity) (*postgres_entity.QuickbooksSettingsEntity, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "QuickbooksSettingsRepository.Save")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "QuickbooksSettingsRepository.Save")
+	defer spans.Finish()
+	spans.LogObjectAsJson("quickbooksSettings", quickbooksSettings)
 
 	quickbooksSettings.UpdatedAt = utils.NowPtr()
 	result := repo.db.Save(&quickbooksSettings)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
 	return &quickbooksSettings, nil
 }
 
 func (repo *quickbooksSettingsRepository) Delete(ctx context.Context, tenant string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "QuickbooksSettingsRepository.Delete")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "QuickbooksSettingsRepository.Delete")
+	defer spans.Finish()
+	spans.LogKV("tenant", tenant)
 
 	existing, err := repo.Get(ctx, tenant)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	err = repo.db.Delete(&existing).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/scraped_webpage_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/scraped_webpage_repository.go
@@ -6,12 +6,10 @@ import (
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/lib/pq"
-	"github.com/opentracing/opentracing-go"
 	"gorm.io/gorm"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -38,9 +36,8 @@ func NewScrapedWebpageRepository(gormDb *gorm.DB) ScrapedWebpageRepository {
 }
 
 func (r *scrapedWebpageRepository) Save(ctx context.Context, webpageData postgres_entity.ScrapedWebpage) (*postgres_entity.ScrapedWebpage, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "scrapedWebpageRepository.Save")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "scrapedWebpageRepository.Save")
+	defer spans.Finish()
 
 	// Check if a record with this URL already exists
 	var existingRecord postgres_entity.ScrapedWebpage
@@ -86,10 +83,9 @@ func (r *scrapedWebpageRepository) Save(ctx context.Context, webpageData postgre
 }
 
 func (r *scrapedWebpageRepository) GetWebpage(ctx context.Context, url string, lookbackInDays int) (*postgres_entity.ScrapedWebpage, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ScrapedWebpageRepository.GetWebpage")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("url", url, "lookbackInDays", lookbackInDays)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "ScrapedWebpageRepository.GetWebpage")
+	defer spans.Finish()
+	spans.LogKV("url", url, "lookbackInDays", lookbackInDays)
 
 	// Calculate the cutoff date
 	cutoffDate := utils.Now().AddDate(0, 0, -lookbackInDays)
@@ -102,20 +98,20 @@ func (r *scrapedWebpageRepository) GetWebpage(ctx context.Context, url string, l
 		Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			span.LogFields(log.Bool("result.found", false))
+			spans.LogKV("result.found", false)
 			return nil, nil
 		}
 		return nil, err
 	}
 
-	tracing.LogObjectAsJson(span, "result.webpage", record)
+	spans.LogObjectAsJson("result.webpage", record)
 	return &record, nil
 }
 
 func (r *scrapedWebpageRepository) GetAllWebpagesByPrimaryDomains(ctx context.Context, primaryDomains []string) ([]*postgres_entity.ScrapedWebpage, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "scrapedWebpageRepository.GetAllWebpagesByPrimaryDomains")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "scrapedWebpageRepository.GetAllWebpagesByPrimaryDomains")
+	defer spans.Finish()
+	spans.LogObjectAsJson("primaryDomains", primaryDomains)
 
 	var records []*postgres_entity.ScrapedWebpage
 
@@ -131,11 +127,10 @@ func (r *scrapedWebpageRepository) GetAllWebpagesByPrimaryDomains(ctx context.Co
 }
 
 func (r *scrapedWebpageRepository) SetLinks(ctx context.Context, url string, links []string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ScrapedWebpageRepository.SetLinks")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("url", url)
-	tracing.LogObjectAsJson(span, "links", links)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "ScrapedWebpageRepository.SetLinks")
+	defer spans.Finish()
+	spans.LogKV("url", url)
+	spans.LogObjectAsJson("links", links)
 
 	err := r.gormDb.Model(&postgres_entity.ScrapedWebpage{}).
 		Where("url = ?", url).
@@ -149,69 +144,84 @@ func (r *scrapedWebpageRepository) SetLinks(ctx context.Context, url string, lin
 }
 
 func (r *scrapedWebpageRepository) SetContent(ctx context.Context, url string, content string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ScrapedWebpageRepository.SetContent")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("url", url, "content.length", len(content))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "ScrapedWebpageRepository.SetContent")
+	defer spans.Finish()
+	spans.LogKV("url", url, "content.length", len(content))
 
 	err := r.gormDb.Model(&postgres_entity.ScrapedWebpage{}).
 		Where("url = ?", url).
 		Update("content", content).
 		Error
 
-	return err
+	if err != nil {
+		spans.TraceError(err)
+		return err
+	}
+
+	return nil
 }
 
 func (r *scrapedWebpageRepository) SetContentStage(ctx context.Context, url string, contentStage enum.CustomerJourneyStage) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ScrapedWebpageRepository.SetContentStage")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("url", url, "contentStage", contentStage)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "ScrapedWebpageRepository.SetContentStage")
+	defer spans.Finish()
+	spans.LogKV("url", url, "contentStage", contentStage)
 
 	err := r.gormDb.Model(&postgres_entity.ScrapedWebpage{}).
 		Where("url = ?", url).
 		Update("content_stage", contentStage).
 		Error
 
-	return err
+	if err != nil {
+		spans.TraceError(err)
+		return err
+	}
+
+	return nil
 }
 
 func (r *scrapedWebpageRepository) SetWebpageTopics(ctx context.Context, url string, topics []string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ScrapedWebpageRepository.SetWebpageTopics")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("url", url, "topics.length", len(topics))
-	tracing.LogObjectAsJson(span, "topics", topics)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "ScrapedWebpageRepository.SetWebpageTopics")
+	defer spans.Finish()
+	spans.LogKV("url", url, "topics.length", len(topics))
+	spans.LogObjectAsJson("topics", topics)
 
 	err := r.gormDb.Model(&postgres_entity.ScrapedWebpage{}).
 		Where("url = ?", url).
 		Update("topics", pq.StringArray(topics)).
 		Error
 
-	return err
+	if err != nil {
+		spans.TraceError(err)
+		return err
+	}
+
+	return nil
 }
 
 func (r *scrapedWebpageRepository) SetWebpageCategory(ctx context.Context, url string, category enum.WebpageCategory) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ScrapedWebpageRepository.SetWebpageCategory")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("url", url, "category", category)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "ScrapedWebpageRepository.SetWebpageCategory")
+	defer spans.Finish()
+	spans.LogKV("url", url, "category", category)
 
 	err := r.gormDb.Model(&postgres_entity.ScrapedWebpage{}).
 		Where("url = ?", url).
 		Update("category", category.String()).
 		Error
 
-	return err
+	if err != nil {
+		spans.TraceError(err)
+		return err
+	}
+
+	return nil
 }
 
 // Number of days to recheck links
 const LinksCheckStaleThresholdDays = 30
 
 func (r *scrapedWebpageRepository) GetWebpagesWithoutLinks(ctx context.Context, limit int) ([]*postgres_entity.ScrapedWebpage, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ScrapedWebpageRepository.GetWebpagesWithoutLinks")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "ScrapedWebpageRepository.GetWebpagesWithoutLinks")
+	defer spans.Finish()
 
 	webpages := make([]*postgres_entity.ScrapedWebpage, 0)
 
@@ -233,7 +243,7 @@ func (r *scrapedWebpageRepository) GetWebpagesWithoutLinks(ctx context.Context, 
 		Limit(halfLimit).
 		Find(&recentWebpages)
 	if resultRecent.Error != nil {
-		tracing.TraceErr(span, resultRecent.Error)
+		spans.TraceError(resultRecent.Error)
 		return nil, resultRecent.Error
 	}
 
@@ -261,13 +271,13 @@ func (r *scrapedWebpageRepository) GetWebpagesWithoutLinks(ctx context.Context, 
 			Limit(remainingLimit).
 			Find(&randomWebpages)
 		if resultRandom.Error != nil {
-			tracing.TraceErr(span, resultRandom.Error)
+			spans.TraceError(resultRandom.Error)
 			return nil, resultRandom.Error
 		}
 
 		webpages = append(webpages, randomWebpages...)
 	}
 
-	span.LogKV("result.count", len(webpages))
+	spans.LogKV("result.count", len(webpages))
 	return webpages, nil
 }

--- a/packages/server/customer-os-postgres-repository/repository/sku_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/sku_repository.go
@@ -3,10 +3,8 @@ package postgres_repository
 import (
 	"errors"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgresentity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -29,10 +27,9 @@ func NewSkuRepository(db *gorm.DB) SkuRepository {
 }
 
 func (repo *skuRepository) Get(ctx context.Context, tenant, skuId string) (*postgresentity.SkuEntity, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "SkuRepository.Get")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(tracingLog.String("skuId", skuId))
+	spans, _ := telemetry.StartPostgresSpan(ctx, "SkuRepository.Get")
+	defer spans.Finish()
+	spans.LogKV("skuId", skuId)
 
 	if skuId == "" {
 		return nil, nil
@@ -41,27 +38,26 @@ func (repo *skuRepository) Get(ctx context.Context, tenant, skuId string) (*post
 	var existing *postgresentity.SkuEntity
 	err := repo.db.First(&existing, "tenant = ? and id = ?", tenant, skuId).Error
 	if err != nil {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	if existing == nil {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(tracingLog.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return existing, nil
 }
 
 func (repo *skuRepository) GetAll(ctx context.Context, tenant string, archived *bool) ([]*postgresentity.SkuEntity, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "SkuRepository.GetAll")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "SkuRepository.GetAll")
+	defer spans.Finish()
 
 	var err error
 	var existing []*postgresentity.SkuEntity
@@ -73,8 +69,8 @@ func (repo *skuRepository) GetAll(ctx context.Context, tenant string, archived *
 	}
 
 	if err != nil {
-		span.LogFields(tracingLog.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -82,23 +78,21 @@ func (repo *skuRepository) GetAll(ctx context.Context, tenant string, archived *
 }
 
 func (repo *skuRepository) Save(ctx context.Context, sku *postgresentity.SkuEntity) (*postgresentity.SkuEntity, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "SkuRepository.Save")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "SkuRepository.Save")
+	defer spans.Finish()
 
 	result := repo.db.Save(sku)
 	if result.Error != nil {
+		spans.TraceError(result.Error)
 		return nil, fmt.Errorf("saving slack settings failed: %w", result.Error)
 	}
 	return sku, nil
 }
 
 func (repo *skuRepository) Archive(ctx context.Context, tenant, id string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "SkuRepository.Archive")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-
-	span.LogFields(tracingLog.String("id", id))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "SkuRepository.Archive")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	existing, err := repo.Get(ctx, tenant, id)
 	if err != nil {
@@ -109,7 +103,7 @@ func (repo *skuRepository) Archive(ctx context.Context, tenant, id string) error
 
 	result := repo.db.Save(existing)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return fmt.Errorf("archiving sku failed: %w", result.Error)
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/slack_channel_notification_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/slack_channel_notification_repository.go
@@ -5,8 +5,7 @@ import (
 	"errors"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/opentracing/opentracing-go"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"gorm.io/gorm"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -25,18 +24,17 @@ func NewSlackChannelNotificationRepository(db *gorm.DB) SlackChannelNotification
 }
 
 func (r *slackChannelNotificationRepository) GetSlackChannel(c context.Context, workflow postgres_entity.SlackChannelNotificationWorkflow) (*postgres_entity.SlackChannelNotification, error) {
-	span, ctx := opentracing.StartSpanFromContext(c, "SlackChannelNotificationRepository.GetSlackChannels")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("workflow", workflow)
+	spans, ctx := telemetry.StartPostgresSpan(c, "SlackChannelNotificationRepository.GetSlackChannels")
+	defer spans.Finish()
+	spans.LogKV("workflow", workflow)
 
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {
 		err := errors.New("tenant not set on context")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	tracing.TagTenant(span, tenant)
+	spans.LogKV("tenant", tenant)
 
 	var e *postgres_entity.SlackChannelNotification
 	err := r.db.
@@ -47,7 +45,7 @@ func (r *slackChannelNotificationRepository) GetSlackChannel(c context.Context, 
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/slack_channel_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/slack_channel_repository.go
@@ -2,10 +2,9 @@ package postgres_repository
 
 import (
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"github.com/google/uuid"
-	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -29,10 +28,9 @@ func NewSlackChannelRepository(db *gorm.DB) SlackChannelRepository {
 }
 
 func (r *slackChannelRepository) GetSlackChannel(ctx context.Context, tenant, channelId string) (*postgres_entity.SlackChannel, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SlackChannelRepository.GetSlackChannel")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("channelId", channelId)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "SlackChannelRepository.GetSlackChannel")
+	defer spans.Finish()
+	spans.LogKV("channelId", channelId)
 
 	var entities []postgres_entity.SlackChannel
 	err := r.db.
@@ -41,6 +39,7 @@ func (r *slackChannelRepository) GetSlackChannel(ctx context.Context, tenant, ch
 		Find(&entities).Error
 
 	if err != nil {
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -55,9 +54,9 @@ func (r *slackChannelRepository) GetSlackChannel(ctx context.Context, tenant, ch
 }
 
 func (r *slackChannelRepository) GetSlackChannels(ctx context.Context, tenant string) ([]*postgres_entity.SlackChannel, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SlackChannelRepository.GetSlackChannels")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "SlackChannelRepository.GetSlackChannels")
+	defer spans.Finish()
+	spans.LogKV("tenant", tenant)
 
 	var entities []*postgres_entity.SlackChannel
 	err := r.db.
@@ -65,6 +64,7 @@ func (r *slackChannelRepository) GetSlackChannels(ctx context.Context, tenant st
 		Find(&entities).Error
 
 	if err != nil {
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -72,9 +72,9 @@ func (r *slackChannelRepository) GetSlackChannels(ctx context.Context, tenant st
 }
 
 func (r *slackChannelRepository) GetPaginatedSlackChannels(ctx context.Context, tenant string, skip, limit int) ([]*postgres_entity.SlackChannel, int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SlackChannelRepository.GetPaginatedSlackChannels")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "SlackChannelRepository.GetPaginatedSlackChannels")
+	defer spans.Finish()
+	spans.LogKV("tenant", tenant, "skip", skip, "limit", limit)
 
 	var err error
 	var total int64
@@ -85,6 +85,7 @@ func (r *slackChannelRepository) GetPaginatedSlackChannels(ctx context.Context, 
 		Where("tenant_name = ?", tenant).
 		Count(&total).Error
 	if err != nil {
+		spans.TraceError(err)
 		return nil, 0, err
 	}
 
@@ -96,6 +97,7 @@ func (r *slackChannelRepository) GetPaginatedSlackChannels(ctx context.Context, 
 		Find(&entities).Error
 
 	if err != nil {
+		spans.TraceError(err)
 		return nil, 0, err
 	}
 
@@ -103,12 +105,12 @@ func (r *slackChannelRepository) GetPaginatedSlackChannels(ctx context.Context, 
 }
 
 func (r *slackChannelRepository) CreateSlackChannel(ctx context.Context, postgres_entity *postgres_entity.SlackChannel) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SlackChannelRepository.CreateSlackChannel")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "SlackChannelRepository.CreateSlackChannel")
+	defer spans.Finish()
 
 	err := r.db.Create(postgres_entity).Error
 	if err != nil {
+		spans.TraceError(err)
 		return err
 	}
 
@@ -116,17 +118,17 @@ func (r *slackChannelRepository) CreateSlackChannel(ctx context.Context, postgre
 }
 
 func (r *slackChannelRepository) UpdateSlackChannelOrganization(ctx context.Context, postgres_entityId uuid.UUID, organizationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SlackChannelRepository.UpdateSlackChannelOrganization")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "SlackChannelRepository.UpdateSlackChannelOrganization")
+	defer spans.Finish()
+	spans.LogKV("postgres_entityId", postgres_entityId, "organizationId", organizationId)
 
 	return r.db.Model(&postgres_entity.SlackChannel{}).Where("id = ?", postgres_entityId).Update("organization_id", organizationId).Error
 }
 
 func (r *slackChannelRepository) UpdateSlackChannelName(ctx context.Context, postgres_entityId uuid.UUID, channelName string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SlackChannelRepository.UpdateSlackChannelName")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "SlackChannelRepository.UpdateSlackChannelName")
+	defer spans.Finish()
+	spans.LogKV("postgres_entityId", postgres_entityId, "channelName", channelName)
 
 	return r.db.Model(&postgres_entity.SlackChannel{}).Where("id = ?", postgres_entityId).Update("channel_name", channelName).Error
 }

--- a/packages/server/customer-os-postgres-repository/repository/slack_settings_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/slack_settings_repository.go
@@ -2,10 +2,8 @@ package postgres_repository
 
 import (
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -27,60 +25,58 @@ func NewSlackSettingsRepository(db *gorm.DB) SlackSettingsRepository {
 }
 
 func (repo *slackSettingsRepository) Get(ctx context.Context, tenant string) (*postgres_entity.SlackSettingsEntity, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "SlackSettingsRepository.Get")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-
+	spans, _ := telemetry.StartPostgresSpan(ctx, "SlackSettingsRepository.Get")
+	defer spans.Finish()
+	spans.LogKV("tenant", tenant)
 	var existing *postgres_entity.SlackSettingsEntity
 	err := repo.db.Find(&existing, "tenant_name = ?", tenant).Error
 
 	if err != nil {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	if existing == nil {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	} else if existing.TenantName == "" {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(tracingLog.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return existing, nil
 }
 
 func (repo *slackSettingsRepository) Save(ctx context.Context, slackSettings postgres_entity.SlackSettingsEntity) (*postgres_entity.SlackSettingsEntity, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "SlackSettingsRepository.Save")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "SlackSettingsRepository.Save")
+	defer spans.Finish()
 
 	result := repo.db.Save(&slackSettings)
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return nil, result.Error
 	}
 	return &slackSettings, nil
 }
 
 func (repo *slackSettingsRepository) Delete(ctx context.Context, tenant string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "SlackSettingsRepository.Delete")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "SlackSettingsRepository.Delete")
+	defer spans.Finish()
+	spans.LogKV("tenant", tenant)
 
 	existing, err := repo.Get(ctx, tenant)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	err = repo.db.Delete(&existing).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/tenant_settings_email_exclusion_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/tenant_settings_email_exclusion_repository.go
@@ -1,10 +1,8 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -22,19 +20,18 @@ func NewEmailExclusionRepository(gormDb *gorm.DB) TenantSettingsEmailExclusionRe
 }
 
 func (repo *tenantSettingsEmailExclusionRepositoryImpl) GetExclusionList(ctx context.Context) ([]postgres_entity.TenantSettingsEmailExclusion, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TenantSettingsEmailExclusionRepository.GetExclusionList")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "TenantSettingsEmailExclusionRepository.GetExclusionList")
+	defer spans.Finish()
 
 	result := []postgres_entity.TenantSettingsEmailExclusion{}
 	err := repo.gormDb.Find(&result).Limit(5000).Error
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result)))
+	spans.LogKV("result.count", len(result))
 
 	return result, nil
 }

--- a/packages/server/customer-os-postgres-repository/repository/tenant_settings_opportunity_stage_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/tenant_settings_opportunity_stage_repository.go
@@ -3,11 +3,9 @@ package postgres_repository
 import (
 	"context"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -29,10 +27,9 @@ func NewTenantSettingsOpportunityStageRepository(db *gorm.DB) TenantSettingsOppo
 }
 
 func (r *tenantSettingsOpportunityStageRepository) GetById(ctx context.Context, tenant, id string) (*postgres_entity.TenantSettingsOpportunityStage, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantSettingsOpportunityStageRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogFields(tracingLog.String("id", id))
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "TenantSettingsOpportunityStageRepository.GetById")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	var result postgres_entity.TenantSettingsOpportunityStage
 	err := r.gormDb.
@@ -44,7 +41,7 @@ func (r *tenantSettingsOpportunityStageRepository) GetById(ctx context.Context, 
 		if err == gorm.ErrRecordNotFound {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -52,9 +49,8 @@ func (r *tenantSettingsOpportunityStageRepository) GetById(ctx context.Context, 
 }
 
 func (r *tenantSettingsOpportunityStageRepository) GetOrInitialize(ctx context.Context, tenant string) ([]*postgres_entity.TenantSettingsOpportunityStage, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantSettingsOpportunityStageRepository.Get")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "TenantSettingsOpportunityStageRepository.Get")
+	defer spans.Finish()
 
 	var entities []*postgres_entity.TenantSettingsOpportunityStage
 	err := r.gormDb.
@@ -63,14 +59,14 @@ func (r *tenantSettingsOpportunityStageRepository) GetOrInitialize(ctx context.C
 		Find(&entities).Error
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, errors.Wrap(err, "error while getting tenant settings opportunity stages")
 	}
 
 	if len(entities) == 0 {
 		err = r.Init(ctx, tenant)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, errors.Wrap(err, "error while initializing tenant settings opportunity stages")
 		}
 
@@ -80,7 +76,7 @@ func (r *tenantSettingsOpportunityStageRepository) GetOrInitialize(ctx context.C
 			Find(&entities).Error
 
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, errors.Wrap(err, "error while getting tenant settings opportunity stages")
 		}
 	}
@@ -89,9 +85,8 @@ func (r *tenantSettingsOpportunityStageRepository) GetOrInitialize(ctx context.C
 }
 
 func (r *tenantSettingsOpportunityStageRepository) Init(c context.Context, tenant string) error {
-	span, ctx := opentracing.StartSpanFromContext(c, "TenantSettingsOpportunityStageRepository.Init")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(c, "TenantSettingsOpportunityStageRepository.Init")
+	defer spans.Finish()
 
 	r.Store(ctx, postgres_entity.TenantSettingsOpportunityStage{
 		Tenant:  tenant,
@@ -127,7 +122,7 @@ func (r *tenantSettingsOpportunityStageRepository) Init(c context.Context, tenan
 		})
 
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}
@@ -136,27 +131,25 @@ func (r *tenantSettingsOpportunityStageRepository) Init(c context.Context, tenan
 }
 
 func (r *tenantSettingsOpportunityStageRepository) Store(ctx context.Context, postgres_entity postgres_entity.TenantSettingsOpportunityStage) (*postgres_entity.TenantSettingsOpportunityStage, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantSettingsOpportunityStageRepository.Store")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "TenantSettingsOpportunityStageRepository.Store")
+	defer spans.Finish()
 
 	err := r.gormDb.Save(&postgres_entity).Error
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(tracingLog.String("postgres_entity.id", postgres_entity.ID))
+	spans.LogKV("postgres_entity.id", postgres_entity.ID)
 
 	return &postgres_entity, nil
 }
 
 func (r *tenantSettingsOpportunityStageRepository) Update(ctx context.Context, tenant, id string, label *string, likelihoodRate *int64, visible *bool) (*postgres_entity.TenantSettingsOpportunityStage, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TenantSettingsOpportunityStageRepository.Update")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("id", id)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "TenantSettingsOpportunityStageRepository.Update")
+	defer spans.Finish()
+	spans.LogKV("id", id)
 
 	// update label, rate and visible if not null
 	updateFields := map[string]interface{}{}
@@ -178,7 +171,7 @@ func (r *tenantSettingsOpportunityStageRepository) Update(ctx context.Context, t
 		Error
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/tenant_settings_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/tenant_settings_repository.go
@@ -1,10 +1,8 @@
 package postgres_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	tracingLog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
@@ -26,9 +24,8 @@ func NewTenantSettingsRepository(db *gorm.DB) TenantSettingsRepository {
 }
 
 func (r *tenantSettingsRepo) FindForTenantName(ctx context.Context, tenantName string) (*postgres_entity.TenantSettings, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TenantSettingsRepository.FindForTenantName")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "TenantSettingsRepository.FindForTenantName")
+	defer spans.Finish()
 
 	var tenantSettings postgres_entity.TenantSettings
 
@@ -37,29 +34,28 @@ func (r *tenantSettingsRepo) FindForTenantName(ctx context.Context, tenantName s
 		First(&tenantSettings).Error
 
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
-		span.LogFields(tracingLog.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(tracingLog.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 
 	return &tenantSettings, nil
 }
 
 func (r *tenantSettingsRepo) Save(ctx context.Context, tenantSettings *postgres_entity.TenantSettings) (*postgres_entity.TenantSettings, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TenantSettingsRepository.Save")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, _ := telemetry.StartPostgresSpan(ctx, "TenantSettingsRepository.Save")
+	defer spans.Finish()
 
 	err := r.db.Save(tenantSettings).Error
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/tenant_webhook_api_key_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/tenant_webhook_api_key_repository.go
@@ -2,11 +2,9 @@ package postgres_repository
 
 import (
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 	"gorm.io/gorm"
 )
@@ -26,9 +24,8 @@ func NewTenantWebhookApiKeyRepository(gormDb *gorm.DB) TenantWebhookApiKeyReposi
 }
 
 func (r *tenantWebhookApiKeyRepository) CreateApiKey(ctx context.Context, tenant string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantWebhookApiKeyRepository.CreateApiKey")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "TenantWebhookApiKeyRepository.CreateApiKey")
+	defer spans.Finish()
 
 	now := utils.Now()
 	apiKey := postgres_entity.TenantWebhookApiKey{
@@ -41,15 +38,15 @@ func (r *tenantWebhookApiKeyRepository) CreateApiKey(ctx context.Context, tenant
 
 	err := r.gormDb.Create(&apiKey).Error
 	if err != nil {
+		spans.TraceError(err)
 		return err
 	}
 	return nil
 }
 
 func (r *tenantWebhookApiKeyRepository) GetTenantForApiKey(ctx context.Context, apiKey string) (*postgres_entity.TenantWebhookApiKey, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantWebhookApiKeyRepository.GetTenantWithApiKey")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "TenantWebhookApiKeyRepository.GetTenantWithApiKey")
+	defer spans.Finish()
 
 	// get record for api key or nil if not found
 	var apiKeyRecord postgres_entity.TenantWebhookApiKey
@@ -61,15 +58,15 @@ func (r *tenantWebhookApiKeyRepository) GetTenantForApiKey(ctx context.Context, 
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
+		spans.TraceError(err)
 		return nil, err
 	}
 	return &apiKeyRecord, nil
 }
 
 func (r *tenantWebhookApiKeyRepository) GetFirstApiKeyForTenant(ctx context.Context, tenant string) (*postgres_entity.TenantWebhookApiKey, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantWebhookApiKeyRepository.GetFirstApiKeyForTenant")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "TenantWebhookApiKeyRepository.GetFirstApiKeyForTenant")
+	defer spans.Finish()
 
 	// get record for tenant or nil if not found
 	var apiKeyRecord postgres_entity.TenantWebhookApiKey
@@ -80,11 +77,12 @@ func (r *tenantWebhookApiKeyRepository) GetFirstApiKeyForTenant(ctx context.Cont
 		Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			span.LogFields(log.Bool("result.found", false))
+			spans.LogKV("result.found", false)
 			return nil, nil
 		}
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return &apiKeyRecord, nil
 }

--- a/packages/server/customer-os-postgres-repository/repository/webhook_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/webhook_repository.go
@@ -7,9 +7,8 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
 	"gorm.io/gorm"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -32,9 +31,8 @@ func NewWebhooksRepository(gormDb *gorm.DB) WebhooksRepository {
 }
 
 func (r *webhooksRepository) Create(ctx context.Context, webhook postgres_entity.Webhooks) (*postgres_entity.Webhooks, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebhooksRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebhooksRepository.Create")
+	defer spans.Finish()
 
 	var created postgres_entity.Webhooks
 	now := utils.Now()
@@ -49,6 +47,7 @@ func (r *webhooksRepository) Create(ctx context.Context, webhook postgres_entity
             AND enabled = TRUE
         `, now, webhook.Integration, webhook.Tenant).Error
 		if err != nil {
+			spans.TraceError(err)
 			return err
 		}
 
@@ -76,7 +75,7 @@ func (r *webhooksRepository) Create(ctx context.Context, webhook postgres_entity
 		).Scan(&created).Error
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -84,14 +83,13 @@ func (r *webhooksRepository) Create(ctx context.Context, webhook postgres_entity
 }
 
 func (r *webhooksRepository) FindAll(ctx context.Context) (*[]postgres_entity.Webhooks, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebhooksRepository.FindAll")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebhooksRepository.FindAll")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {
 		err := errors.New("Tenant not set in context")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -101,7 +99,7 @@ func (r *webhooksRepository) FindAll(ctx context.Context) (*[]postgres_entity.We
 		Order("created_at DESC").
 		Find(&webhooks).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -109,15 +107,14 @@ func (r *webhooksRepository) FindAll(ctx context.Context) (*[]postgres_entity.We
 }
 
 func (r *webhooksRepository) Find(ctx context.Context, webhook postgres_entity.Webhooks) (*postgres_entity.Webhooks, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebhooksRepository.Find")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebhooksRepository.Find")
+	defer spans.Finish()
 
 	if webhook.Tenant == "" {
 		webhook.Tenant = common.GetTenantFromContext(ctx)
 		if webhook.Tenant == "" {
 			err := errors.New("Tenant not set in context")
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 	}
@@ -135,7 +132,7 @@ func (r *webhooksRepository) Find(ctx context.Context, webhook postgres_entity.W
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -143,9 +140,8 @@ func (r *webhooksRepository) Find(ctx context.Context, webhook postgres_entity.W
 }
 
 func (r *webhooksRepository) FindLastRotationCount(ctx context.Context, integration enum.Source) (int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebhooksRepository.FindLastRotationCount")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebhooksRepository.FindLastRotationCount")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {
@@ -162,29 +158,28 @@ func (r *webhooksRepository) FindLastRotationCount(ctx context.Context, integrat
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return 0, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return 0, err
 	}
 	return webhook.RotationCount, nil
 }
 
 func (r *webhooksRepository) Deactivate(ctx context.Context, webhook postgres_entity.Webhooks) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebhooksRepository.Update")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebhooksRepository.Update")
+	defer spans.Finish()
 
 	if webhook.Tenant == "" {
 		webhook.Tenant = common.GetTenantFromContext(ctx)
 		if webhook.Tenant == "" {
 			err := errors.New("Tenant not set in context")
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return false, err
 		}
 	}
 
 	if webhook.WebhookPath == "" {
 		err := errors.New("Webhook path is missing")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return false, err
 	}
 
@@ -196,7 +191,7 @@ func (r *webhooksRepository) Deactivate(ctx context.Context, webhook postgres_en
 		})
 
 	if result.Error != nil {
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return false, result.Error
 	}
 

--- a/packages/server/customer-os-postgres-repository/repository/websession_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/websession_repository.go
@@ -6,11 +6,9 @@ import (
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/lib/pq"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"gorm.io/gorm"
 
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -39,15 +37,14 @@ func NewWebSessionRepository(gormDb *gorm.DB) WebSessionRepository {
 }
 
 func (r *webSessionRepository) Create(ctx context.Context, webSessionData postgres_entity.WebSession) (*postgres_entity.WebSession, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "webSessionData", webSessionData)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebSessionRepository.Create")
+	defer spans.Finish()
+	spans.LogObjectAsJson("webSessionData", webSessionData)
 
 	var created postgres_entity.WebSession
 	err := r.gormDb.Create(&webSessionData).Scan(&created).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -55,9 +52,8 @@ func (r *webSessionRepository) Create(ctx context.Context, webSessionData postgr
 }
 
 func (r *webSessionRepository) FindAllActiveSessions(ctx context.Context, webSessionData postgres_entity.WebSession, sessionTimeoutInMins *int) ([]postgres_entity.WebSession, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.FindAll")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebSessionRepository.FindAll")
+	defer spans.Finish()
 
 	// Start with a base query
 	query := r.gormDb.Model(&postgres_entity.WebSession{})
@@ -86,19 +82,18 @@ func (r *webSessionRepository) FindAllActiveSessions(ctx context.Context, webSes
 	var results []postgres_entity.WebSession
 	err := query.Order("created_at DESC").Find(&results).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	return results, nil
 }
 
 func (r *webSessionRepository) FindSession(ctx context.Context, webSessionData postgres_entity.WebSession, lookbackPeriodInMins *int) (*postgres_entity.WebSession, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.FindSession")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "webSessionData", webSessionData)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebSessionRepository.FindSession")
+	defer spans.Finish()
+	spans.LogObjectAsJson("webSessionData", webSessionData)
 	if lookbackPeriodInMins != nil {
-		span.LogFields(log.Int("lookbackPeriodInMins", *lookbackPeriodInMins))
+		spans.LogKV("lookbackPeriodInMins", *lookbackPeriodInMins)
 	}
 
 	query := r.gormDb.Where(&webSessionData).Order("last_activity DESC")
@@ -113,22 +108,21 @@ func (r *webSessionRepository) FindSession(ctx context.Context, webSessionData p
 	err := query.First(&result).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			span.LogFields(log.Bool("result.found", false))
+			spans.LogKV("result.found", false)
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.String("result.sessionId", result.ID))
+	spans.LogKV("result.sessionId", result.ID)
 	return &result, nil
 }
 
 func (r *webSessionRepository) FindLastNotification(ctx context.Context, tenant, domain string) (*postgres_entity.WebSession, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.FindLastNotification")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("tenant", tenant, "domain", domain)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebSessionRepository.FindLastNotification")
+	defer spans.Finish()
+	spans.LogKV("tenant", tenant, "domain", domain)
 
 	var result postgres_entity.WebSession
 	err := r.gormDb.
@@ -139,21 +133,20 @@ func (r *webSessionRepository) FindLastNotification(ctx context.Context, tenant,
 		Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			span.LogFields(log.String("result", "No record found"))
+			spans.LogKV("result", "No record found")
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.String("result", "Record found: "+result.ID))
+	spans.LogKV("result", "Record found: "+result.ID)
 	return &result, nil
 }
 
 func (r *webSessionRepository) FindLatestSessionWithDomainByIP(ctx context.Context, ipAddress string) (*postgres_entity.WebSession, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.FindLatestSessionWithDomainByIP")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebSessionRepository.FindLatestSessionWithDomainByIP")
+	defer spans.Finish()
 
 	// Build the query with IP and ensure domain is not null
 	query := r.gormDb.Where("ip = ?", ipAddress).
@@ -165,23 +158,21 @@ func (r *webSessionRepository) FindLatestSessionWithDomainByIP(ctx context.Conte
 	err := query.First(&result).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			span.LogFields(log.Bool("result.found", false))
+			spans.LogKV("result.found", false)
 			return nil, nil
 		}
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.String("result.sessionId", result.ID))
-	span.LogFields(log.String("result.domain", *result.Domain))
+	spans.LogKV("result.sessionId", result.ID)
+	spans.LogKV("result.domain", *result.Domain)
 	return &result, nil
 }
 
 func (r *webSessionRepository) UpdateLastActivity(ctx context.Context, sessionID, eventType string) (*postgres_entity.WebSession, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.UpdateLastActivity")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, sessionID)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebSessionRepository.UpdateLastActivity")
+	defer spans.Finish()
 
 	var updatedSession postgres_entity.WebSession
 	err := r.gormDb.
@@ -194,7 +185,7 @@ func (r *webSessionRepository) UpdateLastActivity(ctx context.Context, sessionID
 		First(&updatedSession, "id = ?", sessionID).
 		Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -202,10 +193,9 @@ func (r *webSessionRepository) UpdateLastActivity(ctx context.Context, sessionID
 }
 
 func (r *webSessionRepository) SetSessionEnd(ctx context.Context, sessionID string, endTime time.Time) (*postgres_entity.WebSession, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.SetSessionEnd")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, sessionID)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebSessionRepository.SetSessionEnd")
+	defer spans.Finish()
+	spans.TagEntity(sessionID)
 
 	var updatedSession postgres_entity.WebSession
 	err := r.gormDb.
@@ -219,7 +209,7 @@ func (r *webSessionRepository) SetSessionEnd(ctx context.Context, sessionID stri
 		First(&updatedSession, "id = ?", sessionID).
 		Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -227,10 +217,9 @@ func (r *webSessionRepository) SetSessionEnd(ctx context.Context, sessionID stri
 }
 
 func (r *webSessionRepository) SetOrganizationId(ctx context.Context, sessionID, organizationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.SetOrganizationId")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, sessionID)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebSessionRepository.SetOrganizationId")
+	defer spans.Finish()
+	spans.TagEntity(sessionID)
 
 	// Perform a single-column update on organization_id for the matching session
 	result := r.gormDb.Model(&postgres_entity.WebSession{}).
@@ -238,8 +227,7 @@ func (r *webSessionRepository) SetOrganizationId(ctx context.Context, sessionID,
 		Update("organization_id", &organizationId)
 
 	if result.Error != nil {
-		// Log the error with tracing and return it
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 
@@ -247,11 +235,10 @@ func (r *webSessionRepository) SetOrganizationId(ctx context.Context, sessionID,
 }
 
 func (r *webSessionRepository) SetSessionPageViews(ctx context.Context, sessionID, tenant string, pageViews []string) (*postgres_entity.WebSession, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.SetSessionPageViews")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("sessionID", sessionID, "tenant", tenant)
-	tracing.LogObjectAsJson(span, "pageViews", pageViews)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebSessionRepository.SetSessionPageViews")
+	defer spans.Finish()
+	spans.LogKV("sessionID", sessionID, "tenant", tenant)
+	spans.LogObjectAsJson("pageViews", pageViews)
 
 	var updatedSession postgres_entity.WebSession
 	err := r.gormDb.Model(&postgres_entity.WebSession{}).
@@ -260,7 +247,7 @@ func (r *webSessionRepository) SetSessionPageViews(ctx context.Context, sessionI
 		First(&updatedSession).
 		Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -268,10 +255,9 @@ func (r *webSessionRepository) SetSessionPageViews(ctx context.Context, sessionI
 }
 
 func (r *webSessionRepository) SetSlackSentAt(ctx context.Context, sessionID string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.SetSlackSentAt")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, sessionID)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebSessionRepository.SetSlackSentAt")
+	defer spans.Finish()
+	spans.TagEntity(sessionID)
 
 	// Perform a single-column update on sent_slack_notification for the matching session
 	result := r.gormDb.Model(&postgres_entity.WebSession{}).
@@ -279,8 +265,7 @@ func (r *webSessionRepository) SetSlackSentAt(ctx context.Context, sessionID str
 		Update("sent_slack_notification", utils.Now())
 
 	if result.Error != nil {
-		// Log the error with tracing and return it
-		tracing.TraceErr(span, result.Error)
+		spans.TraceError(result.Error)
 		return result.Error
 	}
 
@@ -288,9 +273,8 @@ func (r *webSessionRepository) SetSlackSentAt(ctx context.Context, sessionID str
 }
 
 func (r *webSessionRepository) SetVisitorIdentity(ctx context.Context, sessionID string, domain, email *string, emailType *enum.EmailType) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebSessionRepository.SetVisitorIdentity")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebSessionRepository.SetVisitorIdentity")
+	defer spans.Finish()
 
 	// Start building the query
 	query := r.gormDb.Model(&postgres_entity.WebSession{}).
@@ -315,7 +299,7 @@ func (r *webSessionRepository) SetVisitorIdentity(ctx context.Context, sessionID
 	if len(updates) > 0 {
 		err := query.Updates(updates).Error
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}

--- a/packages/server/customer-os-postgres-repository/repository/webtracker_events_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/webtracker_events_repository.go
@@ -2,13 +2,11 @@ package postgres_repository
 
 import (
 	"context"
-	"github.com/opentracing/opentracing-go/log"
 	"strings"
 	"time"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 
@@ -30,15 +28,14 @@ func NewWebTrackerEventsRepository(gormDb *gorm.DB) WebTrackerEventsRepository {
 }
 
 func (r *webTrackerEventsRepository) Create(ctx context.Context, webTrackerData postgres_entity.WebTrackerEvents) (*postgres_entity.WebTrackerEvents, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebTrackerEventsRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "webTrackerData", webTrackerData)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebTrackerEventsRepository.Create")
+	defer spans.Finish()
+	spans.LogKV("webTrackerData", webTrackerData)
 
 	var created postgres_entity.WebTrackerEvents
 	err := r.gormDb.Create(&webTrackerData).Scan(&created).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -46,9 +43,8 @@ func (r *webTrackerEventsRepository) Create(ctx context.Context, webTrackerData 
 }
 
 func (r *webTrackerEventsRepository) FindAll(ctx context.Context, webTrackerData postgres_entity.WebTrackerEvents, cacheLookbackInDays *int) ([]postgres_entity.WebTrackerEvents, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebTrackerEventsRepository.FindAll")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebTrackerEventsRepository.FindAll")
+	defer spans.Finish()
 
 	query := r.gormDb.Where(&webTrackerData).Order("created_at DESC")
 
@@ -61,7 +57,7 @@ func (r *webTrackerEventsRepository) FindAll(ctx context.Context, webTrackerData
 	var results []postgres_entity.WebTrackerEvents
 	err := query.Find(&results).Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -69,10 +65,9 @@ func (r *webTrackerEventsRepository) FindAll(ctx context.Context, webTrackerData
 }
 
 func (r *webTrackerEventsRepository) FindEventsForPageVisit(ctx context.Context, sessionId, page string) ([]postgres_entity.WebTrackerEvents, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WebTrackerEventsRepository.FindEventsForPageVisit")
-	defer span.Finish()
-	tracing.SetDefaultPostgresRepositorySpanTags(ctx, span)
-	span.LogKV("sessionId", sessionId, "page", page)
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "WebTrackerEventsRepository.FindEventsForPageVisit")
+	defer spans.Finish()
+	spans.LogKV("sessionId", sessionId, "page", page)
 
 	if sessionId == "" {
 		return nil, errors.New("sessionId cannot be empty")
@@ -90,7 +85,7 @@ func (r *webTrackerEventsRepository) FindEventsForPageVisit(ctx context.Context,
 			pathname += "/"
 		}
 	}
-	span.LogKV("pathname", pathname)
+	spans.LogKV("pathname", pathname)
 
 	var results []postgres_entity.WebTrackerEvents
 	err := r.gormDb.
@@ -100,9 +95,9 @@ func (r *webTrackerEventsRepository) FindEventsForPageVisit(ctx context.Context,
 		Find(&results).
 		Error
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(results)))
+	spans.LogKV("result.count", len(results))
 	return results, nil
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update tracing mechanism in `customer-os-postgres-repository` to use `telemetry` module for span management and error logging.
> 
>   - **Tracing Updates**:
>     - Replace `opentracing` with `telemetry` for span management in all repository files.
>     - Use `telemetry.StartPostgresSpan()` to start spans and `spans.Finish()` to end them.
>     - Update error logging to use `spans.TraceError()` instead of `tracing.TraceErr()`.
>   - **Affected Files**:
>     - `helpers.go`: Add `GetTraceIds()` function for extracting trace IDs.
>     - `jaeger.go`: Add `ExtractTextMapCarrier()` and `InjectTextMapCarrier()` for handling span context.
>     - `agent_execution_repository.go`, `agent_registry_repository.go`, `agents_repository.go`: Update span management and error logging.
>     - ... and 30+ other repository files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d8a84b3b8bd8ed3b68314a117e1d1eed1f1e48fa. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->