### PR TITLE
Cancel meeting API

### DIFF
--- a/packages/server/customer-os-api/rest/public/calendar.go
+++ b/packages/server/customer-os-api/rest/public/calendar.go
@@ -58,6 +58,11 @@ type timezoneResponse struct {
 	Label string `json:"label"`
 }
 
+type cancelMeetingRequest struct {
+	CalendarId string `json:"calendarId"`
+	Email      string `json:"email"`
+}
+
 // mapToRestDaySlots converts service response to REST API format
 func mapToRestDaySlots(result *interfaces.CalendarAvailabilityResult) []DaySlot {
 	if result == nil || len(result.Days) == 0 {
@@ -378,5 +383,61 @@ func BookMeeting(s *cosapi_services.Services) gin.HandlerFunc {
 			"hostName":  bookMeetingResult.HostName,
 			"status":    "created",
 		})
+	}
+}
+
+func CancelMeeting(s *cosapi_services.Services) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		spans, ctx := telemetry.StartRestSpan(c.Request.Context(), "CancelMeeting")
+		defer spans.Finish()
+
+		var request cancelMeetingRequest
+		if err := c.ShouldBindJSON(&request); err != nil {
+			spans.TraceError(err)
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		if request.CalendarId == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "missing calendarId in request"})
+			return
+		}
+
+		if request.Email == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "missing email in request"})
+			return
+		}
+
+		// Get meeting booking event to determine tenant
+		meetingBookingEvent, err := s.Repositories.PostgresRepositories.MeetingBookingEventRepository.GetByIdCrossTenant(ctx, request.CalendarId)
+		if err != nil {
+			spans.TraceError(err)
+			s.Log.Error("Failed to get meeting booking event: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Calendar not found"})
+			return
+		}
+		if meetingBookingEvent == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Calendar not found"})
+			return
+		}
+
+		// Set tenant in context
+		ctx = common.WithCustomContext(
+			ctx,
+			&common.CustomContext{
+				Tenant: meetingBookingEvent.Tenant,
+			},
+		)
+		spans.TagTenant(meetingBookingEvent.Tenant)
+
+		err = s.CommonServices.MeetingService.CancelMeeting(ctx, meetingBookingEvent.ID, request.Email)
+		if err != nil {
+			spans.TraceError(err)
+			s.Log.Error("Failed to cancel meeting: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to cancel meeting"})
+			return
+		}
+
+		c.Status(http.StatusNoContent)
 	}
 }

