### PR TITLE
public endpoint for timezones

### DIFF
--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -213,14 +213,21 @@ type ComplexityRoot struct {
 		UpdatedAt     func(childComplexity int) int
 	}
 
+	CalendarAvailabilityDetailsResponse struct {
+		BookingDescription       func(childComplexity int) int
+		BookingFormEmailEnabled  func(childComplexity int) int
+		BookingFormNameEnabled   func(childComplexity int) int
+		BookingFormPhoneEnabled  func(childComplexity int) int
+		BookingFormPhoneRequired func(childComplexity int) int
+		BookingTitle             func(childComplexity int) int
+		DurationMins             func(childComplexity int) int
+		Location                 func(childComplexity int) int
+		TenantLogoURL            func(childComplexity int) int
+		TenantName               func(childComplexity int) int
+	}
+
 	CalendarAvailabilityResponse struct {
-		BookingDescription func(childComplexity int) int
-		BookingTitle       func(childComplexity int) int
-		Days               func(childComplexity int) int
-		DurationMins       func(childComplexity int) int
-		Location           func(childComplexity int) int
-		TenantLogoURL      func(childComplexity int) int
-		TenantName         func(childComplexity int) int
+		Days func(childComplexity int) int
 	}
 
 	Capability struct {
@@ -1676,6 +1683,8 @@ type ComplexityRoot struct {
 		Attachment                         func(childComplexity int, id string) int
 		BankAccounts                       func(childComplexity int) int
 		BillableInfo                       func(childComplexity int) int
+		CalendarAvailability               func(childComplexity int, input model.CalendarAvailabilityInput) int
+		CalendarAvailabilityDetails        func(childComplexity int, meetingBookingEventID string) int
 		CalendarAvailableHours             func(childComplexity int, email string) int
 		CalendarTimezones                  func(childComplexity int) int
 		CheckDomain                        func(childComplexity int, domain string) int
@@ -1721,7 +1730,6 @@ type ComplexityRoot struct {
 		Issue                              func(childComplexity int, id string) int
 		JobRoles                           func(childComplexity int, ids []string) int
 		LogEntry                           func(childComplexity int, id string) int
-		M                                  func(childComplexity int, input model.CalendarAvailabilityInput) int
 		MailstackCheckUnavailableDomains   func(childComplexity int, domains []string) int
 		MailstackDomainPurchaseSuggestions func(childComplexity int, domain string) int
 		MailstackDomains                   func(childComplexity int) int
@@ -2455,7 +2463,8 @@ type QueryResolver interface {
 	BankAccounts(ctx context.Context) ([]*model.BankAccount, error)
 	Version(ctx context.Context) (float64, error)
 	GlobalCache(ctx context.Context) (*model.GlobalCache, error)
-	M(ctx context.Context, input model.CalendarAvailabilityInput) (*model.CalendarAvailabilityResponse, error)
+	CalendarAvailability(ctx context.Context, input model.CalendarAvailabilityInput) (*model.CalendarAvailabilityResponse, error)
+	CalendarAvailabilityDetails(ctx context.Context, meetingBookingEventID string) (*model.CalendarAvailabilityDetailsResponse, error)
 	CalendarAvailableHours(ctx context.Context, email string) (*model.UserCalendarAvailability, error)
 	CalendarTimezones(ctx context.Context) ([]string, error)
 	Contact(ctx context.Context, id string) (*model.Contact, error)
@@ -3290,19 +3299,75 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Calendar.UpdatedAt(childComplexity), true
 
-	case "CalendarAvailabilityResponse.bookingDescription":
-		if e.complexity.CalendarAvailabilityResponse.BookingDescription == nil {
+	case "CalendarAvailabilityDetailsResponse.bookingDescription":
+		if e.complexity.CalendarAvailabilityDetailsResponse.BookingDescription == nil {
 			break
 		}
 
-		return e.complexity.CalendarAvailabilityResponse.BookingDescription(childComplexity), true
+		return e.complexity.CalendarAvailabilityDetailsResponse.BookingDescription(childComplexity), true
 
-	case "CalendarAvailabilityResponse.bookingTitle":
-		if e.complexity.CalendarAvailabilityResponse.BookingTitle == nil {
+	case "CalendarAvailabilityDetailsResponse.bookingFormEmailEnabled":
+		if e.complexity.CalendarAvailabilityDetailsResponse.BookingFormEmailEnabled == nil {
 			break
 		}
 
-		return e.complexity.CalendarAvailabilityResponse.BookingTitle(childComplexity), true
+		return e.complexity.CalendarAvailabilityDetailsResponse.BookingFormEmailEnabled(childComplexity), true
+
+	case "CalendarAvailabilityDetailsResponse.bookingFormNameEnabled":
+		if e.complexity.CalendarAvailabilityDetailsResponse.BookingFormNameEnabled == nil {
+			break
+		}
+
+		return e.complexity.CalendarAvailabilityDetailsResponse.BookingFormNameEnabled(childComplexity), true
+
+	case "CalendarAvailabilityDetailsResponse.bookingFormPhoneEnabled":
+		if e.complexity.CalendarAvailabilityDetailsResponse.BookingFormPhoneEnabled == nil {
+			break
+		}
+
+		return e.complexity.CalendarAvailabilityDetailsResponse.BookingFormPhoneEnabled(childComplexity), true
+
+	case "CalendarAvailabilityDetailsResponse.bookingFormPhoneRequired":
+		if e.complexity.CalendarAvailabilityDetailsResponse.BookingFormPhoneRequired == nil {
+			break
+		}
+
+		return e.complexity.CalendarAvailabilityDetailsResponse.BookingFormPhoneRequired(childComplexity), true
+
+	case "CalendarAvailabilityDetailsResponse.bookingTitle":
+		if e.complexity.CalendarAvailabilityDetailsResponse.BookingTitle == nil {
+			break
+		}
+
+		return e.complexity.CalendarAvailabilityDetailsResponse.BookingTitle(childComplexity), true
+
+	case "CalendarAvailabilityDetailsResponse.durationMins":
+		if e.complexity.CalendarAvailabilityDetailsResponse.DurationMins == nil {
+			break
+		}
+
+		return e.complexity.CalendarAvailabilityDetailsResponse.DurationMins(childComplexity), true
+
+	case "CalendarAvailabilityDetailsResponse.location":
+		if e.complexity.CalendarAvailabilityDetailsResponse.Location == nil {
+			break
+		}
+
+		return e.complexity.CalendarAvailabilityDetailsResponse.Location(childComplexity), true
+
+	case "CalendarAvailabilityDetailsResponse.tenantLogoUrl":
+		if e.complexity.CalendarAvailabilityDetailsResponse.TenantLogoURL == nil {
+			break
+		}
+
+		return e.complexity.CalendarAvailabilityDetailsResponse.TenantLogoURL(childComplexity), true
+
+	case "CalendarAvailabilityDetailsResponse.tenantName":
+		if e.complexity.CalendarAvailabilityDetailsResponse.TenantName == nil {
+			break
+		}
+
+		return e.complexity.CalendarAvailabilityDetailsResponse.TenantName(childComplexity), true
 
 	case "CalendarAvailabilityResponse.days":
 		if e.complexity.CalendarAvailabilityResponse.Days == nil {
@@ -3310,34 +3375,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.CalendarAvailabilityResponse.Days(childComplexity), true
-
-	case "CalendarAvailabilityResponse.durationMins":
-		if e.complexity.CalendarAvailabilityResponse.DurationMins == nil {
-			break
-		}
-
-		return e.complexity.CalendarAvailabilityResponse.DurationMins(childComplexity), true
-
-	case "CalendarAvailabilityResponse.location":
-		if e.complexity.CalendarAvailabilityResponse.Location == nil {
-			break
-		}
-
-		return e.complexity.CalendarAvailabilityResponse.Location(childComplexity), true
-
-	case "CalendarAvailabilityResponse.tenantLogoUrl":
-		if e.complexity.CalendarAvailabilityResponse.TenantLogoURL == nil {
-			break
-		}
-
-		return e.complexity.CalendarAvailabilityResponse.TenantLogoURL(childComplexity), true
-
-	case "CalendarAvailabilityResponse.tenantName":
-		if e.complexity.CalendarAvailabilityResponse.TenantName == nil {
-			break
-		}
-
-		return e.complexity.CalendarAvailabilityResponse.TenantName(childComplexity), true
 
 	case "Capability.active":
 		if e.complexity.Capability.Active == nil {
@@ -12164,6 +12201,30 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Query.BillableInfo(childComplexity), true
 
+	case "Query.calendar_availability":
+		if e.complexity.Query.CalendarAvailability == nil {
+			break
+		}
+
+		args, err := ec.field_Query_calendar_availability_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.CalendarAvailability(childComplexity, args["input"].(model.CalendarAvailabilityInput)), true
+
+	case "Query.calendar_availability_details":
+		if e.complexity.Query.CalendarAvailabilityDetails == nil {
+			break
+		}
+
+		args, err := ec.field_Query_calendar_availability_details_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.CalendarAvailabilityDetails(childComplexity, args["meetingBookingEventId"].(string)), true
+
 	case "Query.calendar_available_hours":
 		if e.complexity.Query.CalendarAvailableHours == nil {
 			break
@@ -12658,18 +12719,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.LogEntry(childComplexity, args["id"].(string)), true
-
-	case "Query.m":
-		if e.complexity.Query.M == nil {
-			break
-		}
-
-		args, err := ec.field_Query_m_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.M(childComplexity, args["input"].(model.CalendarAvailabilityInput)), true
 
 	case "Query.mailstack_CheckUnavailableDomains":
 		if e.complexity.Query.MailstackCheckUnavailableDomains == nil {
@@ -15293,12 +15342,19 @@ Response for calendar availability query
 """
 type CalendarAvailabilityResponse {
     days:               [DaySlot!]!
+}
+
+type CalendarAvailabilityDetailsResponse {
     location:           String!
     tenantName:         String!
     tenantLogoUrl:      String!
     durationMins:       Int64!
     bookingTitle:       String!
     bookingDescription: String!
+    bookingFormNameEnabled:     Boolean!
+    bookingFormEmailEnabled:    Boolean!
+    bookingFormPhoneEnabled:    Boolean!
+    bookingFormPhoneRequired:   Boolean!
 }
 
 type DaySlot {
@@ -15379,7 +15435,8 @@ extend type Query {
     """
     Get availability across all users in the tenant for a given time range
     """
-    m(input: CalendarAvailabilityInput!): CalendarAvailabilityResponse!
+    calendar_availability(input: CalendarAvailabilityInput!): CalendarAvailabilityResponse!
+    calendar_availability_details(meetingBookingEventId: ID!): CalendarAvailabilityDetailsResponse!
 
     """
     Get user's calendar available hours configuration
@@ -27593,6 +27650,62 @@ func (ec *executionContext) field_Query_attachment_argsID(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Query_calendar_availability_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query_calendar_availability_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_calendar_availability_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.CalendarAvailabilityInput, error) {
+	if _, ok := rawArgs["input"]; !ok {
+		var zeroVal model.CalendarAvailabilityInput
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNCalendarAvailabilityInput2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐCalendarAvailabilityInput(ctx, tmp)
+	}
+
+	var zeroVal model.CalendarAvailabilityInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_calendar_availability_details_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query_calendar_availability_details_argsMeetingBookingEventID(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["meetingBookingEventId"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_calendar_availability_details_argsMeetingBookingEventID(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (string, error) {
+	if _, ok := rawArgs["meetingBookingEventId"]; !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("meetingBookingEventId"))
+	if tmp, ok := rawArgs["meetingBookingEventId"]; ok {
+		return ec.unmarshalNID2string(ctx, tmp)
+	}
+
+	var zeroVal string
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Query_calendar_available_hours_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -28943,34 +29056,6 @@ func (ec *executionContext) field_Query_logEntry_argsID(
 	}
 
 	var zeroVal string
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_m_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := ec.field_Query_m_argsInput(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg0
-	return args, nil
-}
-func (ec *executionContext) field_Query_m_argsInput(
-	ctx context.Context,
-	rawArgs map[string]any,
-) (model.CalendarAvailabilityInput, error) {
-	if _, ok := rawArgs["input"]; !ok {
-		var zeroVal model.CalendarAvailabilityInput
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-	if tmp, ok := rawArgs["input"]; ok {
-		return ec.unmarshalNCalendarAvailabilityInput2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐCalendarAvailabilityInput(ctx, tmp)
-	}
-
-	var zeroVal model.CalendarAvailabilityInput
 	return zeroVal, nil
 }
 
@@ -34555,6 +34640,446 @@ func (ec *executionContext) fieldContext_Calendar_appSource(_ context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _CalendarAvailabilityDetailsResponse_location(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityDetailsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CalendarAvailabilityDetailsResponse_location(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Location, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CalendarAvailabilityDetailsResponse_location(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CalendarAvailabilityDetailsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CalendarAvailabilityDetailsResponse_tenantName(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityDetailsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CalendarAvailabilityDetailsResponse_tenantName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TenantName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CalendarAvailabilityDetailsResponse_tenantName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CalendarAvailabilityDetailsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CalendarAvailabilityDetailsResponse_tenantLogoUrl(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityDetailsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CalendarAvailabilityDetailsResponse_tenantLogoUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TenantLogoURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CalendarAvailabilityDetailsResponse_tenantLogoUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CalendarAvailabilityDetailsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CalendarAvailabilityDetailsResponse_durationMins(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityDetailsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CalendarAvailabilityDetailsResponse_durationMins(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DurationMins, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt642int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CalendarAvailabilityDetailsResponse_durationMins(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CalendarAvailabilityDetailsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CalendarAvailabilityDetailsResponse_bookingTitle(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityDetailsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingTitle(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BookingTitle, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CalendarAvailabilityDetailsResponse_bookingTitle(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CalendarAvailabilityDetailsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CalendarAvailabilityDetailsResponse_bookingDescription(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityDetailsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingDescription(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BookingDescription, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CalendarAvailabilityDetailsResponse_bookingDescription(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CalendarAvailabilityDetailsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CalendarAvailabilityDetailsResponse_bookingFormNameEnabled(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityDetailsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingFormNameEnabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BookingFormNameEnabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CalendarAvailabilityDetailsResponse_bookingFormNameEnabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CalendarAvailabilityDetailsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CalendarAvailabilityDetailsResponse_bookingFormEmailEnabled(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityDetailsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingFormEmailEnabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BookingFormEmailEnabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CalendarAvailabilityDetailsResponse_bookingFormEmailEnabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CalendarAvailabilityDetailsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CalendarAvailabilityDetailsResponse_bookingFormPhoneEnabled(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityDetailsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingFormPhoneEnabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BookingFormPhoneEnabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CalendarAvailabilityDetailsResponse_bookingFormPhoneEnabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CalendarAvailabilityDetailsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CalendarAvailabilityDetailsResponse_bookingFormPhoneRequired(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityDetailsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingFormPhoneRequired(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BookingFormPhoneRequired, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CalendarAvailabilityDetailsResponse_bookingFormPhoneRequired(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CalendarAvailabilityDetailsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CalendarAvailabilityResponse_days(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityResponse) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CalendarAvailabilityResponse_days(ctx, field)
 	if err != nil {
@@ -34600,270 +35125,6 @@ func (ec *executionContext) fieldContext_CalendarAvailabilityResponse_days(_ con
 				return ec.fieldContext_DaySlot_timeSlots(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type DaySlot", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CalendarAvailabilityResponse_location(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityResponse) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CalendarAvailabilityResponse_location(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Location, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CalendarAvailabilityResponse_location(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CalendarAvailabilityResponse",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CalendarAvailabilityResponse_tenantName(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityResponse) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CalendarAvailabilityResponse_tenantName(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.TenantName, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CalendarAvailabilityResponse_tenantName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CalendarAvailabilityResponse",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CalendarAvailabilityResponse_tenantLogoUrl(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityResponse) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CalendarAvailabilityResponse_tenantLogoUrl(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.TenantLogoURL, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CalendarAvailabilityResponse_tenantLogoUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CalendarAvailabilityResponse",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CalendarAvailabilityResponse_durationMins(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityResponse) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CalendarAvailabilityResponse_durationMins(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.DurationMins, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int64)
-	fc.Result = res
-	return ec.marshalNInt642int64(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CalendarAvailabilityResponse_durationMins(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CalendarAvailabilityResponse",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int64 does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CalendarAvailabilityResponse_bookingTitle(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityResponse) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CalendarAvailabilityResponse_bookingTitle(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.BookingTitle, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CalendarAvailabilityResponse_bookingTitle(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CalendarAvailabilityResponse",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _CalendarAvailabilityResponse_bookingDescription(ctx context.Context, field graphql.CollectedField, obj *model.CalendarAvailabilityResponse) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_CalendarAvailabilityResponse_bookingDescription(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.BookingDescription, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_CalendarAvailabilityResponse_bookingDescription(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "CalendarAvailabilityResponse",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -101900,8 +102161,8 @@ func (ec *executionContext) fieldContext_Query_global_Cache(_ context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_m(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_m(ctx, field)
+func (ec *executionContext) _Query_calendar_availability(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_calendar_availability(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -101914,7 +102175,7 @@ func (ec *executionContext) _Query_m(ctx context.Context, field graphql.Collecte
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().M(rctx, fc.Args["input"].(model.CalendarAvailabilityInput))
+		return ec.resolvers.Query().CalendarAvailability(rctx, fc.Args["input"].(model.CalendarAvailabilityInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -101931,7 +102192,7 @@ func (ec *executionContext) _Query_m(ctx context.Context, field graphql.Collecte
 	return ec.marshalNCalendarAvailabilityResponse2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐCalendarAvailabilityResponse(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_m(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_calendar_availability(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -101941,18 +102202,6 @@ func (ec *executionContext) fieldContext_Query_m(ctx context.Context, field grap
 			switch field.Name {
 			case "days":
 				return ec.fieldContext_CalendarAvailabilityResponse_days(ctx, field)
-			case "location":
-				return ec.fieldContext_CalendarAvailabilityResponse_location(ctx, field)
-			case "tenantName":
-				return ec.fieldContext_CalendarAvailabilityResponse_tenantName(ctx, field)
-			case "tenantLogoUrl":
-				return ec.fieldContext_CalendarAvailabilityResponse_tenantLogoUrl(ctx, field)
-			case "durationMins":
-				return ec.fieldContext_CalendarAvailabilityResponse_durationMins(ctx, field)
-			case "bookingTitle":
-				return ec.fieldContext_CalendarAvailabilityResponse_bookingTitle(ctx, field)
-			case "bookingDescription":
-				return ec.fieldContext_CalendarAvailabilityResponse_bookingDescription(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type CalendarAvailabilityResponse", field.Name)
 		},
@@ -101964,7 +102213,84 @@ func (ec *executionContext) fieldContext_Query_m(ctx context.Context, field grap
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_m_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Query_calendar_availability_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_calendar_availability_details(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_calendar_availability_details(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().CalendarAvailabilityDetails(rctx, fc.Args["meetingBookingEventId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.CalendarAvailabilityDetailsResponse)
+	fc.Result = res
+	return ec.marshalNCalendarAvailabilityDetailsResponse2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐCalendarAvailabilityDetailsResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_calendar_availability_details(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "location":
+				return ec.fieldContext_CalendarAvailabilityDetailsResponse_location(ctx, field)
+			case "tenantName":
+				return ec.fieldContext_CalendarAvailabilityDetailsResponse_tenantName(ctx, field)
+			case "tenantLogoUrl":
+				return ec.fieldContext_CalendarAvailabilityDetailsResponse_tenantLogoUrl(ctx, field)
+			case "durationMins":
+				return ec.fieldContext_CalendarAvailabilityDetailsResponse_durationMins(ctx, field)
+			case "bookingTitle":
+				return ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingTitle(ctx, field)
+			case "bookingDescription":
+				return ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingDescription(ctx, field)
+			case "bookingFormNameEnabled":
+				return ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingFormNameEnabled(ctx, field)
+			case "bookingFormEmailEnabled":
+				return ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingFormEmailEnabled(ctx, field)
+			case "bookingFormPhoneEnabled":
+				return ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingFormPhoneEnabled(ctx, field)
+			case "bookingFormPhoneRequired":
+				return ec.fieldContext_CalendarAvailabilityDetailsResponse_bookingFormPhoneRequired(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CalendarAvailabilityDetailsResponse", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_calendar_availability_details_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -132832,6 +133158,90 @@ func (ec *executionContext) _Calendar(ctx context.Context, sel ast.SelectionSet,
 	return out
 }
 
+var calendarAvailabilityDetailsResponseImplementors = []string{"CalendarAvailabilityDetailsResponse"}
+
+func (ec *executionContext) _CalendarAvailabilityDetailsResponse(ctx context.Context, sel ast.SelectionSet, obj *model.CalendarAvailabilityDetailsResponse) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, calendarAvailabilityDetailsResponseImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CalendarAvailabilityDetailsResponse")
+		case "location":
+			out.Values[i] = ec._CalendarAvailabilityDetailsResponse_location(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "tenantName":
+			out.Values[i] = ec._CalendarAvailabilityDetailsResponse_tenantName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "tenantLogoUrl":
+			out.Values[i] = ec._CalendarAvailabilityDetailsResponse_tenantLogoUrl(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "durationMins":
+			out.Values[i] = ec._CalendarAvailabilityDetailsResponse_durationMins(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "bookingTitle":
+			out.Values[i] = ec._CalendarAvailabilityDetailsResponse_bookingTitle(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "bookingDescription":
+			out.Values[i] = ec._CalendarAvailabilityDetailsResponse_bookingDescription(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "bookingFormNameEnabled":
+			out.Values[i] = ec._CalendarAvailabilityDetailsResponse_bookingFormNameEnabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "bookingFormEmailEnabled":
+			out.Values[i] = ec._CalendarAvailabilityDetailsResponse_bookingFormEmailEnabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "bookingFormPhoneEnabled":
+			out.Values[i] = ec._CalendarAvailabilityDetailsResponse_bookingFormPhoneEnabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "bookingFormPhoneRequired":
+			out.Values[i] = ec._CalendarAvailabilityDetailsResponse_bookingFormPhoneRequired(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var calendarAvailabilityResponseImplementors = []string{"CalendarAvailabilityResponse"}
 
 func (ec *executionContext) _CalendarAvailabilityResponse(ctx context.Context, sel ast.SelectionSet, obj *model.CalendarAvailabilityResponse) graphql.Marshaler {
@@ -132845,36 +133255,6 @@ func (ec *executionContext) _CalendarAvailabilityResponse(ctx context.Context, s
 			out.Values[i] = graphql.MarshalString("CalendarAvailabilityResponse")
 		case "days":
 			out.Values[i] = ec._CalendarAvailabilityResponse_days(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "location":
-			out.Values[i] = ec._CalendarAvailabilityResponse_location(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "tenantName":
-			out.Values[i] = ec._CalendarAvailabilityResponse_tenantName(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "tenantLogoUrl":
-			out.Values[i] = ec._CalendarAvailabilityResponse_tenantLogoUrl(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "durationMins":
-			out.Values[i] = ec._CalendarAvailabilityResponse_durationMins(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "bookingTitle":
-			out.Values[i] = ec._CalendarAvailabilityResponse_bookingTitle(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "bookingDescription":
-			out.Values[i] = ec._CalendarAvailabilityResponse_bookingDescription(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -145175,7 +145555,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "m":
+		case "calendar_availability":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -145184,7 +145564,29 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_m(ctx, field)
+				res = ec._Query_calendar_availability(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "calendar_availability_details":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_calendar_availability_details(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -150455,6 +150857,20 @@ func (ec *executionContext) marshalNCalendar2ᚖgithubᚗcomᚋcustomerosᚋcust
 		return graphql.Null
 	}
 	return ec._Calendar(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNCalendarAvailabilityDetailsResponse2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐCalendarAvailabilityDetailsResponse(ctx context.Context, sel ast.SelectionSet, v model.CalendarAvailabilityDetailsResponse) graphql.Marshaler {
+	return ec._CalendarAvailabilityDetailsResponse(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCalendarAvailabilityDetailsResponse2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐCalendarAvailabilityDetailsResponse(ctx context.Context, sel ast.SelectionSet, v *model.CalendarAvailabilityDetailsResponse) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CalendarAvailabilityDetailsResponse(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNCalendarAvailabilityInput2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐCalendarAvailabilityInput(ctx context.Context, v any) (model.CalendarAvailabilityInput, error) {

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -348,6 +348,19 @@ type Calendar struct {
 	AppSource     string       `json:"appSource"`
 }
 
+type CalendarAvailabilityDetailsResponse struct {
+	Location                 string `json:"location"`
+	TenantName               string `json:"tenantName"`
+	TenantLogoURL            string `json:"tenantLogoUrl"`
+	DurationMins             int64  `json:"durationMins"`
+	BookingTitle             string `json:"bookingTitle"`
+	BookingDescription       string `json:"bookingDescription"`
+	BookingFormNameEnabled   bool   `json:"bookingFormNameEnabled"`
+	BookingFormEmailEnabled  bool   `json:"bookingFormEmailEnabled"`
+	BookingFormPhoneEnabled  bool   `json:"bookingFormPhoneEnabled"`
+	BookingFormPhoneRequired bool   `json:"bookingFormPhoneRequired"`
+}
+
 // Input for calendar availability query
 type CalendarAvailabilityInput struct {
 	MeetingBookingEventID string    `json:"meetingBookingEventId"`
@@ -358,13 +371,7 @@ type CalendarAvailabilityInput struct {
 
 // Response for calendar availability query
 type CalendarAvailabilityResponse struct {
-	Days               []*DaySlot `json:"days"`
-	Location           string     `json:"location"`
-	TenantName         string     `json:"tenantName"`
-	TenantLogoURL      string     `json:"tenantLogoUrl"`
-	DurationMins       int64      `json:"durationMins"`
-	BookingTitle       string     `json:"bookingTitle"`
-	BookingDescription string     `json:"bookingDescription"`
+	Days []*DaySlot `json:"days"`
 }
 
 type Capability struct {

--- a/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
@@ -7,6 +7,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/data"
 	"sort"
 	"time"
 
@@ -61,81 +62,7 @@ func (r *queryResolver) CalendarTimezones(ctx context.Context) ([]string, error)
 	defer spans.Finish()
 
 	// Define comprehensive list of timezone locations
-	zones := []string{
-		// UTC and GMT
-		"Etc/UTC",
-		"Etc/GMT",
-
-		// Americas (UTC-10 to UTC-3)
-		"America/Adak",         // UTC-10
-		"Pacific/Honolulu",     // UTC-10
-		"America/Anchorage",    // UTC-9
-		"America/Los_Angeles",  // UTC-8
-		"America/Phoenix",      // UTC-7
-		"America/Denver",       // UTC-7
-		"America/Chicago",      // UTC-6
-		"America/Mexico_City",  // UTC-6
-		"America/New_York",     // UTC-5
-		"America/Toronto",      // UTC-5
-		"America/Caracas",      // UTC-4
-		"America/Halifax",      // UTC-4
-		"America/Santiago",     // UTC-4
-		"America/Sao_Paulo",    // UTC-3
-		"America/Buenos_Aires", // UTC-3
-
-		// Europe & Africa (UTC-1 to UTC+3)
-		"Atlantic/Azores",     // UTC-1
-		"Europe/London",       // UTC+0
-		"Europe/Dublin",       // UTC+0
-		"Europe/Lisbon",       // UTC+0
-		"Europe/Paris",        // UTC+1
-		"Europe/Berlin",       // UTC+1
-		"Europe/Madrid",       // UTC+1
-		"Europe/Rome",         // UTC+1
-		"Europe/Amsterdam",    // UTC+1
-		"Europe/Warsaw",       // UTC+1
-		"Europe/Stockholm",    // UTC+1
-		"Europe/Helsinki",     // UTC+2
-		"Europe/Athens",       // UTC+2
-		"Europe/Bucharest",    // UTC+2
-		"Europe/Kyiv",         // UTC+2
-		"Europe/Istanbul",     // UTC+3
-		"Europe/Moscow",       // UTC+3
-		"Africa/Cairo",        // UTC+2
-		"Africa/Johannesburg", // UTC+2
-		"Africa/Nairobi",      // UTC+3
-
-		// Asia (UTC+3 to UTC+9)
-		"Asia/Baghdad",   // UTC+3
-		"Asia/Dubai",     // UTC+4
-		"Asia/Tehran",    // UTC+3:30
-		"Asia/Kabul",     // UTC+4:30
-		"Asia/Karachi",   // UTC+5
-		"Asia/Kolkata",   // UTC+5:30
-		"Asia/Kathmandu", // UTC+5:45
-		"Asia/Dhaka",     // UTC+6
-		"Asia/Yangon",    // UTC+6:30
-		"Asia/Bangkok",   // UTC+7
-		"Asia/Jakarta",   // UTC+7
-		"Asia/Singapore", // UTC+8
-		"Asia/Shanghai",  // UTC+8
-		"Asia/Hong_Kong", // UTC+8
-		"Asia/Taipei",    // UTC+8
-		"Asia/Seoul",     // UTC+9
-		"Asia/Tokyo",     // UTC+9
-
-		// Oceania (UTC+8 to UTC+12)
-		"Australia/Perth",     // UTC+8
-		"Australia/Darwin",    // UTC+9:30
-		"Australia/Brisbane",  // UTC+10
-		"Australia/Adelaide",  // UTC+9:30
-		"Australia/Sydney",    // UTC+10
-		"Australia/Melbourne", // UTC+10
-		"Australia/Hobart",    // UTC+10
-		"Pacific/Noumea",      // UTC+11
-		"Pacific/Auckland",    // UTC+12
-		"Pacific/Fiji",        // UTC+12
-	}
+	zones := data.Timezones()
 
 	// Verify each timezone is valid
 	validZones := make([]string, 0, len(zones))

--- a/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
@@ -7,13 +7,14 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/data"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"sort"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
 	"github.com/customeros/customeros/packages/server/customer-os-api/mapper"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/data"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 )
 
@@ -34,9 +35,112 @@ func (r *mutationResolver) SaveCalendarAvailableHours(ctx context.Context, input
 	return mapper.MapUserCalendarAvailabilityEntityToModel(userCalendarAvailabilityEntity), nil
 }
 
-// M is the resolver for the m field.
-func (r *queryResolver) M(ctx context.Context, input model.CalendarAvailabilityInput) (*model.CalendarAvailabilityResponse, error) {
-	panic(fmt.Errorf("not implemented: M - m"))
+// CalendarAvailability is the resolver for the calendar_availability field.
+func (r *queryResolver) CalendarAvailability(ctx context.Context, input model.CalendarAvailabilityInput) (*model.CalendarAvailabilityResponse, error) {
+	spans, ctx := telemetry.StartGraphQLSpan(ctx, "QueryResolver.CalendarAvailability", graphql.GetOperationContext(ctx))
+	defer spans.Finish()
+	spans.LogObjectAsJson("input", input)
+
+	// Validate time range
+	if input.StartTime.After(input.EndTime) {
+		graphql.AddErrorf(ctx, "End time must be after start time")
+		return nil, fmt.Errorf("invalid time range: end time must be after start time")
+	}
+
+	// Convert input times to UTC for processing
+	startTimeUTC := input.StartTime.UTC()
+	endTimeUTC := input.EndTime.UTC()
+
+	spans.LogKV("startTimeUTC", startTimeUTC)
+	spans.LogKV("endTimeUTC", endTimeUTC)
+
+	tenant := common.GetTenantFromContext(ctx)
+
+	// Get meeting booking event details
+	meetingBookingEvent, err := r.Services.Repositories.PostgresRepositories.MeetingBookingEventRepository.GetById(ctx, tenant, input.MeetingBookingEventID)
+	if err != nil {
+		spans.TraceError(err)
+		graphql.AddErrorf(ctx, "Failed to get meeting booking event: %s", err.Error())
+		return nil, err
+	}
+	if meetingBookingEvent == nil {
+		graphql.AddErrorf(ctx, "Meeting booking event with id %s not found", input.MeetingBookingEventID)
+		return nil, nil
+	}
+
+	// Round up duration to nearest 5 minutes if needed
+	durationMins := meetingBookingEvent.DurationMins
+	if durationMins%5 != 0 {
+		durationMins = ((durationMins / 5) + 1) * 5
+	}
+
+	// Get calendar availability data using UTC times
+	availabilityResult, err := r.Services.CommonServices.MeetingService.GetCalendarAvailability(ctx, input.MeetingBookingEventID, startTimeUTC, endTimeUTC, input.Timezone)
+	if err != nil {
+		spans.TraceError(err)
+		graphql.AddErrorf(ctx, "Failed to get calendar availability: %s", err.Error())
+		return nil, err
+	}
+
+	// Convert availability data using mapper
+	daySlots := mapper.MapCalendarAvailabilityResultToDaySlotsModel(availabilityResult)
+
+	// Return response with meeting booking event details and availability data
+	return &model.CalendarAvailabilityResponse{
+		Days: daySlots,
+	}, nil
+}
+
+// CalendarAvailabilityDetails is the resolver for the calendar_availability_details field.
+func (r *queryResolver) CalendarAvailabilityDetails(ctx context.Context, meetingBookingEventID string) (*model.CalendarAvailabilityDetailsResponse, error) {
+	spans, ctx := telemetry.StartGraphQLSpan(ctx, "QueryResolver.CalendarAvailabilityDetails", graphql.GetOperationContext(ctx))
+	defer spans.Finish()
+	spans.LogKV("meetingBookingEventID", meetingBookingEventID)
+
+	tenant := common.GetTenantFromContext(ctx)
+
+	// Get meeting booking event details
+	meetingBookingEvent, err := r.Services.Repositories.PostgresRepositories.MeetingBookingEventRepository.GetById(ctx, tenant, meetingBookingEventID)
+	if err != nil {
+		spans.TraceError(err)
+		graphql.AddErrorf(ctx, "Failed to get meeting booking event: %s", err.Error())
+		return nil, err
+	}
+	if meetingBookingEvent == nil {
+		graphql.AddErrorf(ctx, "Meeting booking event with id %s not found", meetingBookingEventID)
+		return nil, nil
+	}
+
+	tenantSettings, err := r.Services.CommonServices.TenantSettingsService.GetTenantSettings(ctx)
+	if err != nil {
+		spans.TraceError(err)
+	}
+	tenantName := tenant
+	if tenantSettings != nil {
+		if tenantSettings.WorkspaceName != "" {
+			tenantName = tenantSettings.WorkspaceName
+		}
+	}
+
+	// Round up duration to nearest 5 minutes if needed
+	durationMins := meetingBookingEvent.DurationMins
+	if durationMins%5 != 0 {
+		durationMins = ((durationMins / 5) + 1) * 5
+	}
+
+	// Return response with meeting booking event details and availability data
+	return &model.CalendarAvailabilityDetailsResponse{
+		Location:                 meetingBookingEvent.Location,
+		TenantName:               tenantName,
+		TenantLogoURL:            "", // TODO: Get from tenant service when available
+		DurationMins:             durationMins,
+		BookingTitle:             meetingBookingEvent.Title,
+		BookingDescription:       meetingBookingEvent.Description,
+		BookingFormNameEnabled:   meetingBookingEvent.BookingFormNameEnabled,
+		BookingFormEmailEnabled:  meetingBookingEvent.BookingFormEmailEnabled,
+		BookingFormPhoneEnabled:  meetingBookingEvent.BookingFormPhoneEnabled,
+		BookingFormPhoneRequired: meetingBookingEvent.BookingFormPhoneRequired,
+	}, nil
 }
 
 // CalendarAvailableHours is the resolver for the calendar_available_hours field.

--- a/packages/server/customer-os-api/graphql/schemas/calendar.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/calendar.graphqls
@@ -26,12 +26,19 @@ Response for calendar availability query
 """
 type CalendarAvailabilityResponse {
     days:               [DaySlot!]!
+}
+
+type CalendarAvailabilityDetailsResponse {
     location:           String!
     tenantName:         String!
     tenantLogoUrl:      String!
     durationMins:       Int64!
     bookingTitle:       String!
     bookingDescription: String!
+    bookingFormNameEnabled:     Boolean!
+    bookingFormEmailEnabled:    Boolean!
+    bookingFormPhoneEnabled:    Boolean!
+    bookingFormPhoneRequired:   Boolean!
 }
 
 type DaySlot {
@@ -112,7 +119,8 @@ extend type Query {
     """
     Get availability across all users in the tenant for a given time range
     """
-    m(input: CalendarAvailabilityInput!): CalendarAvailabilityResponse!
+    calendar_availability(input: CalendarAvailabilityInput!): CalendarAvailabilityResponse!
+    calendar_availability_details(meetingBookingEventId: ID!): CalendarAvailabilityDetailsResponse!
 
     """
     Get user's calendar available hours configuration

--- a/packages/server/customer-os-api/rest/public/calendar.go
+++ b/packages/server/customer-os-api/rest/public/calendar.go
@@ -1,6 +1,7 @@
 package public
 
 import (
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/data"
 	"net/http"
 	"strconv"
 	"time"
@@ -252,5 +253,14 @@ func GetCalendarDetails(s *cosapi_services.Services) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, response)
+	}
+}
+
+func GetTimezones() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		spans, _ := telemetry.StartRestSpan(c.Request.Context(), "GetTimezones")
+		defer spans.Finish()
+
+		c.JSON(http.StatusOK, gin.H{"timezones": data.Timezones()})
 	}
 }

--- a/packages/server/customer-os-api/server/public_routes.go
+++ b/packages/server/customer-os-api/server/public_routes.go
@@ -101,6 +101,13 @@ func registerPublicRoutes(ctx context.Context, r *gin.Engine, s *cosapi_services
 	})
 
 	registerRoute(ctx, r, RouteConfig{
+		method:    "GET",
+		path:      "/calendar/timezones",
+		handler:   public.GetTimezones(),
+		routeType: RoutePublic,
+	})
+
+	registerRoute(ctx, r, RouteConfig{
 		method:    "POST",
 		path:      "/reveal",
 		handler:   h.WebsiteTrackerEvents.Handle(),

--- a/packages/server/customer-os-common-module/data/timezones.go
+++ b/packages/server/customer-os-common-module/data/timezones.go
@@ -1,0 +1,133 @@
+package data
+
+import (
+	"sort"
+)
+
+func Timezones() []string {
+	// Get all timezone names from the IANA database
+	zones := make([]string, 0)
+
+	// Add all IANA timezones
+	zones = append(zones, []string{
+		// Americas
+		"America/Adak", "America/Anchorage", "America/Anguilla", "America/Antigua", "America/Araguaina",
+		"America/Argentina/Buenos_Aires", "America/Argentina/Catamarca", "America/Argentina/Cordoba",
+		"America/Argentina/Jujuy", "America/Argentina/La_Rioja", "America/Argentina/Mendoza",
+		"America/Argentina/Rio_Gallegos", "America/Argentina/Salta", "America/Argentina/San_Juan",
+		"America/Argentina/San_Luis", "America/Argentina/Tucuman", "America/Argentina/Ushuaia",
+		"America/Aruba", "America/Asuncion", "America/Atikokan", "America/Bahia", "America/Bahia_Banderas",
+		"America/Barbados", "America/Belem", "America/Belize", "America/Blanc-Sablon", "America/Boa_Vista",
+		"America/Bogota", "America/Boise", "America/Cambridge_Bay", "America/Campo_Grande", "America/Cancun",
+		"America/Caracas", "America/Cayenne", "America/Cayman", "America/Chicago", "America/Chihuahua",
+		"America/Costa_Rica", "America/Creston", "America/Cuiaba", "America/Curacao", "America/Danmarkshavn",
+		"America/Dawson", "America/Dawson_Creek", "America/Denver", "America/Detroit", "America/Dominica",
+		"America/Edmonton", "America/Eirunepe", "America/El_Salvador", "America/Fort_Nelson", "America/Fortaleza",
+		"America/Glace_Bay", "America/Godthab", "America/Goose_Bay", "America/Grand_Turk", "America/Grenada",
+		"America/Guadeloupe", "America/Guatemala", "America/Guayaquil", "America/Guyana", "America/Halifax",
+		"America/Havana", "America/Hermosillo", "America/Indiana/Indianapolis", "America/Indiana/Knox",
+		"America/Indiana/Marengo", "America/Indiana/Petersburg", "America/Indiana/Tell_City", "America/Indiana/Vevay",
+		"America/Indiana/Vincennes", "America/Indiana/Winamac", "America/Inuvik", "America/Iqaluit", "America/Jamaica",
+		"America/Juneau", "America/Kentucky/Louisville", "America/Kentucky/Monticello", "America/Kralendijk",
+		"America/La_Paz", "America/Lima", "America/Los_Angeles", "America/Lower_Princes", "America/Maceio",
+		"America/Managua", "America/Manaus", "America/Marigot", "America/Martinique", "America/Matamoros",
+		"America/Mazatlan", "America/Menominee", "America/Merida", "America/Metlakatla", "America/Mexico_City",
+		"America/Miquelon", "America/Moncton", "America/Monterrey", "America/Montevideo", "America/Montserrat",
+		"America/Nassau", "America/New_York", "America/Nipigon", "America/Nome", "America/Noronha",
+		"America/North_Dakota/Beulah", "America/North_Dakota/Center", "America/North_Dakota/New_Salem",
+		"America/Nuuk", "America/Ojinaga", "America/Panama", "America/Pangnirtung", "America/Paramaribo",
+		"America/Phoenix", "America/Port-au-Prince", "America/Port_of_Spain", "America/Porto_Velho",
+		"America/Puerto_Rico", "America/Punta_Arenas", "America/Rainy_River", "America/Rankin_Inlet",
+		"America/Recife", "America/Regina", "America/Resolute", "America/Rio_Branco", "America/Santarem",
+		"America/Santiago", "America/Santo_Domingo", "America/Sao_Paulo", "America/Scoresbysund",
+		"America/Sitka", "America/St_Barthelemy", "America/St_Johns", "America/St_Kitts", "America/St_Lucia",
+		"America/St_Thomas", "America/St_Vincent", "America/Swift_Current", "America/Tegucigalpa",
+		"America/Thule", "America/Thunder_Bay", "America/Tijuana", "America/Toronto", "America/Tortola",
+		"America/Vancouver", "America/Whitehorse", "America/Winnipeg", "America/Yakutat", "America/Yellowknife",
+
+		// Europe
+		"Europe/Amsterdam", "Europe/Andorra", "Europe/Astrakhan", "Europe/Athens", "Europe/Belgrade",
+		"Europe/Berlin", "Europe/Bratislava", "Europe/Brussels", "Europe/Bucharest", "Europe/Budapest",
+		"Europe/Busingen", "Europe/Chisinau", "Europe/Copenhagen", "Europe/Dublin", "Europe/Gibraltar",
+		"Europe/Guernsey", "Europe/Helsinki", "Europe/Isle_of_Man", "Europe/Istanbul", "Europe/Jersey",
+		"Europe/Kaliningrad", "Europe/Kiev", "Europe/Kirov", "Europe/Lisbon", "Europe/Ljubljana",
+		"Europe/London", "Europe/Luxembourg", "Europe/Madrid", "Europe/Malta", "Europe/Mariehamn",
+		"Europe/Minsk", "Europe/Monaco", "Europe/Moscow", "Europe/Oslo", "Europe/Paris",
+		"Europe/Podgorica", "Europe/Prague", "Europe/Riga", "Europe/Rome", "Europe/Samara",
+		"Europe/San_Marino", "Europe/Sarajevo", "Europe/Saratov", "Europe/Simferopol", "Europe/Skopje",
+		"Europe/Sofia", "Europe/Stockholm", "Europe/Tallinn", "Europe/Tirane", "Europe/Ulyanovsk",
+		"Europe/Uzhgorod", "Europe/Vaduz", "Europe/Vatican", "Europe/Vienna", "Europe/Vilnius",
+		"Europe/Volgograd", "Europe/Warsaw", "Europe/Zagreb", "Europe/Zaporozhye", "Europe/Zurich",
+
+		// Asia
+		"Asia/Aden", "Asia/Almaty", "Asia/Amman", "Asia/Anadyr", "Asia/Aqtau", "Asia/Aqtobe", "Asia/Ashgabat",
+		"Asia/Atyrau", "Asia/Baghdad", "Asia/Bahrain", "Asia/Baku", "Asia/Bangkok", "Asia/Barnaul",
+		"Asia/Beirut", "Asia/Bishkek", "Asia/Brunei", "Asia/Chita", "Asia/Choibalsan", "Asia/Colombo",
+		"Asia/Damascus", "Asia/Dhaka", "Asia/Dili", "Asia/Dubai", "Asia/Dushanbe", "Asia/Famagusta",
+		"Asia/Gaza", "Asia/Hebron", "Asia/Ho_Chi_Minh", "Asia/Hong_Kong", "Asia/Hovd", "Asia/Irkutsk",
+		"Asia/Jakarta", "Asia/Jayapura", "Asia/Jerusalem", "Asia/Kabul", "Asia/Kamchatka", "Asia/Karachi",
+		"Asia/Kathmandu", "Asia/Khandyga", "Asia/Kolkata", "Asia/Krasnoyarsk", "Asia/Kuala_Lumpur",
+		"Asia/Kuching", "Asia/Kuwait", "Asia/Macau", "Asia/Magadan", "Asia/Makassar", "Asia/Manila",
+		"Asia/Muscat", "Asia/Nicosia", "Asia/Novokuznetsk", "Asia/Novosibirsk", "Asia/Omsk",
+		"Asia/Oral", "Asia/Phnom_Penh", "Asia/Pontianak", "Asia/Pyongyang", "Asia/Qatar", "Asia/Qostanay",
+		"Asia/Qyzylorda", "Asia/Riyadh", "Asia/Sakhalin", "Asia/Samarkand", "Asia/Seoul", "Asia/Shanghai",
+		"Asia/Singapore", "Asia/Srednekolymsk", "Asia/Taipei", "Asia/Tashkent", "Asia/Tbilisi",
+		"Asia/Tehran", "Asia/Thimphu", "Asia/Tokyo", "Asia/Tomsk", "Asia/Ulaanbaatar", "Asia/Urumqi",
+		"Asia/Ust-Nera", "Asia/Vientiane", "Asia/Vladivostok", "Asia/Yakutsk", "Asia/Yangon",
+		"Asia/Yekaterinburg", "Asia/Yerevan",
+
+		// Africa
+		"Africa/Abidjan", "Africa/Accra", "Africa/Addis_Ababa", "Africa/Algiers", "Africa/Asmara",
+		"Africa/Asmera", "Africa/Bamako", "Africa/Bangui", "Africa/Banjul", "Africa/Bissau",
+		"Africa/Blantyre", "Africa/Brazzaville", "Africa/Bujumbura", "Africa/Cairo", "Africa/Casablanca",
+		"Africa/Ceuta", "Africa/Conakry", "Africa/Dakar", "Africa/Dar_es_Salaam", "Africa/Djibouti",
+		"Africa/Douala", "Africa/El_Aaiun", "Africa/Freetown", "Africa/Gaborone", "Africa/Harare",
+		"Africa/Johannesburg", "Africa/Juba", "Africa/Kampala", "Africa/Khartoum", "Africa/Kigali",
+		"Africa/Kinshasa", "Africa/Lagos", "Africa/Libreville", "Africa/Lome", "Africa/Luanda",
+		"Africa/Lubumbashi", "Africa/Lusaka", "Africa/Malabo", "Africa/Maputo", "Africa/Maseru",
+		"Africa/Mbabane", "Africa/Mogadishu", "Africa/Monrovia", "Africa/Nairobi", "Africa/Ndjamena",
+		"Africa/Niamey", "Africa/Nouakchott", "Africa/Ouagadougou", "Africa/Porto-Novo", "Africa/Sao_Tome",
+		"Africa/Timbuktu", "Africa/Tripoli", "Africa/Tunis", "Africa/Windhoek",
+
+		// Pacific
+		"Pacific/Apia", "Pacific/Auckland", "Pacific/Bougainville", "Pacific/Chatham", "Pacific/Chuuk",
+		"Pacific/Easter", "Pacific/Efate", "Pacific/Enderbury", "Pacific/Fakaofo", "Pacific/Fiji",
+		"Pacific/Funafuti", "Pacific/Galapagos", "Pacific/Gambier", "Pacific/Guadalcanal", "Pacific/Guam",
+		"Pacific/Honolulu", "Pacific/Kiritimati", "Pacific/Kosrae", "Pacific/Kwajalein", "Pacific/Majuro",
+		"Pacific/Marquesas", "Pacific/Midway", "Pacific/Nauru", "Pacific/Niue", "Pacific/Norfolk",
+		"Pacific/Noumea", "Pacific/Pago_Pago", "Pacific/Palau", "Pacific/Pitcairn", "Pacific/Pohnpei",
+		"Pacific/Port_Moresby", "Pacific/Rarotonga", "Pacific/Saipan", "Pacific/Tahiti", "Pacific/Tarawa",
+		"Pacific/Tongatapu", "Pacific/Wake", "Pacific/Wallis",
+
+		// Atlantic
+		"Atlantic/Azores", "Atlantic/Bermuda", "Atlantic/Canary", "Atlantic/Cape_Verde", "Atlantic/Faroe",
+		"Atlantic/Madeira", "Atlantic/Reykjavik", "Atlantic/South_Georgia", "Atlantic/St_Helena",
+		"Atlantic/Stanley",
+
+		// Indian
+		"Indian/Antananarivo", "Indian/Chagos", "Indian/Christmas", "Indian/Cocos", "Indian/Comoro",
+		"Indian/Kerguelen", "Indian/Mahe", "Indian/Maldives", "Indian/Mauritius", "Indian/Mayotte",
+		"Indian/Reunion",
+
+		// Australia
+		"Australia/Adelaide", "Australia/Brisbane", "Australia/Broken_Hill", "Australia/Currie",
+		"Australia/Darwin", "Australia/Eucla", "Australia/Hobart", "Australia/Lindeman", "Australia/Lord_Howe",
+		"Australia/Melbourne", "Australia/Perth", "Australia/Sydney",
+
+		// Antarctica
+		"Antarctica/Casey", "Antarctica/Davis", "Antarctica/DumontDUrville", "Antarctica/Macquarie",
+		"Antarctica/Mawson", "Antarctica/McMurdo", "Antarctica/Palmer", "Antarctica/Rothera",
+		"Antarctica/Syowa", "Antarctica/Troll", "Antarctica/Vostok",
+
+		// Etc
+		"Etc/GMT", "Etc/GMT+1", "Etc/GMT+2", "Etc/GMT+3", "Etc/GMT+4", "Etc/GMT+5", "Etc/GMT+6",
+		"Etc/GMT+7", "Etc/GMT+8", "Etc/GMT+9", "Etc/GMT+10", "Etc/GMT+11", "Etc/GMT+12",
+		"Etc/GMT-1", "Etc/GMT-2", "Etc/GMT-3", "Etc/GMT-4", "Etc/GMT-5", "Etc/GMT-6",
+		"Etc/GMT-7", "Etc/GMT-8", "Etc/GMT-9", "Etc/GMT-10", "Etc/GMT-11", "Etc/GMT-12",
+		"Etc/GMT-13", "Etc/GMT-14", "Etc/UTC",
+	}...)
+
+	// Sort the timezones alphabetically
+	sort.Strings(zones)
+	return zones
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a public endpoint for timezones and refactors GraphQL queries for calendar availability and details.
> 
>   - **Endpoints**:
>     - Adds `GetTimezones` endpoint in `calendar.go` to return a list of timezones.
>     - Registers `/calendar/timezones` route in `public_routes.go`.
>   - **GraphQL Resolvers**:
>     - Adds `CalendarAvailability` and `CalendarAvailabilityDetails` resolvers in `calendar.resolvers.go`.
>     - Validates time range and fetches meeting booking event details.
>   - **GraphQL Schema**:
>     - Adds `CalendarAvailabilityDetailsResponse` type in `calendar.graphqls`.
>     - Updates `Query` type to include `calendar_availability` and `calendar_availability_details` queries.
>   - **Data**:
>     - Introduces `Timezones` function in `timezones.go` to provide a sorted list of IANA timezones.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 4b3371625d0c3132850443ba6f18e2d60acb834b. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->