### PR TITLE
set timezone on nylas connect

### DIFF
--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -18036,6 +18036,7 @@ input NylasConnectInput {
     email:          String!
     refreshToken:   String!
     provider:       NylasProvider!
+    timezone:       String
 }
 
 enum NylasProvider {
@@ -127115,7 +127116,7 @@ func (ec *executionContext) unmarshalInputNylasConnectInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"email", "refreshToken", "provider"}
+	fieldsInOrder := [...]string{"email", "refreshToken", "provider", "timezone"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -127143,6 +127144,13 @@ func (ec *executionContext) unmarshalInputNylasConnectInput(ctx context.Context,
 				return it, err
 			}
 			it.Provider = data
+		case "timezone":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("timezone"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Timezone = data
 		}
 	}
 

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -2124,6 +2124,7 @@ type NylasConnectInput struct {
 	Email        string        `json:"email"`
 	RefreshToken string        `json:"refreshToken"`
 	Provider     NylasProvider `json:"provider"`
+	Timezone     *string       `json:"timezone,omitempty"`
 }
 
 type NylasDetails struct {

--- a/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
@@ -48,7 +48,7 @@ func (r *mutationResolver) NylasConnect(ctx context.Context, input model.NylasCo
 		return &model.NylasDetails{Connected: false}, nil
 	}
 
-	_, err = r.Services.CommonServices.MeetingService.GetUserCalendarAvailability(ctx, input.Email)
+	_, err = r.Services.CommonServices.MeetingService.SetDefaultUserCalendarAvailability(ctx, input.Email, utils.IfNotNilString(input.Timezone))
 	if err != nil {
 		spans.TraceError(err)
 	}

--- a/packages/server/customer-os-api/graphql/schemas/nylas.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/nylas.graphqls
@@ -27,6 +27,7 @@ input NylasConnectInput {
     email:          String!
     refreshToken:   String!
     provider:       NylasProvider!
+    timezone:       String
 }
 
 enum NylasProvider {

--- a/packages/server/customer-os-common-module/interfaces/meeting.go
+++ b/packages/server/customer-os-common-module/interfaces/meeting.go
@@ -29,7 +29,7 @@ type CalendarAvailabilityResult struct {
 type MeetingService interface {
 	GetUserCalendarAvailability(ctx context.Context, email string) (*postgresEntity.UserCalendarAvailability, error)
 	SaveUserCalendarAvailability(ctx context.Context, availability *postgresEntity.UserCalendarAvailability) (*postgresEntity.UserCalendarAvailability, error)
-	SetDefaultUserCalendarAvailability(ctx context.Context, email string) (*postgresEntity.UserCalendarAvailability, error)
+	SetDefaultUserCalendarAvailability(ctx context.Context, email, timezone string) (*postgresEntity.UserCalendarAvailability, error)
 
 	// GetCalendarAvailability returns the available time slots for a meeting booking event
 	// It takes into account:

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -92,10 +92,10 @@ func (s *meetingService) SaveUserCalendarAvailability(ctx context.Context, avail
 	return saved, nil
 }
 
-func (s *meetingService) SetDefaultUserCalendarAvailability(ctx context.Context, email string) (*postgresEntity.UserCalendarAvailability, error) {
+func (s *meetingService) SetDefaultUserCalendarAvailability(ctx context.Context, email, timezone string) (*postgresEntity.UserCalendarAvailability, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.SetDefaultUserCalendarAvailability")
 	defer spans.Finish()
-	spans.LogKV("email", email)
+	spans.LogKV("email", email, "timezone", timezone)
 
 	// validate tenant
 	err := common.ValidateTenant(ctx)
@@ -116,10 +116,14 @@ func (s *meetingService) SetDefaultUserCalendarAvailability(ctx context.Context,
 		return availability, nil
 	}
 
+	if timezone == "" {
+		timezone = postgresEntity.DefaultTimezone
+	}
+
 	defaultAvailability := &postgresEntity.UserCalendarAvailability{
 		Tenant:   tenant,
 		Email:    email,
-		Timezone: postgresEntity.DefaultTimezone,
+		Timezone: timezone,
 		Monday: postgresEntity.DayAvailability{
 			Enabled:   true,
 			StartHour: "08:30",

--- a/packages/server/customer-os-common-module/services/nylas/service.go
+++ b/packages/server/customer-os-common-module/services/nylas/service.go
@@ -386,7 +386,7 @@ func (s *nylasService) GetCalendarAvailability(ctx context.Context, email, calen
 	})
 
 	if email == "" {
-		return nil, fmt.Errorf("grantID is required")
+		return nil, fmt.Errorf("email is required")
 	}
 	if calendarID == "" {
 		return nil, fmt.Errorf("calendarID is required")

--- a/packages/server/customer-os-postgres-repository/entity/user_calendar_availability.go
+++ b/packages/server/customer-os-postgres-repository/entity/user_calendar_availability.go
@@ -42,7 +42,7 @@ func standardizeTimeFormat(timeStr string) (string, error) {
 		if len(parts) == 2 {
 			// Handle single digit minute
 			if len(parts[1]) == 1 {
-				parts[1] = parts[1] + "0"
+				parts[1] = "0" + parts[1]
 			}
 			timeStr = parts[0] + ":" + parts[1]
 		}

--- a/packages/server/customer-os-postgres-repository/entity/user_calendar_availability.go
+++ b/packages/server/customer-os-postgres-repository/entity/user_calendar_availability.go
@@ -36,6 +36,18 @@ func standardizeTimeFormat(timeStr string) (string, error) {
 		return "24:00", nil
 	}
 
+	// Handle single digit minutes
+	if strings.Contains(timeStr, ":") {
+		parts := strings.Split(timeStr, ":")
+		if len(parts) == 2 {
+			// Handle single digit minute
+			if len(parts[1]) == 1 {
+				parts[1] = parts[1] + "0"
+			}
+			timeStr = parts[0] + ":" + parts[1]
+		}
+	}
+
 	// Try parsing with different formats
 	formats := []string{"15:04", "3:04PM", "3:04 PM", "3PM", "15", "3"}
 	var t time.Time
@@ -178,7 +190,7 @@ func (u *UserCalendarAvailability) Validate() error {
 	u.Timezone = strings.TrimSpace(u.Timezone)
 	_, err := time.LoadLocation(u.Timezone)
 	if err != nil {
-		return fmt.Errorf("invalid timezone: %s, %s", u.Timezone, err.Error())
+		u.Timezone = DefaultTimezone
 	}
 
 	// Validate each day's availability


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add timezone support to Nylas connection process, allowing users to specify timezone when connecting email, and update related services and interfaces.
> 
>   - **GraphQL Schema**:
>     - Add `timezone` field to `NylasConnectInput` in `nylas.graphqls`.
>   - **Resolvers**:
>     - Update `NylasConnect` in `nylas.resolvers.go` to pass `timezone` to `SetDefaultUserCalendarAvailability`.
>   - **Services**:
>     - Modify `SetDefaultUserCalendarAvailability` in `service.go` to accept `timezone` and use `DefaultTimezone` if not provided.
>     - Fix error message in `GetCalendarAvailability` in `service.go` to correctly reference `email` instead of `grantID`.
>   - **Models**:
>     - Update `NylasConnectInput` in `models_gen.go` to include `timezone` field.
>   - **Interfaces**:
>     - Update `MeetingService` interface in `meeting.go` to include `timezone` in `SetDefaultUserCalendarAvailability`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 04cf513744ec8d4044749e32244c134e40bbd32e. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->