### PR TITLE
trace slack alert request

### DIFF
--- a/packages/runner/integrity-checker/service/neo4j_integrity_checker_service.go
+++ b/packages/runner/integrity-checker/service/neo4j_integrity_checker_service.go
@@ -233,6 +233,8 @@ func (h *neo4jIntegrityCheckerService) alertInSlack(ctx context.Context, results
 		return nil
 	}
 
+	spans.LogKV("slackUrl", h.cfg.SlackConfig.DataAlertsRegisteredWebhook)
+
 	var alertMessages []string
 	hasAlert := false
 	var issues []struct {
@@ -300,6 +302,8 @@ func (h *neo4jIntegrityCheckerService) alertInSlack(ctx context.Context, results
 		return fmt.Errorf("error encoding JSON: %w", err)
 	}
 
+	spans.LogObjectAsJson("request", string(jsonData))
+
 	// Send POST request
 	resp, err := http.Post(h.cfg.SlackConfig.DataAlertsRegisteredWebhook, "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
@@ -313,7 +317,8 @@ func (h *neo4jIntegrityCheckerService) alertInSlack(ctx context.Context, results
 	// Check response status
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		spans.TraceError(errors.New("unexpected status code"))
+		spans.TraceError(errors.New("unexpected status code: " + resp.Status))
+		spans.LogKV("response.body", string(body))
 		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance logging in `alertInSlack()` to trace Slack webhook URL, request payload, and response body in `neo4j_integrity_checker_service.go`.
> 
>   - **Logging Enhancements**:
>     - In `alertInSlack()` in `neo4j_integrity_checker_service.go`, log Slack webhook URL with `spans.LogKV()`.
>     - Log JSON request payload with `spans.LogObjectAsJson()`.
>     - Log response body on error with `spans.LogKV()`.
>   - **Error Handling**:
>     - Improve error message in `spans.TraceError()` to include response status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f9cbe1758120cca9e0f16c29b812dc7586f7ca40. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->