### PR TITLE
fix integrity checker query

### DIFF
--- a/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
+++ b/packages/runner/integrity-checker/neo4j-integrity-checker-queries.json
@@ -382,11 +382,11 @@
         },
         {
           "name": "Service line item price is not of type float",
-          "query": "MATCH (sli:ServiceLineItem) WHERE apoc.meta.cypher.type(sli.price) <> 'FLOAT' RETURN count(sli) as cnt"
+          "query": "MATCH (sli:ServiceLineItem) WHERE NOT (sli.price >= 0.0 OR sli.price <= 0.0) RETURN count(sli) AS cnt"
         },
         {
           "name": "Service line item quantity is not of type integer",
-          "query": "MATCH (sli:ServiceLineItem) WHERE apoc.meta.cypher.type(sli.quantity) <> 'INTEGER' RETURN count(sli)"
+          "query": "MATCH (sli:ServiceLineItem) WHERE NOT (sli.quantity % 1 = 0) RETURN count(sli)"
         },
         {
           "name": "Service line items with missing end date",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes integrity checker queries for `ServiceLineItem` to validate `price` and `quantity` types using direct value checks instead of `apoc.meta.cypher.type`.
> 
>   - **Behavior**:
>     - Updates query for `ServiceLineItem` price validation to check if `price` is not a valid float by ensuring it is neither greater nor less than 0.0.
>     - Updates query for `ServiceLineItem` quantity validation to check if `quantity` is not a valid integer by ensuring it is not divisible by 1 without remainder.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8be80b4aa96e471889cf896b63b452187e7289a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->