### PR TITLE
return timzone value and label

### DIFF
--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -2019,6 +2019,11 @@ type ComplexityRoot struct {
 		StartTime func(childComplexity int) int
 	}
 
+	Timezone struct {
+		Label func(childComplexity int) int
+		Value func(childComplexity int) int
+	}
+
 	User struct {
 		AppSource        func(childComplexity int) int
 		Bot              func(childComplexity int) int
@@ -2466,7 +2471,7 @@ type QueryResolver interface {
 	CalendarAvailability(ctx context.Context, input model.CalendarAvailabilityInput) (*model.CalendarAvailabilityResponse, error)
 	CalendarAvailabilityDetails(ctx context.Context, meetingBookingEventID string) (*model.CalendarAvailabilityDetailsResponse, error)
 	CalendarAvailableHours(ctx context.Context, email string) (*model.UserCalendarAvailability, error)
-	CalendarTimezones(ctx context.Context) ([]string, error)
+	CalendarTimezones(ctx context.Context) ([]*model.Timezone, error)
 	Contact(ctx context.Context, id string) (*model.Contact, error)
 	Contacts(ctx context.Context, pagination *model.Pagination, where *model.Filter, sort []*model1.SortBy) (*model.ContactsPage, error)
 	ContactByPhone(ctx context.Context, e164 string) (*model.Contact, error)
@@ -14359,6 +14364,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TimeSlot.StartTime(childComplexity), true
 
+	case "Timezone.label":
+		if e.complexity.Timezone.Label == nil {
+			break
+		}
+
+		return e.complexity.Timezone.Label(childComplexity), true
+
+	case "Timezone.value":
+		if e.complexity.Timezone.Value == nil {
+			break
+		}
+
+		return e.complexity.Timezone.Value(childComplexity), true
+
 	case "User.appSource":
 		if e.complexity.User.AppSource == nil {
 			break
@@ -15431,6 +15450,11 @@ input UserCalendarAvailabilityInput {
     sunday: DayAvailabilityInput!
 }
 
+type Timezone {
+    value: String!
+    label: String!
+}
+
 extend type Query {
     """
     Get availability across all users in the tenant for a given time range
@@ -15443,7 +15467,7 @@ extend type Query {
     """
     calendar_available_hours(email: String!): UserCalendarAvailability @hasRole(roles: [ADMIN, USER]) @hasTenant
 
-    calendar_timezones: [String!]!
+    calendar_timezones: [Timezone!]!
 }
 
 extend type Mutation {
@@ -102435,9 +102459,9 @@ func (ec *executionContext) _Query_calendar_timezones(ctx context.Context, field
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]string)
+	res := resTmp.([]*model.Timezone)
 	fc.Result = res
-	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+	return ec.marshalNTimezone2ᚕᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐTimezoneᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_calendar_timezones(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -102447,7 +102471,13 @@ func (ec *executionContext) fieldContext_Query_calendar_timezones(_ context.Cont
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			switch field.Name {
+			case "value":
+				return ec.fieldContext_Timezone_value(ctx, field)
+			case "label":
+				return ec.fieldContext_Timezone_label(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Timezone", field.Name)
 		},
 	}
 	return fc, nil
@@ -119615,6 +119645,94 @@ func (ec *executionContext) fieldContext_TimeSlot_endTime(_ context.Context, fie
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Timezone_value(ctx context.Context, field graphql.CollectedField, obj *model.Timezone) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Timezone_value(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Value, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Timezone_value(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Timezone",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Timezone_label(ctx context.Context, field graphql.CollectedField, obj *model.Timezone) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Timezone_label(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Label, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Timezone_label(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Timezone",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -149350,6 +149468,50 @@ func (ec *executionContext) _TimeSlot(ctx context.Context, sel ast.SelectionSet,
 	return out
 }
 
+var timezoneImplementors = []string{"Timezone"}
+
+func (ec *executionContext) _Timezone(ctx context.Context, sel ast.SelectionSet, obj *model.Timezone) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, timezoneImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Timezone")
+		case "value":
+			out.Values[i] = ec._Timezone_value(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "label":
+			out.Values[i] = ec._Timezone_label(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var userImplementors = []string{"User"}
 
 func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj *model.User) graphql.Marshaler {
@@ -156263,6 +156425,60 @@ func (ec *executionContext) unmarshalNTimelineEventType2githubᚗcomᚋcustomero
 
 func (ec *executionContext) marshalNTimelineEventType2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐTimelineEventType(ctx context.Context, sel ast.SelectionSet, v model.TimelineEventType) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) marshalNTimezone2ᚕᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐTimezoneᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Timezone) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTimezone2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐTimezone(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTimezone2ᚖgithubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐTimezone(ctx context.Context, sel ast.SelectionSet, v *model.Timezone) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Timezone(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNUser2githubᚗcomᚋcustomerosᚋcustomerosᚋpackagesᚋserverᚋcustomerᚑosᚑapiᚋgraphqlᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v model.User) graphql.Marshaler {

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -3307,6 +3307,11 @@ type TimeSlot struct {
 	EndTime   time.Time `json:"endTime"`
 }
 
+type Timezone struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
 // Describes the User of customerOS.  A user is the person who logs into the Openline platform.
 // **A `return` object**
 type User struct {

--- a/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/calendar.resolvers.go
@@ -7,13 +7,13 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"sort"
+	"strings"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
 	"github.com/customeros/customeros/packages/server/customer-os-api/mapper"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 )
@@ -161,7 +161,7 @@ func (r *queryResolver) CalendarAvailableHours(ctx context.Context, email string
 }
 
 // CalendarTimezones is the resolver for the calendar_timezones field.
-func (r *queryResolver) CalendarTimezones(ctx context.Context) ([]string, error) {
+func (r *queryResolver) CalendarTimezones(ctx context.Context) ([]*model.Timezone, error) {
 	spans, ctx := telemetry.StartGraphQLSpan(ctx, "QueryResolver.CalendarTimezones", graphql.GetOperationContext(ctx))
 	defer spans.Finish()
 
@@ -169,15 +169,15 @@ func (r *queryResolver) CalendarTimezones(ctx context.Context) ([]string, error)
 	zones := data.Timezones()
 
 	// Verify each timezone is valid
-	validZones := make([]string, 0, len(zones))
+	validZones := make([]*model.Timezone, 0, len(zones))
 	for _, zone := range zones {
 		if _, err := time.LoadLocation(zone); err == nil {
-			validZones = append(validZones, zone)
+			validZones = append(validZones, &model.Timezone{
+				Value: zone,
+				Label: strings.ReplaceAll(zone, "_", " "),
+			})
 		}
 	}
-
-	// Sort the timezones alphabetically
-	sort.Strings(validZones)
 
 	return validZones, nil
 }

--- a/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
@@ -7,20 +7,20 @@ package resolver
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
-	postgresEntity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/constants"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	commonmodel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	common_srv "github.com/customeros/customeros/packages/server/customer-os-common-module/services/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
+	postgresEntity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 )
 
 // NylasConnect is the resolver for the nylasConnect field.

--- a/packages/server/customer-os-api/graphql/schemas/calendar.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/calendar.graphqls
@@ -115,6 +115,11 @@ input UserCalendarAvailabilityInput {
     sunday: DayAvailabilityInput!
 }
 
+type Timezone {
+    value: String!
+    label: String!
+}
+
 extend type Query {
     """
     Get availability across all users in the tenant for a given time range
@@ -127,7 +132,7 @@ extend type Query {
     """
     calendar_available_hours(email: String!): UserCalendarAvailability @hasRole(roles: [ADMIN, USER]) @hasTenant
 
-    calendar_timezones: [String!]!
+    calendar_timezones: [Timezone!]!
 }
 
 extend type Mutation {

--- a/packages/server/customer-os-api/rest/public/calendar.go
+++ b/packages/server/customer-os-api/rest/public/calendar.go
@@ -3,6 +3,7 @@ package public
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	cosapi_services "github.com/customeros/customeros/packages/server/customer-os-api/services"
@@ -49,6 +50,11 @@ type bookMeetingRequest struct {
 	Name       string `json:"name"`
 	Email      string `json:"email"`
 	Phone      string `json:"phone"`
+}
+
+type timezoneResponse struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
 }
 
 // mapToRestDaySlots converts service response to REST API format
@@ -268,7 +274,14 @@ func GetTimezones() gin.HandlerFunc {
 		spans, _ := telemetry.StartRestSpan(c.Request.Context(), "GetTimezones")
 		defer spans.Finish()
 
-		c.JSON(http.StatusOK, gin.H{"timezones": data.Timezones()})
+		timezones := make([]timezoneResponse, len(data.Timezones()))
+		for i, timezone := range data.Timezones() {
+			timezones[i] = timezoneResponse{
+				Value: timezone,
+				Label: strings.ReplaceAll(timezone, "_", " "),
+			}
+		}
+		c.JSON(http.StatusOK, gin.H{"timezones": timezones})
 	}
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update GraphQL and REST API to return timezone objects with value and label instead of plain strings.
> 
>   - **GraphQL Schema**:
>     - Update `calendar_timezones` query to return `[Timezone!]!` instead of `[String!]!` in `calendar.graphqls`.
>     - Add `Timezone` type with `value` and `label` fields in `calendar.graphqls`.
>   - **Resolvers**:
>     - Modify `CalendarTimezones` resolver in `calendar.resolvers.go` to return `[]*model.Timezone`.
>     - Update `CalendarTimezones` resolver logic to construct `Timezone` objects with `value` and `label`.
>   - **REST API**:
>     - Update `GetTimezones` handler in `calendar.go` to return `timezoneResponse` objects with `value` and `label`.
>     - Modify `timezoneResponse` struct to include `value` and `label` fields in `calendar.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8e93bb217c588fcf4093e978693c9189eac9e25c. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->