### PR TITLE
patch: update to only build arm

### DIFF
--- a/packages/server/leads/deployments/build/create-manifest.sh
+++ b/packages/server/leads/deployments/build/create-manifest.sh
@@ -8,18 +8,16 @@ SAFE_TAG=$4
 REF_NAME=$5
 EVENT_NAME=$6
 
-# Create and push the SHA manifest
+# Create and push the SHA manifest (ARM64 only)
 echo "Creating SHA manifest..."
 docker buildx imagetools create \
   --tag ${REGISTRY}/${IMAGE_NAME}:${SHA} \
-  ${REGISTRY}/${IMAGE_NAME}:${SHA}-amd64 \
   ${REGISTRY}/${IMAGE_NAME}:${SHA}-arm64
 
-# Create and push the branch/PR manifest
+# Create and push the branch/PR manifest (ARM64 only)
 echo "Creating branch/PR manifest..."
 docker buildx imagetools create \
   --tag ${REGISTRY}/${IMAGE_NAME}:${SAFE_TAG} \
-  ${REGISTRY}/${IMAGE_NAME}:${SHA}-amd64 \
   ${REGISTRY}/${IMAGE_NAME}:${SHA}-arm64
 
 # If this is the otter branch, also tag as latest
@@ -27,7 +25,6 @@ if [[ "${REF_NAME}" == "otter" ]]; then
   echo "Creating latest manifest..."
   docker buildx imagetools create \
     --tag ${REGISTRY}/${IMAGE_NAME}:latest \
-    ${REGISTRY}/${IMAGE_NAME}:${SHA}-amd64 \
     ${REGISTRY}/${IMAGE_NAME}:${SHA}-arm64
 fi
 
@@ -38,7 +35,6 @@ if [[ "${EVENT_NAME}" == "release" ]]; then
   echo "Creating release manifest for ${RELEASE_TAG}..."
   docker buildx imagetools create \
     --tag ${REGISTRY}/${IMAGE_NAME}:${RELEASE_TAG} \
-    ${REGISTRY}/${IMAGE_NAME}:${SHA}-amd64 \
     ${REGISTRY}/${IMAGE_NAME}:${SHA}-arm64
 fi
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `create-manifest.sh` to build only ARM64 images, removing AMD64 references.
> 
>   - **Behavior**:
>     - Update `create-manifest.sh` to build only ARM64 images, removing AMD64 references.
>     - Affects SHA, branch/PR, latest, and release manifests.
>   - **Misc**:
>     - Removed `${REGISTRY}/${IMAGE_NAME}:${SHA}-amd64` from all `docker buildx imagetools create` commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 94733f6a2d7817cb07aeb188cab73c35be110c34. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->