### PR TITLE
zero journal entry on voiding invoice

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_invoice_sync_to_accounting.go
@@ -183,15 +183,6 @@ func (c *SyncInvoiceToAccountingCapability) Execute(ctx context.Context, executi
 				return enum.CapabilityExecutionRetry, result, err
 			}
 		}
-
-		// TODO alexb remove this code and invoked QBO services in May
-		//if invoiceEntity.QuickbooksPaymentId == "" {
-		//	err = c.syncPaymentLinkingJournalEntryToInvoice(ctx, *invoiceEntity)
-		//	if err != nil {
-		//		spans.TraceError( err)
-		//		return enum.CapabilityExecutionRetry, result, err
-		//	}
-		//}
 	}
 
 	// re-fetch invoice to get updated quickbooks journal id
@@ -213,12 +204,22 @@ func (c *SyncInvoiceToAccountingCapability) Execute(ctx context.Context, executi
 			spans.TraceError(err)
 			return enum.CapabilityExecutionRetry, result, err
 		}
-		if executionContainer.ConfigData.AccountingMethodAccrual.Value && invoiceEntity.QuickbooksJournalEntryId != "" {
-			err = c.quickbooksService.ZeroJournalEntry(ctx, invoiceEntity.QuickbooksJournalEntryId)
-			if err != nil {
-				spans.TraceError(err)
-				return enum.CapabilityExecutionRetry, result, err
+		if executionContainer.ConfigData.AccountingMethodAccrual.Value {
+			if invoiceEntity.QuickbooksJournalEntryId != "" {
+				err = c.quickbooksService.ZeroJournalEntry(ctx, invoiceEntity.QuickbooksJournalEntryId)
+				if err != nil {
+					spans.TraceError(err)
+					return enum.CapabilityExecutionRetry, result, err
+				}
 			}
+			if invoiceEntity.QuickbooksJournalEntryIdReverse != "" {
+				err = c.quickbooksService.ZeroJournalEntry(ctx, invoiceEntity.QuickbooksJournalEntryIdReverse)
+				if err != nil {
+					spans.TraceError(err)
+					return enum.CapabilityExecutionRetry, result, err
+				}
+			}
+
 			if invoiceEntity.QuickbooksPaymentId != "" {
 				contractEntity, err := c.contractService.GetContractForInvoice(ctx, invoiceEntity.Id)
 				if err != nil {

--- a/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
+++ b/packages/server/customer-os-common-module/services/quickbooks/quickbooks.go
@@ -6,12 +6,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/config"
@@ -470,6 +471,7 @@ func (s *quickbooksService) SaveInvoice(ctx context.Context, quickbooksCustomerI
 func (s *quickbooksService) VoidInvoice(ctx context.Context, invoiceId string) (*interfaces.QuickbooksSaveInvoiceResponse, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "QuickbooksService.VoidInvoice")
 	defer spans.Finish()
+	spans.LogKV("invoiceId", invoiceId)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -754,9 +756,9 @@ func (s *quickbooksService) SaveJournalEntry(ctx context.Context, txnDate time.T
 func (s *quickbooksService) ZeroJournalEntry(ctx context.Context, journalEntryId string) error {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "QuickbooksService.ZeroJournalEntry")
 	defer spans.Finish()
-	tenant := common.GetTenantFromContext(ctx)
 	spans.LogKV("journalEntryId", journalEntryId)
 
+	tenant := common.GetTenantFromContext(ctx)
 	// Retrieve QuickBooks settings for the tenant.
 	qbSettings, err := s.postgres.QuickbooksSettingsRepository.Get(ctx, tenant)
 	if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance voiding invoice handling by zeroing related journal entries in QuickBooks and improve logging in `quickbooks.go`.
> 
>   - **Behavior**:
>     - In `capability_invoice_sync_to_accounting.go`, `ZeroJournalEntry` is now called for both `QuickbooksJournalEntryId` and `QuickbooksJournalEntryIdReverse` when voiding invoices.
>     - Removed unused code related to `syncPaymentLinkingJournalEntryToInvoice`.
>   - **Logging**:
>     - Added logging for `invoiceId` in `VoidInvoice()` in `quickbooks.go`.
>     - Adjusted logging order in `ZeroJournalEntry()` in `quickbooks.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 5932e94d21a407fed6fa2f0a8e72370092c9b340. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->