### PR TITLE
change return code for meeting cancelation

### DIFF
--- a/packages/server/customer-os-api/rest/public/calendar.go
+++ b/packages/server/customer-os-api/rest/public/calendar.go
@@ -438,6 +438,8 @@ func CancelMeeting(s *cosapi_services.Services) gin.HandlerFunc {
 			return
 		}
 
-		c.Status(http.StatusNoContent)
+		c.JSON(http.StatusOK, gin.H{
+			"message": "Meeting canceled successfully",
+		})
 	}
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change HTTP response in `CancelMeeting` function to return `http.StatusOK` with a success message.
> 
>   - **Behavior**:
>     - Change HTTP response in `CancelMeeting` function in `calendar.go` from `http.StatusNoContent` to `http.StatusOK`.
>     - Add JSON response with message "Meeting canceled successfully".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 0ce79028d2625bec2047730f933e68532169109a. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->