### PR TITLE
add new org store channel

### DIFF
--- a/packages/server/realtime/lib/realtime/rabbitmq_consumer.ex
+++ b/packages/server/realtime/lib/realtime/rabbitmq_consumer.ex
@@ -10,7 +10,7 @@ defmodule Realtime.RabbitMQConsumer do
 
   @queue_name "notifications"
   @entityToChannelMap %{
-    "ORGANIZATION" => "Organizations",
+    "ORGANIZATION" => "OrganizationStore",
     "CONTACT" => "Contacts",
     "CONTRACT" => "Contracts",
     "OPPORTUNITY" => "Opportunities",
@@ -75,6 +75,14 @@ defmodule Realtime.RabbitMQConsumer do
               true -> message
             end
 
+          event_type =
+            cond do
+              create -> "store:set"
+              update -> "store:invalidate"
+              delete -> "store:delete"
+              true -> message
+            end
+
           Tracer.set_attributes(%{
             tenant: tenant,
             entity_type: entity_type,
@@ -89,6 +97,17 @@ defmodule Realtime.RabbitMQConsumer do
             nil ->
               Logger.warning(
                 "No channel_topic detected for entity:#{entity_type} - tenant:#{tenant}, will ack and do nothing."
+              )
+
+            "OrganizationStore:" <> _topic ->
+              Endpoint.broadcast!(channel_topic, event_type, %{
+                key: Enum.at(entity_ids, 0),
+                source: "__system__",
+                type: event_type
+              })
+
+              Logger.info(
+                "Broadcasted notification:#{event_type} to #{channel_topic} for #{tenant}"
               )
 
             _ ->

--- a/packages/server/realtime/lib/realtime_web/channels/organization_store_channel.ex
+++ b/packages/server/realtime/lib/realtime_web/channels/organization_store_channel.ex
@@ -1,0 +1,62 @@
+defmodule RealtimeWeb.OrganizationStoreChannel do
+  @moduledoc """
+  This channel broadcasts sync events to entity subscribers.
+  It is used to dynamically handle multiple entity types.
+  """
+  require Logger
+  use RealtimeWeb, :channel
+
+  @impl true
+  def join(
+        _topic,
+        %{"user_id" => user_id, "username" => username},
+        socket
+      ) do
+    socket =
+      socket
+      |> assign(:user_id, user_id)
+      |> assign(:username, username)
+
+    send(self(), :after_join)
+    {:ok, %{}, socket}
+  end
+
+  @impl true
+  def join(_, _, _) do
+    {:ok, self()}
+  end
+
+  @impl true
+  def handle_info(:after_join, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_in("store:set", payload, socket) do
+    broadcast!(socket, "store:set", payload)
+    {:reply, {:ok, %{}}, socket}
+  end
+
+  @impl true
+  def handle_in("store:delete", payload, socket) do
+    broadcast!(socket, "store:delete", payload)
+    {:reply, {:ok, %{}}, socket}
+  end
+
+  @impl true
+  def handle_in("store:clear", payload, socket) do
+    broadcast!(socket, "store:clear", payload)
+    {:reply, {:ok, %{}}, socket}
+  end
+
+  @impl true
+  def handle_in("store:invalidate", payload, socket) do
+    broadcast!(socket, "store:invalidate", payload)
+    {:reply, {:ok, %{}}, socket}
+  end
+
+  @impl true
+  def terminate(_, socket) do
+    {:ok, socket}
+  end
+end

--- a/packages/server/realtime/lib/realtime_web/channels/user_socket.ex
+++ b/packages/server/realtime/lib/realtime_web/channels/user_socket.ex
@@ -79,6 +79,8 @@ defmodule RealtimeWeb.UserSocket do
   channel "Document:*", RealtimeWeb.DocumentChannel
   channel "Documents:*", RealtimeWeb.DocumentsChannel
   channel "Tasks:*", RealtimeWeb.TasksChannel
+  #
+  channel "OrganizationStore:*", RealtimeWeb.OrganizationStoreChannel
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `OrganizationStoreChannel` for handling organization store events and updates `RabbitMQConsumer` and `UserSocket` to support it.
> 
>   - **Behavior**:
>     - Adds `OrganizationStoreChannel` in `organization_store_channel.ex` to handle `store:set`, `store:delete`, `store:clear`, and `store:invalidate` events.
>     - Updates `RabbitMQConsumer` in `rabbitmq_consumer.ex` to map `ORGANIZATION` to `OrganizationStore` and broadcast events to `OrganizationStoreChannel`.
>   - **Channels**:
>     - Registers `OrganizationStore:*` channel in `user_socket.ex` to use `OrganizationStoreChannel`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f366e6e0c17345f32b886343cca3878e78cd07ad. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->