### PR TITLE
accept day for calendar input

### DIFF
--- a/packages/server/customer-os-api/rest/public/calendar.go
+++ b/packages/server/customer-os-api/rest/public/calendar.go
@@ -1,9 +1,11 @@
 package public
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"net/http"
 	"time"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 
 	"github.com/gin-gonic/gin"
 
@@ -74,9 +76,13 @@ func GetCalendarAvailability(s *cosapi_services.Services) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Start time is required"})
 			return
 		}
-		startTime, err := time.Parse(time.RFC3339, startTimeStr)
+		startTime, err := utils.UnmarshalDateTime(startTimeStr)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid start time format. Expected RFC3339 format (e.g., 2024-03-20T10:00:00Z)"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if startTime == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid start time format"})
 			return
 		}
 
@@ -86,9 +92,13 @@ func GetCalendarAvailability(s *cosapi_services.Services) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "End time is required"})
 			return
 		}
-		endTime, err := time.Parse(time.RFC3339, endTimeStr)
+		endTime, err := utils.UnmarshalDateTime(endTimeStr)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid end time format. Expected RFC3339 format (e.g., 2024-03-20T11:00:00Z)"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if endTime == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid end time format"})
 			return
 		}
 
@@ -96,7 +106,7 @@ func GetCalendarAvailability(s *cosapi_services.Services) gin.HandlerFunc {
 		timezone := c.Query("timezone")
 
 		// Validate time range
-		if startTime.After(endTime) {
+		if startTime.After(*endTime) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "End time must be after start time"})
 			return
 		}

--- a/packages/server/customer-os-common-module/utils/time_utils.go
+++ b/packages/server/customer-os-common-module/utils/time_utils.go
@@ -11,15 +11,16 @@ import (
 )
 
 const (
-	customLayout1 = "2006-01-02 15:04:05"
-	customLayout2 = "2006-01-02T15:04:05.000-0700"
-	customLayout3 = "2006-01-02T15:04:05-07:00"
-	customLayout4 = "Mon, 2 Jan 2006 15:04:05 -0700 (MST)"
-	customLayout5 = "Mon, 2 Jan 2006 15:04:05 MST"
-	customLayout6 = "Mon, 2 Jan 2006 15:04:05 -0700"
-	customLayout7 = "Mon, 2 Jan 2006 15:04:05 +0000 (GMT)"
-	customLayout8 = "Mon, 2 Jan 2006 15:04:05 -0700 (MST)"
-	customLayout9 = "2 Jan 2006 15:04:05 -0700"
+	customLayout1  = "2006-01-02 15:04:05"
+	customLayout2  = "2006-01-02T15:04:05.000-0700"
+	customLayout3  = "2006-01-02T15:04:05-07:00"
+	customLayout4  = "Mon, 2 Jan 2006 15:04:05 -0700 (MST)"
+	customLayout5  = "Mon, 2 Jan 2006 15:04:05 MST"
+	customLayout6  = "Mon, 2 Jan 2006 15:04:05 -0700"
+	customLayout7  = "Mon, 2 Jan 2006 15:04:05 +0000 (GMT)"
+	customLayout8  = "Mon, 2 Jan 2006 15:04:05 -0700 (MST)"
+	customLayout9  = "2 Jan 2006 15:04:05 -0700"
+	customLayout10 = "2006-01-02"
 )
 
 type YearMonth struct {
@@ -99,7 +100,7 @@ func UnmarshalDateTime(input string) (*time.Time, error) {
 	}
 
 	// Try custom layouts
-	customLayouts := []string{customLayout1, customLayout2, customLayout4, customLayout5, customLayout6, customLayout7, customLayout8, customLayout9}
+	customLayouts := []string{customLayout1, customLayout2, customLayout3, customLayout4, customLayout5, customLayout6, customLayout7, customLayout8, customLayout9, customLayout10}
 
 	for _, layout := range customLayouts {
 		t, err = time.Parse(layout, input)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `GetCalendarAvailability` now accepts day format for calendar input by updating `UnmarshalDateTime` to handle a new date format.
> 
>   - **Behavior**:
>     - `GetCalendarAvailability` in `calendar.go` now accepts day format for `startTime` and `endTime` using `utils.UnmarshalDateTime`.
>     - Returns error if `startTime` or `endTime` is invalid or missing.
>   - **Utilities**:
>     - Adds `customLayout10` for day format (`2006-01-02`) in `time_utils.go`.
>     - Updates `UnmarshalDateTime` in `time_utils.go` to include `customLayout10` for parsing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a20f52cc492520862109b8a21e9ad86e30df8ab1. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->