### PR TITLE
patch: add tracker api

### DIFF
--- a/packages/server/leads/.env
+++ b/packages/server/leads/.env
@@ -1,4 +1,4 @@
-APP_PORT=8080
+APP_PORT="8080"
 API_KEY="customeros123"
 
 LEADS_POSTGRES_HOST=localhost

--- a/packages/server/leads/api/graphql/generated/generated.go
+++ b/packages/server/leads/api/graphql/generated/generated.go
@@ -420,7 +420,7 @@ type Webtracker {
   isCnameConfigured: Boolean!
   isProxyActive: Boolean!
   isArchived: Boolean!
-  lastEventAt: Time!
+  lastEventAt: Time
   createdAt: Time!
   updatedAt: Time
 }
@@ -1766,14 +1766,11 @@ func (ec *executionContext) _Webtracker_lastEventAt(ctx context.Context, field g
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(time.Time)
+	res := resTmp.(*time.Time)
 	fc.Result = res
-	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Webtracker_lastEventAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -4174,9 +4171,6 @@ func (ec *executionContext) _Webtracker(ctx context.Context, sel ast.SelectionSe
 			}
 		case "lastEventAt":
 			out.Values[i] = ec._Webtracker_lastEventAt(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "createdAt":
 			out.Values[i] = ec._Webtracker_createdAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/packages/server/leads/api/graphql/graphql_model/models_gen.go
+++ b/packages/server/leads/api/graphql/graphql_model/models_gen.go
@@ -38,7 +38,7 @@ type Webtracker struct {
 	IsCnameConfigured bool       `json:"isCnameConfigured"`
 	IsProxyActive     bool       `json:"isProxyActive"`
 	IsArchived        bool       `json:"isArchived"`
-	LastEventAt       time.Time  `json:"lastEventAt"`
+	LastEventAt       *time.Time `json:"lastEventAt,omitempty"`
 	CreatedAt         time.Time  `json:"createdAt"`
 	UpdatedAt         *time.Time `json:"updatedAt,omitempty"`
 }

--- a/packages/server/leads/api/graphql/mappers/webtracker.go
+++ b/packages/server/leads/api/graphql/mappers/webtracker.go
@@ -14,7 +14,7 @@ func ToWebtrackerGraphQL(w *models.WebTracker) *graphql_model.Webtracker {
 		IsCnameConfigured: w.IsCNAMEConfigured,
 		IsProxyActive:     w.IsProxyActive,
 		IsArchived:        w.IsArchived,
-		LastEventAt:       *w.LastEventAt,
+		LastEventAt:       w.LastEventAt,
 		CreatedAt:         w.CreatedAt,
 		UpdatedAt:         w.UpdatedAt,
 	}
@@ -29,7 +29,7 @@ func ToWebtrackerDBModel(dto *graphql_model.Webtracker) *models.WebTracker {
 		IsCNAMEConfigured: dto.IsCnameConfigured,
 		IsProxyActive:     dto.IsProxyActive,
 		IsArchived:        dto.IsArchived,
-		LastEventAt:       &dto.LastEventAt,
+		LastEventAt:       dto.LastEventAt,
 		CreatedAt:         dto.CreatedAt,
 		UpdatedAt:         dto.UpdatedAt,
 	}

--- a/packages/server/leads/api/graphql/resolver/webtracker_resolvers.go
+++ b/packages/server/leads/api/graphql/resolver/webtracker_resolvers.go
@@ -21,15 +21,13 @@ func (r *mutationResolver) CreateWebtracker(ctx context.Context, tracker graphql
 	defer span.Finish()
 
 	cnameHost := ""
-	switch {
-	case tracker.CnameHost == nil && *tracker.CnameHost == "":
-		// do nothing
-	case utils.IsLowerAlphanumeric(*tracker.CnameHost):
+	if tracker.CnameHost != nil {
 		cnameHost = *tracker.CnameHost
-	default:
-		err := errors.New("Invalid CNAME Host")
-		span.TraceError(err)
-		return nil, err
+		if !utils.IsLowerAlphanumeric(cnameHost) {
+			err := errors.New("Invalid CNAME Host")
+			span.TraceError(err)
+			return nil, err
+		}
 	}
 
 	newTracker := &models.WebTracker{
@@ -38,7 +36,13 @@ func (r *mutationResolver) CreateWebtracker(ctx context.Context, tracker graphql
 		CNAMEHost: cnameHost,
 	}
 
-	return mappers.ToWebtrackerGraphQL(newTracker), nil
+	createdWebtracker, err := r.services.WebtrackerService.CreateWebtracker(ctx, newTracker)
+	if err != nil {
+		span.TraceError(err)
+		return nil, err
+	}
+
+	return mappers.ToWebtrackerGraphQL(createdWebtracker), nil
 }
 
 // UpdateWebtracker is the resolver for the updateWebtracker field.
@@ -46,25 +50,29 @@ func (r *mutationResolver) UpdateWebtracker(ctx context.Context, tracker graphql
 	span, ctx := telemetry.StartGraphQLSpan(ctx, "graphQLResolvers.UpdateWebtracker")
 	defer span.Finish()
 
+	if tracker.ID == nil || *tracker.ID == "" {
+		err := errors.New("ID is required to update webtracker")
+		span.TraceError(err)
+		return nil, err
+	}
+
 	cnameHost := ""
-	switch {
-	case tracker.CnameHost == nil && *tracker.CnameHost == "":
-		err := errors.New("cnameHost is empty")
-		span.TraceError(err)
-		return nil, err
-	case !utils.IsLowerAlphanumeric(*tracker.CnameHost):
-		err := errors.New("Invalid cnameHost")
-		span.TraceError(err)
-		return nil, err
-	default:
+	if tracker.CnameHost != nil {
 		cnameHost = *tracker.CnameHost
-		updatedTracker, err := r.services.WebtrackerService.UpdateCNAMEHost(ctx, cnameHost)
-		if err != nil {
+		if !utils.IsLowerAlphanumeric(cnameHost) {
+			err := errors.New("Invalid CNAME Host")
 			span.TraceError(err)
 			return nil, err
 		}
-		return mappers.ToWebtrackerGraphQL(updatedTracker), nil
 	}
+
+	updatedTracker, err := r.services.WebtrackerService.UpdateCNAMEHost(ctx, cnameHost)
+	if err != nil {
+		span.TraceError(err)
+		return nil, err
+	}
+
+	return mappers.ToWebtrackerGraphQL(updatedTracker), nil
 }
 
 // VerifyWebtrackerCname is the resolver for the verifyWebtrackerCname field.

--- a/packages/server/leads/api/graphql/schemas/webtracker.graphqls
+++ b/packages/server/leads/api/graphql/schemas/webtracker.graphqls
@@ -12,7 +12,7 @@ type Webtracker {
   isCnameConfigured: Boolean!
   isProxyActive: Boolean!
   isArchived: Boolean!
-  lastEventAt: Time!
+  lastEventAt: Time
   createdAt: Time!
   updatedAt: Time
 }

--- a/packages/server/leads/api/handlers/init.go
+++ b/packages/server/leads/api/handlers/init.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"github.com/customeros/customeros/packages/server/leads/internal/repository"
 	"github.com/customeros/customeros/packages/server/leads/services"
 )
 
@@ -9,7 +8,7 @@ type APIHandlers struct {
 	WebEvents *WebsiteEventsHandler
 }
 
-func InitHandlers(services *services.Services, r *repository.Repositories) *APIHandlers {
+func InitHandlers(services *services.Services) *APIHandlers {
 	return &APIHandlers{
 		WebEvents: NewWebsiteEventsHandler(services),
 	}

--- a/packages/server/leads/api/middleware/context.go
+++ b/packages/server/leads/api/middleware/context.go
@@ -1,9 +1,11 @@
 package middleware
 
 import (
+	"context"
+
 	"github.com/gin-gonic/gin"
 
-	"github.com/customeros/mailstack/internal/utils"
+	"github.com/customeros/customeros/packages/server/leads/internal/utils"
 )
 
 // CustomContextMiddleware adds custom context to all requests
@@ -13,4 +15,19 @@ func CustomContextMiddleware() gin.HandlerFunc {
 		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	}
+}
+
+// GinContextToContextMiddleware adds the Gin context to the request context
+func GinContextToContextMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := context.WithValue(c.Request.Context(), ginContextKey{}, c)
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}
+
+// GinContextFromContext extracts the Gin context from a context
+func GinContextFromContext(ctx context.Context) (*gin.Context, bool) {
+	ginContext, ok := ctx.Value(ginContextKey{}).(*gin.Context)
+	return ginContext, ok
 }

--- a/packages/server/leads/api/middleware/tenant.go
+++ b/packages/server/leads/api/middleware/tenant.go
@@ -8,6 +8,8 @@ import (
 	"github.com/customeros/customeros/packages/server/leads/internal/utils"
 )
 
+type ginContextKey struct{}
+
 func TenantValidationMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tenant := ""

--- a/packages/server/leads/api/routes.go
+++ b/packages/server/leads/api/routes.go
@@ -8,32 +8,32 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler/lru"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
-	"github.com/customeros/mailstack/api/middleware"
 	"github.com/gin-gonic/gin"
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/customeros/customeros/packages/server/leads/api/graphql/generated"
 	"github.com/customeros/customeros/packages/server/leads/api/graphql/resolver"
 	"github.com/customeros/customeros/packages/server/leads/api/handlers"
+	"github.com/customeros/customeros/packages/server/leads/api/middleware"
 	"github.com/customeros/customeros/packages/server/leads/internal/config"
-	"github.com/customeros/customeros/packages/server/leads/internal/repository"
+	"github.com/customeros/customeros/packages/server/leads/internal/utils"
 	"github.com/customeros/customeros/packages/server/leads/services"
 )
 
 // RegisterRoutes sets up all API endpoints
-func RegisterRoutes(ctx context.Context, r *gin.Engine, services *services.Services, repos *repository.Repositories, config *config.AppConfig) {
+func RegisterRoutes(ctx context.Context, r *gin.Engine, services *services.Services, config *config.AppConfig) *handlers.APIHandlers {
 	if services == nil {
 		panic("Services cannot be nil")
 	}
-	if repos == nil {
-		panic("Repositories cannot be nil")
+	if config == nil {
+		panic("Config cannot be nil")
 	}
 
 	// Add recovery middlewares
 	r.Use(gin.Recovery()) // Gin's built-in recovery
 
 	// setup handlers
-	apiHandlers := handlers.InitHandlers(services, repos)
+	apiHandlers := handlers.InitHandlers(services)
 
 	// Health check and status endpoints (no custom context needed)
 	r.GET("/health", handlers.HealthCheck)
@@ -43,9 +43,8 @@ func RegisterRoutes(ctx context.Context, r *gin.Engine, services *services.Servi
 	{
 		// Domain endpoints
 		events := api.Group("/events")
-		events.Use(middleware.TenantValidationMiddleware()) // Tenant validation for domains
-		events.Use(middleware.CustomContextMiddleware())    // Add custom context
-		events.Use(middleware.TracingMiddleware(ctx))       // Add tracing with parent context
+		events.Use(middleware.CustomContextMiddleware()) // Add custom context
+		events.Use(middleware.TracingMiddleware(ctx))    // Add tracing with parent context
 		{
 			events.POST("", apiHandlers.WebEvents.Handle())
 		}
@@ -73,6 +72,8 @@ func RegisterRoutes(ctx context.Context, r *gin.Engine, services *services.Servi
 	{
 		query.POST("", graphqlHandler) // query
 	}
+
+	return apiHandlers
 }
 
 // SetupGraphQLServer configures and returns the GraphQL server and playground handlers
@@ -82,7 +83,9 @@ func SetupGraphQLServer(services *services.Services) (graphqlHandler, playground
 
 	// Create a new schema with your resolvers
 	schema := generated.NewExecutableSchema(generated.Config{
-		Resolvers: resolver,
+		Resolvers:  resolver,
+		Directives: generated.DirectiveRoot{},
+		Complexity: generated.ComplexityRoot{},
 	})
 
 	// Create the GraphQL server with custom options
@@ -103,6 +106,16 @@ func SetupGraphQLServer(services *services.Services) (graphqlHandler, playground
 	// Create playground handler
 	playground := playground.Handler("GraphQL", "/query")
 
-	// Return handlers wrapped for Gin
-	return gin.WrapH(srv), gin.WrapH(playground)
+	// Return handlers wrapped for Gin with our custom middleware
+	return func(c *gin.Context) {
+		// Explicitly add the Gin context to the request context
+		ginCtx := middleware.GinContextToContextMiddleware()
+		ginCtx(c)
+
+		// Add custom middleware to extract tenant from Gin context
+		c.Request = c.Request.WithContext(utils.WithTenantContext(c.Request.Context(), c.GetString("Tenant")))
+
+		// Call the GraphQL handler
+		srv.ServeHTTP(c.Writer, c.Request)
+	}, gin.WrapH(playground)
 }

--- a/packages/server/leads/errors/errors.go
+++ b/packages/server/leads/errors/errors.go
@@ -6,4 +6,5 @@ var (
 	ErrTenantMissing      = errors.New("Tenant not set on context")
 	ErrUserIdMissing      = errors.New("UserID not set on context")
 	ErrWebtrackerNotFound = errors.New("Webtracker not found")
+	ErrWebtrackerExists   = errors.New("Webtracker already exists")
 )

--- a/packages/server/leads/internal/config/config.go
+++ b/packages/server/leads/internal/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 type AppConfig struct {
-	APIPort     string `env:"API_PORT,required" envDefault:"16600"`
+	APIPort     string `env:"API_PORT,required" envDefault:"8080"`
 	APIKey      string `env:"API_KEY,required"`
 	Environment string `env:"ENVIRONMENT,required" envDefault:"dev"`
 }

--- a/packages/server/leads/internal/models/outbox_event.go
+++ b/packages/server/leads/internal/models/outbox_event.go
@@ -9,14 +9,13 @@ import (
 type OutboxEvent struct {
 	ID           string            `gorm:"column:id;primaryKey;type:varchar(50);"`
 	EventType    enum.Events       `gorm:"column:event_type;type:varchar(100);index;not null"`
-	Payload      []byte            `gorm:"column:payload;type:jsonb;not null"`
+	Payload      []byte            `gorm:"column:payload;type:bytea;not null"`
 	Status       enum.OutboxStatus `gorm:"column:status;type:varchar(20);index;not null"`
 	CreatedAt    time.Time         `gorm:"column:created_at;not null;index"`      // When the event was created
 	ProcessedAt  *time.Time        `gorm:"column:processed_at;"`                  // When the event was processed
 	RetryCount   int               `gorm:"column:retry_count;type:int;default:0"` // For error handling
 	ErrorMessage string            `gorm:"column:error_message;type:text;"`       // Last error message if failed
 	LockUntil    *time.Time        `gorm:"column:lock_until;index"`               // For distributed processing
-	Version      int               `gorm:"column:version;type:int;default:1"`     // For optimistic locking
 }
 
 func (OutboxEvent) TableName() string {

--- a/packages/server/leads/internal/repository/init.go
+++ b/packages/server/leads/internal/repository/init.go
@@ -1,7 +1,13 @@
 package repository
 
 import (
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/customeros/customeros/packages/server/leads/internal/config"
 	"github.com/customeros/customeros/packages/server/leads/internal/database"
+	"github.com/customeros/customeros/packages/server/leads/internal/models"
 )
 
 type Repositories struct {
@@ -20,4 +26,45 @@ func InitRepositories(leadsDB, warehouseDB *database.DbConnections) *Repositorie
 		WebEvent:             NewWebTrackerEventRepository(warehouseDB),
 		WebTracker:           NewWebTrackerRepository(leadsDB),
 	}
+}
+
+func MigrateLeadsDB(dbConfig *config.LeadsDatabaseConfig, leadsDB *gorm.DB) error {
+	db, err := leadsDB.DB()
+	if err != nil {
+		return err
+	}
+
+	db.SetMaxOpenConns(5)
+
+	err = leadsDB.AutoMigrate(
+		&models.IPIntelligence{},
+		&models.OutboxEvent{},
+		&models.WebTracker{},
+	)
+
+	db.SetMaxIdleConns(dbConfig.MaxIdleConn)
+	db.SetMaxOpenConns(dbConfig.MaxConn)
+	db.SetConnMaxLifetime(time.Duration(dbConfig.ConnMaxLifetime) * time.Minute)
+
+	return err
+}
+
+func MigrateDataWarehouse(dbConfig *config.DataWarehouseConfig, warehouseDB *gorm.DB) error {
+	db, err := warehouseDB.DB()
+	if err != nil {
+		return err
+	}
+
+	db.SetMaxOpenConns(5)
+
+	err = warehouseDB.AutoMigrate(
+		&models.APICallLog{},
+		&models.WebTrackerEvent{},
+	)
+
+	db.SetMaxIdleConns(dbConfig.MaxIdleConn)
+	db.SetMaxOpenConns(dbConfig.MaxConn)
+	db.SetConnMaxLifetime(time.Duration(dbConfig.ConnMaxLifetime) * time.Minute)
+
+	return err
 }

--- a/packages/server/leads/internal/repository/webtracker.go
+++ b/packages/server/leads/internal/repository/webtracker.go
@@ -49,6 +49,14 @@ func (r *webTrackerRepository) Create(ctx context.Context, tracker *models.WebTr
 	span, ctx := telemetry.StartPostgresSpan(ctx, "webTrackerRepository.Create")
 	defer span.Finish()
 
+	tenant := utils.GetTenantFromContext(ctx)
+	if tenant == "" {
+		err := leads_errors.ErrTenantMissing
+		span.TraceError(err)
+		return err
+	}
+	tracker.Tenant = tenant
+
 	if tracker.ID == "" {
 		tracker.ID = uuid.New().String()
 	}
@@ -60,6 +68,19 @@ func (r *webTrackerRepository) Create(ctx context.Context, tracker *models.WebTr
 func (r *webTrackerRepository) CreateWithTxn(ctx context.Context, txn *gorm.DB, tracker *models.WebTracker) error {
 	span, ctx := telemetry.StartPostgresSpan(ctx, "webTrackerRepository.Create")
 	defer span.Finish()
+
+	tenant := utils.GetTenantFromContext(ctx)
+	if tenant == "" {
+		err := leads_errors.ErrTenantMissing
+		span.TraceError(err)
+		return err
+	}
+	tracker.Tenant = tenant
+
+	// Generate ID if not provided
+	if tracker.ID == "" {
+		tracker.ID = uuid.New().String()
+	}
 
 	return txn.Create(tracker).Error
 }
@@ -94,21 +115,13 @@ func (r *webTrackerRepository) GetByDomain(ctx context.Context, domain string) (
 	span, ctx := telemetry.StartPostgresSpan(ctx, "webTrackerRepository.GetByDomain")
 	defer span.Finish()
 
-	tenant := utils.GetTenantFromContext(ctx)
-	if tenant == "" {
-		err := leads_errors.ErrTenantMissing
-		span.TraceError(err)
-		return nil, err
-	}
-
 	var tracker models.WebTracker
 	result := r.read.WithContext(ctx).
 		Where("domain = ?", domain).
-		Where("tenant = ?", tenant).
 		First(&tracker)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, leads_errors.ErrWebtrackerNotFound
+			return nil, nil
 		}
 		return nil, result.Error
 	}

--- a/packages/server/leads/internal/server/server.go
+++ b/packages/server/leads/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/customeros/customeros/packages/server/leads/api"
 	"github.com/customeros/customeros/packages/server/leads/api/handlers"
 	"github.com/customeros/customeros/packages/server/leads/internal/config"
 	"github.com/customeros/customeros/packages/server/leads/internal/cron"
@@ -64,14 +65,14 @@ func NewServer(cfg *config.Config, leadsDB *database.DbConnections, warehouseDB 
 	}
 
 	// Initialize services
-	svcs := services.InitServices(natsConn, repos, cfg)
+	svcs := services.InitServices(cfg, leadsDB, natsConn, repos)
 
 	// Initialize Gin
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.Default()
 
-	// Initialize API Handlers
-	handlers := handlers.InitHandlers(svcs, repos)
+	// register API Routes
+	handlers := api.RegisterRoutes(context.Background(), router, svcs, cfg.AppConfig)
 
 	// Try to get Kubernetes config
 	var k8sClient kubernetes.Interface
@@ -147,13 +148,14 @@ func (s *Server) Run() error {
 
 	// Start HTTP server in a goroutine with panic recovery
 	go s.wrapGoroutine("http_server", func() {
-		log.Println("Starting HTTP server")
-		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		err := s.httpServer.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
 			log.Printf("❌ HTTP server error: %v", err)
 		}
 	})
 	log.Println("✅ HTTP server started successfully")
-	log.Println("EventStraem is now running. Press Ctrl+C to exit.")
+	log.Printf("Leads is now running and listening on port %s. Press Ctrl+C to exit.", s.httpServer.Addr)
+	fmt.Println("")
 
 	return s.waitForShutdown()
 }

--- a/packages/server/leads/justfile
+++ b/packages/server/leads/justfile
@@ -29,5 +29,7 @@ run:
 tidy:
     go mod tidy
 
+warehouse:
+    pgcli postgresql://postgres:password@localhost:5556/warehouse
 
 

--- a/packages/server/leads/main.go
+++ b/packages/server/leads/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/customeros/customeros/packages/server/leads/internal/config"
 	"github.com/customeros/customeros/packages/server/leads/internal/database"
+	"github.com/customeros/customeros/packages/server/leads/internal/repository"
 	"github.com/customeros/customeros/packages/server/leads/internal/server"
 )
 
@@ -60,7 +61,7 @@ func main() {
 		log.Fatalf("Openline database initialization failed: %v", err)
 	}
 
-	err = runDBMigration()
+	err = runDBMigration(cfg, leadsDB, warehouseDB)
 	if err != nil {
 		log.Fatalf("Database migration failed...")
 	}
@@ -80,6 +81,19 @@ func main() {
 	}
 }
 
-func runDBMigration() error {
+func runDBMigration(config *config.Config, leadsDB, warehouseDB *database.DbConnections) error {
+	log.Println("Migrating Leads DB...")
+
+	err := repository.MigrateLeadsDB(config.LeadsDatabaseConfig, leadsDB.WriteDB)
+	if err != nil {
+		return err
+	}
+
+	log.Println("Migrating Warehouse DB...")
+	err = repository.MigrateDataWarehouse(config.DataWarehouseConfig, warehouseDB.WriteDB)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/packages/server/leads/services/init.go
+++ b/packages/server/leads/services/init.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/customeros/customeros/packages/server/leads/interfaces"
 	"github.com/customeros/customeros/packages/server/leads/internal/config"
+	"github.com/customeros/customeros/packages/server/leads/internal/database"
 	nats_internal "github.com/customeros/customeros/packages/server/leads/internal/nats"
 	"github.com/customeros/customeros/packages/server/leads/internal/repository"
 	"github.com/customeros/customeros/packages/server/leads/services/ipdata"
 	"github.com/customeros/customeros/packages/server/leads/services/proxy_manager"
+	"github.com/customeros/customeros/packages/server/leads/services/session_manager"
 	"github.com/customeros/customeros/packages/server/leads/services/snitcher"
 	"github.com/customeros/customeros/packages/server/leads/services/web_event_processor"
 	"github.com/customeros/customeros/packages/server/leads/services/webtracker"
@@ -31,6 +33,12 @@ func (s *Services) Stop(ctx context.Context) {
 	return
 }
 
-func InitServices(natsConn *nats_internal.NATSConnections, repositories *repository.Repositories, config *config.Config) *Services {
-	return nil
+func InitServices(config *config.Config, leadsDB *database.DbConnections, natsConn *nats_internal.NATSConnections, repositories *repository.Repositories) *Services {
+	return &Services{
+		IPDataService:     ipdata.NewIPDataService(config.IPDataConfig, natsConn, repositories),
+		SessionManager:    session_manager.NewSessionManager(natsConn, repositories),
+		SnitcherService:   snitcher.NewSnitcherService(config.SnitcherConfig, repositories, natsConn),
+		WebEventProcessor: web_event_processor.NewWebEventProcessor(natsConn, leadsDB.WriteDB, repositories),
+		WebtrackerService: webtracker.NewWebtrackerService(leadsDB.WriteDB, repositories),
+	}
 }

--- a/packages/server/leads/services/web_event_processor/process.go
+++ b/packages/server/leads/services/web_event_processor/process.go
@@ -114,7 +114,7 @@ func (s *webEventProcessor) logWebtrackerEvent(ctx context.Context, webtrackerID
 	span, ctx := telemetry.StartServiceSpan(ctx, "webEventProcessor.logWebtrackerEvent")
 	defer span.Finish()
 
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.leadsWriteDB.Transaction(func(tx *gorm.DB) error {
 		// Update the WebTracker's last event timestamp
 		err := s.repositories.WebTracker.UpdateLastEventAtWithTxn(ctx, tx, webtrackerID, event.Timestamp)
 		if err != nil {

--- a/packages/server/leads/services/web_event_processor/service.go
+++ b/packages/server/leads/services/web_event_processor/service.go
@@ -16,18 +16,18 @@ type WebEventProcessor interface {
 
 type webEventProcessor struct {
 	natsConn     *nats_internal.NATSConnections
-	db           *gorm.DB
+	leadsWriteDB *gorm.DB
 	repositories *repository.Repositories
 }
 
 func NewWebEventProcessor(
 	natsConn *nats_internal.NATSConnections,
-	db *gorm.DB,
+	leadsWriteDB *gorm.DB,
 	repositories *repository.Repositories,
 ) WebEventProcessor {
 	return &webEventProcessor{
 		natsConn:     natsConn,
-		db:           db,
+		leadsWriteDB: leadsWriteDB,
 		repositories: repositories,
 	}
 }

--- a/packages/server/leads/services/webtracker/create_webtracker.go
+++ b/packages/server/leads/services/webtracker/create_webtracker.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"gorm.io/gorm"
 
+	leads_errors "github.com/customeros/customeros/packages/server/leads/errors"
 	"github.com/customeros/customeros/packages/server/leads/internal/enum"
 	"github.com/customeros/customeros/packages/server/leads/internal/models"
 	"github.com/customeros/customeros/packages/server/leads/internal/telemetry"
@@ -30,10 +31,16 @@ func (s *webtrackerService) CreateWebtracker(ctx context.Context, webtracker *mo
 		return nil, err
 	}
 
+	err = s.validateWebtrackerDoesNotExist(ctx, webtracker.Domain)
+	if err != nil {
+		span.TraceError(err)
+		return nil, err
+	}
+
 	webTrackerRecord := buildWebTrackerRecord(webtracker)
 
 	// Use transaction
-	err = s.db.Transaction(func(tx *gorm.DB) error {
+	err = s.leadsWriteDB.Transaction(func(tx *gorm.DB) error {
 		// Create webtracker
 		err := s.repositories.WebTracker.CreateWithTxn(ctx, tx, webTrackerRecord)
 		if err != nil {
@@ -64,6 +71,23 @@ func (s *webtrackerService) CreateWebtracker(ctx context.Context, webtracker *mo
 	}
 
 	return webTrackerRecord, nil
+}
+
+func (s *webtrackerService) validateWebtrackerDoesNotExist(ctx context.Context, domain string) error {
+	span, ctx := telemetry.StartServiceSpan(ctx, "webtrackerService.validateWebtrackerDoesNotExist")
+	defer span.Finish()
+
+	record, err := s.repositories.WebTracker.GetByDomain(ctx, domain)
+	if err != nil {
+		span.TraceError(err)
+		return err
+	}
+	if record != nil {
+		err := leads_errors.ErrWebtrackerExists
+		span.TraceError(err)
+		return err
+	}
+	return nil
 }
 
 func (s *webtrackerService) buildOutboxEventPayload(ctx context.Context, webtracker *models.WebTracker) ([]byte, error) {

--- a/packages/server/leads/services/webtracker/service.go
+++ b/packages/server/leads/services/webtracker/service.go
@@ -21,13 +21,13 @@ type WebtrackerService interface {
 }
 
 type webtrackerService struct {
-	db           *gorm.DB
+	leadsWriteDB *gorm.DB
 	repositories *repository.Repositories
 }
 
-func NewWebtrackerService(leadsDB *gorm.DB, repos *repository.Repositories) WebtrackerService {
+func NewWebtrackerService(leadsWriteDB *gorm.DB, repos *repository.Repositories) WebtrackerService {
 	return &webtrackerService{
-		db:           leadsDB,
+		leadsWriteDB: leadsWriteDB,
 		repositories: repos,
 	}
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR introduces a new tracker API with nullable `lastEventAt`, new middleware, updated GraphQL schema and resolvers, and enhanced server and database configurations.
> 
>   - **GraphQL Schema and Resolvers**:
>     - Made `lastEventAt` field nullable in `Webtracker` type in `generated.go`, `models_gen.go`, and `webtracker.graphqls`.
>     - Updated `CreateWebtracker` and `UpdateWebtracker` resolvers in `webtracker_resolvers.go` to handle nullable `lastEventAt`.
>   - **Middleware**:
>     - Added `GinContextToContextMiddleware` and `GinContextFromContext` in `context.go`.
>     - Updated `TenantValidationMiddleware` in `tenant.go` to store tenant in context.
>   - **Server and Routes**:
>     - Updated `RegisterRoutes` in `routes.go` to include new middleware and GraphQL setup.
>     - Modified `NewServer` in `server.go` to initialize services and handlers with new configurations.
>   - **Database and Models**:
>     - Updated `OutboxEvent` model in `outbox_event.go` to change `Payload` type to `bytea`.
>     - Added migration functions in `init.go` for leads and warehouse databases.
>   - **Services**:
>     - Implemented `CreateWebtracker` and `validateWebtrackerDoesNotExist` in `create_webtracker.go`.
>     - Updated `WebEventProcessor` in `process.go` to handle new session creation and logging.
>   - **Miscellaneous**:
>     - Updated `AppConfig` in `config.go` to change default API port.
>     - Added error `ErrWebtrackerExists` in `errors.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 9c1aaaefe4bab4e5f42b1bc0cc273d5563573205. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->