--- a/packages/server/customer-os-api/server/public_routes.go
+++ b/packages/server/customer-os-api/server/public_routes.go
@@ -115,6 +115,13 @@ func registerPublicRoutes(ctx context.Context, r *gin.Engine, s *cosapi_services
 	})
 
 	registerRoute(ctx, r, RouteConfig{
+		method:    "DELETE",
+		path:      "/calendar/meeting",
+		handler:   public.CancelMeeting(s),
+		routeType: RoutePublic,
+	})
+
+	registerRoute(ctx, r, RouteConfig{
 		method:    "POST",
 		path:      "/reveal",
 		handler:   h.WebsiteTrackerEvents.Handle(),

--- a/packages/server/customer-os-common-module/interfaces/meeting.go
+++ b/packages/server/customer-os-common-module/interfaces/meeting.go
@@ -50,4 +50,5 @@ type MeetingService interface {
 	GetAvailableCalendarParticipantEmailsForTimeRange(ctx context.Context, meetingBookingEventID string, startTime, endTime time.Time) ([]string, error)
 
 	BookMeeting(ctx context.Context, meetingBookingEventID string, startTime time.Time, timezone, name, email, phone string) (*BookMeetingResult, error)
+	CancelMeeting(ctx context.Context, meetingBookingEventID, clientEmail string) error
 }

--- a/packages/server/customer-os-common-module/interfaces/nylas.go
+++ b/packages/server/customer-os-common-module/interfaces/nylas.go
@@ -27,6 +27,7 @@ type NylasService interface {
 
 	// Meeting operations
 	CreateEvent(ctx context.Context, meetingData NylasCreateEventRequest, hostEmail, calendarID string, notifyParticipants bool) (*NylasEvent, string, error)
+	DeleteEvent(ctx context.Context, calendarID, hostEmail, eventID string, notifyParticipants bool) error
 }
 
 type NylasCalendarsResponse struct {
@@ -135,5 +136,6 @@ type NylasEvent struct {
 		Busy       bool   `json:"busy"`
 		CalendarID string `json:"calendar_id"`
 		HtmlLink   string `json:"html_link"`
+		ID         string `json:"id"`
 	} `json:"data"`
 }

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -953,6 +953,7 @@ func (s *meetingService) BookMeeting(ctx context.Context, meetingBookingEventID 
 	err = s.postgres.MeetingBookedEventRepository.Create(ctx, &postgresEntity.MeetingBookedEvent{
 		MeetingBookingEventID: meetingBookingEventID,
 		Tenant:                tenant,
+		HostCalendarID:        calendar.ID,
 		HostEmail:             hostEmail,
 		HostName:              hostName,
 		ClientEmail:           clientEmail,
@@ -962,6 +963,7 @@ func (s *meetingService) BookMeeting(ctx context.Context, meetingBookingEventID 
 		EndTime:               endTimeInUTC,
 		DurationMins:          int64(durationMins),
 		NylasResponse:         nylasResponse,
+		NylasEventID:          createdEvent.Data.ID,
 		Canceled:              false,
 	})
 	if err != nil {
@@ -991,4 +993,64 @@ func (s *meetingService) BookMeeting(ctx context.Context, meetingBookingEventID 
 
 func pickRandomParticipant(availableParticipantEmails []string) string {
 	return availableParticipantEmails[rand.Intn(len(availableParticipantEmails))]
+}
+
+// CancelMeeting implements interfaces.MeetingService
+func (s *meetingService) CancelMeeting(ctx context.Context, meetingBookingEventID, clientEmail string) error {
+	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.CancelMeeting")
+	defer spans.Finish()
+	spans.LogObjectAsJson("request", map[string]interface{}{
+		"meetingBookingEventID": meetingBookingEventID,
+		"clientEmail":           clientEmail,
+	})
+
+	// validate tenant
+	err := common.ValidateTenant(ctx)
+	if err != nil {
+		spans.TraceError(err)
+		return err
+	}
+	tenant := common.GetTenantFromContext(ctx)
+
+	// get meeting booking event
+	meetingBookingEvent, err := s.postgres.MeetingBookingEventRepository.GetById(ctx, tenant, meetingBookingEventID)
+	if err != nil {
+		spans.TraceError(err)
+		return fmt.Errorf("failed to get meeting booking event: %v", err)
+	}
+	if meetingBookingEvent == nil {
+		return fmt.Errorf("meeting booking event not found")
+	}
+
+	meetingBookedEvent, err := s.postgres.MeetingBookedEventRepository.GetActiveFirstUpcomingByMeetingBookingEventIDAndClientEmail(ctx, tenant, meetingBookingEventID, clientEmail)
+	if err != nil {
+		spans.TraceError(err)
+		return fmt.Errorf("failed to get meeting booked event: %v", err)
+	}
+	if meetingBookedEvent == nil {
+		spans.LogKV("result", "no meeting booked event found")
+		return nil
+	}
+	if meetingBookedEvent.Canceled {
+		spans.LogKV("result", "meeting already canceled")
+		return nil
+	}
+
+	// call nylas to delete event
+	if meetingBookedEvent.NylasEventID != "" {
+		err = s.nylas.DeleteEvent(ctx, meetingBookedEvent.HostCalendarID, meetingBookedEvent.HostEmail, meetingBookedEvent.NylasEventID, meetingBookingEvent.EmailNotificationEnabled)
+		if err != nil {
+			spans.TraceError(err)
+			return fmt.Errorf("failed to cancel meeting on nylas: %v", err)
+		}
+	}
+
+	// update meeting booked event as canceled in COS
+	err = s.postgres.MeetingBookedEventRepository.Cancel(ctx, meetingBookedEvent.ID)
+	if err != nil {
+		spans.TraceError(err)
+		return fmt.Errorf("failed to cancel meeting booked event: %v", err)
+	}
+
+	return nil
 }

--- a/packages/server/customer-os-common-module/services/nylas/service.go
+++ b/packages/server/customer-os-common-module/services/nylas/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
@@ -542,4 +543,63 @@ func (s *nylasService) CreateEvent(ctx context.Context, meetingData interfaces.N
 	}
 
 	return &response, string(bodyBytes), nil
+}
+
+func (s *nylasService) DeleteEvent(ctx context.Context, calendarID, hostEmail, eventID string, notifyParticipants bool) error {
+	spans, ctx := telemetry.StartServiceSpan(ctx, "NylasService.DeleteEvent")
+	defer spans.Finish()
+	spans.LogKV("calendarID", calendarID, "hostEmail", hostEmail, "eventID", eventID, "notifyParticipants", notifyParticipants)
+
+	// Get Nylas grant ID
+	grant, err := s.postgres.NylasGrantRepository.GetByTenantAndEmail(ctx, common.GetTenantFromContext(ctx), hostEmail)
+	if err != nil {
+		spans.TraceError(err)
+		return fmt.Errorf("failed to get Nylas grant ID: %v", err)
+	}
+	if grant == nil {
+		return fmt.Errorf("Nylas grant not found")
+	}
+
+	// Create request to Nylas v3 API
+	encodedEventID := url.PathEscape(eventID)
+	url := fmt.Sprintf("%s/v3/grants/%s/events/%s?calendar_id=%s", s.config.APIUrl, grant.NylasGrantId, encodedEventID, calendarID)
+	if notifyParticipants {
+		url = fmt.Sprintf("%s&notify_participants=true", url)
+	} else {
+		url = fmt.Sprintf("%s&notify_participants=false", url)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
+	if err != nil {
+		spans.TraceError(err)
+		return fmt.Errorf("failed to create request: %v", err)
+	}
+
+	// Set headers
+	req.Header.Set("Authorization", "Bearer "+s.config.APIKey)
+	req.Header.Set("Accept", "application/json, application/gzip")
+
+	// Make request
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		spans.TraceError(err)
+		return fmt.Errorf("failed to make request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		spans.TraceError(err)
+		return fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	spans.LogKV("nylas.response", string(bodyBytes))
+	spans.LogKV("nylas.response.statusCode", resp.StatusCode)
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		spans.TraceError(fmt.Errorf("unexpected status code: %d", resp.StatusCode))
+		return fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	return nil
 }

--- a/packages/server/customer-os-postgres-repository/entity/meeting_booked_event.go
+++ b/packages/server/customer-os-postgres-repository/entity/meeting_booked_event.go
@@ -13,6 +13,7 @@ type MeetingBookedEvent struct {
 	CreatedAt             time.Time `gorm:"column:created_at;type:timestamp;DEFAULT:current_timestamp" json:"createdAt"`
 	UpdatedAt             time.Time `gorm:"column:updated_at;type:timestamp;DEFAULT:current_timestamp" json:"updatedAt"`
 	MeetingBookingEventID string    `gorm:"column:meeting_booking_event_id;type:varchar(21);not null" json:"meetingBookingEventId"`
+	HostCalendarID        string    `gorm:"column:host_calendar_id;size:255" json:"hostCalendarId"`
 	HostEmail             string    `gorm:"column:host_email;size:255;not null" json:"hostEmail"`
 	HostName              string    `gorm:"column:host_name;type:text" json:"hostName"`
 	ClientEmail           string    `gorm:"column:client_email;size:255;not null" json:"clientEmail"`
@@ -22,6 +23,7 @@ type MeetingBookedEvent struct {
 	EndTime               time.Time `gorm:"column:end_time;type:timestamp;not null" json:"endTime"`
 	DurationMins          int64     `gorm:"column:duration_mins;not null" json:"durationMins"`
 	NylasResponse         string    `gorm:"column:nylas_response;type:text;not null" json:"nylasResponse"`
+	NylasEventID          string    `gorm:"column:nylas_event_id;type:varchar(255)" json:"nylasEventId"`
 	Canceled              bool      `gorm:"column:canceled;type:boolean;not null;default:false" json:"canceled"`
 }
 

--- a/packages/server/customer-os-postgres-repository/repository/meeting_booked_event_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/meeting_booked_event_repository.go
@@ -13,6 +13,8 @@ import (
 type MeetingBookedEventRepository interface {
 	Create(ctx context.Context, meetingBookedEvent *postgres_entity.MeetingBookedEvent) error
 	GetActiveFirstUpcomingByMeetingBookingEventIDAndClientEmail(ctx context.Context, tenant, meetingBookingEventID, clientEmail string) (*postgres_entity.MeetingBookedEvent, error)
+	Cancel(ctx context.Context, id string) error
+	DeleteByConditions(ctx context.Context, conditions *postgres_entity.MeetingBookedEvent) error
 }
 
 type meetingBookedEventRepository struct {
@@ -49,4 +51,36 @@ func (r *meetingBookedEventRepository) GetActiveFirstUpcomingByMeetingBookingEve
 	}
 
 	return &meetingBookedEvent, nil
+}
+
+func (r *meetingBookedEventRepository) Cancel(ctx context.Context, id string) error {
+	spans, _ := telemetry.StartPostgresSpan(ctx, "MeetingBookedEventRepository.Cancel")
+	defer spans.Finish()
+	spans.TagEntity(id)
+
+	return r.gormDb.Model(&postgres_entity.MeetingBookedEvent{}).Where("id = ?", id).Update("canceled", true).Error
+}
+
+func (r *meetingBookedEventRepository) DeleteByConditions(ctx context.Context, conditions *postgres_entity.MeetingBookedEvent) error {
+	spans, _ := telemetry.StartPostgresSpan(ctx, "MeetingBookedEventRepository.DeleteByConditions")
+	defer spans.Finish()
+	spans.LogObjectAsJson("conditions", conditions)
+
+	query := r.gormDb.Model(&postgres_entity.MeetingBookedEvent{})
+
+	// Build where conditions based on provided fields
+	if conditions.Tenant != "" {
+		query = query.Where("tenant = ?", conditions.Tenant)
+	}
+	if conditions.MeetingBookingEventID != "" {
+		query = query.Where("meeting_booking_event_id = ?", conditions.MeetingBookingEventID)
+	}
+	if conditions.ClientEmail != "" {
+		query = query.Where("client_email = ?", conditions.ClientEmail)
+	}
+	if !conditions.StartTime.IsZero() {
+		query = query.Where("start_time = ?", conditions.StartTime)
+	}
+
+	return query.Delete(&postgres_entity.MeetingBookedEvent{}).Error
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add API endpoint and backend support for meeting cancellation, including changes to services, repositories, and models.
> 
>   - **API Changes**:
>     - Add `CancelMeeting` function in `calendar.go` to handle meeting cancellation requests.
>     - Register DELETE `/calendar/meeting` route in `public_routes.go`.
>   - **Service Changes**:
>     - Implement `CancelMeeting` in `MeetingService` in `service.go` to handle business logic for meeting cancellation.
>     - Implement `DeleteEvent` in `NylasService` in `service.go` to handle event deletion from Nylas.
>   - **Repository Changes**:
>     - Add `Cancel` and `DeleteByConditions` methods to `MeetingBookedEventRepository` in `meeting_booked_event_repository.go`.
>   - **Model Changes**:
>     - Add `HostCalendarID` and `NylasEventID` fields to `MeetingBookedEvent` in `meeting_booked_event.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 503f59ca45646b264d2583400bb30fc3905c6f3d. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->