### PR TITLE
add tenant to workspace switcher

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/service/tenant_service.go
+++ b/packages/runner/customer-os-data-upkeeper/service/tenant_service.go
@@ -62,7 +62,7 @@ func (s *tenantService) CheckOnboarding() {
 
 	for _, tenantDbNode := range tenantDbNodes {
 		func(tenantDbNode *dbtype.Node) {
-			recordSpans, ctx := telemetry.StartCronSpan(ctx, "TenantService.CheckOnboarding.Record")
+			recordSpans, ctx := telemetry.StartCronSpan(ctx, "TenantService.CheckOnboarding.Record", telemetry.WithNewRoot())
 			defer recordSpans.Finish()
 
 			tenantEntity := neo4jmapper.MapDbNodeToTenantEntity(tenantDbNode)
@@ -83,6 +83,7 @@ func (s *tenantService) CheckOnboarding() {
 			//s.checkWebVisitorAgents(innerCtx, tenantEntity.Name) // temporary disabled
 			//s.checkIcpQualificationAgents(innerCtx, tenantEntity.Name) // temporary disabled
 			s.checkTestMailbox(innerCtx, tenantEntity.Name)
+			s.checkTenantPresentInWorkspaceSwitcher(innerCtx, tenantEntity.Name)
 		}(tenantDbNode)
 	}
 }
@@ -195,4 +196,16 @@ func (s *tenantService) checkTestMailbox(ctx context.Context, tenant string) {
 	}
 
 	spans.LogKV("result.created", true)
+}
+
+func (s *tenantService) checkTenantPresentInWorkspaceSwitcher(ctx context.Context, tenant string) {
+	spans, ctx := telemetry.StartCronSpan(ctx, "TenantService.checkTenantPresentInWorkspaceSwitcher")
+	defer spans.Finish()
+
+	// just assign the tenant to the platform owners, method is idempotent
+	err := s.commonServices.RegistrationService.ProvideAccessToPlatformOwners(ctx, tenant)
+	if err != nil {
+		spans.TraceError(errors.Wrap(err, "failed to provide access to platform owners"))
+		s.log.Errorf("Error providing access to platform owners: %s", err.Error())
+	}
 }

--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -530,12 +530,12 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 			}
 
 			if !isPersonalEmail {
-				err = services.CommonServices.RegistrationService.InitialTenantSetup(ctx, signInRequest.LoggedInEmail)
+				err = services.CommonServices.RegistrationService.ProvideAccessToPlatformOwners(ctx, defaultTenant)
 				if err != nil {
 					spans.TraceError(err)
 				}
 
-				err = services.CommonServices.RegistrationService.ProvideAccessToPlatformOwners(ctx, defaultTenant)
+				err = services.CommonServices.RegistrationService.InitialTenantSetup(ctx, signInRequest.LoggedInEmail)
 				if err != nil {
 					spans.TraceError(err)
 				}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add tenant check in workspace switcher and reorder sign-in setup calls for proper tenant assignment.
> 
>   - **Behavior**:
>     - Adds `checkTenantPresentInWorkspaceSwitcher()` in `tenant_service.go` to ensure tenant is assigned to platform owners.
>     - Modifies `signIn()` in `registration.go` to call `ProvideAccessToPlatformOwners()` before `InitialTenantSetup()`.
>   - **Functions**:
>     - `checkTenantPresentInWorkspaceSwitcher()` logs errors if access provision fails.
>     - `signIn()` reorders function calls for tenant setup.
>   - **Misc**:
>     - Adds telemetry span `TenantService.checkTenantPresentInWorkspaceSwitcher` in `tenant_service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 7a0bb5a25b82cf317b98e722c98001ca9cc429bd. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->