### PR TITLE
new nylas connect

### DIFF
--- a/packages/server/customer-os-api/.env
+++ b/packages/server/customer-os-api/.env
@@ -123,4 +123,4 @@ OTEL_SERVICE_NAME=customer-os-api
 OTEL_TIMEOUT=10
 
 NYLAS_API_KEY: nyk_v0_8WMUsfA55r5z8Agzn26vblF1CZHSDOBAZhKoViiAgMP6sJvNEawc8b5l7Huf7mdG
-NYLAS_API_URL: https://api.nylas.com
+NYLAS_API_URL: https://api.eu.nylas.com

--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -1271,7 +1271,7 @@ type ComplexityRoot struct {
 		NoteLinkAttachment                         func(childComplexity int, noteID string, attachmentID string) int
 		NoteUnlinkAttachment                       func(childComplexity int, noteID string, attachmentID string) int
 		NoteUpdate                                 func(childComplexity int, input model.NoteUpdateInput) int
-		NylasConnect                               func(childComplexity int, email string) int
+		NylasConnect                               func(childComplexity int, input model.NylasConnectInput) int
 		NylasDisconnect                            func(childComplexity int, email string) int
 		OpportunityArchive                         func(childComplexity int, id string) int
 		OpportunityRenewalUpdate                   func(childComplexity int, input model.OpportunityRenewalUpdateInput, ownerUserID *string) int
@@ -2248,7 +2248,7 @@ type MutationResolver interface {
 	NoteDelete(ctx context.Context, id string) (*model.Result, error)
 	NoteLinkAttachment(ctx context.Context, noteID string, attachmentID string) (*model.Note, error)
 	NoteUnlinkAttachment(ctx context.Context, noteID string, attachmentID string) (*model.Note, error)
-	NylasConnect(ctx context.Context, email string) (bool, error)
+	NylasConnect(ctx context.Context, input model.NylasConnectInput) (bool, error)
 	NylasDisconnect(ctx context.Context, email string) (bool, error)
 	OpportunitySave(ctx context.Context, input model.OpportunitySaveInput) (*model.Opportunity, error)
 	OpportunityArchive(ctx context.Context, id string) (*model.ActionResponse, error)
@@ -9369,7 +9369,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.NylasConnect(childComplexity, args["email"].(string)), true
+		return e.complexity.Mutation.NylasConnect(childComplexity, args["input"].(model.NylasConnectInput)), true
 
 	case "Mutation.nylasDisconnect":
 		if e.complexity.Mutation.NylasDisconnect == nil {
@@ -14225,6 +14225,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputMeetingUpdateInput,
 		ec.unmarshalInputNoteInput,
 		ec.unmarshalInputNoteUpdateInput,
+		ec.unmarshalInputNylasConnectInput,
 		ec.unmarshalInputOnboardingStatusInput,
 		ec.unmarshalInputOpportunityCreateInput,
 		ec.unmarshalInputOpportunityRenewalUpdateAllForOrganizationInput,
@@ -15429,7 +15430,7 @@ type BillingDetails {
 input ContractInput {
     organizationId:             ID!
     contractName:               String
-    committedPeriodInMonths:   Int64
+    committedPeriodInMonths:    Int64
     appSource:                  String
     contractUrl:                String
     serviceStarted:             Time
@@ -17470,14 +17471,23 @@ extend type Mutation {
     """
     Connect a user's email to Nylas service
     """
-    nylasConnect(email: String!): Boolean! @hasRole(roles: [ADMIN, USER]) @hasTenant
+    nylasConnect(input: NylasConnectInput!): Boolean! @hasRole(roles: [ADMIN, USER]) @hasTenant
 
     """
     Disconnect a user's email from Nylas service
     """
     nylasDisconnect(email: String!): Boolean! @hasRole(roles: [ADMIN, USER]) @hasTenant
 }
-`, BuiltIn: false},
+
+input NylasConnectInput {
+    email:          String!
+    refreshToken:   String!
+    provider:       NylasProvider!
+}
+
+enum NylasProvider {
+    NYLAS_PROVIDER_GOOGLE
+}`, BuiltIn: false},
 	{Name: "../schemas/opportunity.graphqls", Input: `extend type Query {
     opportunity(id: ID!): Opportunity @hasRole(roles: [ADMIN, USER]) @hasTenant
     opportunities_LinkedToOrganizations(pagination: Pagination): OpportunityPage! @hasRole(roles: [ADMIN, USER]) @hasTenant
@@ -24410,28 +24420,28 @@ func (ec *executionContext) field_Mutation_note_Update_argsInput(
 func (ec *executionContext) field_Mutation_nylasConnect_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
-	arg0, err := ec.field_Mutation_nylasConnect_argsEmail(ctx, rawArgs)
+	arg0, err := ec.field_Mutation_nylasConnect_argsInput(ctx, rawArgs)
 	if err != nil {
 		return nil, err
 	}
-	args["email"] = arg0
+	args["input"] = arg0
 	return args, nil
 }
-func (ec *executionContext) field_Mutation_nylasConnect_argsEmail(
+func (ec *executionContext) field_Mutation_nylasConnect_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
-) (string, error) {
-	if _, ok := rawArgs["email"]; !ok {
-		var zeroVal string
+) (model.NylasConnectInput, error) {
+	if _, ok := rawArgs["input"]; !ok {
+		var zeroVal model.NylasConnectInput
 		return zeroVal, nil
 	}
 
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
-	if tmp, ok := rawArgs["email"]; ok {
-		return ec.unmarshalNString2string(ctx, tmp)
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNNylasConnectInput2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐNylasConnectInput(ctx, tmp)
 	}
 
-	var zeroVal string
+	var zeroVal model.NylasConnectInput
 	return zeroVal, nil
 }
 
@@ -78497,7 +78507,7 @@ func (ec *executionContext) _Mutation_nylasConnect(ctx context.Context, field gr
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		directive0 := func(rctx context.Context) (any, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().NylasConnect(rctx, fc.Args["email"].(string))
+			return ec.resolvers.Mutation().NylasConnect(rctx, fc.Args["input"].(model.NylasConnectInput))
 		}
 
 		directive1 := func(ctx context.Context) (any, error) {
@@ -124082,6 +124092,47 @@ func (ec *executionContext) unmarshalInputNoteUpdateInput(ctx context.Context, o
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputNylasConnectInput(ctx context.Context, obj any) (model.NylasConnectInput, error) {
+	var it model.NylasConnectInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"email", "refreshToken", "provider"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "email":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Email = data
+		case "refreshToken":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("refreshToken"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RefreshToken = data
+		case "provider":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("provider"))
+			data, err := ec.unmarshalNNylasProvider2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐNylasProvider(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Provider = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputOnboardingStatusInput(ctx context.Context, obj any) (model.OnboardingStatusInput, error) {
 	var it model.OnboardingStatusInput
 	asMap := map[string]any{}
@@ -149541,6 +149592,21 @@ func (ec *executionContext) marshalNNote2ᚖgithubᚗcomᚋcustomerosᚋcustomer
 func (ec *executionContext) unmarshalNNoteUpdateInput2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐNoteUpdateInput(ctx context.Context, v any) (model.NoteUpdateInput, error) {
 	res, err := ec.unmarshalInputNoteUpdateInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNNylasConnectInput2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐNylasConnectInput(ctx context.Context, v any) (model.NylasConnectInput, error) {
+	res, err := ec.unmarshalInputNylasConnectInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNNylasProvider2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐNylasProvider(ctx context.Context, v any) (model.NylasProvider, error) {
+	var res model.NylasProvider
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNNylasProvider2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐNylasProvider(ctx context.Context, sel ast.SelectionSet, v model.NylasProvider) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNOnboardingStatus2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐOnboardingStatus(ctx context.Context, v any) (model.OnboardingStatus, error) {

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -2075,6 +2075,12 @@ type NoteUpdateInput struct {
 	ContentType *string `json:"contentType,omitempty"`
 }
 
+type NylasConnectInput struct {
+	Email        string        `json:"email"`
+	RefreshToken string        `json:"refreshToken"`
+	Provider     NylasProvider `json:"provider"`
+}
+
 type OnboardingDetails struct {
 	Status    OnboardingStatus `json:"status"`
 	Comments  *string          `json:"comments,omitempty"`
@@ -5218,6 +5224,45 @@ func (e *MeetingStatus) UnmarshalGQL(v any) error {
 }
 
 func (e MeetingStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type NylasProvider string
+
+const (
+	NylasProviderNylasProviderGoogle NylasProvider = "NYLAS_PROVIDER_GOOGLE"
+)
+
+var AllNylasProvider = []NylasProvider{
+	NylasProviderNylasProviderGoogle,
+}
+
+func (e NylasProvider) IsValid() bool {
+	switch e {
+	case NylasProviderNylasProviderGoogle:
+		return true
+	}
+	return false
+}
+
+func (e NylasProvider) String() string {
+	return string(e)
+}
+
+func (e *NylasProvider) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = NylasProvider(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid NylasProvider", str)
+	}
+	return nil
+}
+
+func (e NylasProvider) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
@@ -9,44 +9,33 @@ import (
 	"errors"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
+	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 )
 
 // NylasConnect is the resolver for the nylasConnect field.
-func (r *mutationResolver) NylasConnect(ctx context.Context, email string) (bool, error) {
+func (r *mutationResolver) NylasConnect(ctx context.Context, input model.NylasConnectInput) (bool, error) {
 	spans, ctx := telemetry.StartGraphQLSpan(ctx, "MutationResolver.NylasConnect", graphql.GetOperationContext(ctx))
 	defer spans.Finish()
-	spans.LogKV("email", email)
+	spans.LogKV("email", input.Email, "provider", input.Provider)
 
-	// first check if oauth token exists
-	oauthToken, err := r.Services.Repositories.PostgresRepositories.OAuthTokenRepository.GetByEmail(ctx, common.GetTenantFromContext(ctx), email)
-	if err != nil {
-		spans.TraceError(err)
-		graphql.AddErrorf(ctx, "Failed to get OAuth token")
+	if input.RefreshToken == "" {
+		spans.TraceError(errors.New("missing refresh token"))
+		graphql.AddErrorf(ctx, "Missing refresh token")
 		return false, nil
 	}
 
-	// if oauth token is not found, return error
-	if oauthToken == nil {
-		spans.TraceError(errors.New("no OAuth token found for email"))
-		graphql.AddErrorf(ctx, "No OAuth token found for email: %s", email)
-		return false, nil
+	nylasProvider := interfaces.NylasProviderGoogle
+	switch input.Provider {
+	case model.NylasProviderNylasProviderGoogle:
+		nylasProvider = interfaces.NylasProviderGoogle
 	}
 
-	// connect to nylas
-	oauthProvider, err := enum.GetOAuthEmailProvider(oauthToken.Provider)
+	_, err := r.Services.CommonServices.NylasService.GrantAccess(ctx, input.Email, input.RefreshToken, nylasProvider)
 	if err != nil {
 		spans.TraceError(err)
-		graphql.AddErrorf(ctx, "Failed to get OAuth provider: %v", err)
-		return false, nil
-	}
-
-	_, err = r.Services.CommonServices.NylasService.GrantAccess(ctx, email, oauthProvider)
-	if err != nil {
-		spans.TraceError(err)
-		graphql.AddErrorf(ctx, "Failed to connect to Nylas")
+		graphql.AddErrorf(ctx, "Failed to grant access with Nylas")
 		return false, nil
 	}
 

--- a/packages/server/customer-os-api/graphql/schemas/nylas.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/nylas.graphqls
@@ -9,10 +9,20 @@ extend type Mutation {
     """
     Connect a user's email to Nylas service
     """
-    nylasConnect(email: String!): Boolean! @hasRole(roles: [ADMIN, USER]) @hasTenant
+    nylasConnect(input: NylasConnectInput!): Boolean! @hasRole(roles: [ADMIN, USER]) @hasTenant
 
     """
     Disconnect a user's email from Nylas service
     """
     nylasDisconnect(email: String!): Boolean! @hasRole(roles: [ADMIN, USER]) @hasTenant
+}
+
+input NylasConnectInput {
+    email:          String!
+    refreshToken:   String!
+    provider:       NylasProvider!
+}
+
+enum NylasProvider {
+    NYLAS_PROVIDER_GOOGLE
 }

--- a/packages/server/customer-os-common-module/config/nylas_config.go
+++ b/packages/server/customer-os-common-module/config/nylas_config.go
@@ -2,5 +2,5 @@ package config
 
 type NylasConfig struct {
 	APIKey string `env:"NYLAS_API_KEY"`
-	APIUrl string `env:"NYLAS_API_URL" envDefault:"https://api.nylas.com"`
+	APIUrl string `env:"NYLAS_API_URL"`
 }

--- a/packages/server/customer-os-common-module/interfaces/nylas.go
+++ b/packages/server/customer-os-common-module/interfaces/nylas.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 )
 
@@ -16,12 +15,12 @@ const (
 
 type NylasService interface {
 	// Access operations
-	GrantAccess(ctx context.Context, email string, oauthProvider enum.OAuthEmailProvider) (*postgres_entity.NylasGrant, error)
+	GrantAccess(ctx context.Context, email, refreshToken string, nylasProvider NylasProvider) (*postgres_entity.NylasGrant, error)
 	RevokeAccess(ctx context.Context, email string) error
 	GetGrant(ctx context.Context, email string) (*postgres_entity.NylasGrant, error)
 
 	// Calendar management
-	ListCalendars(ctx context.Context, email string, oauthProvider enum.OAuthEmailProvider) ([]*Calendar, error)
+	ListCalendars(ctx context.Context, email string) ([]*Calendar, error)
 	GetCalendar(ctx context.Context, calendarID string) (*Calendar, error)
 
 	// Calendar operations

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
@@ -93,12 +92,7 @@ func (s *meetingService) GetCalendarAvailabilityForEmail(ctx context.Context, em
 	}
 
 	// Get calendars for the user
-	oauthProvider, err := enum.GetOAuthEmailProvider(oauthToken.Provider)
-	if err != nil {
-		spans.TraceError(err)
-		return nil, fmt.Errorf("failed to get oauth provider: %v", err)
-	}
-	calendars, err := s.nylasService.ListCalendars(ctx, email, oauthProvider)
+	calendars, err := s.nylasService.ListCalendars(ctx, email)
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to list calendars: %v", err)

--- a/packages/server/customer-os-common-module/services/nylas/service.go
+++ b/packages/server/customer-os-common-module/services/nylas/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
+	postgresEntity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgresRepository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 )
 
@@ -72,10 +72,10 @@ func (s *nylasService) getProviderRefreshToken(ctx context.Context, email string
 }
 
 // Authenticate into Nylas and save the grant
-func (s *nylasService) GrantAccess(ctx context.Context, email string, provider enum.OAuthEmailProvider) (*postgres_entity.NylasGrant, error) {
+func (s *nylasService) GrantAccess(ctx context.Context, email, refreshToken string, nylasProvider interfaces.NylasProvider) (*postgresEntity.NylasGrant, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "NylasService.GrantAccess")
 	defer spans.Finish()
-	spans.LogKV("email", email, "provider", provider.String())
+	spans.LogKV("email", email, "nylasProvider", nylasProvider)
 
 	// validate tenant
 	err := common.ValidateTenant(ctx)
@@ -86,31 +86,14 @@ func (s *nylasService) GrantAccess(ctx context.Context, email string, provider e
 	tenant := common.GetTenantFromContext(ctx)
 
 	// Check if account already exists
-	existingGrant, err := s.postgres.NylasGrantRepository.GetByTenantAndEmail(ctx, tenant, email)
+	nylasGrantEntity, err := s.postgres.NylasGrantRepository.GetByTenantAndEmail(ctx, tenant, email)
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to check if Nylas account exists: %v", err)
 	}
-	if existingGrant != nil {
-		return existingGrant, nil
+	if nylasGrantEntity == nil {
+		nylasGrantEntity = &postgresEntity.NylasGrant{}
 	}
-
-	// Nylas account does not exist, create a new one
-
-	// Get refresh token from provider
-	refreshToken, err := s.getProviderRefreshToken(ctx, email, provider)
-	if err != nil {
-		spans.TraceError(err)
-		return nil, fmt.Errorf("failed to get refresh token: %v", err)
-	}
-
-	// Prepare Nylas provider
-	nylasProvider, err := s.prepareNylasProvider(provider)
-	if err != nil {
-		spans.TraceError(err)
-		return nil, fmt.Errorf("failed to get Nylas provider: %v", err)
-	}
-	spans.LogKV("nylas_provider", nylasProvider)
 
 	// Prepare request body
 	requestBody := struct {
@@ -121,7 +104,7 @@ func (s *nylasService) GrantAccess(ctx context.Context, email string, provider e
 		Email string `json:"email,omitempty"`
 		State string `json:"state,omitempty"`
 	}{
-		Provider: nylasProvider,
+		Provider: string(nylasProvider),
 		Settings: struct {
 			RefreshToken string `json:"refresh_token"`
 		}{
@@ -130,8 +113,6 @@ func (s *nylasService) GrantAccess(ctx context.Context, email string, provider e
 		Email: email,
 		State: tenant, // Using tenant as state to track the origin
 	}
-
-	spans.LogObjectAsJson("request", requestBody)
 
 	// Log request body (without sensitive data)
 	spans.LogObjectAsJson("request", map[string]interface{}{
@@ -180,28 +161,21 @@ func (s *nylasService) GrantAccess(ctx context.Context, email string, provider e
 	}
 
 	// Parse response
-	var response struct {
-		RequestID string `json:"request_id"`
-		Data      struct {
-			ID string `json:"id"`
-		} `json:"data"`
-	}
+	var responseStruct postgresEntity.NylasGrantResponse
 
-	if err := json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(&response); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(&responseStruct); err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to decode response: %v", err)
 	}
 
-	// Save account to database
-	grant := &postgres_entity.NylasGrant{
-		Tenant:               tenant,
-		Email:                email,
-		NylasGrantId:         response.Data.ID,
-		NylasProvider:        nylasProvider,
-		NylasConnectResponse: string(bodyBytes),
-	}
+	// Save grant to database
+	nylasGrantEntity.Tenant = tenant
+	nylasGrantEntity.Email = email
+	nylasGrantEntity.NylasGrantId = responseStruct.Data.ID
+	nylasGrantEntity.NylasProvider = string(nylasProvider)
+	nylasGrantEntity.NylasConnectResponse = string(bodyBytes)
 
-	savedGrant, err := s.postgres.NylasGrantRepository.Save(ctx, grant)
+	savedGrant, err := s.postgres.NylasGrantRepository.Save(ctx, nylasGrantEntity)
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to save grant: %v", err)
@@ -272,7 +246,7 @@ func (s *nylasService) RevokeAccess(ctx context.Context, email string) error {
 }
 
 // GetAccount retrieves a Nylas account for the given email
-func (s *nylasService) GetGrant(ctx context.Context, email string) (*postgres_entity.NylasGrant, error) {
+func (s *nylasService) GetGrant(ctx context.Context, email string) (*postgresEntity.NylasGrant, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "NylasService.GetGrant")
 	defer spans.Finish()
 	spans.LogKV("email", email)
@@ -297,55 +271,24 @@ func (s *nylasService) GetGrant(ctx context.Context, email string) (*postgres_en
 	return grant, nil
 }
 
-// prepareNylasGrantID prepares the Nylas grant ID for a user
-func (s *nylasService) prepareNylasGrantID(ctx context.Context, email string, provider enum.OAuthEmailProvider) (string, error) {
-	spans, ctx := telemetry.StartServiceSpan(ctx, "NylasService.prepareNylasGrantID")
-	defer spans.Finish()
-	spans.LogKV("email", email, "provider", provider)
-
-	// Get tenant from context
-	tenant := common.GetTenantFromContext(ctx)
-	if tenant == "" {
-		spans.TraceError(fmt.Errorf("tenant not found in context"))
-		return "", fmt.Errorf("tenant not found in context")
-	}
-
-	// Check if account exists in database
-	grant, err := s.postgres.NylasGrantRepository.GetByTenantAndEmail(ctx, tenant, email)
-	if err != nil {
-		spans.TraceError(err)
-		return "", fmt.Errorf("failed to get Nylas account: %v", err)
-	}
-
-	if grant != nil {
-		return grant.NylasGrantId, nil
-	}
-
-	// Connect new account
-	newGrant, err := s.GrantAccess(ctx, email, provider)
-	if err != nil {
-		spans.TraceError(err)
-		return "", fmt.Errorf("failed to connect account: %v", err)
-	}
-
-	return newGrant.NylasGrantId, nil
-}
-
 // ListCalendars lists all calendars for a user
-func (s *nylasService) ListCalendars(ctx context.Context, email string, provider enum.OAuthEmailProvider) ([]*interfaces.Calendar, error) {
+func (s *nylasService) ListCalendars(ctx context.Context, email string) ([]*interfaces.Calendar, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "NylasService.ListCalendars")
 	defer spans.Finish()
-	spans.LogKV("email", email, "provider", provider)
+	spans.LogKV("email", email)
 
 	// Get Nylas grant ID
-	grantID, err := s.prepareNylasGrantID(ctx, email, provider)
+	grant, err := s.postgres.NylasGrantRepository.GetByTenantAndEmail(ctx, common.GetTenantFromContext(ctx), email)
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to get Nylas grant ID: %v", err)
 	}
+	if grant == nil {
+		return nil, fmt.Errorf("Nylas grant not found")
+	}
 
 	// Create request to Nylas v3 API
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/v3/calendars?account_id=%s", s.config.APIUrl, grantID), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/v3/calendars?account_id=%s", s.config.APIUrl, grant.NylasGrantId), nil)
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to create request: %v", err)
@@ -400,17 +343,20 @@ func (s *nylasService) ListEvents(ctx context.Context, calendarID string, startT
 		return nil, fmt.Errorf("no provider found in context")
 	}
 
-	// Get Nylas account ID for this email
-	grantID, err := s.prepareNylasGrantID(ctx, email, provider)
+	// Get Nylas grant ID for this email
+	grant, err := s.postgres.NylasGrantRepository.GetByTenantAndEmail(ctx, common.GetTenantFromContext(ctx), email)
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to get Nylas grant ID: %v", err)
+	}
+	if grant == nil {
+		return nil, fmt.Errorf("Nylas grant not found")
 	}
 
 	// Create request to Nylas v3 API
 	url := fmt.Sprintf("%s/v3/events?account_id=%s&calendar_id=%s&start=%d&end=%d",
 		s.config.APIUrl,
-		grantID,
+		grant.NylasGrantId,
 		calendarID,
 		startTime.Unix(),
 		endTime.Unix(),
@@ -496,14 +442,4 @@ func (s *nylasService) GetEvent(ctx context.Context, calendarID string, eventID 
 func (s *nylasService) GetCalendar(ctx context.Context, calendarID string) (*interfaces.Calendar, error) {
 	// TODO: Implement Nylas API call to get calendar
 	return nil, nil
-}
-
-// prepareNylasProvider maps customer os oauth provider to Nylas provider
-func (s *nylasService) prepareNylasProvider(provider enum.OAuthEmailProvider) (string, error) {
-	switch provider {
-	case enum.ProviderGoogle:
-		return string(interfaces.NylasProviderGoogle), nil
-	default:
-		return "", fmt.Errorf("unsupported provider for Nylas: %s", provider)
-	}
 }

--- a/packages/server/customer-os-postgres-repository/entity/nylas_grant.go
+++ b/packages/server/customer-os-postgres-repository/entity/nylas_grant.go
@@ -26,3 +26,23 @@ func (n *NylasGrant) BeforeCreate(tx *gorm.DB) error {
 	n.ID = utils.GenerateNanoIdWithPrefix("nylas", 16)
 	return nil
 }
+
+type NylasGrantResponse struct {
+	RequestID string `json:"request_id"`
+	Data      struct {
+		ID             string   `json:"id"`
+		GrantStatus    string   `json:"grant_status"`
+		Provider       string   `json:"provider"`
+		Scope          []string `json:"scope"`
+		State          string   `json:"state"`
+		Email          string   `json:"email"`
+		Name           string   `json:"name"`
+		IP             string   `json:"ip"`
+		UserAgent      string   `json:"user_agent"`
+		CreatedAt      int64    `json:"created_at"`
+		UpdatedAt      int64    `json:"updated_at"`
+		IDToken        string   `json:"id_token"`
+		ProviderUserID string   `json:"provider_user_id"`
+		Blocked        bool     `json:"blocked"`
+	} `json:"data"`
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor Nylas connection to use `NylasConnectInput` with email, refresh token, and provider, updating GraphQL schema, resolvers, services, and database entities.
> 
>   - **GraphQL Schema**:
>     - Updated `nylasConnect` mutation in `nylas.graphqls` to accept `NylasConnectInput` instead of `email`.
>     - Added `NylasConnectInput` type with `email`, `refreshToken`, and `provider` fields.
>     - Added `NylasProvider` enum with `NYLAS_PROVIDER_GOOGLE`.
>   - **Resolvers**:
>     - Updated `NylasConnect` resolver in `nylas.resolvers.go` to use `NylasConnectInput`.
>     - Added error handling for missing `refreshToken`.
>   - **Services**:
>     - Updated `GrantAccess` method in `nylas/service.go` to use `refreshToken` and `nylasProvider`.
>     - Removed dependency on `enum.OAuthEmailProvider`.
>     - Updated `ListCalendars` and `ListEvents` to use `NylasGrant` entity.
>   - **Database**:
>     - Modified `NylasGrant` entity in `nylas_grant.go` to include `NylasConnectResponse`.
>     - Added `NylasGrantResponse` struct to parse Nylas API responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7f150439c10b386662384ae639af346a4571a745. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->