### PR TITLE
patch: distroless image build fix

### DIFF
--- a/.github/workflows/release-leads.yml
+++ b/.github/workflows/release-leads.yml
@@ -11,6 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   REPOSITORY_BASE: ${{ github.repository_owner }}
+  IMAGE_NAME: ${{ github.repository_owner }}/customer-os-leads
 
 jobs:
   check-release-needed:
@@ -66,8 +67,7 @@ jobs:
 
   publish-images:
     needs: create-release
-    # Only run if the create-release job completed successfully (implies a release was created)
-    runs-on: ubicloud-standard-2
+    runs-on: ubicloud-standard-2-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -82,13 +82,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image for leads
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          # Use the path output from the script and hardcoded service name
-          file: packages/server/leads/deployments/build/Containerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY_BASE }}/leads:latest 
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY_BASE }}/leads:${{ needs.create-release.outputs.next_version }}
+      - name: Build and push ARM64 image
+        run: |
+          ./packages/server/leads/deployments/build/build-push.sh \
+            "${{ env.REGISTRY }}" \
+            "${{ env.IMAGE_NAME }}" \
+            "${{ needs.create-release.outputs.next_version }}" \
+            "linux/arm64" \
+            "arm64"
+
+          # Tag as latest as well
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.create-release.outputs.next_version }}-arm64

--- a/packages/server/leads/deployments/build/build-push.sh
+++ b/packages/server/leads/deployments/build/build-push.sh
@@ -7,7 +7,6 @@ SHA=$3
 PLATFORM=$4
 ARCH=$5
 
-# Log in to registry - we assume credentials are already available
 echo "Building and pushing ${PLATFORM} image..."
 
 # Use Docker Buildx to build and push
@@ -17,7 +16,7 @@ docker buildx build \
   --tag ${REGISTRY}/${IMAGE_NAME}:${SHA}-${ARCH} \
   --provenance=false \
   --file ./packages/server/leads/deployments/build/Containerfile \
-  ./packages/server
+  .
 
 # Get and output the image digest
 digest=$(docker buildx imagetools inspect ${REGISTRY}/${IMAGE_NAME}:${SHA}-${ARCH} --format "{{json .Manifest}}" | jq -r '.digest')


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes ARM64 Docker image build in GitHub Actions by updating workflow and build script.
> 
>   - **GitHub Actions Workflow**:
>     - Adds `IMAGE_NAME` environment variable in `release-leads.yml`.
>     - Changes `runs-on` to `ubicloud-standard-2-arm` for `publish-images` job.
>     - Replaces Docker build and push steps with a script call in `publish-images` job.
>   - **Build Script**:
>     - Removes registry login assumption in `build-push.sh`.
>     - Simplifies build context path in `build-push.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f3da3c3c3f4b69853f8031c3c70d5af42a7cb721. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->