### PR TITLE
get default calendar from nylas

### DIFF
--- a/packages/server/customer-os-common-module/interfaces/nylas.go
+++ b/packages/server/customer-os-common-module/interfaces/nylas.go
@@ -21,6 +21,7 @@ type NylasService interface {
 
 	// Calendar management
 	ListCalendars(ctx context.Context, email string) ([]*Calendar, error)
+	GetDefaultCalendar(ctx context.Context, email string) (*Calendar, error)
 	GetCalendar(ctx context.Context, calendarID string) (*Calendar, error)
 
 	// Calendar operations

--- a/packages/server/customer-os-common-module/interfaces/nylas.go
+++ b/packages/server/customer-os-common-module/interfaces/nylas.go
@@ -20,9 +20,8 @@ type NylasService interface {
 	GetGrant(ctx context.Context, email string) (*postgres_entity.NylasGrant, error)
 
 	// Calendar management
-	ListCalendars(ctx context.Context, email string) ([]*Calendar, error)
-	GetDefaultCalendar(ctx context.Context, email string) (*Calendar, error)
-	GetCalendar(ctx context.Context, calendarID string) (*Calendar, error)
+	ListCalendars(ctx context.Context, email string) ([]*NylasCalendar, error)
+	GetDefaultCalendar(ctx context.Context, email string) (*NylasCalendar, error)
 
 	// Calendar operations
 	CreateEvent(ctx context.Context, calendarID string, event *CalendarEvent) (*CalendarEvent, error)
@@ -56,9 +55,23 @@ type Recurrence struct {
 	Until     time.Time
 }
 
-type Calendar struct {
-	ID          string
-	Name        string
-	Description string
-	IsPrimary   bool
+type NylasCalendarsResponse struct {
+	RequestID  string           `json:"request_id"`
+	Data       []*NylasCalendar `json:"data"`
+	NextCursor string           `json:"next_cursor"`
+}
+
+type NylasCalendar struct {
+	Description        string                 `json:"description"`
+	HexColor           string                 `json:"hex_color"`
+	HexForegroundColor string                 `json:"hex_foreground_color"`
+	ID                 string                 `json:"id"`
+	IsOwnedByUser      bool                   `json:"is_owned_by_user"`
+	IsPrimary          bool                   `json:"is_primary"`
+	Location           string                 `json:"location"`
+	Metadata           map[string]interface{} `json:"metadata"`
+	Name               string                 `json:"name"`
+	Object             string                 `json:"object"`
+	ReadOnly           bool                   `json:"read_only"`
+	Timezone           string                 `json:"timezone"`
 }

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -3,7 +3,6 @@ package meeting
 import (
 	"context"
 	"fmt"
-	"maps"
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
@@ -295,12 +294,7 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 	}
 
 	// 1. Get default calendar for each participant
-	type participantCalendars struct {
-		email    string
-		calendar *interfaces.Calendar
-	}
-
-	participantsData := make(map[string]participantCalendars)
+	participantsData := make(map[string]*interfaces.NylasCalendar)
 	for _, email := range meetingBookingEvent.AllowedParticipants {
 		// Get default calendar for the participant
 		calendar, err := s.nylas.GetDefaultCalendar(ctx, email)
@@ -313,13 +307,10 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 			continue
 		}
 
-		participantsData[email] = participantCalendars{
-			email:    email,
-			calendar: calendar,
-		}
+		participantsData[email] = calendar
 	}
 
-	spans.LogKV("participants_with_calendars", maps.Keys(participantsData))
+	spans.LogObjectAsJson("participants_with_calendars", participantsData)
 
 	// TODO: Implement the following steps:
 	// 2. Get working hours for each participant

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -3,6 +3,7 @@ package meeting
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
@@ -293,14 +294,41 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 		meetingDurationMins = ((meetingDurationMins / 15) + 1) * 15
 	}
 
+	// 1. Get default calendar for each participant
+	type participantCalendars struct {
+		email    string
+		calendar *interfaces.Calendar
+	}
+
+	participantsData := make(map[string]participantCalendars)
+	for _, email := range meetingBookingEvent.AllowedParticipants {
+		// Get default calendar for the participant
+		calendar, err := s.nylas.GetDefaultCalendar(ctx, email)
+		if err != nil {
+			spans.TraceError(err)
+			continue
+		}
+		if calendar == nil {
+			s.log.Warn("No default calendar found for participant: %s", email)
+			continue
+		}
+
+		participantsData[email] = participantCalendars{
+			email:    email,
+			calendar: calendar,
+		}
+	}
+
+	spans.LogKV("participants_with_calendars", maps.Keys(participantsData))
+
 	// TODO: Implement the following steps:
-	// 1. Get Nylas calendars for each participant
 	// 2. Get working hours for each participant
 	// 3. Get calendar events for each participant's calendar
 	// 4. Generate time slots based on duration and rules
 	// 5. Apply meeting booking event rules
-	// 6. Convert to requested timezone
-	// 7. Return the result
+	// 6. Combine all participants' availability
+	// 7. Convert to requested timezone
+	// 8. Return the result
 
 	return &interfaces.CalendarAvailabilityResult{
 		Days: []*interfaces.DaySlot{},

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -9,17 +9,17 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
+	postgresEntity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
+	postgresRepository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 )
 
 type meetingService struct {
 	log      logger.Logger
 	nylas    interfaces.NylasService
-	postgres *postgres_repository.Repositories
+	postgres *postgresRepository.Repositories
 }
 
-func NewMeetingService(log logger.Logger, nylasService interfaces.NylasService, postgresRepository *postgres_repository.Repositories) interfaces.MeetingService {
+func NewMeetingService(log logger.Logger, nylasService interfaces.NylasService, postgresRepository *postgresRepository.Repositories) interfaces.MeetingService {
 	return &meetingService{
 		log:      log,
 		nylas:    nylasService,
@@ -27,101 +27,7 @@ func NewMeetingService(log logger.Logger, nylasService interfaces.NylasService, 
 	}
 }
 
-// GetCalendarAvailabilityForEmail implements interfaces.MeetingService.
-//func (s *meetingService) GetCalendarAvailabilityForEmail(ctx context.Context, email string, startTime time.Time, endTime time.Time, duration int, timezone string) (*interfaces.CalendarAvailability, error) {
-//	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.GetCalendarAvailabilityForEmail")
-//	defer spans.Finish()
-//	spans.LogObjectAsJson("request", map[string]interface{}{
-//		"email":     email,
-//		"startTime": startTime,
-//		"endTime":   endTime,
-//		"duration":  duration,
-//		"timezone":  timezone,
-//	})
-//
-//	// validate tenant
-//	err := common.ValidateTenant(ctx)
-//	if err != nil {
-//		spans.TraceError(err)
-//		return nil, err
-//	}
-//	tenant := common.GetTenantFromContext(ctx)
-//
-//	// Get OAuth token for the email
-//	oauthToken, err := s.postgresRepository.OAuthTokenRepository.GetByEmail(ctx, tenant, email)
-//	if err != nil {
-//		spans.TraceError(err)
-//		return nil, err
-//	}
-//	if oauthToken == nil {
-//		return nil, fmt.Errorf("no oauth token found for email: %s", email)
-//	}
-//
-//	// check if token has calendar read scope
-//	if !oauthToken.HasCalendarReadScope() {
-//		return nil, fmt.Errorf("oauth token does not have calendar read scope")
-//	}
-//
-//	// Get calendars for the user
-//	calendars, err := s.nylasService.ListCalendars(ctx, email)
-//	if err != nil {
-//		spans.TraceError(err)
-//		return nil, fmt.Errorf("failed to list calendars: %v", err)
-//	}
-//
-//	if len(calendars) == 0 {
-//		return &interfaces.CalendarAvailability{
-//			TimeSlots:      []interfaces.TimeSlot{},
-//			TotalUsers:     0,
-//			AvailableUsers: 0,
-//		}, nil
-//	}
-//
-//	// Get events for the primary calendar
-//	// TODO alexb to test if first calendar is primary or select default calendar
-//	primaryCalendar := calendars[0] // Assuming first calendar is primary
-//	events, err := s.nylasService.ListEvents(ctx, primaryCalendar.ID, startTime, endTime)
-//	if err != nil {
-//		spans.TraceError(err)
-//		return nil, fmt.Errorf("failed to list events: %v", err)
-//	}
-//
-//	// Generate time slots
-//	timeSlots := generateTimeSlots(startTime, endTime, duration, timezone)
-//
-//	// Check availability for each time slot
-//	availableSlots := make([]interfaces.TimeSlot, 0)
-//	totalUsers := 1 // Single user
-//	availableUsers := 0
-//
-//	for _, slot := range timeSlots {
-//		isAvailable := true
-//		for _, event := range events {
-//			if isTimeSlotOverlapping(slot.StartTime, slot.EndTime, event.StartTime, event.EndTime) {
-//				isAvailable = false
-//				break
-//			}
-//		}
-//
-//		if isAvailable {
-//			availableUsers++
-//		}
-//
-//		availableSlots = append(availableSlots, interfaces.TimeSlot{
-//			StartTime:   slot.StartTime,
-//			EndTime:     slot.EndTime,
-//			IsAvailable: isAvailable,
-//		})
-//	}
-//
-//	return &interfaces.CalendarAvailability{
-//		TimeSlots:      availableSlots,
-//		TotalUsers:     totalUsers,
-//		AvailableUsers: availableUsers,
-//	}, nil
-//}
-
-func (s *meetingService) GetUserCalendarAvailability(ctx context.Context, email string) (*postgres_entity.UserCalendarAvailability, error) {
+func (s *meetingService) GetUserCalendarAvailability(ctx context.Context, email string) (*postgresEntity.UserCalendarAvailability, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.GetUserCalendarAvailability")
 	defer spans.Finish()
 	spans.LogKV("email", email)
@@ -159,7 +65,7 @@ func (s *meetingService) GetUserCalendarAvailability(ctx context.Context, email 
 }
 
 // SaveCalendarAvailableHours implements interfaces.MeetingService
-func (s *meetingService) SaveUserCalendarAvailability(ctx context.Context, availability *postgres_entity.UserCalendarAvailability) (*postgres_entity.UserCalendarAvailability, error) {
+func (s *meetingService) SaveUserCalendarAvailability(ctx context.Context, availability *postgresEntity.UserCalendarAvailability) (*postgresEntity.UserCalendarAvailability, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.SaveCalendarAvailableHours")
 	defer spans.Finish()
 	spans.LogKV("email", availability.Email)
@@ -185,7 +91,7 @@ func (s *meetingService) SaveUserCalendarAvailability(ctx context.Context, avail
 	return saved, nil
 }
 
-func (s *meetingService) SetDefaultUserCalendarAvailability(ctx context.Context, email string) (*postgres_entity.UserCalendarAvailability, error) {
+func (s *meetingService) SetDefaultUserCalendarAvailability(ctx context.Context, email string) (*postgresEntity.UserCalendarAvailability, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.SetDefaultUserCalendarAvailability")
 	defer spans.Finish()
 	spans.LogKV("email", email)
@@ -209,41 +115,41 @@ func (s *meetingService) SetDefaultUserCalendarAvailability(ctx context.Context,
 		return availability, nil
 	}
 
-	defaultAvailability := &postgres_entity.UserCalendarAvailability{
+	defaultAvailability := &postgresEntity.UserCalendarAvailability{
 		Tenant:   tenant,
 		Email:    email,
-		Timezone: "Etc/UTC",
-		Monday: postgres_entity.DayAvailability{
+		Timezone: postgresEntity.DefaultTimezone,
+		Monday: postgresEntity.DayAvailability{
 			Enabled:   true,
 			StartHour: "08:30",
 			EndHour:   "17:00",
 		},
-		Tuesday: postgres_entity.DayAvailability{
+		Tuesday: postgresEntity.DayAvailability{
 			Enabled:   true,
 			StartHour: "08:30",
 			EndHour:   "17:00",
 		},
-		Wednesday: postgres_entity.DayAvailability{
+		Wednesday: postgresEntity.DayAvailability{
 			Enabled:   true,
 			StartHour: "08:30",
 			EndHour:   "17:00",
 		},
-		Thursday: postgres_entity.DayAvailability{
+		Thursday: postgresEntity.DayAvailability{
 			Enabled:   true,
 			StartHour: "08:30",
 			EndHour:   "17:00",
 		},
-		Friday: postgres_entity.DayAvailability{
+		Friday: postgresEntity.DayAvailability{
 			Enabled:   true,
 			StartHour: "08:30",
 			EndHour:   "17:00",
 		},
-		Saturday: postgres_entity.DayAvailability{
+		Saturday: postgresEntity.DayAvailability{
 			Enabled:   false,
 			StartHour: "08:30",
 			EndHour:   "17:00",
 		},
-		Sunday: postgres_entity.DayAvailability{
+		Sunday: postgresEntity.DayAvailability{
 			Enabled:   false,
 			StartHour: "08:30",
 			EndHour:   "17:00",
@@ -259,6 +165,146 @@ func (s *meetingService) SetDefaultUserCalendarAvailability(ctx context.Context,
 	return defaultAvailability, nil
 }
 
+// generateTimeSlots generates 15-minute time slots between start and end time
+func generateTimeSlots(startTime, endTime time.Time) []*interfaces.TimeSlot {
+	slots := []*interfaces.TimeSlot{}
+	current := startTime
+
+	for current.Before(endTime) {
+		slotEnd := current.Add(15 * time.Minute)
+		if slotEnd.After(endTime) {
+			slotEnd = endTime
+		}
+
+		slots = append(slots, &interfaces.TimeSlot{
+			StartTime:   current,
+			EndTime:     slotEnd,
+			IsAvailable: true,
+		})
+
+		current = slotEnd
+	}
+
+	return slots
+}
+
+// convertTimeSlotsToTimezone converts all time slots to the specified timezone
+func convertTimeSlotsToTimezone(slots []*interfaces.TimeSlot, timezone string) ([]*interfaces.TimeSlot, error) {
+	location, err := time.LoadLocation(timezone)
+	if err != nil {
+		return nil, fmt.Errorf("invalid timezone %s: %v", timezone, err)
+	}
+
+	convertedSlots := make([]*interfaces.TimeSlot, len(slots))
+	for i, slot := range slots {
+		convertedSlots[i] = &interfaces.TimeSlot{
+			StartTime:   slot.StartTime.In(location),
+			EndTime:     slot.EndTime.In(location),
+			IsAvailable: slot.IsAvailable,
+		}
+	}
+
+	return convertedSlots, nil
+}
+
+// convertTimeSlotsToDaySlots converts time slots to day slots
+func convertTimeSlotsToDaySlots(slots []*interfaces.TimeSlot) []*interfaces.DaySlot {
+	// Group time slots by date
+	slotsByDate := make(map[string][]*interfaces.TimeSlot)
+	for _, slot := range slots {
+		// Get date without time component
+		date := time.Date(slot.StartTime.Year(), slot.StartTime.Month(), slot.StartTime.Day(), 0, 0, 0, 0, slot.StartTime.Location())
+		dateStr := date.Format("2006-01-02")
+		slotsByDate[dateStr] = append(slotsByDate[dateStr], slot)
+	}
+
+	// Convert to day slots
+	daySlots := make([]*interfaces.DaySlot, 0, len(slotsByDate))
+	for dateStr, timeSlots := range slotsByDate {
+		// Parse date back to time.Time
+		date, _ := time.Parse("2006-01-02", dateStr)
+
+		// Check if any time slot is available
+		isAvailable := false
+		for _, slot := range timeSlots {
+			if slot.IsAvailable {
+				isAvailable = true
+				break
+			}
+		}
+
+		// Convert []*TimeSlot to []TimeSlot
+		convertedTimeSlots := make([]interfaces.TimeSlot, len(timeSlots))
+		for i, slot := range timeSlots {
+			convertedTimeSlots[i] = *slot
+		}
+
+		daySlot := &interfaces.DaySlot{
+			Date:        date,
+			TimeSlots:   convertedTimeSlots,
+			IsAvailable: isAvailable,
+		}
+		daySlots = append(daySlots, daySlot)
+	}
+
+	return daySlots
+}
+
+// isTimeInDayAvailability checks if a given time is within the day's availability window
+func isTimeInDayAvailability(t time.Time, dayAvailability postgresEntity.DayAvailability) bool {
+	if !dayAvailability.Enabled {
+		return false
+	}
+
+	// Parse start and end hours
+	startTime, _ := time.Parse("15:04", dayAvailability.StartHour)
+	endTime, _ := time.Parse("15:04", dayAvailability.EndHour)
+
+	// Get just the time part of the input time
+	timeOnly := time.Date(0, 1, 1, t.Hour(), t.Minute(), 0, 0, t.Location())
+
+	// Compare times
+	return !timeOnly.Before(startTime) && !timeOnly.After(endTime)
+}
+
+// isSlotInUserAvailability checks if a time slot is within user's calendar availability
+func isSlotInUserAvailability(slot *interfaces.TimeSlot, availability *postgresEntity.UserCalendarAvailability) bool {
+	if availability == nil {
+		return true // If no availability defined, consider it available
+	}
+
+	// Convert slot times to user's timezone
+	userLoc, err := time.LoadLocation(availability.Timezone)
+	if err != nil {
+		return true // If timezone invalid, consider it available
+	}
+
+	slotStart := slot.StartTime.In(userLoc)
+	slotEnd := slot.EndTime.In(userLoc)
+
+	// Get day of week and corresponding availability
+	var dayAvailability postgresEntity.DayAvailability
+	switch slotStart.Weekday() {
+	case time.Monday:
+		dayAvailability = availability.Monday
+	case time.Tuesday:
+		dayAvailability = availability.Tuesday
+	case time.Wednesday:
+		dayAvailability = availability.Wednesday
+	case time.Thursday:
+		dayAvailability = availability.Thursday
+	case time.Friday:
+		dayAvailability = availability.Friday
+	case time.Saturday:
+		dayAvailability = availability.Saturday
+	case time.Sunday:
+		dayAvailability = availability.Sunday
+	}
+
+	// Check if both start and end times are within availability
+	return isTimeInDayAvailability(slotStart, dayAvailability) && isTimeInDayAvailability(slotEnd, dayAvailability)
+}
+
 // GetCalendarAvailability implements interfaces.MeetingService
 func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBookingEventID string, startTime time.Time, endTime time.Time, timezone string) (*interfaces.CalendarAvailabilityResult, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.GetCalendarAvailability")
@@ -269,6 +315,9 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 		"endTime":               endTime,
 		"timezone":              timezone,
 	})
+	if timezone == "" {
+		timezone = postgresEntity.DefaultTimezone
+	}
 
 	// validate tenant
 	err := common.ValidateTenant(ctx)
@@ -312,16 +361,54 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 
 	spans.LogObjectAsJson("participants_with_calendars", participantsData)
 
-	// TODO: Implement the following steps:
-	// 2. Get working hours for each participant
-	// 3. Get calendar events for each participant's calendar
-	// 4. Generate time slots based on duration and rules
-	// 5. Apply meeting booking event rules
-	// 6. Combine all participants' availability
-	// 7. Convert to requested timezone
-	// 8. Return the result
+	// 2a. Generate initial time slots for each participant
+	participantTimeSlots := make(map[string][]*interfaces.TimeSlot)
+	for email := range participantsData {
+		// Generate 15-minute time slots for the participant
+		slots := generateTimeSlots(startTime, endTime)
+		participantTimeSlots[email] = slots
+	}
+
+	// 2b. Apply calendar availability restrictions for each participant
+	for email, slots := range participantTimeSlots {
+		// Get user's calendar availability
+		userAvailability, err := s.postgres.UserCalendarAvailabilityRepository.GetByTenantAndEmail(ctx, tenant, email)
+		if err != nil {
+			s.log.Warn("Failed to get calendar availability for user %s: %v", email, err)
+			continue
+		}
+
+		// If user has defined calendar availability, apply the restrictions
+		if userAvailability != nil {
+			// Check each slot against user's calendar availability
+			for _, slot := range slots {
+				if !isSlotInUserAvailability(slot, userAvailability) {
+					slot.IsAvailable = false
+				}
+			}
+		}
+	}
+
+	// 3. Convert all time slots to requested timezone
+	convertedParticipantTimeSlots := make(map[string][]*interfaces.TimeSlot)
+	for email, slots := range participantTimeSlots {
+		convertedSlots, err := convertTimeSlotsToTimezone(slots, timezone)
+		if err != nil {
+			spans.TraceError(err)
+			return nil, fmt.Errorf("failed to convert time slots to timezone %s: %v", timezone, err)
+		}
+		convertedParticipantTimeSlots[email] = convertedSlots
+	}
+
+	// 4. Group time slots into day slots
+	var daySlots []*interfaces.DaySlot
+	for _, slots := range convertedParticipantTimeSlots {
+		daySlots = convertTimeSlotsToDaySlots(slots)
+		// Only process first participant
+		break
+	}
 
 	return &interfaces.CalendarAvailabilityResult{
-		Days: []*interfaces.DaySlot{},
+		Days: daySlots,
 	}, nil
 }

--- a/packages/server/customer-os-common-module/services/nylas/service.go
+++ b/packages/server/customer-os-common-module/services/nylas/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
@@ -333,6 +334,42 @@ func (s *nylasService) ListCalendars(ctx context.Context, email string) ([]*inte
 	}
 
 	return calendars, nil
+}
+
+func (s *nylasService) GetDefaultCalendar(ctx context.Context, email string) (*interfaces.Calendar, error) {
+	spans, ctx := telemetry.StartServiceSpan(ctx, "NylasService.GetDefaultCalendar")
+	defer spans.Finish()
+	spans.LogKV("email", email)
+
+	// Get all calendars for the user
+	calendars, err := s.ListCalendars(ctx, email)
+	if err != nil {
+		spans.TraceError(err)
+		return nil, fmt.Errorf("failed to list calendars: %v", err)
+	}
+
+	if len(calendars) == 0 {
+		return nil, nil
+	}
+
+	// Look for the default calendar
+	// First try to find a calendar marked as primary
+	for _, calendar := range calendars {
+		if calendar.IsPrimary {
+			return calendar, nil
+		}
+	}
+
+	// If no primary calendar found, look for one with "primary" in the name (case insensitive)
+	for _, calendar := range calendars {
+		name := strings.ToLower(calendar.Name)
+		if strings.Contains(name, "primary") || strings.Contains(name, "default") {
+			return calendar, nil
+		}
+	}
+
+	// If still no default calendar found, return the first one
+	return calendars[0], nil
 }
 
 // Update ListEvents to use prepareNylasAccountID

--- a/packages/server/customer-os-common-module/services/nylas/service.go
+++ b/packages/server/customer-os-common-module/services/nylas/service.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
@@ -287,7 +286,7 @@ func (s *nylasService) GetGrant(ctx context.Context, email string) (*postgresEnt
 }
 
 // ListCalendars lists all calendars for a user
-func (s *nylasService) ListCalendars(ctx context.Context, email string) ([]*interfaces.Calendar, error) {
+func (s *nylasService) ListCalendars(ctx context.Context, email string) ([]*interfaces.NylasCalendar, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "NylasService.ListCalendars")
 	defer spans.Finish()
 	spans.LogKV("email", email)
@@ -303,7 +302,7 @@ func (s *nylasService) ListCalendars(ctx context.Context, email string) ([]*inte
 	}
 
 	// Create request to Nylas v3 API
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/v3/calendars?account_id=%s", s.config.APIUrl, grant.NylasGrantId), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/v3/grants/%s/calendars?limit=200", s.config.APIUrl, grant.NylasGrantId), nil)
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to create request: %v", err)
@@ -321,22 +320,29 @@ func (s *nylasService) ListCalendars(ctx context.Context, email string) ([]*inte
 	}
 	defer resp.Body.Close()
 
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		spans.TraceError(err)
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
 	if resp.StatusCode != http.StatusOK {
+		spans.LogKV("response", string(bodyBytes))
 		spans.TraceError(fmt.Errorf("unexpected status code: %d", resp.StatusCode))
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	// Parse response
-	var calendars []*interfaces.Calendar
-	if err := json.NewDecoder(resp.Body).Decode(&calendars); err != nil {
+	var response interfaces.NylasCalendarsResponse
+	if err := json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(&response); err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to decode response: %v", err)
 	}
 
-	return calendars, nil
+	return response.Data, nil
 }
 
-func (s *nylasService) GetDefaultCalendar(ctx context.Context, email string) (*interfaces.Calendar, error) {
+func (s *nylasService) GetDefaultCalendar(ctx context.Context, email string) (*interfaces.NylasCalendar, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "NylasService.GetDefaultCalendar")
 	defer spans.Finish()
 	spans.LogKV("email", email)
@@ -352,23 +358,18 @@ func (s *nylasService) GetDefaultCalendar(ctx context.Context, email string) (*i
 		return nil, nil
 	}
 
-	// Look for the default calendar
 	// First try to find a calendar marked as primary
 	for _, calendar := range calendars {
 		if calendar.IsPrimary {
+			spans.LogKV("result.primaryFound", true)
+			spans.LogObjectAsJson("result.calendar", calendar)
 			return calendar, nil
 		}
 	}
 
-	// If no primary calendar found, look for one with "primary" in the name (case insensitive)
-	for _, calendar := range calendars {
-		name := strings.ToLower(calendar.Name)
-		if strings.Contains(name, "primary") || strings.Contains(name, "default") {
-			return calendar, nil
-		}
-	}
-
-	// If still no default calendar found, return the first one
+	// If no primary calendar found, return the first one
+	spans.LogKV("result.primaryFound", false)
+	spans.LogObjectAsJson("result.calendar", calendars[0])
 	return calendars[0], nil
 }
 
@@ -487,10 +488,5 @@ func (s *nylasService) DeleteEvent(ctx context.Context, calendarID string, event
 
 func (s *nylasService) GetEvent(ctx context.Context, calendarID string, eventID string) (*interfaces.CalendarEvent, error) {
 	// TODO: Implement Nylas API call to get event
-	return nil, nil
-}
-
-func (s *nylasService) GetCalendar(ctx context.Context, calendarID string) (*interfaces.Calendar, error) {
-	// TODO: Implement Nylas API call to get calendar
 	return nil, nil
 }

--- a/packages/server/customer-os-postgres-repository/entity/meeting_booking_event.go
+++ b/packages/server/customer-os-postgres-repository/entity/meeting_booking_event.go
@@ -1,12 +1,49 @@
 package postgres_entity
 
 import (
+	"database/sql"
+	"database/sql/driver"
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	"github.com/lib/pq"
 	"gorm.io/gorm"
 )
+
+type StringArray []string
+
+func (a *StringArray) Scan(value interface{}) error {
+	if value == nil {
+		*a = StringArray{}
+		return nil
+	}
+
+	switch v := value.(type) {
+	case []byte:
+		// If it's already a byte array, convert it to string first
+		return pq.Array((*[]string)(a)).Scan(string(v))
+	case string:
+		// If it's a string, scan directly
+		return pq.Array((*[]string)(a)).Scan(v)
+	case sql.NullString:
+		if !v.Valid {
+			*a = StringArray{}
+			return nil
+		}
+		return pq.Array((*[]string)(a)).Scan(v.String)
+	default:
+		// For any other type, try using pq.Array directly
+		return pq.Array((*[]string)(a)).Scan(value)
+	}
+}
+
+func (a StringArray) Value() (driver.Value, error) {
+	if a == nil {
+		return pq.Array([]string{}).Value()
+	}
+	return pq.Array([]string(a)).Value()
+}
 
 type MeetingBookingEvent struct {
 	ID        string    `gorm:"column:id;type:varchar(21);primaryKey" json:"id"`
@@ -14,10 +51,10 @@ type MeetingBookingEvent struct {
 	CreatedAt time.Time `gorm:"column:created_at;type:timestamp;DEFAULT:current_timestamp" json:"createdAt"`
 	UpdatedAt time.Time `gorm:"column:updated_at;type:timestamp;DEFAULT:current_timestamp" json:"updatedAt"`
 
-	Title               string   `gorm:"column:title;size:255;not null" json:"title"`
-	DurationMins        int64    `gorm:"column:duration_mins;not null;default:30" json:"durationMins"`
-	Description         string   `gorm:"column:description;type:text;not null;default:''" json:"description"`
-	AllowedParticipants []string `gorm:"column:allowed_participants;type:text[];default:'{}'" json:"allowedParticipants"`
+	Title               string      `gorm:"column:title;size:255;not null" json:"title"`
+	DurationMins        int64       `gorm:"column:duration_mins;not null;default:30" json:"durationMins"`
+	Description         string      `gorm:"column:description;type:text;not null;default:''" json:"description"`
+	AllowedParticipants StringArray `gorm:"column:allowed_participants;type:text[];not null;default:'{}'" json:"allowedParticipants"`
 
 	BookingFormName  string `gorm:"column:booking_form_name;size:255;not null;default:''" json:"bookingFormName"`
 	BookingFormEmail string `gorm:"column:booking_form_email;size:255;not null;default:''" json:"bookingFormEmail"`

--- a/packages/server/customer-os-postgres-repository/entity/user_calendar_availability.go
+++ b/packages/server/customer-os-postgres-repository/entity/user_calendar_availability.go
@@ -14,6 +14,10 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	DefaultTimezone string = "Etc/UTC"
+)
+
 // DayAvailability represents the availability for a single day
 type DayAvailability struct {
 	Enabled   bool   `json:"enabled" gorm:"type:boolean;default:false"`
@@ -167,8 +171,9 @@ func (UserCalendarAvailability) TableName() string {
 func (u *UserCalendarAvailability) Validate() error {
 	// Validate timezone
 	if u.Timezone == "" {
-		u.Timezone = "Etc/UTC"
+		u.Timezone = DefaultTimezone
 	}
+
 	// Trim any whitespace that might have been added
 	u.Timezone = strings.TrimSpace(u.Timezone)
 	_, err := time.LoadLocation(u.Timezone)

--- a/packages/server/customer-os-postgres-repository/repository/user_calendar_availability_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/user_calendar_availability_repository.go
@@ -2,6 +2,7 @@ package postgres_repository
 
 import (
 	"context"
+	"strings"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
@@ -29,7 +30,7 @@ func (r *userCalendarAvailabilityRepository) GetByTenantAndEmail(ctx context.Con
 	spans.LogKV("email", email)
 
 	var availability postgres_entity.UserCalendarAvailability
-	result := r.db.Where("tenant = ? AND email = ?", tenant, email).First(&availability)
+	result := r.db.Where("tenant = ? AND LOWER(email) = LOWER(?)", tenant, email).First(&availability)
 	if result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
 			spans.LogKV("result.found", false)
@@ -63,6 +64,7 @@ func (r *userCalendarAvailabilityRepository) SaveOrUpdate(ctx context.Context, a
 		}
 	} else {
 		// Create new record
+		availability.Email = strings.ToLower(availability.Email)
 		result := r.db.Create(availability)
 		if result.Error != nil {
 			return nil, result.Error


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `GetDefaultCalendar` to Nylas integration and updates meeting service for calendar availability management.
> 
>   - **Behavior**:
>     - Adds `GetDefaultCalendar` to `NylasService` interface in `nylas.go` to retrieve the default calendar for a user.
>     - Updates `GetCalendarAvailability` in `service.go` to use `GetDefaultCalendar` for each participant.
>     - Introduces `generateTimeSlots`, `convertTimeSlotsToTimezone`, and `convertTimeSlotsToDaySlots` in `service.go` for time slot management.
>   - **Models**:
>     - Adds `StringArray` type in `meeting_booking_event.go` for handling string arrays in GORM.
>     - Updates `UserCalendarAvailability` in `user_calendar_availability.go` to use `DefaultTimezone` constant.
>   - **Misc**:
>     - Renames imports in `service.go` for consistency.
>     - Fixes email case sensitivity in `user_calendar_availability_repository.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for cd04bcbe3ff6757fb5fcf0d4906ccb9be3087af0. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->