### PR TITLE
autocreate google conferencing

### DIFF
--- a/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
@@ -84,7 +84,7 @@ func (r *mutationResolver) NylasConnect(ctx context.Context, input model.NylasCo
 		defaultMeetingBookingEventEntity := postgresEntity.MeetingBookingEvent{
 			ParticipantEmails:                   []string{input.Email},
 			Title:                               "Product overview",
-			Location:                            "Google Meet",
+			Location:                            enum.MeetingLocationGoogleMeet.String(),
 			Description:                         "",
 			DurationMins:                        30,
 			BookingFormNameEnabled:              true,

--- a/packages/server/customer-os-common-module/enum/meeting_location.go
+++ b/packages/server/customer-os-common-module/enum/meeting_location.go
@@ -1,0 +1,28 @@
+package enum
+
+type MeetingLocation string
+
+const (
+	MeetingLocationGoogleMeet MeetingLocation = "Google Meet"
+)
+
+var AllMeetingLocations = []MeetingLocation{
+	MeetingLocationGoogleMeet,
+}
+
+func IsValidMeetingLocation(s string) bool {
+	for _, loc := range AllMeetingLocations {
+		if loc == MeetingLocation(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m MeetingLocation) String() string {
+	return string(m)
+}
+
+func IsGoogleMeet(location string) bool {
+	return location == MeetingLocationGoogleMeet.String()
+}

--- a/packages/server/customer-os-common-module/interfaces/nylas.go
+++ b/packages/server/customer-os-common-module/interfaces/nylas.go
@@ -10,7 +10,8 @@ import (
 type NylasProvider string
 
 const (
-	NylasProviderGoogle NylasProvider = "google"
+	NylasProviderGoogle     NylasProvider = "google"
+	NylasProviderGoogleMeet NylasProvider = "Google Meet"
 )
 
 type NylasService interface {
@@ -110,6 +111,7 @@ type NylasCreateEventRequest struct {
 	} `json:"when"`
 	Location     string                  `json:"location,omitempty"`
 	Participants []NylasEventParticipant `json:"participants"`
+	Conferencing NylasConferencing       `json:"conferencing,omitempty"`
 	Resources    []struct {
 		Name  string `json:"name"`
 		Email string `json:"email"`
@@ -121,6 +123,10 @@ type NylasEventParticipant struct {
 	Email       string `json:"email"`
 	Name        string `json:"name"`
 	PhoneNumber string `json:"phone_number"`
+}
+type NylasConferencing struct {
+	Provider   string   `json:"provider"`
+	Autocreate struct{} `json:"autocreate"`
 }
 
 type NylasEvent struct {

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -862,11 +862,10 @@ func (s *meetingService) BookMeeting(ctx context.Context, meetingBookingEventID 
 	}
 
 	// create meeting event
-	createdEvent, nylasResponse, err := s.nylas.CreateEvent(ctx, interfaces.NylasCreateEventRequest{
+	createEventRequest := interfaces.NylasCreateEventRequest{
 		Busy:        true,
 		Title:       meetingBookingEvent.Title,
 		Description: meetingBookingEvent.Description,
-		Location:    meetingBookingEvent.Location,
 		Participants: []interfaces.NylasEventParticipant{
 			{
 				Email: hostEmail,
@@ -888,7 +887,14 @@ func (s *meetingService) BookMeeting(ctx context.Context, meetingBookingEventID 
 			StartTimezone: "Etc/UTC",
 			EndTimezone:   "Etc/UTC",
 		},
-	}, hostEmail, calendar.ID, meetingBookingEvent.EmailNotificationEnabled)
+	}
+	if enum.IsGoogleMeet(meetingBookingEvent.Location) {
+		createEventRequest.Conferencing = interfaces.NylasConferencing{
+			Provider:   string(interfaces.NylasProviderGoogleMeet),
+			Autocreate: struct{}{},
+		}
+	}
+	createdEvent, nylasResponse, err := s.nylas.CreateEvent(ctx, createEventRequest, hostEmail, calendar.ID, meetingBookingEvent.EmailNotificationEnabled)
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to create meeting event: %v", err)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds automatic Google Meet link creation for meetings with Google Meet location.
> 
>   - **Behavior**:
>     - Automatically creates Google Meet links for meetings if `Location` is set to Google Meet in `BookMeeting()` in `service.go`.
>     - Updates `NylasCreateEventRequest` to include `Conferencing` field for Google Meet in `nylas.go`.
>   - **Enums**:
>     - Adds `MeetingLocationGoogleMeet` to `meeting_location.go`.
>     - Adds `NylasProviderGoogleMeet` to `nylas.go`.
>   - **Functions**:
>     - Modifies `BookMeeting()` in `service.go` to check if `Location` is Google Meet and set `Conferencing` accordingly.
>     - Updates `NylasConnect()` in `nylas.resolvers.go` to set default `Location` to Google Meet.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 44190c36a5623ccf64a51f36b071c49df638f6b4. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->