### PR TITLE
track slack alert params

### DIFF
--- a/packages/runner/integrity-checker/service/neo4j_integrity_checker_service.go
+++ b/packages/runner/integrity-checker/service/neo4j_integrity_checker_service.go
@@ -269,6 +269,7 @@ func (h *neo4jIntegrityCheckerService) alertInSlack(ctx context.Context, results
 		spans.TraceError(errors.Wrap(err, "error getting previous alert messages"))
 	}
 	if utils.StringSlicesEqualIgnoreOrder(previousAlertMessages, alertMessages) {
+		spans.LogKV("result", "no changes from previous run")
 		return nil
 	}
 
@@ -279,6 +280,7 @@ func (h *neo4jIntegrityCheckerService) alertInSlack(ctx context.Context, results
 
 	// If no alerts, return early
 	if !hasAlert {
+		spans.LogKV("result", "no alerts to send")
 		return nil
 	}
 
@@ -311,8 +313,10 @@ func (h *neo4jIntegrityCheckerService) alertInSlack(ctx context.Context, results
 	// Check response status
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		spans.TraceError(errors.New("unexpected status code"))
 		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
 	}
 
+	spans.LogKV("result", "alert sent successfully")
 	return nil
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance logging in `alertInSlack()` of `neo4jIntegrityCheckerService` to track alert status and errors.
> 
>   - **Logging Enhancements**:
>     - In `neo4jIntegrityCheckerService.alertInSlack()`, added `spans.LogKV()` to log when there are no changes from the previous run and when there are no alerts to send.
>     - Added `spans.LogKV()` to log successful alert sending.
>     - Added `spans.TraceError()` to log unexpected status code errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for dce81948796f3d94593f2e3d130cd5dbf4cb3d73. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->