### PR TITLE
patch: remove build script output

### DIFF
--- a/packages/server/leads/deployments/build/build-push.sh
+++ b/packages/server/leads/deployments/build/build-push.sh
@@ -11,13 +11,10 @@ echo "Building and pushing ${PLATFORM} image..."
 
 # Use Docker Buildx to build and push
 docker buildx build \
-  --platform ${PLATFORM} \
   --push \
   --tag ${REGISTRY}/${IMAGE_NAME}:${SHA}-${ARCH} \
   --provenance=false \
   --file ./packages/server/leads/deployments/build/Containerfile \
   .
 
-# Return success regardless of digest parsing
-echo "Successfully built and pushed ${REGISTRY}/${IMAGE_NAME}:${VERSION}-${ARCH}"
 exit 0


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies `build-push.sh` by removing `--platform` option and success message output.
> 
>   - **Script Changes**:
>     - Removed `--platform` option from `docker buildx build` command in `build-push.sh`.
>     - Removed success message output after the build and push process in `build-push.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 885f529c8f1d4ed0c7b01c9ce4faae69524752e7. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->