### PR TITLE
get user calendar availablitity

### DIFF
--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -564,6 +564,12 @@ type ComplexityRoot struct {
 		Year  func(childComplexity int) int
 	}
 
+	DayAvailability struct {
+		Enabled   func(childComplexity int) int
+		EndHour   func(childComplexity int) int
+		StartHour func(childComplexity int) int
+	}
+
 	DeleteResponse struct {
 		Accepted  func(childComplexity int) int
 		Completed func(childComplexity int) int
@@ -1311,6 +1317,7 @@ type ComplexityRoot struct {
 		ReminderUpdate                             func(childComplexity int, input model.ReminderUpdateInput) int
 		RemoveTag                                  func(childComplexity int, input model.RemoveTagInput) int
 		RemoveTags                                 func(childComplexity int, input model.RemoveTagsInput) int
+		SaveCalendarAvailableHours                 func(childComplexity int, input model.UserCalendarAvailabilityInput) int
 		SendEmail                                  func(childComplexity int, input model.SendEmailInput) int
 		ServiceLineItemDelete                      func(childComplexity int, id string) int
 		SkuArchive                                 func(childComplexity int, id string) int
@@ -1619,6 +1626,7 @@ type ComplexityRoot struct {
 		BankAccounts                       func(childComplexity int) int
 		BillableInfo                       func(childComplexity int) int
 		CalendarAvailability               func(childComplexity int, input model.CalendarAvailabilityInput) int
+		CalendarAvailableHours             func(childComplexity int, email string) int
 		CheckDomain                        func(childComplexity int, domain string) int
 		Contact                            func(childComplexity int, id string) int
 		ContactByEmail                     func(childComplexity int, email string) int
@@ -1976,6 +1984,21 @@ type ComplexityRoot struct {
 		UpdatedAt        func(childComplexity int) int
 	}
 
+	UserCalendarAvailability struct {
+		CreatedAt func(childComplexity int) int
+		Email     func(childComplexity int) int
+		Friday    func(childComplexity int) int
+		ID        func(childComplexity int) int
+		Monday    func(childComplexity int) int
+		Saturday  func(childComplexity int) int
+		Sunday    func(childComplexity int) int
+		Thursday  func(childComplexity int) int
+		Timezone  func(childComplexity int) int
+		Tuesday   func(childComplexity int) int
+		UpdatedAt func(childComplexity int) int
+		Wednesday func(childComplexity int) int
+	}
+
 	UserOnboardingDetails struct {
 		OnboardingCrmStepCompleted       func(childComplexity int) int
 		OnboardingInboundStepCompleted   func(childComplexity int) int
@@ -2150,6 +2173,7 @@ type MutationResolver interface {
 	BillingProfileUnlinkEmail(ctx context.Context, input model.BillingProfileLinkEmailInput) (string, error)
 	BillingProfileLinkLocation(ctx context.Context, input model.BillingProfileLinkLocationInput) (string, error)
 	BillingProfileUnlinkLocation(ctx context.Context, input model.BillingProfileLinkLocationInput) (string, error)
+	SaveCalendarAvailableHours(ctx context.Context, input model.UserCalendarAvailabilityInput) (*model.UserCalendarAvailability, error)
 	AddTag(ctx context.Context, input model.AddTagInput) (string, error)
 	RemoveTag(ctx context.Context, input model.RemoveTagInput) (*model.Result, error)
 	RemoveTags(ctx context.Context, input model.RemoveTagsInput) (*model.Result, error)
@@ -2378,6 +2402,7 @@ type QueryResolver interface {
 	Version(ctx context.Context) (float64, error)
 	GlobalCache(ctx context.Context) (*model.GlobalCache, error)
 	CalendarAvailability(ctx context.Context, input model.CalendarAvailabilityInput) (*model.CalendarAvailabilityResponse, error)
+	CalendarAvailableHours(ctx context.Context, email string) (*model.UserCalendarAvailability, error)
 	Contact(ctx context.Context, id string) (*model.Contact, error)
 	Contacts(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) (*model.ContactsPage, error)
 	ContactByPhone(ctx context.Context, e164 string) (*model.Contact, error)
@@ -4944,6 +4969,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.DashboardTimeToOnboardPerMonth.Year(childComplexity), true
+
+	case "DayAvailability.enabled":
+		if e.complexity.DayAvailability.Enabled == nil {
+			break
+		}
+
+		return e.complexity.DayAvailability.Enabled(childComplexity), true
+
+	case "DayAvailability.endHour":
+		if e.complexity.DayAvailability.EndHour == nil {
+			break
+		}
+
+		return e.complexity.DayAvailability.EndHour(childComplexity), true
+
+	case "DayAvailability.startHour":
+		if e.complexity.DayAvailability.StartHour == nil {
+			break
+		}
+
+		return e.complexity.DayAvailability.StartHour(childComplexity), true
 
 	case "DeleteResponse.accepted":
 		if e.complexity.DeleteResponse.Accepted == nil {
@@ -9839,6 +9885,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.RemoveTags(childComplexity, args["input"].(model.RemoveTagsInput)), true
 
+	case "Mutation.save_calendar_available_hours":
+		if e.complexity.Mutation.SaveCalendarAvailableHours == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_save_calendar_available_hours_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.SaveCalendarAvailableHours(childComplexity, args["input"].(model.UserCalendarAvailabilityInput)), true
+
 	case "Mutation.sendEmail":
 		if e.complexity.Mutation.SendEmail == nil {
 			break
@@ -11782,6 +11840,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.CalendarAvailability(childComplexity, args["input"].(model.CalendarAvailabilityInput)), true
+
+	case "Query.calendar_available_hours":
+		if e.complexity.Query.CalendarAvailableHours == nil {
+			break
+		}
+
+		args, err := ec.field_Query_calendar_available_hours_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.CalendarAvailableHours(childComplexity, args["email"].(string)), true
 
 	case "Query.checkDomain":
 		if e.complexity.Query.CheckDomain == nil {
@@ -14052,6 +14122,90 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.UpdatedAt(childComplexity), true
 
+	case "UserCalendarAvailability.createdAt":
+		if e.complexity.UserCalendarAvailability.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.CreatedAt(childComplexity), true
+
+	case "UserCalendarAvailability.email":
+		if e.complexity.UserCalendarAvailability.Email == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.Email(childComplexity), true
+
+	case "UserCalendarAvailability.friday":
+		if e.complexity.UserCalendarAvailability.Friday == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.Friday(childComplexity), true
+
+	case "UserCalendarAvailability.id":
+		if e.complexity.UserCalendarAvailability.ID == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.ID(childComplexity), true
+
+	case "UserCalendarAvailability.monday":
+		if e.complexity.UserCalendarAvailability.Monday == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.Monday(childComplexity), true
+
+	case "UserCalendarAvailability.saturday":
+		if e.complexity.UserCalendarAvailability.Saturday == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.Saturday(childComplexity), true
+
+	case "UserCalendarAvailability.sunday":
+		if e.complexity.UserCalendarAvailability.Sunday == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.Sunday(childComplexity), true
+
+	case "UserCalendarAvailability.thursday":
+		if e.complexity.UserCalendarAvailability.Thursday == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.Thursday(childComplexity), true
+
+	case "UserCalendarAvailability.timezone":
+		if e.complexity.UserCalendarAvailability.Timezone == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.Timezone(childComplexity), true
+
+	case "UserCalendarAvailability.tuesday":
+		if e.complexity.UserCalendarAvailability.Tuesday == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.Tuesday(childComplexity), true
+
+	case "UserCalendarAvailability.updatedAt":
+		if e.complexity.UserCalendarAvailability.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.UpdatedAt(childComplexity), true
+
+	case "UserCalendarAvailability.wednesday":
+		if e.complexity.UserCalendarAvailability.Wednesday == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarAvailability.Wednesday(childComplexity), true
+
 	case "UserOnboardingDetails.onboardingCrmStepCompleted":
 		if e.complexity.UserOnboardingDetails.OnboardingCrmStepCompleted == nil {
 			break
@@ -14192,6 +14346,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCustomFieldUpdateInput,
 		ec.unmarshalInputCustomerContactInput,
 		ec.unmarshalInputDashboardPeriodInput,
+		ec.unmarshalInputDayAvailabilityInput,
 		ec.unmarshalInputEmailBody,
 		ec.unmarshalInputEmailInput,
 		ec.unmarshalInputEmailRelationUpdateInput,
@@ -14270,6 +14425,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputTenantSettingsOpportunityStageConfigurationInput,
 		ec.unmarshalInputTestInput,
 		ec.unmarshalInputTimeRange,
+		ec.unmarshalInputUserCalendarAvailabilityInput,
 		ec.unmarshalInputUserInput,
 		ec.unmarshalInputUserOnboardingDetailsInput,
 		ec.unmarshalInputUserUpdateInput,
@@ -14811,11 +14967,74 @@ type CalendarAvailabilityResponse {
     availableUsers: Int!
 }
 
+"""
+Represents availability settings for a single day
+"""
+type DayAvailability {
+    enabled: Boolean!
+    startHour: String! # Format: "HH:MM"
+    endHour: String! # Format: "HH:MM"
+}
+
+"""
+Input for day availability settings
+"""
+input DayAvailabilityInput {
+    enabled: Boolean!
+    startHour: String! # Format: "HH:MM"
+    endHour: String! # Format: "HH:MM"
+}
+
+"""
+Represents a user's calendar available hours configuration
+"""
+type UserCalendarAvailability {
+    id: ID!
+    email: String!
+    timezone: String!
+    monday: DayAvailability!
+    tuesday: DayAvailability!
+    wednesday: DayAvailability!
+    thursday: DayAvailability!
+    friday: DayAvailability!
+    saturday: DayAvailability!
+    sunday: DayAvailability!
+    createdAt: Time!
+    updatedAt: Time!
+}
+
+"""
+Input for saving user's calendar available hours
+"""
+input UserCalendarAvailabilityInput {
+    email: String!
+    timezone: String!
+    monday: DayAvailabilityInput!
+    tuesday: DayAvailabilityInput!
+    wednesday: DayAvailabilityInput!
+    thursday: DayAvailabilityInput!
+    friday: DayAvailabilityInput!
+    saturday: DayAvailabilityInput!
+    sunday: DayAvailabilityInput!
+}
+
 extend type Query {
     """
     Get availability across all users in the tenant for a given time range
     """
     calendar_availability(input: CalendarAvailabilityInput!): CalendarAvailabilityResponse! @hasRole(roles: [ADMIN, USER]) @hasTenant
+
+    """
+    Get user's calendar available hours configuration
+    """
+    calendar_available_hours(email: String!): UserCalendarAvailability @hasRole(roles: [ADMIN, USER]) @hasTenant
+}
+
+extend type Mutation {
+    """
+    Save user's calendar available hours configuration
+    """
+    save_calendar_available_hours(input: UserCalendarAvailabilityInput!): UserCalendarAvailability! @hasRole(roles: [ADMIN, USER]) @hasTenant
 }`, BuiltIn: false},
 	{Name: "../schemas/comment.graphqls", Input: `type Comment {
     id: ID!
@@ -25951,6 +26170,34 @@ func (ec *executionContext) field_Mutation_removeTags_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_save_calendar_available_hours_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_save_calendar_available_hours_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_save_calendar_available_hours_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.UserCalendarAvailabilityInput, error) {
+	if _, ok := rawArgs["input"]; !ok {
+		var zeroVal model.UserCalendarAvailabilityInput
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUserCalendarAvailabilityInput2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐUserCalendarAvailabilityInput(ctx, tmp)
+	}
+
+	var zeroVal model.UserCalendarAvailabilityInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_sendEmail_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -26903,6 +27150,34 @@ func (ec *executionContext) field_Query_calendar_availability_argsInput(
 	}
 
 	var zeroVal model.CalendarAvailabilityInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_calendar_available_hours_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query_calendar_available_hours_argsEmail(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["email"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_calendar_available_hours_argsEmail(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (string, error) {
+	if _, ok := rawArgs["email"]; !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
+	if tmp, ok := rawArgs["email"]; ok {
+		return ec.unmarshalNString2string(ctx, tmp)
+	}
+
+	var zeroVal string
 	return zeroVal, nil
 }
 
@@ -46113,6 +46388,138 @@ func (ec *executionContext) fieldContext_DashboardTimeToOnboardPerMonth_value(_ 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DayAvailability_enabled(ctx context.Context, field graphql.CollectedField, obj *model.DayAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DayAvailability_enabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Enabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DayAvailability_enabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DayAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DayAvailability_startHour(ctx context.Context, field graphql.CollectedField, obj *model.DayAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DayAvailability_startHour(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.StartHour, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DayAvailability_startHour(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DayAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DayAvailability_endHour(ctx context.Context, field graphql.CollectedField, obj *model.DayAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DayAvailability_endHour(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EndHour, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DayAvailability_endHour(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DayAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -68411,6 +68818,121 @@ func (ec *executionContext) fieldContext_Mutation_billingProfile_UnlinkLocation(
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_billingProfile_UnlinkLocation_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_save_calendar_available_hours(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_save_calendar_available_hours(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		directive0 := func(rctx context.Context) (any, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().SaveCalendarAvailableHours(rctx, fc.Args["input"].(model.UserCalendarAvailabilityInput))
+		}
+
+		directive1 := func(ctx context.Context) (any, error) {
+			roles, err := ec.unmarshalNRole2ᚕgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐRoleᚄ(ctx, []any{"ADMIN", "USER"})
+			if err != nil {
+				var zeroVal *model.UserCalendarAvailability
+				return zeroVal, err
+			}
+			if ec.directives.HasRole == nil {
+				var zeroVal *model.UserCalendarAvailability
+				return zeroVal, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, roles)
+		}
+		directive2 := func(ctx context.Context) (any, error) {
+			if ec.directives.HasTenant == nil {
+				var zeroVal *model.UserCalendarAvailability
+				return zeroVal, errors.New("directive hasTenant is not implemented")
+			}
+			return ec.directives.HasTenant(ctx, nil, directive1)
+		}
+
+		tmp, err := directive2(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*model.UserCalendarAvailability); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/customeros/customeros/packages/server/customer-os-api/graphql/model.UserCalendarAvailability`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.UserCalendarAvailability)
+	fc.Result = res
+	return ec.marshalNUserCalendarAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐUserCalendarAvailability(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_save_calendar_available_hours(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_UserCalendarAvailability_id(ctx, field)
+			case "email":
+				return ec.fieldContext_UserCalendarAvailability_email(ctx, field)
+			case "timezone":
+				return ec.fieldContext_UserCalendarAvailability_timezone(ctx, field)
+			case "monday":
+				return ec.fieldContext_UserCalendarAvailability_monday(ctx, field)
+			case "tuesday":
+				return ec.fieldContext_UserCalendarAvailability_tuesday(ctx, field)
+			case "wednesday":
+				return ec.fieldContext_UserCalendarAvailability_wednesday(ctx, field)
+			case "thursday":
+				return ec.fieldContext_UserCalendarAvailability_thursday(ctx, field)
+			case "friday":
+				return ec.fieldContext_UserCalendarAvailability_friday(ctx, field)
+			case "saturday":
+				return ec.fieldContext_UserCalendarAvailability_saturday(ctx, field)
+			case "sunday":
+				return ec.fieldContext_UserCalendarAvailability_sunday(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_UserCalendarAvailability_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_UserCalendarAvailability_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserCalendarAvailability", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_save_calendar_available_hours_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -99209,6 +99731,118 @@ func (ec *executionContext) fieldContext_Query_calendar_availability(ctx context
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_calendar_available_hours(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_calendar_available_hours(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		directive0 := func(rctx context.Context) (any, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Query().CalendarAvailableHours(rctx, fc.Args["email"].(string))
+		}
+
+		directive1 := func(ctx context.Context) (any, error) {
+			roles, err := ec.unmarshalNRole2ᚕgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐRoleᚄ(ctx, []any{"ADMIN", "USER"})
+			if err != nil {
+				var zeroVal *model.UserCalendarAvailability
+				return zeroVal, err
+			}
+			if ec.directives.HasRole == nil {
+				var zeroVal *model.UserCalendarAvailability
+				return zeroVal, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, roles)
+		}
+		directive2 := func(ctx context.Context) (any, error) {
+			if ec.directives.HasTenant == nil {
+				var zeroVal *model.UserCalendarAvailability
+				return zeroVal, errors.New("directive hasTenant is not implemented")
+			}
+			return ec.directives.HasTenant(ctx, nil, directive1)
+		}
+
+		tmp, err := directive2(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*model.UserCalendarAvailability); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/customeros/customeros/packages/server/customer-os-api/graphql/model.UserCalendarAvailability`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.UserCalendarAvailability)
+	fc.Result = res
+	return ec.marshalOUserCalendarAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐUserCalendarAvailability(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_calendar_available_hours(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_UserCalendarAvailability_id(ctx, field)
+			case "email":
+				return ec.fieldContext_UserCalendarAvailability_email(ctx, field)
+			case "timezone":
+				return ec.fieldContext_UserCalendarAvailability_timezone(ctx, field)
+			case "monday":
+				return ec.fieldContext_UserCalendarAvailability_monday(ctx, field)
+			case "tuesday":
+				return ec.fieldContext_UserCalendarAvailability_tuesday(ctx, field)
+			case "wednesday":
+				return ec.fieldContext_UserCalendarAvailability_wednesday(ctx, field)
+			case "thursday":
+				return ec.fieldContext_UserCalendarAvailability_thursday(ctx, field)
+			case "friday":
+				return ec.fieldContext_UserCalendarAvailability_friday(ctx, field)
+			case "saturday":
+				return ec.fieldContext_UserCalendarAvailability_saturday(ctx, field)
+			case "sunday":
+				return ec.fieldContext_UserCalendarAvailability_sunday(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_UserCalendarAvailability_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_UserCalendarAvailability_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserCalendarAvailability", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_calendar_available_hours_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_contact(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_contact(ctx, field)
 	if err != nil {
@@ -117398,6 +118032,590 @@ func (ec *executionContext) fieldContext_User_appSource(_ context.Context, field
 	return fc, nil
 }
 
+func (ec *executionContext) _UserCalendarAvailability_id(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarAvailability_email(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_email(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Email, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_email(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarAvailability_timezone(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_timezone(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Timezone, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_timezone(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarAvailability_monday(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_monday(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Monday, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.DayAvailability)
+	fc.Result = res
+	return ec.marshalNDayAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailability(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_monday(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enabled":
+				return ec.fieldContext_DayAvailability_enabled(ctx, field)
+			case "startHour":
+				return ec.fieldContext_DayAvailability_startHour(ctx, field)
+			case "endHour":
+				return ec.fieldContext_DayAvailability_endHour(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DayAvailability", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarAvailability_tuesday(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_tuesday(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Tuesday, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.DayAvailability)
+	fc.Result = res
+	return ec.marshalNDayAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailability(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_tuesday(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enabled":
+				return ec.fieldContext_DayAvailability_enabled(ctx, field)
+			case "startHour":
+				return ec.fieldContext_DayAvailability_startHour(ctx, field)
+			case "endHour":
+				return ec.fieldContext_DayAvailability_endHour(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DayAvailability", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarAvailability_wednesday(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_wednesday(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Wednesday, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.DayAvailability)
+	fc.Result = res
+	return ec.marshalNDayAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailability(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_wednesday(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enabled":
+				return ec.fieldContext_DayAvailability_enabled(ctx, field)
+			case "startHour":
+				return ec.fieldContext_DayAvailability_startHour(ctx, field)
+			case "endHour":
+				return ec.fieldContext_DayAvailability_endHour(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DayAvailability", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarAvailability_thursday(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_thursday(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Thursday, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.DayAvailability)
+	fc.Result = res
+	return ec.marshalNDayAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailability(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_thursday(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enabled":
+				return ec.fieldContext_DayAvailability_enabled(ctx, field)
+			case "startHour":
+				return ec.fieldContext_DayAvailability_startHour(ctx, field)
+			case "endHour":
+				return ec.fieldContext_DayAvailability_endHour(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DayAvailability", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarAvailability_friday(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_friday(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Friday, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.DayAvailability)
+	fc.Result = res
+	return ec.marshalNDayAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailability(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_friday(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enabled":
+				return ec.fieldContext_DayAvailability_enabled(ctx, field)
+			case "startHour":
+				return ec.fieldContext_DayAvailability_startHour(ctx, field)
+			case "endHour":
+				return ec.fieldContext_DayAvailability_endHour(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DayAvailability", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarAvailability_saturday(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_saturday(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Saturday, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.DayAvailability)
+	fc.Result = res
+	return ec.marshalNDayAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailability(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_saturday(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enabled":
+				return ec.fieldContext_DayAvailability_enabled(ctx, field)
+			case "startHour":
+				return ec.fieldContext_DayAvailability_startHour(ctx, field)
+			case "endHour":
+				return ec.fieldContext_DayAvailability_endHour(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DayAvailability", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarAvailability_sunday(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_sunday(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Sunday, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.DayAvailability)
+	fc.Result = res
+	return ec.marshalNDayAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailability(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_sunday(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enabled":
+				return ec.fieldContext_DayAvailability_enabled(ctx, field)
+			case "startHour":
+				return ec.fieldContext_DayAvailability_startHour(ctx, field)
+			case "endHour":
+				return ec.fieldContext_DayAvailability_endHour(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DayAvailability", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarAvailability_createdAt(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarAvailability_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.UserCalendarAvailability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarAvailability_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarAvailability_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarAvailability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UserOnboardingDetails_showOnboardingPage(ctx context.Context, field graphql.CollectedField, obj *model.UserOnboardingDetails) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UserOnboardingDetails_showOnboardingPage(ctx, field)
 	if err != nil {
@@ -122226,6 +123444,47 @@ func (ec *executionContext) unmarshalInputDashboardPeriodInput(ctx context.Conte
 				return it, err
 			}
 			it.End = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDayAvailabilityInput(ctx context.Context, obj any) (model.DayAvailabilityInput, error) {
+	var it model.DayAvailabilityInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"enabled", "startHour", "endHour"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "enabled":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("enabled"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Enabled = data
+		case "startHour":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("startHour"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.StartHour = data
+		case "endHour":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("endHour"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.EndHour = data
 		}
 	}
 
@@ -127390,6 +128649,89 @@ func (ec *executionContext) unmarshalInputTimeRange(ctx context.Context, obj any
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUserCalendarAvailabilityInput(ctx context.Context, obj any) (model.UserCalendarAvailabilityInput, error) {
+	var it model.UserCalendarAvailabilityInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"email", "timezone", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "email":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Email = data
+		case "timezone":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("timezone"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Timezone = data
+		case "monday":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("monday"))
+			data, err := ec.unmarshalNDayAvailabilityInput2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailabilityInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Monday = data
+		case "tuesday":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tuesday"))
+			data, err := ec.unmarshalNDayAvailabilityInput2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailabilityInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Tuesday = data
+		case "wednesday":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("wednesday"))
+			data, err := ec.unmarshalNDayAvailabilityInput2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailabilityInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Wednesday = data
+		case "thursday":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("thursday"))
+			data, err := ec.unmarshalNDayAvailabilityInput2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailabilityInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Thursday = data
+		case "friday":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("friday"))
+			data, err := ec.unmarshalNDayAvailabilityInput2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailabilityInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Friday = data
+		case "saturday":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("saturday"))
+			data, err := ec.unmarshalNDayAvailabilityInput2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailabilityInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Saturday = data
+		case "sunday":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sunday"))
+			data, err := ec.unmarshalNDayAvailabilityInput2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailabilityInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Sunday = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUserInput(ctx context.Context, obj any) (model.UserInput, error) {
 	var it model.UserInput
 	asMap := map[string]any{}
@@ -132014,6 +133356,55 @@ func (ec *executionContext) _DashboardTimeToOnboardPerMonth(ctx context.Context,
 			}
 		case "value":
 			out.Values[i] = ec._DashboardTimeToOnboardPerMonth_value(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var dayAvailabilityImplementors = []string{"DayAvailability"}
+
+func (ec *executionContext) _DayAvailability(ctx context.Context, sel ast.SelectionSet, obj *model.DayAvailability) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, dayAvailabilityImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DayAvailability")
+		case "enabled":
+			out.Values[i] = ec._DayAvailability_enabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "startHour":
+			out.Values[i] = ec._DayAvailability_startHour(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "endHour":
+			out.Values[i] = ec._DayAvailability_endHour(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -137150,6 +138541,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "save_calendar_available_hours":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_save_calendar_available_hours(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "addTag":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_addTag(ctx, field)
@@ -140916,6 +142314,25 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "calendar_available_hours":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_calendar_available_hours(ctx, field)
 				return res
 			}
 
@@ -144981,6 +146398,100 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 	return out
 }
 
+var userCalendarAvailabilityImplementors = []string{"UserCalendarAvailability"}
+
+func (ec *executionContext) _UserCalendarAvailability(ctx context.Context, sel ast.SelectionSet, obj *model.UserCalendarAvailability) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, userCalendarAvailabilityImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UserCalendarAvailability")
+		case "id":
+			out.Values[i] = ec._UserCalendarAvailability_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "email":
+			out.Values[i] = ec._UserCalendarAvailability_email(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "timezone":
+			out.Values[i] = ec._UserCalendarAvailability_timezone(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "monday":
+			out.Values[i] = ec._UserCalendarAvailability_monday(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "tuesday":
+			out.Values[i] = ec._UserCalendarAvailability_tuesday(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "wednesday":
+			out.Values[i] = ec._UserCalendarAvailability_wednesday(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "thursday":
+			out.Values[i] = ec._UserCalendarAvailability_thursday(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "friday":
+			out.Values[i] = ec._UserCalendarAvailability_friday(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "saturday":
+			out.Values[i] = ec._UserCalendarAvailability_saturday(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "sunday":
+			out.Values[i] = ec._UserCalendarAvailability_sunday(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createdAt":
+			out.Values[i] = ec._UserCalendarAvailability_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updatedAt":
+			out.Values[i] = ec._UserCalendarAvailability_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var userOnboardingDetailsImplementors = []string{"UserOnboardingDetails"}
 
 func (ec *executionContext) _UserOnboardingDetails(ctx context.Context, sel ast.SelectionSet, obj *model.UserOnboardingDetails) graphql.Marshaler {
@@ -147091,6 +148602,21 @@ func (ec *executionContext) unmarshalNDataSource2githubᚗcomᚋcustomerosᚋcus
 
 func (ec *executionContext) marshalNDataSource2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDataSource(ctx context.Context, sel ast.SelectionSet, v model.DataSource) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) marshalNDayAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailability(ctx context.Context, sel ast.SelectionSet, v *model.DayAvailability) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DayAvailability(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDayAvailabilityInput2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDayAvailabilityInput(ctx context.Context, v any) (*model.DayAvailabilityInput, error) {
+	res, err := ec.unmarshalInputDayAvailabilityInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalNDeleteResponse2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐDeleteResponse(ctx context.Context, sel ast.SelectionSet, v model.DeleteResponse) graphql.Marshaler {
@@ -151251,6 +152777,25 @@ func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋcustomerosᚋcustomer
 	return ec._User(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNUserCalendarAvailability2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐUserCalendarAvailability(ctx context.Context, sel ast.SelectionSet, v model.UserCalendarAvailability) graphql.Marshaler {
+	return ec._UserCalendarAvailability(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUserCalendarAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐUserCalendarAvailability(ctx context.Context, sel ast.SelectionSet, v *model.UserCalendarAvailability) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UserCalendarAvailability(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUserCalendarAvailabilityInput2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐUserCalendarAvailabilityInput(ctx context.Context, v any) (model.UserCalendarAvailabilityInput, error) {
+	res, err := ec.unmarshalInputUserCalendarAvailabilityInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNUserOnboardingDetails2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐUserOnboardingDetails(ctx context.Context, sel ast.SelectionSet, v *model.UserOnboardingDetails) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -153415,6 +154960,13 @@ func (ec *executionContext) marshalOUser2ᚖgithubᚗcomᚋcustomerosᚋcustomer
 		return graphql.Null
 	}
 	return ec._User(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOUserCalendarAvailability2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐUserCalendarAvailability(ctx context.Context, sel ast.SelectionSet, v *model.UserCalendarAvailability) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._UserCalendarAvailability(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOUserUpdateInput2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐUserUpdateInput(ctx context.Context, v any) (*model.UserUpdateInput, error) {

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -1053,6 +1053,20 @@ type DashboardTimeToOnboardPerMonth struct {
 	Value float64 `json:"value"`
 }
 
+// Represents availability settings for a single day
+type DayAvailability struct {
+	Enabled   bool   `json:"enabled"`
+	StartHour string `json:"startHour"`
+	EndHour   string `json:"endHour"`
+}
+
+// Input for day availability settings
+type DayAvailabilityInput struct {
+	Enabled   bool   `json:"enabled"`
+	StartHour string `json:"startHour"`
+	EndHour   string `json:"endHour"`
+}
+
 type DeleteResponse struct {
 	Accepted  bool `json:"accepted"`
 	Completed bool `json:"completed"`
@@ -3251,6 +3265,35 @@ type User struct {
 	Source        DataSource  `json:"source"`
 	SourceOfTruth DataSource  `json:"sourceOfTruth"`
 	AppSource     string      `json:"appSource"`
+}
+
+// Represents a user's calendar available hours configuration
+type UserCalendarAvailability struct {
+	ID        string           `json:"id"`
+	Email     string           `json:"email"`
+	Timezone  string           `json:"timezone"`
+	Monday    *DayAvailability `json:"monday"`
+	Tuesday   *DayAvailability `json:"tuesday"`
+	Wednesday *DayAvailability `json:"wednesday"`
+	Thursday  *DayAvailability `json:"thursday"`
+	Friday    *DayAvailability `json:"friday"`
+	Saturday  *DayAvailability `json:"saturday"`
+	Sunday    *DayAvailability `json:"sunday"`
+	CreatedAt time.Time        `json:"createdAt"`
+	UpdatedAt time.Time        `json:"updatedAt"`
+}
+
+// Input for saving user's calendar available hours
+type UserCalendarAvailabilityInput struct {
+	Email     string                `json:"email"`
+	Timezone  string                `json:"timezone"`
+	Monday    *DayAvailabilityInput `json:"monday"`
+	Tuesday   *DayAvailabilityInput `json:"tuesday"`
+	Wednesday *DayAvailabilityInput `json:"wednesday"`
+	Thursday  *DayAvailabilityInput `json:"thursday"`
+	Friday    *DayAvailabilityInput `json:"friday"`
+	Saturday  *DayAvailabilityInput `json:"saturday"`
+	Sunday    *DayAvailabilityInput `json:"sunday"`
 }
 
 // Describes the User of customerOS.  A user is the person who logs into the Openline platform.

--- a/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
@@ -6,12 +6,19 @@ package resolver
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
+	"github.com/customeros/customeros/packages/server/customer-os-api/mapper"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 )
+
+// SaveCalendarAvailableHours is the resolver for the save_calendar_available_hours field.
+func (r *mutationResolver) SaveCalendarAvailableHours(ctx context.Context, input model.UserCalendarAvailabilityInput) (*model.UserCalendarAvailability, error) {
+	panic(fmt.Errorf("not implemented: SaveCalendarAvailableHours - save_calendar_available_hours"))
+}
 
 // CalendarAvailability is the resolver for the calendar_availability field.
 func (r *queryResolver) CalendarAvailability(ctx context.Context, input model.CalendarAvailabilityInput) (*model.CalendarAvailabilityResponse, error) {
@@ -75,4 +82,21 @@ func (r *queryResolver) CalendarAvailability(ctx context.Context, input model.Ca
 		TotalUsers:     availability.TotalUsers,
 		AvailableUsers: availability.AvailableUsers,
 	}, nil
+}
+
+// CalendarAvailableHours is the resolver for the calendar_available_hours field.
+func (r *queryResolver) CalendarAvailableHours(ctx context.Context, email string) (*model.UserCalendarAvailability, error) {
+	spans, ctx := telemetry.StartGraphQLSpan(ctx, "QueryResolver.CalendarAvailableHours", graphql.GetOperationContext(ctx))
+	defer spans.Finish()
+
+	spans.LogKV("email", email)
+
+	userCalendarAvailability, err := r.Services.CommonServices.MeetingService.GetUserCalendarAvailability(ctx, email)
+	if err != nil {
+		spans.TraceError(err)
+		graphql.AddErrorf(ctx, "Failed to get calendar availability")
+		return nil, nil
+	}
+
+	return mapper.MapEntityToModel(userCalendarAvailability), nil
 }

--- a/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
@@ -6,7 +6,6 @@ package resolver
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
@@ -17,7 +16,19 @@ import (
 
 // SaveCalendarAvailableHours is the resolver for the save_calendar_available_hours field.
 func (r *mutationResolver) SaveCalendarAvailableHours(ctx context.Context, input model.UserCalendarAvailabilityInput) (*model.UserCalendarAvailability, error) {
-	panic(fmt.Errorf("not implemented: SaveCalendarAvailableHours - save_calendar_available_hours"))
+	spans, ctx := telemetry.StartGraphQLSpan(ctx, "MutationResolver.SaveCalendarAvailableHours", graphql.GetOperationContext(ctx))
+	defer spans.Finish()
+	spans.LogObjectAsJson("request", input)
+
+	availability := mapper.MapUserCalendarAvailabilityInputToEntity(input)
+	userCalendarAvailabilityEntity, err := r.Services.CommonServices.MeetingService.SaveUserCalendarAvailability(ctx, availability)
+	if err != nil {
+		spans.TraceError(err)
+		graphql.AddErrorf(ctx, "Failed to save calendar availability hours: %s", err.Error())
+		return nil, nil
+	}
+
+	return mapper.MapUserCalendarAvailabilityEntityToModel(userCalendarAvailabilityEntity), nil
 }
 
 // CalendarAvailability is the resolver for the calendar_availability field.
@@ -91,12 +102,12 @@ func (r *queryResolver) CalendarAvailableHours(ctx context.Context, email string
 
 	spans.LogKV("email", email)
 
-	userCalendarAvailability, err := r.Services.CommonServices.MeetingService.GetUserCalendarAvailability(ctx, email)
+	userCalendarAvailabilityEntity, err := r.Services.CommonServices.MeetingService.GetUserCalendarAvailability(ctx, email)
 	if err != nil {
 		spans.TraceError(err)
-		graphql.AddErrorf(ctx, "Failed to get calendar availability")
+		graphql.AddErrorf(ctx, "Failed to get calendar availability hours")
 		return nil, nil
 	}
 
-	return mapper.MapEntityToModel(userCalendarAvailability), nil
+	return mapper.MapUserCalendarAvailabilityEntityToModel(userCalendarAvailabilityEntity), nil
 }

--- a/packages/server/customer-os-api/graphql/schemas/calendar.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/calendar.graphqls
@@ -50,9 +50,72 @@ type CalendarAvailabilityResponse {
     availableUsers: Int!
 }
 
+"""
+Represents availability settings for a single day
+"""
+type DayAvailability {
+    enabled: Boolean!
+    startHour: String! # Format: "HH:MM"
+    endHour: String! # Format: "HH:MM"
+}
+
+"""
+Input for day availability settings
+"""
+input DayAvailabilityInput {
+    enabled: Boolean!
+    startHour: String! # Format: "HH:MM"
+    endHour: String! # Format: "HH:MM"
+}
+
+"""
+Represents a user's calendar available hours configuration
+"""
+type UserCalendarAvailability {
+    id: ID!
+    email: String!
+    timezone: String!
+    monday: DayAvailability!
+    tuesday: DayAvailability!
+    wednesday: DayAvailability!
+    thursday: DayAvailability!
+    friday: DayAvailability!
+    saturday: DayAvailability!
+    sunday: DayAvailability!
+    createdAt: Time!
+    updatedAt: Time!
+}
+
+"""
+Input for saving user's calendar available hours
+"""
+input UserCalendarAvailabilityInput {
+    email: String!
+    timezone: String!
+    monday: DayAvailabilityInput!
+    tuesday: DayAvailabilityInput!
+    wednesday: DayAvailabilityInput!
+    thursday: DayAvailabilityInput!
+    friday: DayAvailabilityInput!
+    saturday: DayAvailabilityInput!
+    sunday: DayAvailabilityInput!
+}
+
 extend type Query {
     """
     Get availability across all users in the tenant for a given time range
     """
     calendar_availability(input: CalendarAvailabilityInput!): CalendarAvailabilityResponse! @hasRole(roles: [ADMIN, USER]) @hasTenant
+
+    """
+    Get user's calendar available hours configuration
+    """
+    calendar_available_hours(email: String!): UserCalendarAvailability @hasRole(roles: [ADMIN, USER]) @hasTenant
+}
+
+extend type Mutation {
+    """
+    Save user's calendar available hours configuration
+    """
+    save_calendar_available_hours(input: UserCalendarAvailabilityInput!): UserCalendarAvailability! @hasRole(roles: [ADMIN, USER]) @hasTenant
 }

--- a/packages/server/customer-os-api/mapper/user_calendar_availability_mapper.go
+++ b/packages/server/customer-os-api/mapper/user_calendar_availability_mapper.go
@@ -1,0 +1,79 @@
+package mapper
+
+import (
+	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
+	postgresEntity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
+)
+
+const defaultTimezone = "Etc/UTC"
+
+func MapEntityToModel(entity *postgresEntity.UserCalendarAvailability) *model.UserCalendarAvailability {
+	if entity == nil {
+		return nil
+	}
+
+	timezone := entity.Timezone
+	if timezone == "" {
+		timezone = defaultTimezone
+	}
+
+	return &model.UserCalendarAvailability{
+		ID:        entity.ID,
+		Email:     entity.Email,
+		Timezone:  timezone,
+		Monday:    mapDayAvailabilityToModel(entity.Monday),
+		Tuesday:   mapDayAvailabilityToModel(entity.Tuesday),
+		Wednesday: mapDayAvailabilityToModel(entity.Wednesday),
+		Thursday:  mapDayAvailabilityToModel(entity.Thursday),
+		Friday:    mapDayAvailabilityToModel(entity.Friday),
+		Saturday:  mapDayAvailabilityToModel(entity.Saturday),
+		Sunday:    mapDayAvailabilityToModel(entity.Sunday),
+		CreatedAt: entity.CreatedAt,
+		UpdatedAt: entity.UpdatedAt,
+	}
+}
+
+func mapDayAvailabilityToModel(day postgresEntity.DayAvailability) *model.DayAvailability {
+	return &model.DayAvailability{
+		Enabled:   day.Enabled,
+		StartHour: day.StartHour,
+		EndHour:   day.EndHour,
+	}
+}
+
+func MapInputToEntity(input *model.UserCalendarAvailabilityInput) *postgresEntity.UserCalendarAvailability {
+	if input == nil {
+		return nil
+	}
+
+	timezone := input.Timezone
+	if timezone == "" {
+		timezone = defaultTimezone
+	}
+
+	return &postgresEntity.UserCalendarAvailability{
+		Email:     input.Email,
+		Timezone:  timezone,
+		Monday:    mapInputToDayAvailability(input.Monday),
+		Tuesday:   mapInputToDayAvailability(input.Tuesday),
+		Wednesday: mapInputToDayAvailability(input.Wednesday),
+		Thursday:  mapInputToDayAvailability(input.Thursday),
+		Friday:    mapInputToDayAvailability(input.Friday),
+		Saturday:  mapInputToDayAvailability(input.Saturday),
+		Sunday:    mapInputToDayAvailability(input.Sunday),
+	}
+}
+
+func mapInputToDayAvailability(input *model.DayAvailabilityInput) postgresEntity.DayAvailability {
+	if input == nil {
+		return postgresEntity.DayAvailability{
+			Enabled: false,
+		}
+	}
+
+	return postgresEntity.DayAvailability{
+		Enabled:   input.Enabled,
+		StartHour: input.StartHour,
+		EndHour:   input.EndHour,
+	}
+}

--- a/packages/server/customer-os-api/mapper/user_calendar_availability_mapper.go
+++ b/packages/server/customer-os-api/mapper/user_calendar_availability_mapper.go
@@ -7,7 +7,7 @@ import (
 
 const defaultTimezone = "Etc/UTC"
 
-func MapEntityToModel(entity *postgresEntity.UserCalendarAvailability) *model.UserCalendarAvailability {
+func MapUserCalendarAvailabilityEntityToModel(entity *postgresEntity.UserCalendarAvailability) *model.UserCalendarAvailability {
 	if entity == nil {
 		return nil
 	}
@@ -41,11 +41,7 @@ func mapDayAvailabilityToModel(day postgresEntity.DayAvailability) *model.DayAva
 	}
 }
 
-func MapInputToEntity(input *model.UserCalendarAvailabilityInput) *postgresEntity.UserCalendarAvailability {
-	if input == nil {
-		return nil
-	}
-
+func MapUserCalendarAvailabilityInputToEntity(input model.UserCalendarAvailabilityInput) *postgresEntity.UserCalendarAvailability {
 	timezone := input.Timezone
 	if timezone == "" {
 		timezone = defaultTimezone
@@ -69,6 +65,14 @@ func mapInputToDayAvailability(input *model.DayAvailabilityInput) postgresEntity
 		return postgresEntity.DayAvailability{
 			Enabled: false,
 		}
+	}
+
+	if input.StartHour == "" {
+		input.StartHour = "00:00"
+	}
+
+	if input.EndHour == "" {
+		input.EndHour = "24:00"
 	}
 
 	return postgresEntity.DayAvailability{

--- a/packages/server/customer-os-common-module/interfaces/meeting.go
+++ b/packages/server/customer-os-common-module/interfaces/meeting.go
@@ -3,11 +3,16 @@ package interfaces
 import (
 	"context"
 	"time"
+
+	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 )
 
 type MeetingService interface {
 	GetCalendarAvailabilityForTenant(ctx context.Context, startTime time.Time, endTime time.Time, duration int, timezone string) (*CalendarAvailability, error)
 	GetCalendarAvailabilityForEmail(ctx context.Context, email string, startTime time.Time, endTime time.Time, duration int, timezone string) (*CalendarAvailability, error)
+
+	GetUserCalendarAvailability(ctx context.Context, email string) (*postgres_entity.UserCalendarAvailability, error)
+	SaveUserCalendarAvailability(ctx context.Context, availability *postgres_entity.UserCalendarAvailability) (*postgres_entity.UserCalendarAvailability, error)
 }
 
 // TimeSlot represents a time slot in calendar availability

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -197,12 +197,6 @@ func (s *meetingService) SaveUserCalendarAvailability(ctx context.Context, avail
 	// Set tenant from context
 	availability.Tenant = tenant
 
-	// Validate time formats
-	if err := validateAvailabilityTimes(availability); err != nil {
-		spans.TraceError(err)
-		return nil, err
-	}
-
 	// Save or update availability
 	saved, err := s.postgresRepository.UserCalendarAvailabilityRepository.SaveOrUpdate(ctx, availability)
 	if err != nil {
@@ -211,45 +205,4 @@ func (s *meetingService) SaveUserCalendarAvailability(ctx context.Context, avail
 	}
 
 	return saved, nil
-}
-
-// validateAvailabilityTimes validates the time formats in the availability settings
-func validateAvailabilityTimes(availability *postgres_entity.UserCalendarAvailability) error {
-	days := []postgres_entity.DayAvailability{
-		availability.Monday,
-		availability.Tuesday,
-		availability.Wednesday,
-		availability.Thursday,
-		availability.Friday,
-		availability.Saturday,
-		availability.Sunday,
-	}
-
-	for _, day := range days {
-		if !day.Enabled {
-			continue
-		}
-
-		// Validate time format (HH:MM)
-		if _, err := time.Parse("15:04", day.StartHour); err != nil {
-			return fmt.Errorf("invalid start hour format: %s", day.StartHour)
-		}
-		if _, err := time.Parse("15:04", day.EndHour); err != nil {
-			return fmt.Errorf("invalid end hour format: %s", day.EndHour)
-		}
-
-		// Validate start time is before end time
-		start, _ := time.Parse("15:04", day.StartHour)
-		end, _ := time.Parse("15:04", day.EndHour)
-		if !start.Before(end) {
-			return fmt.Errorf("start time must be before end time: %s - %s", day.StartHour, day.EndHour)
-		}
-	}
-
-	// Validate timezone
-	if _, err := time.LoadLocation(availability.Timezone); err != nil {
-		return fmt.Errorf("invalid timezone: %s", availability.Timezone)
-	}
-
-	return nil
 }

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 )
 
@@ -154,4 +155,101 @@ func (s *meetingService) GetCalendarAvailabilityForEmail(ctx context.Context, em
 func (s *meetingService) GetCalendarAvailabilityForTenant(ctx context.Context, startTime time.Time, endTime time.Time, duration int, timezone string) (*interfaces.CalendarAvailability, error) {
 	// TODO implement
 	return nil, nil
+}
+
+func (s *meetingService) GetUserCalendarAvailability(ctx context.Context, email string) (*postgres_entity.UserCalendarAvailability, error) {
+	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.GetUserCalendarAvailability")
+	defer spans.Finish()
+	spans.LogKV("email", email)
+
+	// validate tenant
+	err := common.ValidateTenant(ctx)
+	if err != nil {
+		spans.TraceError(err)
+		return nil, err
+	}
+	tenant := common.GetTenantFromContext(ctx)
+
+	// Get user's calendar availability
+	availability, err := s.postgresRepository.UserCalendarAvailabilityRepository.GetByTenantAndEmail(ctx, tenant, email)
+	if err != nil {
+		spans.TraceError(err)
+		return nil, fmt.Errorf("failed to get calendar availability: %v", err)
+	}
+
+	return availability, nil
+}
+
+// SaveCalendarAvailableHours implements interfaces.MeetingService
+func (s *meetingService) SaveUserCalendarAvailability(ctx context.Context, availability *postgres_entity.UserCalendarAvailability) (*postgres_entity.UserCalendarAvailability, error) {
+	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.SaveCalendarAvailableHours")
+	defer spans.Finish()
+	spans.LogKV("email", availability.Email)
+
+	// validate tenant
+	err := common.ValidateTenant(ctx)
+	if err != nil {
+		spans.TraceError(err)
+		return nil, err
+	}
+	tenant := common.GetTenantFromContext(ctx)
+
+	// Set tenant from context
+	availability.Tenant = tenant
+
+	// Validate time formats
+	if err := validateAvailabilityTimes(availability); err != nil {
+		spans.TraceError(err)
+		return nil, err
+	}
+
+	// Save or update availability
+	saved, err := s.postgresRepository.UserCalendarAvailabilityRepository.SaveOrUpdate(ctx, availability)
+	if err != nil {
+		spans.TraceError(err)
+		return nil, fmt.Errorf("failed to save calendar availability: %v", err)
+	}
+
+	return saved, nil
+}
+
+// validateAvailabilityTimes validates the time formats in the availability settings
+func validateAvailabilityTimes(availability *postgres_entity.UserCalendarAvailability) error {
+	days := []postgres_entity.DayAvailability{
+		availability.Monday,
+		availability.Tuesday,
+		availability.Wednesday,
+		availability.Thursday,
+		availability.Friday,
+		availability.Saturday,
+		availability.Sunday,
+	}
+
+	for _, day := range days {
+		if !day.Enabled {
+			continue
+		}
+
+		// Validate time format (HH:MM)
+		if _, err := time.Parse("15:04", day.StartHour); err != nil {
+			return fmt.Errorf("invalid start hour format: %s", day.StartHour)
+		}
+		if _, err := time.Parse("15:04", day.EndHour); err != nil {
+			return fmt.Errorf("invalid end hour format: %s", day.EndHour)
+		}
+
+		// Validate start time is before end time
+		start, _ := time.Parse("15:04", day.StartHour)
+		end, _ := time.Parse("15:04", day.EndHour)
+		if !start.Before(end) {
+			return fmt.Errorf("start time must be before end time: %s - %s", day.StartHour, day.EndHour)
+		}
+	}
+
+	// Validate timezone
+	if _, err := time.LoadLocation(availability.Timezone); err != nil {
+		return fmt.Errorf("invalid timezone: %s", availability.Timezone)
+	}
+
+	return nil
 }

--- a/packages/server/customer-os-postgres-repository/entity/user_calendar_availability.go
+++ b/packages/server/customer-os-postgres-repository/entity/user_calendar_availability.go
@@ -1,6 +1,11 @@
 package postgres_entity
 
 import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
@@ -14,6 +19,125 @@ type DayAvailability struct {
 	EndHour   string `json:"endHour" gorm:"type:varchar(5)"`   // Format: "HH:MM"
 }
 
+// standardizeTimeFormat converts time strings like "8:10" to "08:10"
+func standardizeTimeFormat(timeStr string) (string, error) {
+	if timeStr == "" {
+		return "", nil
+	}
+
+	// Special case for end of day
+	if timeStr == "24:00" {
+		return "24:00", nil
+	}
+
+	// Try parsing with different formats
+	formats := []string{"15:04", "3:04PM", "3:04 PM", "3PM", "15", "3"}
+	var t time.Time
+	var err error
+
+	for _, format := range formats {
+		t, err = time.Parse(format, timeStr)
+		if err == nil {
+			return t.Format("15:04"), nil
+		}
+	}
+
+	// If single digit hour provided, try prefixing with 0
+	if !strings.Contains(timeStr, ":") {
+		timeStr = timeStr + ":00"
+	}
+	if len(timeStr) == 4 && timeStr[1] == ':' {
+		timeStr = "0" + timeStr
+	}
+
+	// Final attempt with standardized format
+	t, err = time.Parse("15:04", timeStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid time format: %s", timeStr)
+	}
+
+	return t.Format("15:04"), nil
+}
+
+// compareTimeStrings compares two time strings in "HH:MM" format
+// returns true if start is before end
+func compareTimeStrings(start, end string) bool {
+	// Parse times
+	startParts := strings.Split(start, ":")
+	endParts := strings.Split(end, ":")
+
+	startHour, _ := strconv.Atoi(startParts[0])
+	startMin, _ := strconv.Atoi(startParts[1])
+	endHour, _ := strconv.Atoi(endParts[0])
+	endMin, _ := strconv.Atoi(endParts[1])
+
+	// Compare hours first
+	if startHour < endHour {
+		return true
+	}
+	if startHour > endHour {
+		return false
+	}
+	// If hours are equal, compare minutes
+	return startMin < endMin
+}
+
+// Validate checks if the day availability is valid
+func (d *DayAvailability) Validate() error {
+	if !d.Enabled {
+		return nil
+	}
+
+	// Validate start time
+	start, err := standardizeTimeFormat(d.StartHour)
+	if err != nil {
+		return err
+	}
+	d.StartHour = start
+
+	// Validate end time
+	end, err := standardizeTimeFormat(d.EndHour)
+	if err != nil {
+		return err
+	}
+	d.EndHour = end
+
+	// Skip time comparison if either time is empty
+	if start == "" || end == "" {
+		return nil
+	}
+
+	// Validate start time is before end time
+	if !compareTimeStrings(start, end) {
+		return fmt.Errorf("start time %s must be before end time %s", start, end)
+	}
+
+	return nil
+}
+
+// Scan implements the sql.Scanner interface for DayAvailability
+func (d *DayAvailability) Scan(value interface{}) error {
+	if value == nil {
+		*d = DayAvailability{}
+		return nil
+	}
+
+	bytes, ok := value.([]byte)
+	if !ok {
+		return nil
+	}
+
+	return json.Unmarshal(bytes, d)
+}
+
+// Value implements the driver.Valuer interface for DayAvailability
+func (d DayAvailability) Value() (driver.Value, error) {
+	if err := d.standardizeAndValidate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(d)
+}
+
 // UserCalendarAvailability represents a user's available hours for calendar bookings
 type UserCalendarAvailability struct {
 	ID        string    `gorm:"type:varchar(21);primaryKey"`
@@ -21,7 +145,7 @@ type UserCalendarAvailability struct {
 	UpdatedAt time.Time `gorm:"column:updated_at;type:timestamp;DEFAULT:current_timestamp"`
 	Tenant    string    `gorm:"size:255;not null;uniqueIndex:idx_tenant_email"`
 	Email     string    `gorm:"size:255;not null;uniqueIndex:idx_tenant_email"`
-	Timezone  string    `gorm:"size:50"` // e.g., "America/New_York"
+	Timezone  string    `gorm:"size:50;not null"` // e.g., "America/New_York"
 
 	// One field for each day of the week
 	Monday    DayAvailability `gorm:"type:jsonb"`
@@ -37,8 +161,88 @@ func (UserCalendarAvailability) TableName() string {
 	return "user_calendar_availability"
 }
 
-// BeforeCreate hook to ensure ID has the correct prefix
+// Validate performs validation on the UserCalendarAvailability entity
+func (u *UserCalendarAvailability) Validate() error {
+	// Validate timezone
+	if u.Timezone == "" {
+		u.Timezone = "Etc/UTC"
+	}
+	_, err := time.LoadLocation(u.Timezone)
+	if err != nil {
+		return fmt.Errorf("invalid timezone: %s", u.Timezone)
+	}
+
+	// Validate each day's availability
+	days := []struct {
+		name string
+		day  *DayAvailability
+	}{
+		{"Monday", &u.Monday},
+		{"Tuesday", &u.Tuesday},
+		{"Wednesday", &u.Wednesday},
+		{"Thursday", &u.Thursday},
+		{"Friday", &u.Friday},
+		{"Saturday", &u.Saturday},
+		{"Sunday", &u.Sunday},
+	}
+
+	for _, d := range days {
+		if err := d.day.standardizeAndValidate(); err != nil {
+			return fmt.Errorf("%s: %v", d.name, err)
+		}
+	}
+
+	return nil
+}
+
+// BeforeCreate hook to ensure ID has the correct prefix and validate
 func (u *UserCalendarAvailability) BeforeCreate(tx *gorm.DB) error {
-	u.ID = utils.GenerateNanoIdWithPrefix("uca", 16)
+	if u.ID == "" {
+		id := utils.GenerateNanoIdWithPrefix("uca", 16)
+		u.ID = id
+	} else if !strings.HasPrefix(u.ID, "uca_") {
+		u.ID = "uca_" + u.ID
+	}
+	return u.Validate()
+}
+
+// BeforeUpdate hook to update the UpdatedAt timestamp and validate
+func (u *UserCalendarAvailability) BeforeUpdate(tx *gorm.DB) error {
+	u.UpdatedAt = time.Now()
+	return u.Validate()
+}
+
+// standardizeAndValidate checks if the day availability is valid and standardizes time formats
+func (d *DayAvailability) standardizeAndValidate() error {
+	if !d.Enabled {
+		d.StartHour = ""
+		d.EndHour = ""
+		return nil
+	}
+
+	// Validate start time
+	start, err := standardizeTimeFormat(d.StartHour)
+	if err != nil {
+		return err
+	}
+	d.StartHour = start
+
+	// Validate end time
+	end, err := standardizeTimeFormat(d.EndHour)
+	if err != nil {
+		return err
+	}
+	d.EndHour = end
+
+	// Skip time comparison if either time is empty
+	if start == "" || end == "" {
+		return nil
+	}
+
+	// Validate start time is before end time
+	if !compareTimeStrings(start, end) {
+		return fmt.Errorf("start time %s must be before end time %s", start, end)
+	}
+
 	return nil
 }

--- a/packages/server/customer-os-postgres-repository/entity/user_calendar_availability.go
+++ b/packages/server/customer-os-postgres-repository/entity/user_calendar_availability.go
@@ -1,0 +1,44 @@
+package postgres_entity
+
+import (
+	"time"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	"gorm.io/gorm"
+)
+
+// DayAvailability represents the availability for a single day
+type DayAvailability struct {
+	Enabled   bool   `json:"enabled" gorm:"type:boolean;default:false"`
+	StartHour string `json:"startHour" gorm:"type:varchar(5)"` // Format: "HH:MM"
+	EndHour   string `json:"endHour" gorm:"type:varchar(5)"`   // Format: "HH:MM"
+}
+
+// UserCalendarAvailability represents a user's available hours for calendar bookings
+type UserCalendarAvailability struct {
+	ID        string    `gorm:"type:varchar(21);primaryKey"`
+	CreatedAt time.Time `gorm:"column:created_at;type:timestamp;DEFAULT:current_timestamp"`
+	UpdatedAt time.Time `gorm:"column:updated_at;type:timestamp;DEFAULT:current_timestamp"`
+	Tenant    string    `gorm:"size:255;not null;uniqueIndex:idx_tenant_email"`
+	Email     string    `gorm:"size:255;not null;uniqueIndex:idx_tenant_email"`
+	Timezone  string    `gorm:"size:50"` // e.g., "America/New_York"
+
+	// One field for each day of the week
+	Monday    DayAvailability `gorm:"type:jsonb"`
+	Tuesday   DayAvailability `gorm:"type:jsonb"`
+	Wednesday DayAvailability `gorm:"type:jsonb"`
+	Thursday  DayAvailability `gorm:"type:jsonb"`
+	Friday    DayAvailability `gorm:"type:jsonb"`
+	Saturday  DayAvailability `gorm:"type:jsonb"`
+	Sunday    DayAvailability `gorm:"type:jsonb"`
+}
+
+func (UserCalendarAvailability) TableName() string {
+	return "user_calendar_availability"
+}
+
+// BeforeCreate hook to ensure ID has the correct prefix
+func (u *UserCalendarAvailability) BeforeCreate(tx *gorm.DB) error {
+	u.ID = utils.GenerateNanoIdWithPrefix("uca", 16)
+	return nil
+}

--- a/packages/server/customer-os-postgres-repository/repository/repositories.go
+++ b/packages/server/customer-os-postgres-repository/repository/repositories.go
@@ -77,6 +77,7 @@ type Repositories struct {
 	TenantWebhookApiKeyRepository                TenantWebhookApiKeyRepository
 	TenantWebhookRepository                      TenantWebhookRepository
 	UserWorkingScheduleRepository                UserWorkingScheduleRepository
+	UserCalendarAvailabilityRepository           UserCalendarAvailabilityRepository
 	WebhooksRepository                           WebhooksRepository
 	WebSessionPageVisitRepository                WebSessionPageVisitRepository
 	WebSessionRepository                         WebSessionRepository
@@ -156,6 +157,7 @@ func InitRepositories(postgresDB *config.PostgresDB) *Repositories {
 		TenantWebhookApiKeyRepository:                NewTenantWebhookApiKeyRepository(postgresDB.GormDB),
 		TenantWebhookRepository:                      NewTenantWebhookRepo(postgresDB.GormDB),
 		UserWorkingScheduleRepository:                NewUserWorkingScheduleRepository(postgresDB.GormDB),
+		UserCalendarAvailabilityRepository:           NewUserCalendarAvailabilityRepository(postgresDB.GormDB),
 		QuickbooksSettingsRepository:                 NewQuickbooksSettingsRepository(postgresDB.GormDB),
 		WebhooksRepository:                           NewWebhooksRepository(postgresDB.GormDB),
 		WebSessionRepository:                         NewWebSessionRepository(postgresDB.GormDB),
@@ -232,6 +234,7 @@ func (r *Repositories) AutoMigrate(postgresDB *config.PostgresDB) error {
 		&postgres_entity.TenantWebhook{},
 		&postgres_entity.TenantWebhookApiKey{},
 		&postgres_entity.UserWorkingSchedule{},
+		&postgres_entity.UserCalendarAvailability{},
 		&postgres_entity.Webhooks{},
 		&postgres_entity.WebSession{},
 		&postgres_entity.WebSessionPageVisit{},

--- a/packages/server/customer-os-postgres-repository/repository/user_calendar_availability_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/user_calendar_availability_repository.go
@@ -1,0 +1,73 @@
+package postgres_repository
+
+import (
+	"context"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
+	"gorm.io/gorm"
+)
+
+type UserCalendarAvailabilityRepository interface {
+	GetByTenantAndEmail(ctx context.Context, tenant string, email string) (*postgres_entity.UserCalendarAvailability, error)
+	SaveOrUpdate(ctx context.Context, availability *postgres_entity.UserCalendarAvailability) (*postgres_entity.UserCalendarAvailability, error)
+}
+
+type userCalendarAvailabilityRepository struct {
+	db *gorm.DB
+}
+
+func NewUserCalendarAvailabilityRepository(db *gorm.DB) UserCalendarAvailabilityRepository {
+	return &userCalendarAvailabilityRepository{
+		db: db,
+	}
+}
+
+func (r *userCalendarAvailabilityRepository) GetByTenantAndEmail(ctx context.Context, tenant string, email string) (*postgres_entity.UserCalendarAvailability, error) {
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "UserCalendarAvailabilityRepository.GetByTenantAndEmail")
+	defer spans.Finish()
+	spans.LogKV("email", email)
+
+	var availability postgres_entity.UserCalendarAvailability
+	result := r.db.Where("tenant = ? AND email = ?", tenant, email).First(&availability)
+	if result.Error != nil {
+		if result.Error == gorm.ErrRecordNotFound {
+			spans.LogKV("result.found", false)
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+
+	spans.LogKV("result.found", true)
+	return &availability, nil
+}
+
+func (r *userCalendarAvailabilityRepository) SaveOrUpdate(ctx context.Context, availability *postgres_entity.UserCalendarAvailability) (*postgres_entity.UserCalendarAvailability, error) {
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "UserCalendarAvailabilityRepository.SaveOrUpdate")
+	defer spans.Finish()
+	spans.LogKV("email", availability.Email)
+
+	// Check if record exists
+	existing, err := r.GetByTenantAndEmail(ctx, availability.Tenant, availability.Email)
+	if err != nil {
+		return nil, err
+	}
+
+	if existing != nil {
+		// Update existing record
+		availability.ID = existing.ID
+		availability.CreatedAt = existing.CreatedAt
+		result := r.db.Save(availability)
+		if result.Error != nil {
+			return nil, result.Error
+		}
+	} else {
+		// Create new record
+		result := r.db.Create(availability)
+		if result.Error != nil {
+			return nil, result.Error
+		}
+	}
+
+	return availability, nil
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add user calendar availability management with GraphQL schema, resolvers, mappers, and repository support.
> 
>   - **GraphQL Schema**:
>     - Add `UserCalendarAvailability` and `DayAvailability` types in `calendar.graphqls`.
>     - Add `UserCalendarAvailabilityInput` and `DayAvailabilityInput` for mutations.
>     - Extend `Query` and `Mutation` to include `calendar_available_hours` and `save_calendar_available_hours`.
>   - **Resolvers**:
>     - Implement `SaveCalendarAvailableHours` and `CalendarAvailableHours` in `calendar.resolvers.go`.
>   - **Mappers**:
>     - Add `MapUserCalendarAvailabilityEntityToModel` and `MapUserCalendarAvailabilityInputToEntity` in `user_calendar_availability_mapper.go`.
>   - **Repository**:
>     - Add `UserCalendarAvailabilityRepository` interface and implementation in `user_calendar_availability_repository.go`.
>     - Implement `GetByTenantAndEmail` and `SaveOrUpdate` methods.
>   - **Service Layer**:
>     - Implement `GetUserCalendarAvailability` and `SaveUserCalendarAvailability` in `service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 3ea58ab595b8eb41d5637cc6d48ccfa654a92fdc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->