### PR TITLE
patch: outbox cron

### DIFF
--- a/packages/server/leads/internal/cron/cron.go
+++ b/packages/server/leads/internal/cron/cron.go
@@ -22,6 +22,7 @@ import (
 
 // CONSTANTS
 const (
+	GroupOutbox     = "outbox"
 	GroupWebSession = "webSession"
 
 	// LeaseDuration is how long a lease lasts before needing renewal
@@ -38,6 +39,7 @@ var jobLocks = struct {
 	locks map[string]*sync.Mutex
 }{
 	locks: map[string]*sync.Mutex{
+		GroupOutbox:     {},
 		GroupWebSession: {},
 	},
 }
@@ -76,7 +78,7 @@ func (cm *CronManager) Start(podName, namespace string) error {
 	// Create the leader election lock
 	lock := &resourcelock.LeaseLock{
 		LeaseMeta: metav1.ObjectMeta{
-			Name:      "mailstack-cron-leader",
+			Name:      "leads-cron-leader",
 			Namespace: namespace,
 		},
 		Client: cm.k8s.CoordinationV1(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `GroupOutbox` for outbox cron jobs and rename leader election lock in `cron.go`.
> 
>   - **Behavior**:
>     - Adds `GroupOutbox` constant to `cron.go` for managing outbox-related cron jobs.
>     - Renames leader election lock from `mailstack-cron-leader` to `leads-cron-leader` in `Start()` function in `cron.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for bc064c9525b4ee5ebab616d7980f308de1b5b7c8. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->