### PR TITLE
prevent registration with persona emails

### DIFF
--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -220,7 +220,7 @@ func Signin(s *cosapi_services.Services) gin.HandlerFunc {
 		defer span.Finish()
 
 		var signInRequest SignInRequest
-		if err := c.BindJSON(&signInRequest); err != nil {
+		if err = c.BindJSON(&signInRequest); err != nil {
 			tracing.TraceErr(span, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"result": fmt.Sprintf("unable to parse json: %v", err.Error()),
@@ -407,7 +407,16 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 				if isNewTenant {
 					tenantStr := ""
 					if isPersonalEmail {
-						tenantStr = utils.GenerateName()
+						// DO NOT ALLOW REGISTERING TENANT WITH PERSONAL EMAIL
+						err = errors.New("personal email domain detected")
+						tracing.TraceErr(span, err)
+						ginContext.JSON(http.StatusBadRequest, gin.H{
+							"error":   "Personal email domains are not allowed for tenant registration",
+							"code":    "PERSONAL_EMAIL_DOMAIN",
+							"message": "Please use a business email address to register a tenant",
+						})
+						return nil, err
+						// tenantStr = utils.GenerateName() // uncomment this when we want to generate a random tenant name for personal email domains
 					} else {
 						tenantStr = utils.Sanitize(domain)
 					}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents tenant registration with personal email domains in `signIn()` by returning an error if detected.
> 
>   - **Behavior**:
>     - Prevents tenant registration with personal email domains in `signIn()` in `registration.go`.
>     - Returns HTTP 400 error with message "Personal email domains are not allowed for tenant registration" if a personal email is detected.
>   - **Error Handling**:
>     - Logs error to tracing if personal email domain is detected.
>   - **Misc**:
>     - Minor change in `Signin()` function to fix error assignment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for d666c03c6f9c268540be8280d07091ca9ab663df. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->