### PR TITLE
return only available days with time slots

### DIFF
--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -575,9 +575,8 @@ type ComplexityRoot struct {
 	}
 
 	DaySlot struct {
-		Date        func(childComplexity int) int
-		IsAvailable func(childComplexity int) int
-		TimeSlots   func(childComplexity int) int
+		Date      func(childComplexity int) int
+		TimeSlots func(childComplexity int) int
 	}
 
 	DeleteResponse struct {
@@ -1994,9 +1993,8 @@ type ComplexityRoot struct {
 	}
 
 	TimeSlot struct {
-		EndTime     func(childComplexity int) int
-		IsAvailable func(childComplexity int) int
-		StartTime   func(childComplexity int) int
+		EndTime   func(childComplexity int) int
+		StartTime func(childComplexity int) int
 	}
 
 	User struct {
@@ -5069,13 +5067,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DaySlot.Date(childComplexity), true
-
-	case "DaySlot.isAvailable":
-		if e.complexity.DaySlot.IsAvailable == nil {
-			break
-		}
-
-		return e.complexity.DaySlot.IsAvailable(childComplexity), true
 
 	case "DaySlot.timeSlots":
 		if e.complexity.DaySlot.TimeSlots == nil {
@@ -14220,13 +14211,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TimeSlot.EndTime(childComplexity), true
 
-	case "TimeSlot.isAvailable":
-		if e.complexity.TimeSlot.IsAvailable == nil {
-			break
-		}
-
-		return e.complexity.TimeSlot.IsAvailable(childComplexity), true
-
 	case "TimeSlot.startTime":
 		if e.complexity.TimeSlot.StartTime == nil {
 			break
@@ -15228,7 +15212,6 @@ type CalendarAvailabilityResponse {
 type DaySlot {
     date:           Time!
     timeSlots:      [TimeSlot!]!
-    isAvailable:    Boolean!
 }
 
 """
@@ -15237,7 +15220,6 @@ Represents a time slot in calendar availability
 type TimeSlot {
     startTime: Time!
     endTime: Time!
-    isAvailable: Boolean!
 }
 
 """
@@ -34510,8 +34492,6 @@ func (ec *executionContext) fieldContext_CalendarAvailabilityResponse_days(_ con
 				return ec.fieldContext_DaySlot_date(ctx, field)
 			case "timeSlots":
 				return ec.fieldContext_DaySlot_timeSlots(ctx, field)
-			case "isAvailable":
-				return ec.fieldContext_DaySlot_isAvailable(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type DaySlot", field.Name)
 		},
@@ -47168,54 +47148,8 @@ func (ec *executionContext) fieldContext_DaySlot_timeSlots(_ context.Context, fi
 				return ec.fieldContext_TimeSlot_startTime(ctx, field)
 			case "endTime":
 				return ec.fieldContext_TimeSlot_endTime(ctx, field)
-			case "isAvailable":
-				return ec.fieldContext_TimeSlot_isAvailable(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TimeSlot", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _DaySlot_isAvailable(ctx context.Context, field graphql.CollectedField, obj *model.DaySlot) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DaySlot_isAvailable(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.IsAvailable, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_DaySlot_isAvailable(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "DaySlot",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -118726,50 +118660,6 @@ func (ec *executionContext) fieldContext_TimeSlot_endTime(_ context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _TimeSlot_isAvailable(ctx context.Context, field graphql.CollectedField, obj *model.TimeSlot) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_TimeSlot_isAvailable(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.IsAvailable, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_TimeSlot_isAvailable(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "TimeSlot",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _User_id(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_User_id(ctx, field)
 	if err != nil {
@@ -135478,11 +135368,6 @@ func (ec *executionContext) _DaySlot(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "isAvailable":
-			out.Values[i] = ec._DaySlot_isAvailable(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -148283,11 +148168,6 @@ func (ec *executionContext) _TimeSlot(ctx context.Context, sel ast.SelectionSet,
 			}
 		case "endTime":
 			out.Values[i] = ec._TimeSlot_endTime(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "isAvailable":
-			out.Values[i] = ec._TimeSlot_isAvailable(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -1072,9 +1072,8 @@ type DayAvailabilityInput struct {
 }
 
 type DaySlot struct {
-	Date        time.Time   `json:"date"`
-	TimeSlots   []*TimeSlot `json:"timeSlots"`
-	IsAvailable bool        `json:"isAvailable"`
+	Date      time.Time   `json:"date"`
+	TimeSlots []*TimeSlot `json:"timeSlots"`
 }
 
 type DeleteResponse struct {
@@ -3282,9 +3281,8 @@ type TimeRange struct {
 
 // Represents a time slot in calendar availability
 type TimeSlot struct {
-	StartTime   time.Time `json:"startTime"`
-	EndTime     time.Time `json:"endTime"`
-	IsAvailable bool      `json:"isAvailable"`
+	StartTime time.Time `json:"startTime"`
+	EndTime   time.Time `json:"endTime"`
 }
 
 // Describes the User of customerOS.  A user is the person who logs into the Openline platform.

--- a/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
@@ -78,10 +78,10 @@ func (r *queryResolver) CalendarAvailability(ctx context.Context, input model.Ca
 		}
 	}
 
-	// Round up duration to nearest 15 minutes if needed
+	// Round up duration to nearest 5 minutes if needed
 	durationMins := meetingBookingEvent.DurationMins
-	if durationMins%15 != 0 {
-		durationMins = ((durationMins / 15) + 1) * 15
+	if durationMins%5 != 0 {
+		durationMins = ((durationMins / 5) + 1) * 5
 	}
 
 	// Get calendar availability data using UTC times

--- a/packages/server/customer-os-api/graphql/schemas/calendar.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/calendar.graphqls
@@ -37,7 +37,6 @@ type CalendarAvailabilityResponse {
 type DaySlot {
     date:           Time!
     timeSlots:      [TimeSlot!]!
-    isAvailable:    Boolean!
 }
 
 """
@@ -46,7 +45,6 @@ Represents a time slot in calendar availability
 type TimeSlot {
     startTime: Time!
     endTime: Time!
-    isAvailable: Boolean!
 }
 
 """

--- a/packages/server/customer-os-api/mapper/calendar_availability_mapper.go
+++ b/packages/server/customer-os-api/mapper/calendar_availability_mapper.go
@@ -30,17 +30,15 @@ func MapDaySlotToModel(daySlot *interfaces.DaySlot) *model.DaySlot {
 	}
 
 	return &model.DaySlot{
-		Date:        daySlot.Date,
-		TimeSlots:   timeSlots,
-		IsAvailable: daySlot.IsAvailable,
+		Date:      daySlot.Date,
+		TimeSlots: timeSlots,
 	}
 }
 
 // MapTimeSlotToModel converts from interface TimeSlot to GraphQL model
 func MapTimeSlotToModel(timeSlot interfaces.TimeSlot) *model.TimeSlot {
 	return &model.TimeSlot{
-		StartTime:   timeSlot.StartTime,
-		EndTime:     timeSlot.EndTime,
-		IsAvailable: timeSlot.IsAvailable,
+		StartTime: timeSlot.StartTime,
+		EndTime:   timeSlot.EndTime,
 	}
 }

--- a/packages/server/customer-os-api/mapper/meeting_booking_event_mapper.go
+++ b/packages/server/customer-os-api/mapper/meeting_booking_event_mapper.go
@@ -16,8 +16,8 @@ func MapMeetingBookingEventInputToEntity(input model.SaveMeetingBookingEventInpu
 	}
 	if input.DurationMins != nil {
 		entity.DurationMins = *input.DurationMins
-		if entity.DurationMins%15 != 0 {
-			entity.DurationMins = ((entity.DurationMins / 15) + 1) * 15
+		if entity.DurationMins%5 != 0 {
+			entity.DurationMins = ((entity.DurationMins / 5) + 1) * 5
 		}
 	}
 	if input.Description != nil {

--- a/packages/server/customer-os-common-module/interfaces/nylas.go
+++ b/packages/server/customer-os-common-module/interfaces/nylas.go
@@ -19,40 +19,10 @@ type NylasService interface {
 	RevokeAccess(ctx context.Context, email string) error
 	GetGrant(ctx context.Context, email string) (*postgres_entity.NylasGrant, error)
 
-	// Calendar management
+	// Calendar operations
 	ListCalendars(ctx context.Context, email string) ([]*NylasCalendar, error)
 	GetDefaultCalendar(ctx context.Context, email string) (*NylasCalendar, error)
-
-	// Calendar operations
-	CreateEvent(ctx context.Context, calendarID string, event *CalendarEvent) (*CalendarEvent, error)
-	UpdateEvent(ctx context.Context, calendarID string, eventID string, event *CalendarEvent) (*CalendarEvent, error)
-	DeleteEvent(ctx context.Context, calendarID string, eventID string) error
-	GetEvent(ctx context.Context, calendarID string, eventID string) (*CalendarEvent, error)
-	ListEvents(ctx context.Context, calendarID string, startTime, endTime time.Time) ([]*CalendarEvent, error)
-}
-
-type CalendarEvent struct {
-	ID           string
-	Title        string
-	Description  string
-	StartTime    time.Time
-	EndTime      time.Time
-	Location     string
-	Participants []Participant
-	Recurrence   *Recurrence
-	Status       string
-}
-
-type Participant struct {
-	Email  string
-	Name   string
-	Status string // accepted, declined, tentative
-}
-
-type Recurrence struct {
-	Frequency string // daily, weekly, monthly, yearly
-	Interval  int
-	Until     time.Time
+	GetCalendarAvailability(ctx context.Context, email, calendarID string, startTime, endTime time.Time, bufferBefore, bufferAfter int) (*NylasAvailabilityResponse, error)
 }
 
 type NylasCalendarsResponse struct {
@@ -74,4 +44,53 @@ type NylasCalendar struct {
 	Object             string                 `json:"object"`
 	ReadOnly           bool                   `json:"read_only"`
 	Timezone           string                 `json:"timezone"`
+}
+
+type NylasAvailabilityParticipant struct {
+	Email       string   `json:"email"`
+	CalendarIds []string `json:"calendar_ids,omitempty"`
+	OpenHours   []struct {
+		Days     []int    `json:"days"`
+		Timezone string   `json:"timezone"`
+		Start    string   `json:"start"`
+		End      string   `json:"end"`
+		Exdates  []string `json:"exdates"`
+	} `json:"open_hours,omitempty"`
+}
+
+type NylasAvailabilityRules struct {
+	AvailabilityMethod string `json:"availability_method"`
+	Buffer             struct {
+		Before int `json:"before"`
+		After  int `json:"after"`
+	} `json:"buffer"`
+	TentativeAsBusy  bool `json:"tentative_as_busy"`
+	DefaultOpenHours []struct {
+		Days     []int    `json:"days"`
+		Timezone string   `json:"timezone"`
+		Start    string   `json:"start"`
+		End      string   `json:"end"`
+		Exdates  []string `json:"exdates"`
+	} `json:"default_open_hours"`
+}
+
+type NylasAvailabilityRequest struct {
+	Participants      []NylasAvailabilityParticipant `json:"participants"`
+	StartTime         int64                          `json:"start_time"`
+	EndTime           int64                          `json:"end_time"`
+	IntervalMinutes   int                            `json:"interval_minutes"`
+	DurationMinutes   int                            `json:"duration_minutes"`
+	RoundTo           int                            `json:"round_to"`
+	AvailabilityRules NylasAvailabilityRules         `json:"availability_rules"`
+}
+
+type NylasAvailabilityResponse struct {
+	RequestID string `json:"request_id"`
+	Data      struct {
+		Order     []string `json:"order"`
+		TimeSlots []struct {
+			StartTime int64 `json:"start_time"`
+			EndTime   int64 `json:"end_time"`
+		} `json:"time_slots"`
+	} `json:"data"`
 }

--- a/packages/server/customer-os-common-module/services/enrichment/ip_identity.go
+++ b/packages/server/customer-os-common-module/services/enrichment/ip_identity.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"io"
 	"net/http"
 	"time"
@@ -46,6 +47,7 @@ func (s *enrichmentService) IPIdentity(ctx context.Context, ip string) (*interfa
 	snitcherResponse, respString, err := s.callSnitcher(ctx, ip)
 	if err != nil {
 		spans.TraceError(err)
+		spans.LogKV("result.rawSnitcherResponse", utils.IfNotNilString(respString))
 		return nil, fmt.Errorf("failed to call snitcher: %w", err)
 	}
 

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -166,15 +166,26 @@ func (s *meetingService) SetDefaultUserCalendarAvailability(ctx context.Context,
 	return defaultAvailability, nil
 }
 
-// generateTimeSlots generates 15-minute time slots between start and end time
+// generateTimeSlots generates 5-minute time slots between start and end time
 func generateTimeSlots(startTime, endTime time.Time) []*interfaces.TimeSlot {
-	slots := []*interfaces.TimeSlot{}
-	current := startTime
+	var slots []*interfaces.TimeSlot
 
-	for current.Before(endTime) {
-		slotEnd := current.Add(15 * time.Minute)
-		if slotEnd.After(endTime) {
-			slotEnd = endTime
+	// Round start time down to nearest 5 minutes
+	startMins := startTime.Minute()
+	roundedStartMins := (startMins / 5) * 5
+	roundedStart := startTime.Add(-time.Duration(startMins-roundedStartMins) * time.Minute)
+
+	// Round end time up to nearest 5 minutes
+	endMins := endTime.Minute()
+	roundedEndMins := ((endMins + 4) / 5) * 5
+	roundedEnd := endTime.Add(time.Duration(roundedEndMins-endMins) * time.Minute)
+
+	current := roundedStart
+
+	for current.Before(roundedEnd) {
+		slotEnd := current.Add(5 * time.Minute)
+		if slotEnd.After(roundedEnd) {
+			slotEnd = roundedEnd
 		}
 
 		slots = append(slots, &interfaces.TimeSlot{
@@ -257,15 +268,17 @@ func isTimeInDayAvailability(t time.Time, dayAvailability postgresEntity.DayAvai
 		return false
 	}
 
-	// Parse start and end hours
+	// Parse start and end hours in local time
 	startTime, _ := time.Parse("15:04", dayAvailability.StartHour)
 	endTime, _ := time.Parse("15:04", dayAvailability.EndHour)
 
-	// Get just the time part of the input time
-	timeOnly := time.Date(0, 1, 1, t.Hour(), t.Minute(), 0, 0, t.Location())
+	// Create reference time points in the user's timezone for today
+	today := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	startTimeToday := today.Add(time.Duration(startTime.Hour())*time.Hour + time.Duration(startTime.Minute())*time.Minute)
+	endTimeToday := today.Add(time.Duration(endTime.Hour())*time.Hour + time.Duration(endTime.Minute())*time.Minute)
 
-	// Compare times
-	return !timeOnly.Before(startTime) && !timeOnly.After(endTime)
+	// Compare the actual time against the window
+	return !t.Before(startTimeToday) && !t.After(endTimeToday)
 }
 
 // isSlotInUserAvailability checks if a time slot is within user's calendar availability
@@ -339,8 +352,8 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 	}
 
 	meetingDurationMins := meetingBookingEvent.DurationMins
-	if meetingDurationMins%15 != 0 {
-		meetingDurationMins = ((meetingDurationMins / 15) + 1) * 15
+	if meetingDurationMins%5 != 0 {
+		meetingDurationMins = ((meetingDurationMins / 5) + 1) * 5
 	}
 
 	// 1. Get default calendar for each participant
@@ -365,7 +378,7 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 	// 2a. Generate initial time slots for each participant
 	participantTimeSlots := make(map[string][]*interfaces.TimeSlot)
 	for email := range participantsData {
-		// Generate 15-minute time slots for the participant
+		// Generate 5-minute time slots for the participant
 		slots := generateTimeSlots(startTime, endTime)
 		participantTimeSlots[email] = slots
 	}
@@ -391,7 +404,12 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 	}
 
 	// 2c. Apply booking option restrictions for minimum notice and maximum advance if enabled
+	bufferBefore := 0
+	bufferAfter := 0
 	if meetingBookingEvent.BookOptionEnabled {
+		bufferBefore = int(meetingBookingEvent.BookOptionBufferBetweenMeetingsMins)
+		bufferAfter = int(meetingBookingEvent.BookOptionBufferBetweenMeetingsMins)
+
 		now := utils.Now()
 		minNotice := meetingBookingEvent.BookOptionMinNoticeMins
 		if minNotice < 0 {
@@ -399,7 +417,7 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 		}
 		maxAdvance := meetingBookingEvent.BookOptionDaysInAdvance
 		if maxAdvance < 0 {
-			maxAdvance = 1
+			maxAdvance = 0
 		}
 		minNoticeTime := now.Add(time.Duration(minNotice) * time.Minute)
 		maxAdvanceTime := now.AddDate(0, 0, int(maxAdvance))
@@ -414,8 +432,49 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 				}
 
 				// Mark slot as unavailable if it's after maximum advance time
-				if slot.StartTime.After(maxAdvanceTime) {
+				if maxAdvance > 0 && slot.StartTime.After(maxAdvanceTime) {
 					slot.IsAvailable = false
+				}
+			}
+		}
+	}
+
+	// 2d. Get calendar availability for each participant
+	for email, calendar := range participantsData {
+		// Get calendar availability from Nylas
+		calendarAvailability, err := s.nylas.GetCalendarAvailability(ctx, email, calendar.ID, startTime, endTime, bufferBefore, bufferAfter)
+		if err != nil {
+			spans.TraceError(err)
+			s.log.Warn("Failed to get calendar availability for participant %s: %v", email, err)
+			// If error occurs, mark all slots as unavailable for this participant
+			for _, slot := range participantTimeSlots[email] {
+				slot.IsAvailable = false
+			}
+			continue
+		}
+
+		// Create a map of available times from Nylas
+		availableTimes := make(map[int64]bool)
+		for _, slot := range calendarAvailability.Data.TimeSlots {
+			// Mark all times between start and end as available
+			for t := slot.StartTime; t < slot.EndTime; t += 300 { // 300 seconds = 5 minutes
+				availableTimes[t] = true
+			}
+		}
+
+		// Update participant's time slots based on Nylas availability
+		// Only mark as unavailable if the slot was previously available
+		for _, slot := range participantTimeSlots[email] {
+			if slot.IsAvailable { // Only check Nylas availability if slot is currently available
+				slotStart := slot.StartTime.UTC().Unix()
+				slotEnd := slot.EndTime.UTC().Unix()
+
+				// Check if all 5-minute intervals are available in Nylas
+				for t := slotStart; t < slotEnd; t += 300 {
+					if !availableTimes[t] {
+						slot.IsAvailable = false
+						break
+					}
 				}
 			}
 		}

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -390,7 +390,7 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 		}
 	}
 
-	// 2c. Apply booking option restrictions if enabled
+	// 2c. Apply booking option restrictions for minimum notice and maximum advance if enabled
 	if meetingBookingEvent.BookOptionEnabled {
 		now := utils.Now()
 		minNotice := meetingBookingEvent.BookOptionMinNoticeMins
@@ -432,9 +432,21 @@ func (s *meetingService) GetCalendarAvailability(ctx context.Context, meetingBoo
 		convertedParticipantTimeSlots[email] = convertedSlots
 	}
 
-	// 4. Group time slots into day slots
+	// 4a. Remove time slots that are not available
+	filteredParticipantTimeSlots := make(map[string][]*interfaces.TimeSlot)
+	for email, slots := range convertedParticipantTimeSlots {
+		availableSlots := make([]*interfaces.TimeSlot, 0)
+		for _, slot := range slots {
+			if slot.IsAvailable {
+				availableSlots = append(availableSlots, slot)
+			}
+		}
+		filteredParticipantTimeSlots[email] = availableSlots
+	}
+
+	// 4b. Group time slots into day slots
 	var daySlots []*interfaces.DaySlot
-	for _, slots := range convertedParticipantTimeSlots {
+	for _, slots := range filteredParticipantTimeSlots {
 		daySlots = convertTimeSlotsToDaySlots(slots)
 		// Only process first participant
 		break

--- a/packages/server/customer-os-common-module/services/nylas/service.go
+++ b/packages/server/customer-os-common-module/services/nylas/service.go
@@ -373,55 +373,69 @@ func (s *nylasService) GetDefaultCalendar(ctx context.Context, email string) (*i
 	return calendars[0], nil
 }
 
-// Update ListEvents to use prepareNylasAccountID
-func (s *nylasService) ListEvents(ctx context.Context, calendarID string, startTime, endTime time.Time) ([]*interfaces.CalendarEvent, error) {
-	spans, ctx := telemetry.StartServiceSpan(ctx, "NylasService.ListEvents")
+func (s *nylasService) GetCalendarAvailability(ctx context.Context, email, calendarID string, startTime, endTime time.Time, bufferBefore, bufferAfter int) (*interfaces.NylasAvailabilityResponse, error) {
+	spans, ctx := telemetry.StartServiceSpan(ctx, "NylasService.GetCalendarAvailability")
 	defer spans.Finish()
 	spans.LogObjectAsJson("request", map[string]interface{}{
-		"calendarID": calendarID,
-		"startTime":  startTime,
-		"endTime":    endTime,
+		"email":        email,
+		"calendarID":   calendarID,
+		"startTime":    startTime,
+		"endTime":      endTime,
+		"bufferBefore": bufferBefore,
+		"bufferAfter":  bufferAfter,
 	})
 
-	// Get email from context
-	email := ctx.Value("email").(string)
 	if email == "" {
-		return nil, fmt.Errorf("no email found in context")
+		return nil, fmt.Errorf("grantID is required")
+	}
+	if calendarID == "" {
+		return nil, fmt.Errorf("calendarID is required")
 	}
 
-	// Get provider from context
-	provider := ctx.Value("provider").(enum.OAuthEmailProvider)
-	if provider == "" {
-		return nil, fmt.Errorf("no provider found in context")
+	// Create availability request
+	request := interfaces.NylasAvailabilityRequest{
+		Participants: []interfaces.NylasAvailabilityParticipant{
+			{
+				Email:       email,
+				CalendarIds: []string{calendarID},
+			},
+		},
+		StartTime:       startTime.UTC().Unix(),
+		EndTime:         endTime.UTC().Unix(),
+		IntervalMinutes: 5, // Match our time slot generation interval
+		DurationMinutes: 5, // Default duration
+		RoundTo:         5, // Match our time slot generation interval
+		AvailabilityRules: interfaces.NylasAvailabilityRules{
+			AvailabilityMethod: "max-availability",
+			Buffer: struct {
+				Before int `json:"before"`
+				After  int `json:"after"`
+			}{
+				Before: bufferBefore,
+				After:  bufferAfter,
+			},
+			TentativeAsBusy: true,
+		},
 	}
 
-	// Get Nylas grant ID for this email
-	grant, err := s.postgres.NylasGrantRepository.GetByTenantAndEmail(ctx, common.GetTenantFromContext(ctx), email)
+	// Marshal request body
+	bodyBytes, err := json.Marshal(request)
 	if err != nil {
 		spans.TraceError(err)
-		return nil, fmt.Errorf("failed to get Nylas grant ID: %v", err)
-	}
-	if grant == nil {
-		return nil, fmt.Errorf("Nylas grant not found")
+		return nil, fmt.Errorf("failed to marshal request body: %v", err)
 	}
 
 	// Create request to Nylas v3 API
-	url := fmt.Sprintf("%s/v3/events?account_id=%s&calendar_id=%s&start=%d&end=%d",
-		s.config.APIUrl,
-		grant.NylasGrantId,
-		calendarID,
-		startTime.Unix(),
-		endTime.Unix(),
-	)
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/v3/calendars/availability", s.config.APIUrl), bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 
-	// Set headers - use Nylas API key for authentication
+	// Set headers
 	req.Header.Set("Authorization", "Bearer "+s.config.APIKey)
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", "application/json, application/gzip")
+	req.Header.Set("Content-Type", "application/json")
 
 	// Make request
 	resp, err := s.httpClient.Do(req)
@@ -431,62 +445,24 @@ func (s *nylasService) ListEvents(ctx context.Context, calendarID string, startT
 	}
 	defer resp.Body.Close()
 
+	respBodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		spans.TraceError(err)
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
 	if resp.StatusCode != http.StatusOK {
+		spans.LogKV("response", string(respBodyBytes))
 		spans.TraceError(fmt.Errorf("unexpected status code: %d", resp.StatusCode))
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return nil, fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, string(respBodyBytes))
 	}
 
 	// Parse response
-	var response struct {
-		Data []struct {
-			ID          string `json:"id"`
-			Title       string `json:"title"`
-			Description string `json:"description"`
-			Start       int64  `json:"start"`
-			End         int64  `json:"end"`
-			Location    string `json:"location"`
-			Status      string `json:"status"`
-		} `json:"data"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+	var response interfaces.NylasAvailabilityResponse
+	if err := json.NewDecoder(bytes.NewReader(respBodyBytes)).Decode(&response); err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to decode response: %v", err)
 	}
 
-	// Convert to our interface type
-	result := make([]*interfaces.CalendarEvent, len(response.Data))
-	for i, event := range response.Data {
-		result[i] = &interfaces.CalendarEvent{
-			ID:          event.ID,
-			Title:       event.Title,
-			Description: event.Description,
-			StartTime:   time.Unix(event.Start, 0),
-			EndTime:     time.Unix(event.End, 0),
-			Location:    event.Location,
-			Status:      event.Status,
-		}
-	}
-
-	return result, nil
-}
-
-func (s *nylasService) CreateEvent(ctx context.Context, calendarID string, event *interfaces.CalendarEvent) (*interfaces.CalendarEvent, error) {
-	// TODO: Implement Nylas API call to create event
-	return nil, nil
-}
-
-func (s *nylasService) UpdateEvent(ctx context.Context, calendarID string, eventID string, event *interfaces.CalendarEvent) (*interfaces.CalendarEvent, error) {
-	// TODO: Implement Nylas API call to update event
-	return nil, nil
-}
-
-func (s *nylasService) DeleteEvent(ctx context.Context, calendarID string, eventID string) error {
-	// TODO: Implement Nylas API call to delete event
-	return nil
-}
-
-func (s *nylasService) GetEvent(ctx context.Context, calendarID string, eventID string) (*interfaces.CalendarEvent, error) {
-	// TODO: Implement Nylas API call to get event
-	return nil, nil
+	return &response, nil
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `isAvailable` from calendar models and update availability logic to return only available time slots.
> 
>   - **GraphQL Schema and Models**:
>     - Remove `isAvailable` field from `DaySlot` and `TimeSlot` in `calendar.graphqls` and `models_gen.go`.
>   - **Resolvers and Mappers**:
>     - Update `CalendarAvailability` resolver in `calendar.resolvers.go` to handle availability without `isAvailable`.
>     - Modify `MapDaySlotToModel` and `MapTimeSlotToModel` in `calendar_availability_mapper.go` to exclude `isAvailable`.
>   - **Services**:
>     - Change `generateTimeSlots` in `service.go` to create 5-minute slots and remove `isAvailable` logic.
>     - Update `GetCalendarAvailability` in `service.go` to filter and group available slots without `isAvailable`.
>     - Modify `GetCalendarAvailability` in `nylas/service.go` to use new availability logic.
>   - **Miscellaneous**:
>     - Adjust rounding logic for meeting durations to nearest 5 minutes in `meeting_booking_event_mapper.go` and `calendar.resolvers.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 10891d7688d47100370787d36ce0d543bad9b206. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->