### PR TITLE
Default meeting booking event

### DIFF
--- a/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
@@ -7,6 +7,8 @@ package resolver
 import (
 	"context"
 	"errors"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
+	postgresEntity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -71,6 +73,34 @@ func (r *mutationResolver) NylasConnect(ctx context.Context, input model.NylasCo
 	_, err = r.Services.CommonServices.MeetingService.SetDefaultUserCalendarAvailability(ctx, input.Email, utils.IfNotNilString(input.Timezone))
 	if err != nil {
 		spans.TraceError(err)
+	}
+
+	// Create default meeting booking event
+	meetingBookingEvents, err := r.Services.Repositories.PostgresRepositories.MeetingBookingEventRepository.GetAll(ctx, common.GetTenantFromContext(ctx))
+	if err != nil {
+		spans.TraceError(err)
+	}
+	if err == nil && len(meetingBookingEvents) == 0 {
+		defaultMeetingBookingEventEntity := postgresEntity.MeetingBookingEvent{
+			ParticipantEmails:                   []string{input.Email},
+			Title:                               "Product overview",
+			DurationMins:                        30,
+			BookingFormNameEnabled:              true,
+			BookingFormEmailEnabled:             true,
+			BookingFormPhoneEnabled:             false,
+			BookingFormPhoneRequired:            false,
+			AssignmentMethod:                    enum.MeetingBookingAssignmentMethodRoundRobinMaxAvailability,
+			BookOptionEnabled:                   false,
+			BookOptionMinNoticeMins:             240,
+			BookOptionDaysInAdvance:             30,
+			BookOptionBufferBetweenMeetingsMins: 15,
+			ShowLogo:                            false,
+			EmailNotificationEnabled:            true,
+		}
+		_, err = r.Services.Repositories.PostgresRepositories.MeetingBookingEventRepository.Save(ctx, &defaultMeetingBookingEventEntity)
+		if err != nil {
+			spans.TraceError(err)
+		}
 	}
 
 	return &model.NylasDetails{Connected: true}, nil


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds default meeting booking event creation in `NylasConnect()` with specific default settings if no events exist.
> 
>   - **Behavior**:
>     - Adds default meeting booking event creation in `NylasConnect()` in `nylas.resolvers.go`.
>     - Checks for existing events; if none, creates a new event with default settings (e.g., 30 mins duration, email notifications enabled).
>   - **Entities**:
>     - Uses `MeetingBookingEvent` from `postgresEntity` for event creation.
>     - Utilizes `MeetingBookingAssignmentMethodRoundRobinMaxAvailability` from `enum` for assignment method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 828d807b24d03ad22b00f9ff11d624c1ec3f4a3a. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->