### PR TITLE
new tracing in neo methods

### DIFF
--- a/packages/server/customer-os-neo4j-repository/entity/organization.go
+++ b/packages/server/customer-os-neo4j-repository/entity/organization.go
@@ -3,8 +3,8 @@ package neo4j_entity
 import (
 	commonenum "github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
-	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"time"
 )
@@ -160,9 +160,9 @@ func (o OrganizationEntity) Labels(tenant string) []string {
 }
 
 func OrganizationStageAndRelationshipCompatible(ctx context.Context, stageStr, relationshipStr string) bool {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationStageAndRelationshipCompatible")
-	defer span.Finish()
-	span.LogKV("stage", stageStr, "relationship", relationshipStr)
+	spans, ctx := telemetry.StartSpan(ctx, "OrganizationStageAndRelationshipCompatible")
+	defer spans.Finish()
+	spans.LogKV("stage", stageStr, "relationship", relationshipStr)
 
 	stage := enum.OrganizationStage(stageStr)
 	relationship := enum.OrganizationRelationship(relationshipStr)

--- a/packages/server/customer-os-neo4j-repository/repository/action_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/action_write_repository.go
@@ -3,19 +3,18 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
+
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/constants"
 	neo4jmodel "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type ActionWriteRepository interface {
@@ -44,16 +43,15 @@ func (r *actionWriteRepository) Create(ctx context.Context, tenant, entityId str
 }
 
 func (r *actionWriteRepository) CreateWithProperties(ctx context.Context, tenant, entityId string, entityType model.EntityType, actionType enum.ActionType, content, metadata string, createdAt time.Time, appSource string, extraProperties map[string]any) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionWriteRepository.CreateWithProperties")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("entityId", entityId),
-		log.String("entityType", entityType.String()),
-		log.String("actionType", string(actionType)),
-		log.String("content", content),
-		log.String("metadata", metadata),
-		log.Object("createdAt", createdAt),
-		log.Object("extraProperties", extraProperties))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ActionWriteRepository.CreateWithProperties")
+	defer spans.Finish()
+	spans.LogKV("entityId", entityId,
+		"entityType", entityType.String(),
+		"actionType", string(actionType),
+		"content", content,
+		"metadata", metadata,
+		"createdAt", createdAt,
+		"extraProperties", extraProperties)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s_%s {id:$entityId}) `, entityType.Neo4jLabel(), tenant)
 	cypher += fmt.Sprintf(` MERGE (n)<-[:ACTION_ON]-(a:Action {id:randomUUID()}) 
@@ -85,8 +83,8 @@ func (r *actionWriteRepository) CreateWithProperties(ctx context.Context, tenant
 	if len(extraProperties) > 0 {
 		params["extraProperties"] = extraProperties
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -99,20 +97,19 @@ func (r *actionWriteRepository) CreateWithProperties(ctx context.Context, tenant
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	return result.(*dbtype.Node), nil
 }
 
 func (r *actionWriteRepository) MergeByActionType(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, entityId string, entityType model.EntityType, actionType enum.ActionType, content, metadata string, createdAt time.Time, appSource string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionWriteRepository.MergeByActionType")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("entityId", entityId),
-		log.String("entityType", entityType.String()),
-		log.String("actionType", string(actionType)),
-		log.String("content", content))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ActionWriteRepository.MergeByActionType")
+	defer spans.Finish()
+	spans.LogKV("entityId", entityId,
+		"entityType", entityType.String(),
+		"actionType", string(actionType),
+		"content", content)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s_%s {id:$entityId}) `, entityType.Neo4jLabel(), tenant)
 	cypher += fmt.Sprintf(`WITH n
@@ -142,8 +139,8 @@ func (r *actionWriteRepository) MergeByActionType(ctx context.Context, tx *neo4j
 		"appSource": neo4jmodel.GetAppSource(appSource),
 		"createdAt": createdAt,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
@@ -153,22 +150,21 @@ func (r *actionWriteRepository) MergeByActionType(ctx context.Context, tx *neo4j
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	return result.(*dbtype.Node), nil
 }
 
 func (r *actionWriteRepository) CreateV2(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, actionId, entityId string, entityType model.EntityType, data data_fields.ActionFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionWriteRepository.CreateV2")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(
-		log.String("tenant", tenant),
-		log.String("actionId", actionId),
-		log.String("entityId", entityId),
-		log.String("entityType", entityType.String()))
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ActionWriteRepository.CreateV2")
+	defer spans.Finish()
+
+	spans.LogKV("tenant", tenant,
+		"actionId", actionId,
+		"entityId", entityId,
+		"entityType", entityType.String())
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s_%s {id:$entityId}) `, entityType.Neo4jLabel(), tenant)
 	cypher += fmt.Sprintf(` MERGE (n)<-[:ACTION_ON]-(a:Action {id:$actionId}) 
@@ -204,8 +200,8 @@ func (r *actionWriteRepository) CreateV2(ctx context.Context, tx *neo4j.ManagedT
 	if len(data.ExtraProperties) > 0 {
 		params["extraProperties"] = data.ExtraProperties
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -214,7 +210,7 @@ func (r *actionWriteRepository) CreateV2(ctx context.Context, tx *neo4j.ManagedT
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 

--- a/packages/server/customer-os-neo4j-repository/repository/attachment_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/attachment_read_repository.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type AttachmentReadRepository interface {
@@ -31,18 +29,18 @@ func NewAttachmentReadRepository(driver *neo4j.DriverWithContext, database strin
 }
 
 func (r *attachmentReadRepository) GetById(ctx context.Context, tenant, id string) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AttachmentReadRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("id", id))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AttachmentReadRepository.GetById")
+	defer spans.Finish()
+
+	spans.LogKV("id", id)
 
 	cypher := fmt.Sprintf("MATCH (a:Attachment_%s {id:$id}) RETURN a", tenant)
 	params := map[string]any{
 		"id": id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -53,26 +51,25 @@ func (r *attachmentReadRepository) GetById(ctx context.Context, tenant, id strin
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
-		span.LogFields(log.Bool("result.found", false))
+		spans.TraceError(err)
+		spans.LogKV("result.found", false)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *attachmentReadRepository) GetFor(ctx context.Context, tenant string, entityType neo4jenum.EntityType, entityRelation *neo4jenum.EntityRelation, ids []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AttachmentReadRepository.GetFor")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(
-		log.String("entityType", entityType.String()),
-		log.Int("ids.count", len(ids)))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AttachmentReadRepository.GetFor")
+	defer spans.Finish()
+
+	spans.LogKV("entityType", entityType.String(),
+		"ids.count", len(ids))
 	if entityRelation != nil {
-		span.LogFields(log.String("entityRelation", entityRelation.String()))
+		spans.LogKV("entityRelation", entityRelation.String())
 	}
-	tracing.LogObjectAsJson(span, "ids", ids)
+	spans.LogObjectAsJson("ids", ids)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s_%s)-`, entityType.Neo4jLabel(), tenant)
 
@@ -89,8 +86,8 @@ func (r *attachmentReadRepository) GetFor(ctx context.Context, tenant string, en
 		"tenant": tenant,
 		"ids":    ids,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -101,12 +98,12 @@ func (r *attachmentReadRepository) GetFor(ctx context.Context, tenant string, en
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
-		span.LogFields(log.Int("result.count", 0))
+		spans.TraceError(err)
+		spans.LogKV("result.count", 0)
 		return nil, err
 	}
 
 	resultArray := result.([]*utils.DbNodeAndId)
-	span.LogFields(log.Int("result.count", len(resultArray)))
+	spans.LogKV("result.count", len(resultArray))
 	return resultArray, nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/attachment_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/attachment_write_repository.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type AttachmentWriteRepository interface {
@@ -31,14 +29,13 @@ func NewAttachmentWriteRepository(driver *neo4j.DriverWithContext, database stri
 }
 
 func (r *attachmentWriteRepository) Create(ctx context.Context, tx neo4j.ManagedTransaction, tenant, id, cdnUrl, basePath, fileName, mimeType string, size int64, createdAt *time.Time, source neo4jentity.DataSource, appSource string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AttachmentWriteRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(
-		log.String("id", id),
-		log.String("fileName", fileName),
-		log.String("mimeType", mimeType),
-		log.Int64("size", size))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AttachmentWriteRepository.Create")
+	defer spans.Finish()
+
+	spans.LogKV("id", id,
+		"fileName", fileName,
+		"mimeType", mimeType,
+		"size", size)
 
 	id = utils.NewUUIDIfEmpty(id)
 
@@ -71,22 +68,22 @@ func (r *attachmentWriteRepository) Create(ctx context.Context, tx neo4j.Managed
 		"appSource": appSource,
 	}
 
-	span.LogFields(log.String("cypher", fmt.Sprintf(cypher, tenant)))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", fmt.Sprintf(cypher, tenant))
+	spans.LogObjectAsJson("params", params)
 
 	queryResult, err := tx.Run(ctx, fmt.Sprintf(cypher, tenant), params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	result, err := utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 	if err != nil {
-		tracing.TraceErr(span, err)
-		span.LogFields(log.Bool("result.found", false))
+		spans.TraceError(err)
+		spans.LogKV("result.found", false)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result, nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/authentication_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/authentication_read_repository.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type TenantHasWorkspace struct {
@@ -40,9 +38,8 @@ func NewAuthenticationReadRepository(driver *neo4j.DriverWithContext, database s
 }
 
 func (r *authenticationReadRepository) GetByAuthIdAndProvider(ctx context.Context, authId string, provider string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AuthenticationReadRepository.GetPlayerByAuthIdProvider")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AuthenticationReadRepository.GetPlayerByAuthIdProvider")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -52,8 +49,8 @@ func (r *authenticationReadRepository) GetByAuthIdAndProvider(ctx context.Contex
 		"authId":   authId,
 		"provider": provider,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	dbRecord, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -61,26 +58,26 @@ func (r *authenticationReadRepository) GetByAuthIdAndProvider(ctx context.Contex
 	})
 
 	if err != nil && err.Error() == "Result contains no more records" {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	} else if err != nil {
 		return nil, err
 	}
 
 	if dbRecord == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return dbRecord.(*dbtype.Node), err
 }
 
 func (r *authenticationReadRepository) GetByAuthId(ctx context.Context, authId string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AuthenticationReadRepository.GetByAuthId")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogKV("authId", authId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AuthenticationReadRepository.GetByAuthId")
+	defer spans.Finish()
+
+	spans.LogKV("authId", authId)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -89,8 +86,8 @@ func (r *authenticationReadRepository) GetByAuthId(ctx context.Context, authId s
 	params := map[string]any{
 		"authId": authId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
@@ -103,22 +100,21 @@ func (r *authenticationReadRepository) GetByAuthId(ctx context.Context, authId s
 		return nil, fmt.Errorf("error getting player by authId: %w", err)
 	}
 
-	span.LogFields(log.Int("result.found", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.found", len(result.([]*dbtype.Node)))
 
 	return result.([]*dbtype.Node), nil
 }
 
 func (r *authenticationReadRepository) GetAuthUser(ctx context.Context, authId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AuthenticationReadRepository.GetAuthUser")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AuthenticationReadRepository.GetAuthUser")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (a:Authentication {id: $authId})-[:%s]->(u:AuthenticationUser) RETURN u`, model.HAS.String())
 	params := map[string]any{
 		"authId": authId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -136,19 +132,18 @@ func (r *authenticationReadRepository) GetAuthUser(ctx context.Context, authId s
 
 	data := result.(*neo4j.Node)
 	if data == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 
 	return data, nil
 }
 
 func (r *authenticationReadRepository) GetTenants(ctx context.Context, authUserId string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AuthenticationReadRepository.GetTenants")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AuthenticationReadRepository.GetTenants")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -157,8 +152,8 @@ func (r *authenticationReadRepository) GetTenants(ctx context.Context, authUserI
 	params := map[string]any{
 		"authUserId": authUserId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
@@ -173,19 +168,18 @@ func (r *authenticationReadRepository) GetTenants(ctx context.Context, authUserI
 
 	data := result.([]*dbtype.Node)
 	if data == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.count", 0)
 		return nil, nil
 	}
 
-	span.LogFields(log.Int("result.found", len(data)))
+	spans.LogKV("result.count", len(data))
 
 	return data, nil
 }
 
 func (r *authenticationReadRepository) GetTenantsForImpersonation(ctx context.Context, authUserId string) ([]*TenantHasWorkspace, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AuthenticationReadRepository.GetTenantsForImpersonation")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AuthenticationReadRepository.GetTenantsForImpersonation")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -201,8 +195,8 @@ func (r *authenticationReadRepository) GetTenantsForImpersonation(ctx context.Co
 	params := map[string]any{
 		"authUserId": authUserId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
@@ -212,7 +206,7 @@ func (r *authenticationReadRepository) GetTenantsForImpersonation(ctx context.Co
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, fmt.Errorf("error getting users for player: %w", err)
 	}
 

--- a/packages/server/customer-os-neo4j-repository/repository/authentication_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/authentication_write_repository.go
@@ -5,11 +5,8 @@ import (
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -38,11 +35,10 @@ func NewAuthenticationWriteRepository(driver *neo4j.DriverWithContext, database 
 }
 
 func (r *authenticationWriteRepository) CreateAuthentication(c context.Context, tx neo4j.ManagedTransaction, data neo4j_entity.AuthenticationEntity) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(c, "AuthenticationWriteRepository.CreateAuthentication")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(c, "AuthenticationWriteRepository.CreateAuthentication")
+	defer spans.Finish()
 
-	tracing.LogObjectAsJson(span, "data", data)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := `MERGE (a:Authentication {authId:$authId, provider:$provider})
 				ON CREATE SET a.id=randomUUID(),
@@ -55,11 +51,11 @@ func (r *authenticationWriteRepository) CreateAuthentication(c context.Context, 
 		"identityId": data.IdentityId,
 		"createdAt":  utils.NowIfZero(data.CreatedAt),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	} else {
 		return utils.ExtractSingleRecordFirstValueAsString(ctx, queryResult, err)
@@ -67,11 +63,10 @@ func (r *authenticationWriteRepository) CreateAuthentication(c context.Context, 
 }
 
 func (r *authenticationWriteRepository) CreateAuthenticationUser(ctx context.Context, tx neo4j.ManagedTransaction, authenticationId string, data neo4j_entity.AuthenticationUserEntity) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AuthenticationWriteRepository.CreateAuthenticationUser")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AuthenticationWriteRepository.CreateAuthenticationUser")
+	defer spans.Finish()
 
-	tracing.LogObjectAsJson(span, "data", data)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (a:Authentication {id:$authenticationId})
 				MERGE (u:AuthenticationUser {id:randomUUID()})
@@ -86,11 +81,11 @@ func (r *authenticationWriteRepository) CreateAuthenticationUser(ctx context.Con
 		"firstName":        data.FirstName,
 		"lastName":         data.LastName,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	} else {
 		return utils.ExtractSingleRecordFirstValueAsString(ctx, queryResult, err)
@@ -98,23 +93,22 @@ func (r *authenticationWriteRepository) CreateAuthenticationUser(ctx context.Con
 }
 
 func (r *authenticationWriteRepository) LinkAuthenticationWithAuthenticationUser(ctx context.Context, tx neo4j.ManagedTransaction, authId, authUserId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AuthenticationWriteRepository.LinkAuthenticationWithAuthenticationUser")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AuthenticationWriteRepository.LinkAuthenticationWithAuthenticationUser")
+	defer spans.Finish()
 
-	span.LogKV("authUserId", authUserId)
-	span.LogKV("authId", authId)
+	spans.LogKV("authUserId", authUserId)
+	spans.LogKV("authId", authId)
 
 	cypher := fmt.Sprintf(`MATCH (a:Authentication {id:$authId}), (au:AuthenticationUser {id:$authUserId}) MERGE (a)-[:%s]->(au)`, model.HAS.String())
 	params := map[string]any{
 		"authId":     authId,
 		"authUserId": authUserId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if _, err := tx.Run(ctx, cypher, params); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -152,20 +146,19 @@ func (r *authenticationWriteRepository) LinkAuthenticationUserWithTenant(ctx con
 }
 
 func (r *authenticationWriteRepository) UnlinkAuthenticationUserWithTenant(ctx context.Context, tx *neo4j.ManagedTransaction, authUserId, tenant string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AuthenticationWriteRepository.UnlinkAuthenticationUserWithTenant")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AuthenticationWriteRepository.UnlinkAuthenticationUserWithTenant")
+	defer spans.Finish()
 
-	span.LogKV("authUserId", authUserId)
-	span.LogKV("tenant", tenant)
+	spans.LogKV("authUserId", authUserId)
+	spans.LogKV("tenant", tenant)
 
 	cypher := `MATCH (u:AuthenticationUser {id:$authUserId})-[r:HAS_WORKSPACE]->(t:Tenant {name:$tenant}) delete r`
 	params := map[string]any{
 		"tenant":     tenant,
 		"authUserId": authUserId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -175,7 +168,7 @@ func (r *authenticationWriteRepository) UnlinkAuthenticationUserWithTenant(ctx c
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -183,23 +176,22 @@ func (r *authenticationWriteRepository) UnlinkAuthenticationUserWithTenant(ctx c
 }
 
 func (r *authenticationWriteRepository) LinkAuthenticationUserWithUser(ctx context.Context, tx neo4j.ManagedTransaction, authUserId, userId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AuthenticationWriteRepository.LinkAuthenticationUserWithUser")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AuthenticationWriteRepository.LinkAuthenticationUserWithUser")
+	defer spans.Finish()
 
-	span.LogKV("authUserId", authUserId)
-	span.LogKV("userId", userId)
+	spans.LogKV("authUserId", authUserId)
+	spans.LogKV("userId", userId)
 
 	cypher := fmt.Sprintf(`MATCH (a:AuthenticationUser {id:$authUserId}), (u:User {id:$userId}) MERGE (u)-[:%s]->(a)`, model.AUTHENTICATED_BY.String())
 	params := map[string]any{
 		"authUserId": authUserId,
 		"userId":     userId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if _, err := tx.Run(ctx, cypher, params); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -207,23 +199,22 @@ func (r *authenticationWriteRepository) LinkAuthenticationUserWithUser(ctx conte
 }
 
 func (r *authenticationWriteRepository) SetDefaultTenant(ctx context.Context, tx neo4j.ManagedTransaction, authUserId, defaultTenant string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AuthenticationWriteRepository.SetDefaultTenant")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "AuthenticationWriteRepository.SetDefaultTenant")
+	defer spans.Finish()
 
-	span.LogKV("authUserId", authUserId)
-	span.LogKV("defaultTenant", defaultTenant)
+	spans.LogKV("authUserId", authUserId)
+	spans.LogKV("defaultTenant", defaultTenant)
 
 	cypher := `MATCH (a:AuthenticationUser {id:$authUserId}) set a.defaultTenant = $defaultTenant`
 	params := map[string]any{
 		"authUserId":    authUserId,
 		"defaultTenant": defaultTenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if _, err := tx.Run(ctx, cypher, params); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -241,7 +232,7 @@ func (r *authenticationWriteRepository) SetCurrentTenant(ctx context.Context, tx
 		"authUserId":    authUserId,
 		"currentTenant": currentTenant,
 	}
-	spans.LogFields(log.String("cypher", cypher))
+	spans.LogKV("cypher", cypher)
 	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {

--- a/packages/server/customer-os-neo4j-repository/repository/bank_account_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/bank_account_read_repository.go
@@ -2,12 +2,10 @@ package neo4j_repository
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type BankAccountReadRepository interface {
@@ -32,18 +30,16 @@ func (r *bankAccountReadRepository) prepareReadSession(ctx context.Context) neo4
 }
 
 func (r *bankAccountReadRepository) GetBankAccounts(ctx context.Context, tenant string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BankAccountReadRepository.GetBankAccounts")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "BankAccountReadRepository.GetBankAccounts")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})-[:HAS_BANK_ACCOUNT]->(ba:BankAccount)
 			RETURN ba ORDER BY ba.createdAt ASC`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -57,7 +53,7 @@ func (r *bankAccountReadRepository) GetBankAccounts(ctx context.Context, tenant 
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	if result == nil {
 		return nil, nil
 	}
@@ -65,10 +61,8 @@ func (r *bankAccountReadRepository) GetBankAccounts(ctx context.Context, tenant 
 }
 
 func (r *bankAccountReadRepository) GetBankAccountById(ctx context.Context, tenant, id string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BankAccountReadRepository.GetBankAccountById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "BankAccountReadRepository.GetBankAccountById")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})-[:HAS_BANK_ACCOUNT]->(ba:BankAccount {id:$id})
 			RETURN ba`
@@ -76,8 +70,8 @@ func (r *bankAccountReadRepository) GetBankAccountById(ctx context.Context, tena
 		"tenant": tenant,
 		"id":     id,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -88,11 +82,11 @@ func (r *bankAccountReadRepository) GetBankAccountById(ctx context.Context, tena
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
-		span.LogFields(log.Bool("result.found", false))
+		spans.TraceError(err)
+		spans.LogKV("result.found", false)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/bank_account_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/bank_account_write_repository.go
@@ -3,12 +3,10 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
 type BankAccountWriteRepository interface {
@@ -30,15 +28,14 @@ func NewBankAccountWriteRepository(driver *neo4j.DriverWithContext, database str
 }
 
 func (r *bankAccountWriteRepository) CreateBankAccount(ctx context.Context, tenant string, data data_fields.BankAccountFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BankAccountWriteRepository.CreateBankAccount")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "BankAccountWriteRepository.CreateBankAccount")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("data", data)
 
 	if data.ID == "" {
 		err := fmt.Errorf("missing bank account id")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -77,26 +74,25 @@ func (r *bankAccountWriteRepository) CreateBankAccount(ctx context.Context, tena
 		"routingNumber":       utils.IfNotNilString(data.RoutingNumber),
 		"otherDetails":        utils.IfNotNilString(data.OtherDetails),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *bankAccountWriteRepository) UpdateBankAccount(ctx context.Context, tenant string, data data_fields.BankAccountFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BankAccountWriteRepository.UpdateBankAccount")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "BankAccountWriteRepository.UpdateBankAccount")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("data", data)
 
 	if data.ID == "" {
 		err := fmt.Errorf("missing bank account id")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -148,21 +144,19 @@ func (r *bankAccountWriteRepository) UpdateBankAccount(ctx context.Context, tena
 		params["otherDetails"] = *data.OtherDetails
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *bankAccountWriteRepository) DeleteBankAccount(ctx context.Context, tenant, id string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BankAccountWriteRepository.DeleteBankAccount")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "BankAccountWriteRepository.DeleteBankAccount")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})-[r:HAS_BANK_ACCOUNT]->(ba:BankAccount {id:$bankAccountId}) 
 							DELETE r, ba`
@@ -170,12 +164,12 @@ func (r *bankAccountWriteRepository) DeleteBankAccount(ctx context.Context, tena
 		"tenant":        tenant,
 		"bankAccountId": id,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/comment_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/comment_read_repository.go
@@ -2,11 +2,9 @@ package neo4j_repository
 
 import (
 	"context"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
 type CommentReadRepository interface {
@@ -26,10 +24,8 @@ func NewCommentReadRepository(driver *neo4j.DriverWithContext, database string) 
 }
 
 func (r *commentReadRepository) GetAllForIssues(ctx context.Context, tenant string, issueIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommentRepository.GetAllForIssues")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommentRepository.GetAllForIssues")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue)<-[:COMMENTED]-(c:Comment) 
 				WHERE i.id IN $issueIds
@@ -38,7 +34,8 @@ func (r *commentReadRepository) GetAllForIssues(ctx context.Context, tenant stri
 		"tenant":   tenant,
 		"issueIds": issueIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -50,7 +47,7 @@ func (r *commentReadRepository) GetAllForIssues(ctx context.Context, tenant stri
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	return result.([]*utils.DbNodeAndId), nil

--- a/packages/server/customer-os-neo4j-repository/repository/comment_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/comment_write_repository.go
@@ -3,13 +3,12 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+
 	"time"
 )
 
@@ -46,12 +45,11 @@ func NewCommentWriteRepository(driver *neo4j.DriverWithContext, database string)
 }
 
 func (r *commentWriteRepository) Create(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, commentId string, data data_fields.CommentFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommentWriteRepository.Create")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, commentId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommentWriteRepository.Create")
+	defer spans.Finish()
+
+	spans.LogKV("commentId", commentId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})
 							OPTIONAL MATCH (t)<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue {id:$commentedIssueId})
@@ -84,8 +82,8 @@ func (r *commentWriteRepository) Create(ctx context.Context, tx *neo4j.ManagedTr
 		"commentedIssueId": utils.IfNotNilString(data.CommentedIssueId),
 		"authorUserId":     utils.IfNotNilString(data.AuthorUserId),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -96,19 +94,18 @@ func (r *commentWriteRepository) Create(ctx context.Context, tx *neo4j.ManagedTr
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *commentWriteRepository) Update(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, commentId string, data data_fields.CommentFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommentWriteRepository.Update")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, commentId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommentWriteRepository.Update")
+	defer spans.Finish()
+
+	spans.TagEntity(commentId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (c:Comment_%s {id:$commentId})
 		 	SET updatedAt = datetime()`, tenant)
@@ -124,8 +121,8 @@ func (r *commentWriteRepository) Update(ctx context.Context, tx *neo4j.ManagedTr
 		params["contentType"] = *data.ContentType
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -136,7 +133,7 @@ func (r *commentWriteRepository) Update(ctx context.Context, tx *neo4j.ManagedTr
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err

--- a/packages/server/customer-os-neo4j-repository/repository/common_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/common_read_repository.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/google/uuid"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -45,17 +44,15 @@ func (r *commonReadRepository) prepareReadSession(ctx context.Context) neo4j.Ses
 }
 
 func (r *commonReadRepository) GenerateId(ctx context.Context, tenant, label string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonReadRepository.GenerateId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonReadRepository.GenerateId")
+	defer spans.Finish()
 
 	id := ""
 	for {
 		id = uuid.New().String()
 		exists, err := r.ExistsById(ctx, tenant, id, label)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return "", err
 		}
 		if !exists {
@@ -63,17 +60,16 @@ func (r *commonReadRepository) GenerateId(ctx context.Context, tenant, label str
 		}
 	}
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	return id, nil
 }
 
 func (r *commonReadRepository) ExistsById(ctx context.Context, tenant, id, label string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonReadRepository.ExistsById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("id", id), log.String("label", label))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonReadRepository.ExistsById")
+	defer spans.Finish()
+
+	spans.LogKV("id", id, "label", label)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -82,26 +78,25 @@ func (r *commonReadRepository) ExistsById(ctx context.Context, tenant, id, label
 		return r.ExistsByIdInTx(ctx, &tx, tenant, id, label)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return false, err
 	}
-	span.LogFields(log.Bool("result.exists", result.(bool)))
+	spans.LogKV("result.exists", result.(bool))
 	return result.(bool), nil
 }
 
 func (r *commonReadRepository) ExistsByIdInTx(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, id, label string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonReadRepository.ExistsByIdInTx")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("id", id), log.String("label", label))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonReadRepository.ExistsByIdInTx")
+	defer spans.Finish()
+
+	spans.LogKV("id", id, "label", label)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s {id:$id}) WHERE n:%s_%s RETURN n.id LIMIT 1`, label, label, tenant)
 	params := map[string]any{
 		"id": id,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -115,23 +110,22 @@ func (r *commonReadRepository) ExistsByIdInTx(ctx context.Context, tx *neo4j.Man
 	})
 
 	nodeFound := result != nil && len(result.([]string)) > 0
-	span.LogFields(log.Bool("result.exists", nodeFound))
+	spans.LogKV("result.exists", nodeFound)
 	return nodeFound, err
 }
 
 func (r *commonReadRepository) GetById(ctx context.Context, tenant, id, label string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonReadRepository.GetById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("id", id), log.String("label", label))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonReadRepository.GetById")
+	defer spans.Finish()
+
+	spans.LogKV("id", id, "label", label)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s {id:$id}) WHERE n:%s_%s RETURN n`, label, label, tenant)
 	params := map[string]any{
 		"id": id,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -141,29 +135,28 @@ func (r *commonReadRepository) GetById(ctx context.Context, tenant, id, label st
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
-		span.LogFields(log.Bool("result.found", false))
+		spans.TraceError(err)
+		spans.LogKV("result.found", false)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *commonReadRepository) IsLinkedWith(ctx context.Context, tenant, parentId string, parentType model.EntityType, relationship, childId string, childType model.EntityType) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonReadRepository.IsLinkedWith")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("relationship", relationship))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonReadRepository.IsLinkedWith")
+	defer spans.Finish()
+
+	spans.LogKV("relationship", relationship, "parentId", parentId, "parentType", parentType, "childId", childId, "childType", childType)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s_%s {id:$parentId})-[:%s]->(m:%s_%s {id:$childId}) RETURN n.id LIMIT 1`, parentType.Neo4jLabel(), tenant, relationship, childType.Neo4jLabel(), tenant)
 	params := map[string]any{
 		"parentId": parentId,
 		"childId":  childId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -176,20 +169,19 @@ func (r *commonReadRepository) IsLinkedWith(ctx context.Context, tenant, parentI
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "error executing neo4j query"))
-		span.LogFields(log.Bool("result.found", false))
+		spans.TraceError(errors.Wrap(err, "error executing neo4j query"))
+		spans.LogKV("result.found", false)
 		return false, err
 	}
-	span.LogFields(log.Bool("result.found", result.(bool)))
+	spans.LogKV("result.found", result.(bool))
 	return result.(bool), err
 }
 
 func (r *commonReadRepository) ExistsByIdLinkedTo(ctx context.Context, tenant, id, label, linkedToId, linkedToLabel, linkRelationship string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonReadRepository.ExistsById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("id", id), log.String("label", label), log.String("linkedToId", linkedToId), log.String("linkedToLabel", linkedToLabel), log.String("linkRelationship", linkRelationship))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonReadRepository.ExistsById")
+	defer spans.Finish()
+
+	spans.LogKV("id", id, "label", label, "linkedToId", linkedToId, "linkedToLabel", linkedToLabel, "linkRelationship", linkRelationship)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s {id:$id})-`, label)
 	if linkRelationship != "" {
@@ -200,8 +192,8 @@ func (r *commonReadRepository) ExistsByIdLinkedTo(ctx context.Context, tenant, i
 		"id":         id,
 		"linkedToId": linkedToId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -214,19 +206,18 @@ func (r *commonReadRepository) ExistsByIdLinkedTo(ctx context.Context, tenant, i
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return false, err
 	}
-	span.LogFields(log.Bool("result.exists", result.(bool)))
+	spans.LogKV("result.exists", result.(bool))
 	return result.(bool), err
 }
 
 func (r *commonReadRepository) ExistsByIdLinkedFrom(ctx context.Context, tenant, id, label, linkedFromId, linkedFromLabel, linkRelationship string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonReadRepository.ExistsById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("id", id), log.String("label", label), log.String("linkedFromId", linkedFromId), log.String("linkedFromLabel", linkedFromLabel), log.String("linkRelationship", linkRelationship))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonReadRepository.ExistsById")
+	defer spans.Finish()
+
+	spans.LogKV("id", id, "label", label, "linkedFromId", linkedFromId, "linkedFromLabel", linkedFromLabel, "linkRelationship", linkRelationship)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s {id:$id})<-`, label)
 	if linkRelationship != "" {
@@ -237,8 +228,8 @@ func (r *commonReadRepository) ExistsByIdLinkedFrom(ctx context.Context, tenant,
 		"id":           id,
 		"linkedFromId": linkedFromId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -251,18 +242,18 @@ func (r *commonReadRepository) ExistsByIdLinkedFrom(ctx context.Context, tenant,
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return false, err
 	}
-	span.LogFields(log.Bool("result.exists", result.(bool)))
+	spans.LogKV("result.exists", result.(bool))
 	return result.(bool), err
 }
 
 func (r *commonReadRepository) ExecuteIntegrityCheckerQuery(ctx context.Context, name, cypherQuery string) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Neo4jRepository.ExecuteIntegrityCheckerQuery")
-	defer span.Finish()
-	span.SetTag("checker-name", name)
-	span.LogFields(log.String("cypherQuery", cypherQuery))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "Neo4jRepository.ExecuteIntegrityCheckerQuery")
+	defer spans.Finish()
+	spans.LogKV("checker-name", name)
+	spans.LogKV("cypherQuery", cypherQuery)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -272,25 +263,24 @@ func (r *commonReadRepository) ExecuteIntegrityCheckerQuery(ctx context.Context,
 		return utils.ExtractSingleRecordFirstValueAsType[int64](ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
-	span.LogFields(log.Int64("output - records", countFoundRecords.(int64)))
+	spans.LogKV("output - records", countFoundRecords.(int64))
 	return countFoundRecords.(int64), err
 }
 
 func (r *commonReadRepository) GetDbNodesLinkedTo(ctx context.Context, tenant, linkToId, linkedToLabel, linkRelationship string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonReadRepository.GetDbNodesLinkedTo")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("linkToId", linkToId), log.String("linkedToLabel", linkedToLabel), log.String("linkRelationship", linkRelationship))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonReadRepository.GetDbNodesLinkedTo")
+	defer spans.Finish()
+
+	spans.LogKV("linkToId", linkToId, "linkedToLabel", linkedToLabel, "linkRelationship", linkRelationship)
 
 	cypher := fmt.Sprintf(`MATCH (to:%s_%s {id:$linkToId})<-[:%s]-(n) RETURN n`, linkedToLabel, tenant, linkRelationship)
 	params := map[string]any{
 		"linkToId": linkToId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -300,7 +290,7 @@ func (r *commonReadRepository) GetDbNodesLinkedTo(ctx context.Context, tenant, l
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	return result.([]*dbtype.Node), nil

--- a/packages/server/customer-os-neo4j-repository/repository/common_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/common_write_repository.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"strings"
 	"time"
 )
@@ -52,9 +51,8 @@ func NewCommonWriteRepository(driver *neo4j.DriverWithContext, database string) 
 }
 
 func (r *commonWriteRepository) Link(ctx context.Context, tx *neo4j.ManagedTransaction, tenant string, details LinkDetails) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.Link")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.Link")
+	defer spans.Finish()
 
 	params := map[string]any{
 		"tenant":       tenant,
@@ -77,8 +75,8 @@ func (r *commonWriteRepository) Link(ctx context.Context, tx *neo4j.ManagedTrans
 		cypher += strings.Join(props, ", ")
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -88,7 +86,7 @@ func (r *commonWriteRepository) Link(ctx context.Context, tx *neo4j.ManagedTrans
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -96,9 +94,8 @@ func (r *commonWriteRepository) Link(ctx context.Context, tx *neo4j.ManagedTrans
 }
 
 func (r *commonWriteRepository) Unlink(ctx context.Context, tx *neo4j.ManagedTransaction, tenant string, details LinkDetails) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.Unlink")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.Unlink")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (parent:%s_%s {id:$entityId})-[r:%s]-(child:%s_%s {id:$withEntityId}) `, details.FromEntityType.Neo4jLabel(), tenant, details.Relationship.String(), details.ToEntityType.Neo4jLabel(), tenant)
 	cypher += `DELETE r`
@@ -109,8 +106,8 @@ func (r *commonWriteRepository) Unlink(ctx context.Context, tx *neo4j.ManagedTra
 		"withEntityId": details.ToEntityId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -120,7 +117,7 @@ func (r *commonWriteRepository) Unlink(ctx context.Context, tx *neo4j.ManagedTra
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -128,11 +125,10 @@ func (r *commonWriteRepository) Unlink(ctx context.Context, tx *neo4j.ManagedTra
 }
 
 func (r *commonWriteRepository) Delete(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, id, label string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.Delete")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.Delete")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name: $tenant})<-[:BELONGS_TO_TENANT]-(n:%s_%s {id:$id}) delete n`, label, tenant)
 
@@ -141,8 +137,8 @@ func (r *commonWriteRepository) Delete(ctx context.Context, tx *neo4j.ManagedTra
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if tx == nil {
 		session := utils.NewNeo4jWriteSession(ctx, *r.driver)
@@ -156,13 +152,13 @@ func (r *commonWriteRepository) Delete(ctx context.Context, tx *neo4j.ManagedTra
 			return nil, nil
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	} else {
 		_, err := (*tx).Run(ctx, cypher, params)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}
@@ -171,12 +167,12 @@ func (r *commonWriteRepository) Delete(ctx context.Context, tx *neo4j.ManagedTra
 }
 
 func (r *commonWriteRepository) UpdateProperties(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, nodeLabel, entityId string, properties map[string]interface{}) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.UpdateProperties")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, entityId)
-	span.LogFields(log.String("nodeLabel", nodeLabel), log.Object("properties", properties))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.UpdateProperties")
+	defer spans.Finish()
+
+	spans.TagEntity(entityId)
+	spans.LogKV("nodeLabel", nodeLabel)
+	spans.LogObjectAsJson("properties", properties)
 
 	// Build the dynamic Cypher query
 	setClauses := make([]string, 0, len(properties))
@@ -194,15 +190,15 @@ func (r *commonWriteRepository) UpdateProperties(ctx context.Context, tx *neo4j.
 		`MATCH (n:%s:%s_%s {id: $entityId}) SET %s`,
 		nodeLabel, nodeLabel, tenant, strings.Join(setClauses, ", "),
 	)
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -210,101 +206,105 @@ func (r *commonWriteRepository) UpdateProperties(ctx context.Context, tx *neo4j.
 }
 
 func (r *commonWriteRepository) UpdateTimeProperty(ctx context.Context, tenant, nodeLabel, entityId, property string, value *time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.UpdateTimeProperty")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.UpdateTimeProperty")
+	defer spans.Finish()
 
-	span.SetTag(tracing.SpanTagEntityId, entityId)
+	spans.TagEntity(entityId)
 
-	span.LogFields(log.String("property", string(property)), log.String("nodeLabel", nodeLabel), log.Object("value", value))
+	spans.LogKV("property", string(property))
+	spans.LogKV("nodeLabel", nodeLabel)
+	spans.LogObjectAsJson("value", value)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s:%s_%s {id: $entityId}) SET n.%s = $value`, nodeLabel, nodeLabel, tenant, property)
 	params := map[string]any{
 		"entityId": entityId,
 		"value":    utils.TimePtrAsAny(value),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *commonWriteRepository) UpdateTimePropertyInTx(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, nodeLabel, entityId, property string, value *time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.UpdateTimeProperty")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.UpdateTimeProperty")
+	defer spans.Finish()
 
-	span.SetTag(tracing.SpanTagEntityId, entityId)
+	spans.TagEntity(entityId)
 
-	span.LogFields(log.String("property", string(property)), log.String("nodeLabel", nodeLabel), log.Object("value", value))
+	spans.LogKV("property", string(property))
+	spans.LogKV("nodeLabel", nodeLabel)
+	spans.LogObjectAsJson("value", value)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s:%s_%s {id: $entityId}) SET n.%s = $value`, nodeLabel, nodeLabel, tenant, property)
 	params := map[string]any{
 		"entityId": entityId,
 		"value":    utils.TimePtrAsAny(value),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *commonWriteRepository) UpdateInt64Property(ctx context.Context, tenant, nodeLabel, entityId, property string, value int64) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.UpdateInt64Property")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.UpdateInt64Property")
+	defer spans.Finish()
 
-	span.SetTag(tracing.SpanTagEntityId, entityId)
+	spans.TagEntity(entityId)
 
-	span.LogFields(log.String("property", string(property)), log.String("nodeLabel", nodeLabel), log.Object("value", value))
+	spans.LogKV("property", string(property))
+	spans.LogKV("nodeLabel", nodeLabel)
+	spans.LogObjectAsJson("value", value)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s:%s_%s {id: $entityId}) SET n.%s = $value, n.updatedAt=datetime()`, nodeLabel, nodeLabel, tenant, property)
 	params := map[string]any{
 		"entityId": entityId,
 		"value":    value,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *commonWriteRepository) UpdateBoolProperty(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, nodeLabel, entityId, property string, value bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.UpdateBoolProperty")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, entityId)
-	span.LogFields(log.String("property", property), log.String("nodeLabel", nodeLabel), log.Object("value", value))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.UpdateBoolProperty")
+	defer spans.Finish()
+
+	spans.TagEntity(entityId)
+	spans.LogKV("property", property)
+	spans.LogKV("nodeLabel", nodeLabel)
+	spans.LogObjectAsJson("value", value)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s:%s_%s {id: $entityId}) SET n.%s = $value, n.updatedAt=datetime()`, nodeLabel, nodeLabel, tenant, property)
 	params := map[string]any{
 		"entityId": entityId,
 		"value":    value,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -312,27 +312,28 @@ func (r *commonWriteRepository) UpdateBoolProperty(ctx context.Context, tx *neo4
 }
 
 func (r *commonWriteRepository) UpdateStringProperty(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, nodeLabel, entityId, property string, value string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.UpdateStringProperty")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, entityId)
-	span.LogFields(log.String("property", property), log.String("nodeLabel", nodeLabel), log.Object("value", value))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.UpdateStringProperty")
+	defer spans.Finish()
+
+	spans.TagEntity(entityId)
+	spans.LogKV("property", property)
+	spans.LogKV("nodeLabel", nodeLabel)
+	spans.LogObjectAsJson("value", value)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s:%s_%s {id: $entityId}) SET n.%s = $value, n.updatedAt=datetime()`, nodeLabel, nodeLabel, tenant, property)
 	params := map[string]any{
 		"entityId": entityId,
 		"value":    value,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -340,13 +341,12 @@ func (r *commonWriteRepository) UpdateStringProperty(ctx context.Context, tx *ne
 }
 
 func (r *commonWriteRepository) IncrementProperty(ctx context.Context, tenant, nodeLabel, entityId, property string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.IncrementProperty")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.IncrementProperty")
+	defer spans.Finish()
 
-	span.SetTag(tracing.SpanTagEntityId, entityId)
-
-	span.LogFields(log.String("property", property), log.String("nodeLabel", nodeLabel))
+	spans.TagEntity(entityId)
+	spans.LogKV("property", property)
+	spans.LogKV("nodeLabel", nodeLabel)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s_%s {id: $entityId}) 
 			SET n.%s = case WHEN n.%s IS NULL THEN 1 ELSE n.%s+1 END,
@@ -354,53 +354,52 @@ func (r *commonWriteRepository) IncrementProperty(ctx context.Context, tenant, n
 	params := map[string]any{
 		"entityId": entityId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *commonWriteRepository) RemoveProperty(ctx context.Context, tenant, nodeLabel, entityId, property string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.RemoveProperty")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.RemoveProperty")
+	defer spans.Finish()
 
-	span.SetTag(tracing.SpanTagEntityId, entityId)
-
-	span.LogFields(log.String("property", property), log.String("nodeLabel", nodeLabel))
+	spans.TagEntity(entityId)
+	spans.LogKV("property", property)
+	spans.LogKV("nodeLabel", nodeLabel)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s_%s {id: $entityId}) REMOVE n.%s SET n.updatedAt=datetime()`, nodeLabel, tenant, property)
 	params := map[string]any{
 		"entityId": entityId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 // update the updatedAt property of the entity to current time
 func (r *commonWriteRepository) TouchEntity(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, nodeLabel, entityId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.TouchEntity")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, entityId)
-	span.LogKV("nodeLabel", nodeLabel)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.TouchEntity")
+	defer spans.Finish()
+
+	spans.TagEntity(entityId)
+	spans.LogKV("nodeLabel", nodeLabel)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s_%s {id: $entityId}) SET n.updatedAt=datetime()`, nodeLabel, tenant)
 	params := map[string]any{
 		"entityId": entityId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -410,7 +409,7 @@ func (r *commonWriteRepository) TouchEntity(ctx context.Context, tx *neo4j.Manag
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err

--- a/packages/server/customer-os-neo4j-repository/repository/contact_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/contact_read_repository.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -75,10 +74,11 @@ func NewContactReadRepository(driver *neo4j.DriverWithContext, database string) 
 }
 
 func (r *contactReadRepository) GetContactsEnrichedNotLinkedToOrganization(ctx context.Context, delayFromPreviousAttemptDays, limit int) ([]TenantAndContactIdAndParams, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsEnrichedNotLinkedToOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("delayFromPreviousAttemptDays", delayFromPreviousAttemptDays), log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsEnrichedNotLinkedToOrganization")
+	defer spans.Finish()
+
+	spans.LogKV("delayFromPreviousAttemptDays", delayFromPreviousAttemptDays)
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant {active:true})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)-[:HAS]->(s:Social)
 			WHERE
@@ -92,8 +92,8 @@ func (r *contactReadRepository) GetContactsEnrichedNotLinkedToOrganization(ctx c
 		"limit":     limit,
 		"delayDays": delayFromPreviousAttemptDays,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -117,16 +117,15 @@ func (r *contactReadRepository) GetContactsEnrichedNotLinkedToOrganization(ctx c
 				FieldStr1: v.Values[2].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *contactReadRepository) GetContactsWithSocialUrl(ctx context.Context, tenant, socialUrl string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsWithSocialUrl")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogKV("socialUrl", socialUrl)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsWithSocialUrl")
+	defer spans.Finish()
+
+	spans.LogKV("socialUrl", socialUrl)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -138,8 +137,8 @@ func (r *contactReadRepository) GetContactsWithSocialUrl(ctx context.Context, te
 		"socialUrl": socialUrl,
 		"tenant":    tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
 		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
@@ -155,10 +154,8 @@ func (r *contactReadRepository) GetContactsWithSocialUrl(ctx context.Context, te
 }
 
 func (r *contactReadRepository) GetContactsWithEmail(ctx context.Context, tenant, email string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsWithEmail")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsWithEmail")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)-[:HAS]->(e:Email) 
 			WHERE e.email=$email OR e.rawEmail=$email
@@ -168,8 +165,8 @@ func (r *contactReadRepository) GetContactsWithEmail(ctx context.Context, tenant
 		"email":  email,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -181,15 +178,15 @@ func (r *contactReadRepository) GetContactsWithEmail(ctx context.Context, tenant
 	if err != nil {
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), err
 }
 
 func (r *contactReadRepository) GetContactsByEmailAddresses(ctx context.Context, tenant string, emailAddresses []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsByEmailAddresses")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "emailAddresses", emailAddresses)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsByEmailAddresses")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("emailAddresses", emailAddresses)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)-[:HAS]->(e:Email)-[:EMAIL_ADDRESS_BELONGS_TO_TENANT]->(t)
 			WHERE toLower(e.email)IN $emailAddresses OR toLower(e.rawEmail) IN $emailAddresses 
@@ -198,8 +195,8 @@ func (r *contactReadRepository) GetContactsByEmailAddresses(ctx context.Context,
 		"tenant":         tenant,
 		"emailAddresses": emailAddresses,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -214,7 +211,7 @@ func (r *contactReadRepository) GetContactsByEmailAddresses(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
@@ -223,19 +220,18 @@ func (r *contactReadRepository) prepareReadSession(ctx context.Context) neo4j.Se
 }
 
 func (r *contactReadRepository) GetContact(ctx context.Context, tenant, contactId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContact")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contactId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContact")
+	defer spans.Finish()
+
+	spans.TagEntity(contactId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact {id:$id}) RETURN c`
 	params := map[string]any{
 		"tenant": tenant,
 		"id":     contactId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -245,27 +241,25 @@ func (r *contactReadRepository) GetContact(ctx context.Context, tenant, contactI
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *contactReadRepository) GetContacts(ctx context.Context, tenant string, contactIds []string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContacts")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContacts")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact) WHERE c.id IN $ids RETURN c`
 	params := map[string]any{
 		"tenant": tenant,
 		"ids":    contactIds,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -278,21 +272,20 @@ func (r *contactReadRepository) GetContacts(ctx context.Context, tenant string, 
 		}
 	})
 	if err != nil {
-		span.LogFields(log.Int("result.count", 0))
+		spans.LogKV("result.count", 0)
 		return nil, err
 	}
 	nodes := result.([]*dbtype.Node)
-	span.LogFields(log.Int("result.count", len(nodes)))
+	spans.LogKV("result.count", len(nodes))
 	return nodes, err
 }
 
 func (r *contactReadRepository) GetContactInOrganizationByEmail(ctx context.Context, tenant, organizationId, email string) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("organizationId", organizationId))
-	span.LogFields(log.String("email", email))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactById")
+	defer spans.Finish()
+
+	spans.LogKV("organizationId", organizationId)
+	spans.LogKV("email", email)
 
 	cypher := `match (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization{id:$organizationId})<-[:ROLE_IN]-(j:JobRole)<-[:WORKS_AS]-(c:Contact)-[:HAS]->(e:Email{rawEmail:$email})
 		return c`
@@ -301,8 +294,8 @@ func (r *contactReadRepository) GetContactInOrganizationByEmail(ctx context.Cont
 		"organizationId": organizationId,
 		"email":          email,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -321,20 +314,19 @@ func (r *contactReadRepository) GetContactInOrganizationByEmail(ctx context.Cont
 }
 
 func (r *contactReadRepository) GetContactById(ctx context.Context, tenant, contactId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contactId)
-	span.LogFields(log.String("contactId", contactId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactById")
+	defer spans.Finish()
+
+	spans.TagEntity(contactId)
+	spans.LogKV("contactId", contactId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact {id:$id}) RETURN c`
 	params := map[string]any{
 		"tenant": tenant,
 		"id":     contactId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -345,21 +337,19 @@ func (r *contactReadRepository) GetContactById(ctx context.Context, tenant, cont
 
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *contactReadRepository) GetActiveContactsForOrganizations(ctx context.Context, tenant string, organizationIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetActiveContactsForOrganizations")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetActiveContactsForOrganizations")
+	defer spans.Finish()
 
-	span.LogFields(log.Object("organizationIds", organizationIds))
+	spans.LogObjectAsJson("organizationIds", organizationIds)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization_%s)
 								WHERE o.id IN $organizationIds
@@ -370,8 +360,8 @@ func (r *contactReadRepository) GetActiveContactsForOrganizations(ctx context.Co
 		"tenant":          tenant,
 		"organizationIds": organizationIds,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -381,18 +371,16 @@ func (r *contactReadRepository) GetActiveContactsForOrganizations(ctx context.Co
 		return utils.ExtractAllRecordsAsDbNodeAndId(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *contactReadRepository) GetContactCountByOrganizations(ctx context.Context, tenant string, ids []string) (map[string]int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactCountByOrganizations")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactCountByOrganizations")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization) 
 				WHERE o.id IN $ids
@@ -403,8 +391,8 @@ func (r *contactReadRepository) GetContactCountByOrganizations(ctx context.Conte
 		"tenant": tenant,
 		"ids":    ids,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -417,7 +405,7 @@ func (r *contactReadRepository) GetContactCountByOrganizations(ctx context.Conte
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	output := make(map[string]int64)
@@ -428,11 +416,11 @@ func (r *contactReadRepository) GetContactCountByOrganizations(ctx context.Conte
 }
 
 func (r *contactReadRepository) GetContactsToFindWorkEmailWithBetterContact(ctx context.Context, minutesFromLastContactUpdate, limit int) ([]ContactsEnrichWorkEmail, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsToFindWorkEmailWithBetterContact")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("minutesFromLastContactUpdate", minutesFromLastContactUpdate))
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsToFindWorkEmailWithBetterContact")
+	defer spans.Finish()
+
+	spans.LogKV("minutesFromLastContactUpdate", minutesFromLastContactUpdate)
+	spans.LogKV("limit", limit)
 
 	cypher := ` MATCH (t:Tenant {active:true})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)--(j:JobRole)--(o:Organization)--(d:Domain), (t)--(ts:TenantSettings)
 				WHERE
@@ -452,8 +440,8 @@ func (r *contactReadRepository) GetContactsToFindWorkEmailWithBetterContact(ctx 
 		"minutesFromLastContactUpdate": minutesFromLastContactUpdate,
 		"limit":                        limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -483,15 +471,15 @@ func (r *contactReadRepository) GetContactsToFindWorkEmailWithBetterContact(ctx 
 				OrganizationDomain: v.Values[7].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *contactReadRepository) GetContactsToEnrichWithEmailFromBetterContact(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsToEnrichWithEmailFromBetterContact")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsToEnrichWithEmailFromBetterContact")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	minutesDelayFromUpdate := 2
 	cypher := ` MATCH (t:Tenant {active:true})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)
@@ -510,8 +498,8 @@ func (r *contactReadRepository) GetContactsToEnrichWithEmailFromBetterContact(ct
 		"limit":        limit,
 		"minutesDelay": minutesDelayFromUpdate,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -536,17 +524,17 @@ func (r *contactReadRepository) GetContactsToEnrichWithEmailFromBetterContact(ct
 				FieldStr1: v.Values[2].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *contactReadRepository) GetContactsToEnrich(ctx context.Context, minutesFromLastContactUpdate, minutesFromLastEnrichAttempt, limit int) ([]TenantAndContactIdAndParams, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsToEnrich")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("minutesFromLastContactUpdate", minutesFromLastContactUpdate))
-	span.LogFields(log.Int("minutesFromLastEnrichAttempt", minutesFromLastEnrichAttempt))
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsToEnrich")
+	defer spans.Finish()
+
+	spans.LogKV("minutesFromLastContactUpdate", minutesFromLastContactUpdate)
+	spans.LogKV("minutesFromLastEnrichAttempt", minutesFromLastEnrichAttempt)
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant {active:true})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact),
 				(t)--(ts:TenantSettings)
@@ -575,8 +563,8 @@ func (r *contactReadRepository) GetContactsToEnrich(ctx context.Context, minutes
 		"limit":                        limit,
 		"maxAttempts":                  1,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -599,15 +587,15 @@ func (r *contactReadRepository) GetContactsToEnrich(ctx context.Context, minutes
 				ContactId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *contactReadRepository) GetContactsWithGroupOrSystemGeneratedEmail(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsWithGroupOrSystemGeneratedEmail")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsWithGroupOrSystemGeneratedEmail")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant)<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)-[:HAS]->(e:Email)
 				WHERE
@@ -617,8 +605,8 @@ func (r *contactReadRepository) GetContactsWithGroupOrSystemGeneratedEmail(ctx c
 	params := map[string]any{
 		"limit": limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -641,15 +629,15 @@ func (r *contactReadRepository) GetContactsWithGroupOrSystemGeneratedEmail(ctx c
 				ContactId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *contactReadRepository) GetContactsWithEmailForNameUpdate(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsWithEmailForNameUpdate")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsWithEmailForNameUpdate")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant {active:true})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)-[:HAS]->(e:Email)
 				WHERE
@@ -663,8 +651,8 @@ func (r *contactReadRepository) GetContactsWithEmailForNameUpdate(ctx context.Co
 	params := map[string]any{
 		"limit": limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -688,17 +676,17 @@ func (r *contactReadRepository) GetContactsWithEmailForNameUpdate(ctx context.Co
 				FieldStr1: v.Values[2].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *contactReadRepository) GetContactsToCheck(ctx context.Context, minutesFromLastUpdate, hoursFromLastCheck, limit int) ([]TenantAndContact, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsToCheck")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit))
-	span.LogFields(log.Int("minutesFromLastUpdate", minutesFromLastUpdate))
-	span.LogFields(log.Int("hoursFromLastCheck", hoursFromLastCheck))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsToCheck")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
+	spans.LogKV("minutesFromLastUpdate", minutesFromLastUpdate)
+	spans.LogKV("hoursFromLastCheck", hoursFromLastCheck)
 
 	cypher := `MATCH (t:Tenant {active:true})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)
 				WHERE
@@ -712,8 +700,8 @@ func (r *contactReadRepository) GetContactsToCheck(ctx context.Context, minutesF
 		"minutesFromLastUpdate": minutesFromLastUpdate,
 		"hoursFromLastCheck":    hoursFromLastCheck,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -736,18 +724,20 @@ func (r *contactReadRepository) GetContactsToCheck(ctx context.Context, minutesF
 				Contact: utils.ToPtr(v.Values[1].(dbtype.Node)),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *contactReadRepository) GetContactsByLinkedIn(ctx context.Context, tenant, url, alias, externalId string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialReadRepository.GetContactsByLinkedIn")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("url", url), log.String("alias", alias), log.String("externalId", externalId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "SocialReadRepository.GetContactsByLinkedIn")
+	defer spans.Finish()
+
+	spans.LogKV("url", url)
+	spans.LogKV("alias", alias)
+	spans.LogKV("externalId", externalId)
 
 	if !strings.Contains(url, "linkedin.com") {
-		span.LogFields(log.Int("result.count", 0))
+		spans.LogKV("result.count", 0)
 		return nil, nil
 	}
 
@@ -779,8 +769,8 @@ func (r *contactReadRepository) GetContactsByLinkedIn(ctx context.Context, tenan
 		"externalId":   externalId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -793,27 +783,25 @@ func (r *contactReadRepository) GetContactsByLinkedIn(ctx context.Context, tenan
 		}
 	})
 	if err != nil {
-		span.LogFields(log.Int("result.count", 0))
+		spans.LogKV("result.count", 0)
 		return nil, err
 	}
 	nodes := result.([]*dbtype.Node)
-	span.LogFields(log.Int("result.count", len(nodes)))
+	spans.LogKV("result.count", len(nodes))
 	return nodes, err
 }
 
 func (r *contactReadRepository) CountByTenant(ctx context.Context, tenant string) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.CountByTenant")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.CountByTenant")
+	defer spans.Finish()
 
 	cypher := `MATCH (c:Contact)-[:CONTACT_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}) WHERE c.hide = false or c.hide IS NULL
 			RETURN count(c)`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -829,15 +817,15 @@ func (r *contactReadRepository) CountByTenant(ctx context.Context, tenant string
 		return 0, err
 	}
 	organizationsCount := dbRecord.(*db.Record).Values[0].(int64)
-	span.LogFields(log.Int64("result", organizationsCount))
+	spans.LogKV("result", organizationsCount)
 	return organizationsCount, nil
 }
 
 func (r *contactReadRepository) GetContactsToSetPrimaryJobRole(ctx context.Context, limit int) ([]TenantAndContactIdAndParams, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsToSetPrimaryJobRole")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsToSetPrimaryJobRole")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant {active:true})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)-[:WORKS_AS]->(j:JobRole)-[:ROLE_IN]->(:Organization)
 				WHERE c.hide IS NULL OR c.hide = false
@@ -847,8 +835,8 @@ func (r *contactReadRepository) GetContactsToSetPrimaryJobRole(ctx context.Conte
 	params := map[string]any{
 		"limit": limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -871,23 +859,21 @@ func (r *contactReadRepository) GetContactsToSetPrimaryJobRole(ctx context.Conte
 				ContactId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *contactReadRepository) GetDistinctContactRegions(ctx context.Context, tenant string) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetDistinctContactRegions")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetDistinctContactRegions")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {active:true, name: $tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)--(l:Location) 
 			WHERE c.hide = false AND l.region IS NOT NULL AND l.region <> '' RETURN DISTINCT l.region`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -900,7 +886,7 @@ func (r *contactReadRepository) GetDistinctContactRegions(ctx context.Context, t
 		}
 	})
 	if err != nil {
-		span.LogFields(log.Int("result.count", 0))
+		spans.LogKV("result.count", 0)
 		return nil, err
 	}
 
@@ -908,18 +894,16 @@ func (r *contactReadRepository) GetDistinctContactRegions(ctx context.Context, t
 }
 
 func (r *contactReadRepository) GetDistinctContactCities(ctx context.Context, tenant string) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetDistinctContactCities")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetDistinctContactCities")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {active:true, name: $tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact_%s)--(l:Location) 
 				WHERE c.hide = false and l.locality IS NOT NULL AND l.locality <> '' RETURN distinct l.locality`, tenant)
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -932,7 +916,7 @@ func (r *contactReadRepository) GetDistinctContactCities(ctx context.Context, te
 		}
 	})
 	if err != nil {
-		span.LogFields(log.Int("result.count", 0))
+		spans.LogKV("result.count", 0)
 		return nil, err
 	}
 
@@ -940,10 +924,10 @@ func (r *contactReadRepository) GetDistinctContactCities(ctx context.Context, te
 }
 
 func (r *contactReadRepository) GetContactsWithProfilePhotoUrlCrossTenant(ctx context.Context, profilePhotoUrl string) ([]TenantAndContactIdAndParams, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetContactsWithProfilePhotoUrlCrossTenant")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.String("profilePhotoUrl", profilePhotoUrl))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetContactsWithProfilePhotoUrlCrossTenant")
+	defer spans.Finish()
+
+	spans.LogKV("profilePhotoUrl", profilePhotoUrl)
 
 	cypher := `MATCH (t:Tenant {active:true})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)
 				WHERE c.profilePhotoUrl = $profilePhotoUrl
@@ -952,8 +936,8 @@ func (r *contactReadRepository) GetContactsWithProfilePhotoUrlCrossTenant(ctx co
 		"profilePhotoUrl": profilePhotoUrl,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -976,6 +960,6 @@ func (r *contactReadRepository) GetContactsWithProfilePhotoUrlCrossTenant(ctx co
 				ContactId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/contact_with_filters_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/contact_with_filters_read_repository.go
@@ -2,13 +2,12 @@ package neo4j_repository
 
 import (
 	"context"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+
 	"strings"
 )
 
@@ -60,11 +59,10 @@ func (r *contactWithFiltersReadRepository) prepareReadSession(ctx context.Contex
 }
 
 func (r *contactWithFiltersReadRepository) GetFilteredContactIds(ctx context.Context, tenant string, filter *model.Filter) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactWithFiltersReadRepository.GetFilteredContactIds")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.LogObjectAsJson(span, "filter", filter)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactWithFiltersReadRepository.GetFilteredContactIds")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("filter", filter)
 
 	params := map[string]any{
 		"tenant": tenant,
@@ -193,8 +191,8 @@ func (r *contactWithFiltersReadRepository) GetFilteredContactIds(ctx context.Con
 	params = utils.MergeMaps(params, locationFilterParams)
 	params = utils.MergeMaps(params, socialFilterParams)
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -207,10 +205,10 @@ func (r *contactWithFiltersReadRepository) GetFilteredContactIds(ctx context.Con
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
-		span.LogFields(log.Int("result.count", 0))
+		spans.TraceError(err)
+		spans.LogKV("result.count", 0)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]string))))
+	spans.LogKV("result.count", len(result.([]string)))
 	return result.([]string), err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/contact_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/contact_write_repository.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type ContactWriteRepository interface {
@@ -29,12 +27,11 @@ func NewContactWriteRepository(driver *neo4j.DriverWithContext, database string)
 }
 
 func (r *contactWriteRepository) SaveContactInTx(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contactId string, data data_fields.ContactFields, updateOnlyIfEmpty bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactWriteRepository.SaveContactInTx")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contactId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactWriteRepository.SaveContactInTx")
+	defer spans.Finish()
+
+	spans.TagEntity(contactId)
+	spans.LogObjectAsJson("data", data)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		cypher := fmt.Sprintf(`
@@ -92,8 +89,8 @@ func (r *contactWriteRepository) SaveContactInTx(ctx context.Context, tx *neo4j.
 			params["hide"] = *data.Hide
 		}
 
-		span.LogFields(log.String("cypher", cypher))
-		tracing.LogObjectAsJson(span, "params", params)
+		spans.LogKV("cypher", cypher)
+		spans.LogObjectAsJson("params", params)
 
 		_, err := tx.Run(ctx, cypher, params)
 		if err != nil {
@@ -104,18 +101,17 @@ func (r *contactWriteRepository) SaveContactInTx(ctx context.Context, tx *neo4j.
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *contactWriteRepository) ResetEnrichAttempts(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contactId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactWriteRepository.ResetEnrichAttempts")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, contactId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactWriteRepository.ResetEnrichAttempts")
+	defer spans.Finish()
+
+	spans.TagEntity(contactId)
 
 	cypher := `MATCH (t:Tenant {name: $tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact {id: $contactId})
 	WHERE c.enrichedAt IS NULL
@@ -124,8 +120,8 @@ func (r *contactWriteRepository) ResetEnrichAttempts(ctx context.Context, tx *ne
 		"tenant":    tenant,
 		"contactId": contactId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -135,7 +131,7 @@ func (r *contactWriteRepository) ResetEnrichAttempts(ctx context.Context, tx *ne
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err

--- a/packages/server/customer-os-neo4j-repository/repository/contract_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/contract_read_repository.go
@@ -2,14 +2,13 @@ package neo4j_repository
 
 import (
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 	"time"
 )
@@ -55,20 +54,19 @@ func (r *contractReadRepository) prepareReadSession(ctx context.Context) neo4j.S
 }
 
 func (r *contractReadRepository) GetContractById(ctx context.Context, tenant, contractId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractReadRepository.GetContractById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
-	span.LogFields(log.String("contractId", contractId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractReadRepository.GetContractById")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
+	spans.LogKV("contractId", contractId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract {id:$id}) RETURN c`
 	params := map[string]any{
 		"tenant": tenant,
 		"id":     contractId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -79,28 +77,27 @@ func (r *contractReadRepository) GetContractById(ctx context.Context, tenant, co
 
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *contractReadRepository) GetContractByServiceLineItemId(ctx context.Context, tenant string, serviceLineItemId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractReadRepository.GetContractByServiceLineItemId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("serviceLineItemId", serviceLineItemId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractReadRepository.GetContractByServiceLineItemId")
+	defer spans.Finish()
+
+	spans.LogKV("serviceLineItemId", serviceLineItemId)
 
 	cypher := `MATCH (sli:ServiceLineItem {id:$id})<-[:HAS_SERVICE]-(c:Contract)-[:CONTRACT_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}) RETURN c LIMIT 1`
 	params := map[string]any{
 		"id":     serviceLineItemId,
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -110,11 +107,11 @@ func (r *contractReadRepository) GetContractByServiceLineItemId(ctx context.Cont
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	records := result.([]*dbtype.Node)
-	span.LogFields(log.Int("result.count", len(records)))
+	spans.LogKV("result.count", len(records))
 	if len(records) == 0 {
 		return nil, nil
 	} else {
@@ -123,19 +120,18 @@ func (r *contractReadRepository) GetContractByServiceLineItemId(ctx context.Cont
 }
 
 func (r *contractReadRepository) GetContractByOpportunityId(ctx context.Context, tenant string, opportunityId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractReadRepository.GetContractByOpportunityId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("opportunityId", opportunityId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractReadRepository.GetContractByOpportunityId")
+	defer spans.Finish()
+
+	spans.LogKV("opportunityId", opportunityId)
 
 	cypher := fmt.Sprintf(`MATCH (:Opportunity {id:$id})<-[:HAS_OPPORTUNITY]-(c:Contract:Contract_%s)-[:CONTRACT_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}) RETURN c LIMIT 1`, tenant)
 	params := map[string]any{
 		"id":     opportunityId,
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -145,11 +141,11 @@ func (r *contractReadRepository) GetContractByOpportunityId(ctx context.Context,
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	records := result.([]*dbtype.Node)
-	span.LogFields(log.Int("result.count", len(records)))
+	spans.LogKV("result.count", len(records))
 	if len(records) == 0 {
 		return nil, nil
 	} else {
@@ -158,10 +154,8 @@ func (r *contractReadRepository) GetContractByOpportunityId(ctx context.Context,
 }
 
 func (r *contractReadRepository) GetContractsForOrganizations(ctx context.Context, tenant string, organizationIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractReadRepository.GetContractsForOrganizations")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractReadRepository.GetContractsForOrganizations")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)-[:HAS_CONTRACT]->(contract:Contract)-[:CONTRACT_BELONGS_TO_TENANT]->(t)
 			WHERE o.id IN $organizationIds
@@ -170,8 +164,8 @@ func (r *contractReadRepository) GetContractsForOrganizations(ctx context.Contex
 		"tenant":          tenant,
 		"organizationIds": organizationIds,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -181,18 +175,16 @@ func (r *contractReadRepository) GetContractsForOrganizations(ctx context.Contex
 		return utils.ExtractAllRecordsAsDbNodeAndId(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *contractReadRepository) GetContractForInvoice(ctx context.Context, tenant string, invoiceId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractReadRepository.GetContractForInvoice")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractReadRepository.GetContractForInvoice")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract)-[:HAS_INVOICE]->(i:Invoice_%s)
 			WHERE i.id = $invoiceId
@@ -201,8 +193,8 @@ func (r *contractReadRepository) GetContractForInvoice(ctx context.Context, tena
 		"tenant":    tenant,
 		"invoiceId": invoiceId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -212,11 +204,11 @@ func (r *contractReadRepository) GetContractForInvoice(ctx context.Context, tena
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	records := result.([]*dbtype.Node)
-	span.LogFields(log.Int("result.count", len(records)))
+	spans.LogKV("result.count", len(records))
 	if len(records) == 0 {
 		return nil, nil
 	} else {
@@ -225,10 +217,8 @@ func (r *contractReadRepository) GetContractForInvoice(ctx context.Context, tena
 }
 
 func (r *contractReadRepository) GetContractsForInvoices(ctx context.Context, tenant string, invoiceIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractReadRepository.GetContractsForInvoices")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractReadRepository.GetContractsForInvoices")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract)-[:HAS_INVOICE]->(i:Invoice_%s)
 			WHERE i.id IN $invoiceIds
@@ -237,8 +227,8 @@ func (r *contractReadRepository) GetContractsForInvoices(ctx context.Context, te
 		"tenant":     tenant,
 		"invoiceIds": invoiceIds,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -248,25 +238,23 @@ func (r *contractReadRepository) GetContractsForInvoices(ctx context.Context, te
 		return utils.ExtractAllRecordsAsDbNodeAndId(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *contractReadRepository) TenantsHasAtLeastOneContract(ctx context.Context, tenant string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractReadRepository.TenantsHasAtLeastOneContract")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractReadRepository.TenantsHasAtLeastOneContract")
+	defer spans.Finish()
 
 	cypher := `MATCH (c:Contract)-[:CONTRACT_BELONGS_TO_TENANT]->(:Tenant{name:$tenant}) RETURN count(c) > 0`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -279,26 +267,24 @@ func (r *contractReadRepository) TenantsHasAtLeastOneContract(ctx context.Contex
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return false, err
 	}
-	span.LogFields(log.Bool("result", result.(bool)))
+	spans.LogKV("result", result.(bool))
 	return result.(bool), err
 }
 
 func (r *contractReadRepository) CountContracts(ctx context.Context, tenant string) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractRepository.CountContracts")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractRepository.CountContracts")
+	defer spans.Finish()
 
 	cypher := `MATCH (c:Contract)-[:CONTRACT_BELONGS_TO_TENANT]->(:Tenant {name:$tenant})MATCH (c)-[:ACTIVE_RENEWAL]->(op:Opportunity)
 			RETURN count(c)`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -314,16 +300,17 @@ func (r *contractReadRepository) CountContracts(ctx context.Context, tenant stri
 		return 0, err
 	}
 	contractsCount := dbRecord.(*db.Record).Values[0].(int64)
-	span.LogFields(log.Int64("result - contractsCount", contractsCount))
+	spans.LogKV("result - contractsCount", contractsCount)
 	return contractsCount, nil
 }
 
 func (r *contractReadRepository) GetContractsToGenerateCycleInvoices(ctx context.Context, tenant string, referenceTime time.Time, delayMinutes, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractReadRepository.GetContractsToGenerateCycleInvoices")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("referenceTime", referenceTime), log.Int("delayMinutes", delayMinutes), log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractReadRepository.GetContractsToGenerateCycleInvoices")
+	defer spans.Finish()
+
+	spans.LogKV("referenceTime", referenceTime)
+	spans.LogKV("delayMinutes", delayMinutes)
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (ts:TenantSettings)<-[:HAS_SETTINGS]-(t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)-[:HAS_CONTRACT]->(c:Contract)-[:HAS_SERVICE]->(:ServiceLineItem)
 			WHERE 
@@ -349,8 +336,8 @@ func (r *contractReadRepository) GetContractsToGenerateCycleInvoices(ctx context
 		"delayMinutes":          delayMinutes,
 		"limit":                 limit,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -364,18 +351,20 @@ func (r *contractReadRepository) GetContractsToGenerateCycleInvoices(ctx context
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *contractReadRepository) GetContractsToGenerateOffCycleInvoices(ctx context.Context, referenceTime time.Time, delayMinutes, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractReadRepository.GetContractsToGenerateOffCycleInvoices")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Object("referenceTime", referenceTime), log.Int("delayMinutes", delayMinutes), log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractReadRepository.GetContractsToGenerateOffCycleInvoices")
+	defer spans.Finish()
+
+	spans.LogKV("referenceTime", referenceTime)
+	spans.LogKV("delayMinutes", delayMinutes)
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (ts:TenantSettings)<-[:HAS_SETTINGS]-(t:Tenant)<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)-[:HAS_CONTRACT]->(c:Contract)-[:HAS_SERVICE]->(sli:ServiceLineItem)
 			WHERE 
@@ -410,8 +399,8 @@ func (r *contractReadRepository) GetContractsToGenerateOffCycleInvoices(ctx cont
 		"delayMinutes":          delayMinutes,
 		"limit":                 limit,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -425,18 +414,20 @@ func (r *contractReadRepository) GetContractsToGenerateOffCycleInvoices(ctx cont
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *contractReadRepository) GetContractsToGenerateNextScheduledInvoices(ctx context.Context, referenceTime time.Time, delayMinutes, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractReadRepository.GetContractsToGenerateNextScheduledInvoices")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Object("referenceTime", referenceTime), log.Int("delayMinutes", delayMinutes), log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractReadRepository.GetContractsToGenerateNextScheduledInvoices")
+	defer spans.Finish()
+
+	spans.LogKV("referenceTime", referenceTime)
+	spans.LogKV("delayMinutes", delayMinutes)
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (ts:TenantSettings)<-[:HAS_SETTINGS]-(t:Tenant)<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)-[:HAS_CONTRACT]->(c:Contract)-[:HAS_SERVICE]->(sli:ServiceLineItem)
 			OPTIONAL MATCH (c)-[:HAS_INVOICE]->(i:Invoice {dryRun: true, preview: true})
@@ -465,8 +456,8 @@ func (r *contractReadRepository) GetContractsToGenerateNextScheduledInvoices(ctx
 		"delayMinutes": delayMinutes,
 		"limit":        limit,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -480,18 +471,20 @@ func (r *contractReadRepository) GetContractsToGenerateNextScheduledInvoices(ctx
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *contractReadRepository) GetContractsForStatusRenewal(ctx context.Context, referenceTime time.Time, limit, delayFromPreviousStatusCheckHours int) ([]TenantAndContractId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractRepository.GetContractsForStatusRenewal")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Object("referenceTime", referenceTime), log.Int("limit", limit), log.Int("delayFromPreviousStatusCheckHours", delayFromPreviousStatusCheckHours))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractRepository.GetContractsForStatusRenewal")
+	defer spans.Finish()
+
+	spans.LogKV("referenceTime", referenceTime)
+	spans.LogKV("limit", limit)
+	spans.LogKV("delayFromPreviousStatusCheckHours", delayFromPreviousStatusCheckHours)
 
 	cypher := `MATCH (t:Tenant)<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract)<-[:HAS_CONTRACT]-(:Organization {hide:false})
 				WHERE c.techStatusRenewalRequestedAt IS NULL OR c.techStatusRenewalRequestedAt + duration({hours: $delayFromPreviousStatusCheckHours}) < $referenceTime
@@ -517,8 +510,8 @@ func (r *contractReadRepository) GetContractsForStatusRenewal(ctx context.Contex
 		"limit":                             limit,
 		"delayFromPreviousStatusCheckHours": delayFromPreviousStatusCheckHours,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -542,15 +535,16 @@ func (r *contractReadRepository) GetContractsForStatusRenewal(ctx context.Contex
 				ContractId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *contractReadRepository) GetContractsForRenewalRollout(ctx context.Context, referenceTime time.Time, limit int) ([]TenantAndContractId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractRepository.GetContractsForStatusRenewal")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Object("referenceTime", referenceTime), log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractRepository.GetContractsForStatusRenewal")
+	defer spans.Finish()
+
+	spans.LogKV("referenceTime", referenceTime)
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant)<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract),
 				(c)-[:ACTIVE_RENEWAL]->(op:RenewalOpportunity)
@@ -568,8 +562,8 @@ func (r *contractReadRepository) GetContractsForRenewalRollout(ctx context.Conte
 		"scheduledStatus":     neo4jenum.ContractStatusScheduled.String(),
 		"limit":               limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -593,16 +587,15 @@ func (r *contractReadRepository) GetContractsForRenewalRollout(ctx context.Conte
 				ContractId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *contractReadRepository) IsContractInvoiced(ctx context.Context, tenant, contractId string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractRepository.IsContractInvoiced")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractRepository.IsContractInvoiced")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract {id:$contractId})-[:HAS_INVOICE]->(i:Invoice {dryRun:false})
 			RETURN count(i) > 0`
@@ -610,8 +603,8 @@ func (r *contractReadRepository) IsContractInvoiced(ctx context.Context, tenant,
 		"contractId": contractId,
 		"tenant":     tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -621,18 +614,16 @@ func (r *contractReadRepository) IsContractInvoiced(ctx context.Context, tenant,
 		return utils.ExtractSingleRecordFirstValueAsType[bool](ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return false, err
 	}
-	span.LogFields(log.Bool("result", result.(bool)))
+	spans.LogKV("result", result.(bool))
 	return result.(bool), err
 }
 
 func (r *contractReadRepository) GetPaginatedContracts(ctx context.Context, tenant string, skip, limit int) (*utils.DbNodesWithTotalCount, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractRepository.IsContractInvoiced")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractRepository.IsContractInvoiced")
+	defer spans.Finish()
 
 	dbNodesWithTotalCount := new(utils.DbNodesWithTotalCount)
 
@@ -647,10 +638,10 @@ func (r *contractReadRepository) GetPaginatedContracts(ctx context.Context, tena
 		"skip":   skip,
 		"limit":  limit,
 	}
-	span.LogFields(log.String("countCypher", countCypher))
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
-	tracing.LogObjectAsJson(span, "countParams", countParams)
+	spans.LogKV("countCypher", countCypher)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
+	spans.LogObjectAsJson("countParams", countParams)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -670,7 +661,7 @@ func (r *contractReadRepository) GetPaginatedContracts(ctx context.Context, tena
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	for _, v := range dbRecords.([]*neo4j.Record) {
@@ -680,10 +671,10 @@ func (r *contractReadRepository) GetPaginatedContracts(ctx context.Context, tena
 }
 
 func (r *contractReadRepository) GetLiveContractsWithoutRenewalOpportunities(ctx context.Context, limit int) ([]TenantAndContractId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractRepository.GetLiveContractsWithoutRenewalOpportunities")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractRepository.GetLiveContractsWithoutRenewalOpportunities")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant)<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract)
 				WHERE c.status = $liveStatus AND c.lengthInMonths > 0  AND NOT (c)-[:ACTIVE_RENEWAL]->(:RenewalOpportunity)
@@ -692,8 +683,8 @@ func (r *contractReadRepository) GetLiveContractsWithoutRenewalOpportunities(ctx
 		"liveStatus": neo4jenum.ContractStatusLive.String(),
 		"limit":      limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -717,6 +708,6 @@ func (r *contractReadRepository) GetLiveContractsWithoutRenewalOpportunities(ctx
 				ContractId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/contract_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/contract_write_repository.go
@@ -7,12 +7,10 @@ import (
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	model2 "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type ContractWriteRepository interface {
@@ -44,12 +42,11 @@ func NewContractWriteRepository(driver *neo4j.DriverWithContext, database string
 }
 
 func (r *contractWriteRepository) CreateForOrganization(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contractId string, data data_fields.ContractSaveFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.CreateForOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.CreateForOrganization")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$orgId})
 							MERGE (t)<-[:CONTRACT_BELONGS_TO_TENANT]-(ct:Contract {id:$contractId})<-[:HAS_CONTRACT]-(org)
@@ -120,26 +117,25 @@ func (r *contractWriteRepository) CreateForOrganization(ctx context.Context, tx 
 		"approved":               utils.IfNotNilBool(data.Approved),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	return nil
 }
 
 func (r *contractWriteRepository) UpdateContract(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contractId string, data data_fields.ContractSaveFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.UpdateContract")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.UpdateContract")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(ct:Contract {id:$contractId})
 				SET 
@@ -278,25 +274,24 @@ func (r *contractWriteRepository) UpdateContract(ctx context.Context, tx *neo4j.
 		params["approved"] = *data.Approved
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	return nil
 }
 
 func (r *contractWriteRepository) UpdateStatus(ctx context.Context, tenant, contractId, status string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.UpdateStatus")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.UpdateStatus")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(ct:Contract {id:$contractId})
 				SET 
@@ -308,22 +303,21 @@ func (r *contractWriteRepository) UpdateStatus(ctx context.Context, tenant, cont
 		"contractId": contractId,
 		"status":     status,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *contractWriteRepository) SuspendActiveRenewalOpportunity(ctx context.Context, tenant, contractId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.SuspendActiveRenewalOpportunity")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("contractId", contractId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.SuspendActiveRenewalOpportunity")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(ct:Contract {id:$contractId})-[r:ACTIVE_RENEWAL]->(op:RenewalOpportunity)
 				SET op.internalStage=$internalStageSuspended, 
@@ -335,22 +329,21 @@ func (r *contractWriteRepository) SuspendActiveRenewalOpportunity(ctx context.Co
 		"contractId":             contractId,
 		"internalStageSuspended": "SUSPENDED",
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *contractWriteRepository) ActivateSuspendedRenewalOpportunity(ctx context.Context, tenant, contractId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.ActivateSuspendedRenewalOpportunity")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("contractId", contractId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.ActivateSuspendedRenewalOpportunity")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(ct:Contract {id:$contractId})-[r:SUSPENDED_RENEWAL]->(op:RenewalOpportunity)
 				SET op.internalStage=$internalStage, 
@@ -362,23 +355,21 @@ func (r *contractWriteRepository) ActivateSuspendedRenewalOpportunity(ctx contex
 		"contractId":    contractId,
 		"internalStage": neo4jenum.OpportunityInternalStageOpen.String(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *contractWriteRepository) ContractCausedOnboardingStatusChange(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contractId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.ContractCausedOnboardingStatusChange")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
-	span.LogFields(log.String("contractId", contractId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.ContractCausedOnboardingStatusChange")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(ct:Contract {id:$contractId})
 				SET ct.triggeredOnboardingStatusChange=true`
@@ -386,25 +377,24 @@ func (r *contractWriteRepository) ContractCausedOnboardingStatusChange(ctx conte
 		"tenant":     tenant,
 		"contractId": contractId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	return nil
 }
 
 func (r *contractWriteRepository) MarkStatusRenewalRequested(ctx context.Context, tenant, contractId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.MarkStatusRenewalRequested")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.MarkStatusRenewalRequested")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(ct:Contract {id:$contractId})
 				SET ct.techStatusRenewalRequestedAt=$now`
@@ -413,22 +403,21 @@ func (r *contractWriteRepository) MarkStatusRenewalRequested(ctx context.Context
 		"contractId": contractId,
 		"now":        utils.Now(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *contractWriteRepository) MarkRolloutRenewalRequested(ctx context.Context, tenant, contractId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.MarkRolloutRenewalRequested")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.MarkRolloutRenewalRequested")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(ct:Contract {id:$contractId})
 				SET ct.techRolloutRenewalRequestedAt=$now`
@@ -437,22 +426,21 @@ func (r *contractWriteRepository) MarkRolloutRenewalRequested(ctx context.Contex
 		"contractId": contractId,
 		"now":        utils.Now(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *contractWriteRepository) MarkCycleInvoicingRequested(ctx context.Context, tenant, contractId string, invoicingStartedAt time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.MarkCycleInvoicingRequested")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.MarkCycleInvoicingRequested")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract {id:$contractId})
 				SET c.techInvoicingStartedAt=$invoicingStartedAt`
@@ -461,22 +449,21 @@ func (r *contractWriteRepository) MarkCycleInvoicingRequested(ctx context.Contex
 		"contractId":         contractId,
 		"invoicingStartedAt": invoicingStartedAt,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *contractWriteRepository) MarkOffCycleInvoicingRequested(ctx context.Context, tenant, contractId string, invoicingStartedAt time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.MarkOffCycleInvoicingRequested")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.MarkOffCycleInvoicingRequested")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract {id:$contractId})
 				SET c.techOffCycleInvoicingStartedAt=$invoicingStartedAt`
@@ -485,22 +472,21 @@ func (r *contractWriteRepository) MarkOffCycleInvoicingRequested(ctx context.Con
 		"contractId":         contractId,
 		"invoicingStartedAt": invoicingStartedAt,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *contractWriteRepository) MarkNextPreviewInvoicingRequested(ctx context.Context, tenant, contractId string, nextPreviewInvoiceRequestedAt time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.MarkNextPreviewInvoicingRequested")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.MarkNextPreviewInvoicingRequested")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract {id:$contractId})
 				SET c.techNextPreviewInvoiceRequestedAt=$nextPreviewInvoiceRequestedAt`
@@ -509,22 +495,21 @@ func (r *contractWriteRepository) MarkNextPreviewInvoicingRequested(ctx context.
 		"contractId":                    contractId,
 		"nextPreviewInvoiceRequestedAt": nextPreviewInvoiceRequestedAt,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *contractWriteRepository) SoftDelete(ctx context.Context, tenant, contractId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.SoftDelete")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.SoftDelete")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(ct:Contract {id:$contractId})
 			SET ct.updatedAt=$deletedAt,
@@ -539,8 +524,8 @@ func (r *contractWriteRepository) SoftDelete(ctx context.Context, tenant, contra
 		"contractId": contractId,
 		"deletedAt":  utils.Now(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -549,16 +534,16 @@ func (r *contractWriteRepository) SoftDelete(ctx context.Context, tenant, contra
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *contractWriteRepository) SetLtv(ctx context.Context, tenant, contractId string, ltv float64) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.SetLtv")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.SetLtv")
+	defer spans.Finish()
+
+	spans.TagEntity(contractId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(ct:Contract {id:$contractId})
 				SET ct.ltv=$ltv, ct.updatedAt=datetime()`
@@ -567,12 +552,12 @@ func (r *contractWriteRepository) SetLtv(ctx context.Context, tenant, contractId
 		"contractId": contractId,
 		"ltv":        ltv,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/country_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/country_read_repository.go
@@ -2,12 +2,11 @@ package neo4j_repository
 
 import (
 	"context"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"strings"
 )
 
@@ -38,10 +37,8 @@ func (r *countryReadRepository) prepareReadSession(ctx context.Context) neo4j.Se
 }
 
 func (r *countryReadRepository) GetDefaultCountryCodeA3(ctx context.Context, tenant string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CountryReadRepository.GetDefaultCountryCodeA3")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CountryReadRepository.GetDefaultCountryCodeA3")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})
 				OPTIONAL MATCH (tenant)-[:DEFAULT_COUNTRY]->(dc:Country)
@@ -49,8 +46,8 @@ func (r *countryReadRepository) GetDefaultCountryCodeA3(ctx context.Context, ten
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -63,17 +60,17 @@ func (r *countryReadRepository) GetDefaultCountryCodeA3(ctx context.Context, ten
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
-	span.LogFields(log.String("result", result.(string)))
+	spans.LogKV("result", result.(string))
 	return result.(string), nil
 }
 
 func (r *countryReadRepository) GetCountryByCodeIfExists(ctx context.Context, code string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CountryReadRepository.GetCountryByCodeIfExists")
-	defer span.Finish()
-	span.LogFields(log.String("code", code))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CountryReadRepository.GetCountryByCodeIfExists")
+	defer spans.Finish()
+	spans.LogKV("code", code)
 
 	if len(strings.TrimSpace(code)) == 2 {
 		return r.GetCountryByCodeA2IfExists(ctx, strings.TrimSpace(code))
@@ -85,16 +82,16 @@ func (r *countryReadRepository) GetCountryByCodeIfExists(ctx context.Context, co
 }
 
 func (r *countryReadRepository) GetCountryByCodeA3IfExists(ctx context.Context, codeA3 string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CountryReadRepository.GetCountryByCodeA3IfExists")
-	defer span.Finish()
-	span.LogFields(log.String("codeA3", codeA3))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CountryReadRepository.GetCountryByCodeA3IfExists")
+	defer spans.Finish()
+	spans.LogKV("codeA3", codeA3)
 
 	cypher := `MATCH (c:Country {codeA3:$codeA3}) WHERE $codeA3 <> "" RETURN c`
 	params := map[string]any{
 		"codeA3": codeA3,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -104,28 +101,28 @@ func (r *countryReadRepository) GetCountryByCodeA3IfExists(ctx context.Context, 
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if len(dbRecords.([]*dbtype.Node)) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return dbRecords.([]*dbtype.Node)[0], err
 }
 
 func (r *countryReadRepository) GetCountryByCodeA2IfExists(ctx context.Context, codeA2 string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CountryReadRepository.GetCountryByCodeA2IfExists")
-	defer span.Finish()
-	span.LogFields(log.String("codeA2", codeA2))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CountryReadRepository.GetCountryByCodeA2IfExists")
+	defer spans.Finish()
+	spans.LogKV("codeA2", codeA2)
 
 	cypher := `MATCH (c:Country {codeA2:$codeA2}) WHERE $codeA2 <> "" RETURN c`
 	params := map[string]any{
 		"codeA2": codeA2,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -135,35 +132,35 @@ func (r *countryReadRepository) GetCountryByCodeA2IfExists(ctx context.Context, 
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if len(dbRecords.([]*dbtype.Node)) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return dbRecords.([]*dbtype.Node)[0], err
 }
 
 func (r *countryReadRepository) GetCountriesPaginated(ctx context.Context, skip, limit int) (*utils.DbNodesWithTotalCount, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CountryReadRepository.GetCountryByCodeA3")
-	defer span.Finish()
-	tracing.LogObjectAsJson(span, "skip", skip)
-	tracing.LogObjectAsJson(span, "limit", limit)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CountryReadRepository.GetCountryByCodeA3")
+	defer spans.Finish()
+	spans.LogObjectAsJson("skip", skip)
+	spans.LogObjectAsJson("limit", limit)
 
 	cypherCount := `MATCH (c:Country) RETURN count(c) as count`
 	paramsCount := map[string]any{}
-	span.LogFields(log.String("cypherCount", cypherCount))
-	tracing.LogObjectAsJson(span, "paramsCount", paramsCount)
+	spans.LogKV("cypherCount", cypherCount)
+	spans.LogObjectAsJson("paramsCount", paramsCount)
 
 	cypher := `MATCH (c:Country) RETURN c ORDER BY c.name SKIP $skip LIMIT $limit`
 	params := map[string]any{
 		"skip":  skip,
 		"limit": limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -185,7 +182,7 @@ func (r *countryReadRepository) GetCountriesPaginated(ctx context.Context, skip,
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	for _, v := range dbRecords.([]*neo4j.Record) {
@@ -195,11 +192,11 @@ func (r *countryReadRepository) GetCountriesPaginated(ctx context.Context, skip,
 }
 
 func (r *countryReadRepository) GetCountries(ctx context.Context) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CountryReadRepository.GetCountries")
-	defer span.Finish()
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CountryReadRepository.GetCountries")
+	defer spans.Finish()
 
 	cypher := `MATCH (c:Country) RETURN c ORDER BY c.name`
-	span.LogFields(log.String("cypher", cypher))
+	spans.LogKV("cypher", cypher)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -225,14 +222,14 @@ func (r *countryReadRepository) GetCountries(ctx context.Context) ([]*dbtype.Nod
 }
 
 func (r *countryReadRepository) GetAllForPhoneNumbers(ctx context.Context, tenant string, ids []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CountryReadRepository.GetAllForPhoneNumbers")
-	defer span.Finish()
-	span.LogFields(log.Object("ids", ids))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CountryReadRepository.GetAllForPhoneNumbers")
+	defer spans.Finish()
+	spans.LogObjectAsJson("ids", ids)
 
 	query := `MATCH (:Tenant {name:$tenant})<-[:PHONE_NUMBER_BELONGS_TO_TENANT]-(p:PhoneNumber)-[:LINKED_TO]->(c:Country)
 		 		WHERE p.id IN $ids 
 		 		RETURN c, p.id`
-	span.LogFields(log.String("query", query))
+	spans.LogKV("query", query)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/country_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/country_write_repository.go
@@ -2,11 +2,10 @@ package neo4j_repository
 
 import (
 	"context"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+
 	"time"
 )
 
@@ -32,14 +31,14 @@ func (r *countryWriteRepository) prepareWriteSession(ctx context.Context) neo4j.
 }
 
 func (r *countryWriteRepository) CreateCountry(ctx context.Context, id, name, codeA2, codeA3, phoneCode string, createdAt time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CountryReadRepository.GetDefaultCountryCodeA3")
-	defer span.Finish()
-	tracing.LogObjectAsJson(span, "id", id)
-	tracing.LogObjectAsJson(span, "name", name)
-	tracing.LogObjectAsJson(span, "codeA2", codeA2)
-	tracing.LogObjectAsJson(span, "codeA3", codeA3)
-	tracing.LogObjectAsJson(span, "phoneCode", phoneCode)
-	tracing.LogObjectAsJson(span, "createdAt", createdAt)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CountryReadRepository.GetDefaultCountryCodeA3")
+	defer spans.Finish()
+	spans.LogObjectAsJson("id", id)
+	spans.LogObjectAsJson("name", name)
+	spans.LogObjectAsJson("codeA2", codeA2)
+	spans.LogObjectAsJson("codeA3", codeA3)
+	spans.LogObjectAsJson("phoneCode", phoneCode)
+	spans.LogObjectAsJson("createdAt", createdAt)
 
 	cypher := " MERGE (c:Country {id: $id})" +
 		" ON CREATE SET c.name=$name, " +
@@ -56,28 +55,28 @@ func (r *countryWriteRepository) CreateCountry(ctx context.Context, id, name, co
 		"phoneCode": phoneCode,
 		"createdAt": createdAt,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareWriteSession(ctx)
 	defer session.Close(ctx)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *countryWriteRepository) UpdateCountry(ctx context.Context, id, name, codeA2, codeA3, phoneCode string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CountryReadRepository.GetDefaultCountryCodeA3")
-	defer span.Finish()
-	tracing.LogObjectAsJson(span, "id", id)
-	tracing.LogObjectAsJson(span, "name", name)
-	tracing.LogObjectAsJson(span, "codeA2", codeA2)
-	tracing.LogObjectAsJson(span, "codeA3", codeA3)
-	tracing.LogObjectAsJson(span, "phoneCode", phoneCode)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CountryReadRepository.GetDefaultCountryCodeA3")
+	defer spans.Finish()
+	spans.LogObjectAsJson("id", id)
+	spans.LogObjectAsJson("name", name)
+	spans.LogObjectAsJson("codeA2", codeA2)
+	spans.LogObjectAsJson("codeA3", codeA3)
+	spans.LogObjectAsJson("phoneCode", phoneCode)
 
 	cypher := `
 			MATCH (c:Country {id:$id})
@@ -93,15 +92,15 @@ func (r *countryWriteRepository) UpdateCountry(ctx context.Context, id, name, co
 		"codeA3":    codeA3,
 		"phoneCode": phoneCode,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareWriteSession(ctx)
 	defer session.Close(ctx)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err

--- a/packages/server/customer-os-neo4j-repository/repository/custom_field_template_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/custom_field_template_read_repository.go
@@ -1,12 +1,11 @@
 package neo4j_repository
 
 import (
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -32,17 +31,15 @@ func (r *customFieldTemplateReadRepository) prepareReadSession(ctx context.Conte
 }
 
 func (r *customFieldTemplateReadRepository) GetAllForTenant(ctx context.Context, tenant string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CustomFieldTemplateReadRepository.GetAllForTenant")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CustomFieldTemplateReadRepository.GetAllForTenant")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CUSTOM_FIELD_TEMPLATE_BELONGS_TO_TENANT]-(cft:CustomFieldTemplate) RETURN cft ORDER BY cft.entityType, cft.order`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -55,27 +52,26 @@ func (r *customFieldTemplateReadRepository) GetAllForTenant(ctx context.Context,
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), err
 }
 
 func (r *customFieldTemplateReadRepository) GetById(ctx context.Context, tenant, id string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CustomFieldTemplateReadRepository.GetById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, id)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CustomFieldTemplateReadRepository.GetById")
+	defer spans.Finish()
+
+	spans.TagEntity(id)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CUSTOM_FIELD_TEMPLATE_BELONGS_TO_TENANT]-(cft:CustomFieldTemplate {id:$id}) RETURN cft`
 	params := map[string]any{
 		"tenant": tenant,
 		"id":     id,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -88,9 +84,9 @@ func (r *customFieldTemplateReadRepository) GetById(ctx context.Context, tenant,
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Object("result", result))
+	spans.LogObjectAsJson("result", result)
 	return result.(*dbtype.Node), err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/custom_field_template_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/custom_field_template_write_repository.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type CustomFieldTemplateSaveFields struct {
@@ -51,11 +49,10 @@ func NewCustomFieldTemplateWriteRepository(driver *neo4j.DriverWithContext, data
 }
 
 func (r *customFieldTemplateWriteRepository) Save(ctx context.Context, tenant, customFieldTemplateId string, data CustomFieldTemplateSaveFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CustomFieldTemplateWriteRepository.Save")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CustomFieldTemplateWriteRepository.Save")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`
 		MATCH (t:Tenant {name:$tenant})
@@ -105,22 +102,21 @@ func (r *customFieldTemplateWriteRepository) Save(ctx context.Context, tenant, c
 		params["max"] = data.Max
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *customFieldTemplateWriteRepository) Delete(ctx context.Context, tenant, customFieldTemplateId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CustomFieldTemplateWriteRepository.Delete")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, customFieldTemplateId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CustomFieldTemplateWriteRepository.Delete")
+	defer spans.Finish()
+
+	spans.TagEntity(customFieldTemplateId)
 
 	cypher := `
 		MATCH (t:Tenant {name:$tenant})<-[rel:CUSTOM_FIELD_TEMPLATE_BELONGS_TO_TENANT]-(cft:CustomFieldTemplate {id:$customFieldTemplateId})
@@ -131,12 +127,12 @@ func (r *customFieldTemplateWriteRepository) Delete(ctx context.Context, tenant,
 		"customFieldTemplateId": customFieldTemplateId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/custom_field_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/custom_field_write_repository.go
@@ -3,13 +3,12 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"time"
 )
 
@@ -41,12 +40,11 @@ func NewCustomFieldWriteRepository(driver *neo4j.DriverWithContext, database str
 }
 
 func (r *customFieldWriteRepository) AddCustomFieldToOrganization(ctx context.Context, tenant, organizationId string, data CustomFieldCreateFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CustomFieldWriteRepository.AddCustomFieldToOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("organizationId", organizationId))
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CustomFieldWriteRepository.AddCustomFieldToOrganization")
+	defer spans.Finish()
+
+	spans.LogKV("organizationId", organizationId)
+	spans.LogObjectAsJson("data", data)
 
 	nodeLabel := enum.NodeLabelForCustomFieldDataType(data.CustomFieldDataType)
 	propertyName := enum.PropertyNameForCustomFieldDataType(data.CustomFieldDataType)
@@ -81,12 +79,12 @@ func (r *customFieldWriteRepository) AddCustomFieldToOrganization(ctx context.Co
 		"value":          data.CustomFieldValue.RealValue(),
 		"templateId":     data.TemplateId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/domain_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/domain_read_repository.go
@@ -3,12 +3,10 @@ package neo4j_repository
 import (
 	"context"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type DomainReadRepository interface {
@@ -34,16 +32,15 @@ func (r *domainReadRepository) prepareReadSession(ctx context.Context) neo4j.Ses
 }
 
 func (r *domainReadRepository) GetDomain(ctx context.Context, tx *neo4j.ManagedTransaction, domain string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "DomainReadRepository.GetDomain")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "DomainReadRepository.GetDomain")
+	defer spans.Finish()
 
 	cypher := `MATCH (d:Domain {domain:$domain}) RETURN d`
 	params := map[string]any{
 		"domain": domain,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -56,21 +53,20 @@ func (r *domainReadRepository) GetDomain(ctx context.Context, tx *neo4j.ManagedT
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if len(result.([]*dbtype.Node)) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.([]*dbtype.Node)[0], nil
 }
 
 func (r *domainReadRepository) GetForOrganizations(ctx context.Context, tenant string, organizationIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "DomainRepository.GetForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "DomainRepository.GetForOrganizations")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)-[:HAS_DOMAIN]->(d:Domain)
 			WHERE o.id IN $organizationIds
@@ -79,11 +75,11 @@ func (r *domainReadRepository) GetForOrganizations(ctx context.Context, tenant s
 		"tenant":          tenant,
 		"organizationIds": organizationIds,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteQuery(ctx, *r.driver, r.database, cypher, params, func(err error) {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	})
 	if err != nil {
 		return nil, err
@@ -92,10 +88,11 @@ func (r *domainReadRepository) GetForOrganizations(ctx context.Context, tenant s
 }
 
 func (r *domainReadRepository) GetDomainsForPrimaryCheck(ctx context.Context, delayFromPreviousCheckInDays, limit int) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "DomainReadRepository.GetDomainsForPrimaryCheck")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Int("delayFromPreviousCheckInDays", delayFromPreviousCheckInDays), log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "DomainReadRepository.GetDomainsForPrimaryCheck")
+	defer spans.Finish()
+
+	spans.LogKV("delayFromPreviousCheckInDays", delayFromPreviousCheckInDays)
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (d:Domain)
 		WHERE d.techPrimaryDomainCheckRequestedAt IS NULL OR d.techPrimaryDomainCheckRequestedAt < datetime() - duration({days:$delayFromPreviousCheckInDays})
@@ -107,8 +104,8 @@ func (r *domainReadRepository) GetDomainsForPrimaryCheck(ctx context.Context, de
 		"limit":                        limit,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -120,6 +117,6 @@ func (r *domainReadRepository) GetDomainsForPrimaryCheck(ctx context.Context, de
 	if err != nil {
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(domains.([]string))))
+	spans.LogKV("result.count", len(domains.([]string)))
 	return domains.([]string), err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/domain_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/domain_write_repository.go
@@ -3,11 +3,9 @@ package neo4j_repository
 import (
 	"context"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type DomainWriteRepository interface {
@@ -28,10 +26,10 @@ func NewDomainWriteRepository(driver *neo4j.DriverWithContext, database string) 
 }
 
 func (r domainWriteRepository) MergeDomain(ctx context.Context, tx *neo4j.ManagedTransaction, domain, source, appSource string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "DomainWriteRepository.MergeDomain")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.SetTag(tracing.SpanTagEntityId, domain)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "DomainWriteRepository.MergeDomain")
+	defer spans.Finish()
+
+	spans.TagEntity(domain)
 
 	cypher := `
 	MERGE (d:Domain {domain:$domain})
@@ -47,27 +45,28 @@ func (r domainWriteRepository) MergeDomain(ctx context.Context, tx *neo4j.Manage
 		"source":    source,
 		"appSource": appSource,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
 		return utils.ExtractSingleRecordFirstValueAsType[bool](ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return false, err
 	}
-	span.LogFields(log.Bool("result.justCreated", result.(bool)))
+	spans.LogKV("result.justCreated", result.(bool))
 	return result.(bool), nil
 }
 
 func (r domainWriteRepository) SetPrimaryDetails(ctx context.Context, domain, primaryDomain string, primary, accessible bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "DomainWriteRepository.SetPrimaryDetails")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.SetTag(tracing.SpanTagEntityId, domain)
-	span.LogFields(log.String("primaryDomain", primaryDomain), log.Bool("primary", primary))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "DomainWriteRepository.SetPrimaryDetails")
+	defer spans.Finish()
+
+	spans.TagEntity(domain)
+	spans.LogKV("primaryDomain", primaryDomain)
+	spans.LogKV("primary", primary)
 
 	cypher := `MATCH (d:Domain {domain:$domain}) 
 				SET d.primary=$primary, 
@@ -81,12 +80,12 @@ func (r domainWriteRepository) SetPrimaryDetails(ctx context.Context, domain, pr
 		"primary":       primary,
 		"accessible":    accessible,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/email_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/email_read_repository.go
@@ -3,13 +3,12 @@ package neo4j_repository
 import (
 	"fmt"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -49,18 +48,17 @@ func (r *emailReadRepository) prepareReadSession(ctx context.Context) neo4j.Sess
 }
 
 func (r *emailReadRepository) GetEmailIdIfExists(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, email string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailReadRepository.GetEmailIdIfExists")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("email", email))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailReadRepository.GetEmailIdIfExists")
+	defer spans.Finish()
+
+	spans.LogKV("email", email)
 
 	cypher := fmt.Sprintf(`MATCH (e:Email_%s) WHERE (lower(e.email) = lower($email) OR lower(e.rawEmail) = lower($email)) AND $email <> '' RETURN e.id ORDER BY e.createdAt LIMIT 1`, tenant)
 	params := map[string]any{
 		"email": email,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -73,31 +71,30 @@ func (r *emailReadRepository) GetEmailIdIfExists(ctx context.Context, tx *neo4j.
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
 	if len(result.([]*db.Record)) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return "", nil
 	}
-	span.LogFields(log.String("result", result.([]*db.Record)[0].Values[0].(string)))
+	spans.LogKV("result", result.([]*db.Record)[0].Values[0].(string))
 	return result.([]*db.Record)[0].Values[0].(string), err
 }
 
 func (r *emailReadRepository) GetEmailForUser(ctx context.Context, tenant string, userId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailReadRepository.GetEmailForUser")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("userId", userId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailReadRepository.GetEmailForUser")
+	defer spans.Finish()
+
+	spans.LogKV("userId", userId)
 
 	cypher := fmt.Sprintf("MATCH (e:Email_%s)<-[:HAS]-(u:User {id:$userId})-[:USER_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}) WHERE u:User_%s return e", tenant, tenant)
 	params := map[string]any{
 		"userId": userId,
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -110,33 +107,32 @@ func (r *emailReadRepository) GetEmailForUser(ctx context.Context, tenant string
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *emailReadRepository) GetById(ctx context.Context, tenant, emailId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailReadRepository.GetById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("emailId", emailId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailReadRepository.GetById")
+	defer spans.Finish()
+
+	spans.LogKV("emailId", emailId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:EMAIL_ADDRESS_BELONGS_TO_TENANT]-(e:Email {id:$emailId}) return e`
 	params := map[string]any{
 		"tenant":  tenant,
 		"emailId": emailId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -148,16 +144,15 @@ func (r *emailReadRepository) GetById(ctx context.Context, tenant, emailId strin
 	if err != nil {
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", dbRecord != nil))
+	spans.LogKV("result.found", dbRecord != nil)
 	return dbRecord.(*dbtype.Node), err
 }
 
 func (r *emailReadRepository) GetFirstByEmail(ctx context.Context, tenant, email string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailRepository.GetFirstByEmail")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("email", email))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailRepository.GetFirstByEmail")
+	defer spans.Finish()
+
+	spans.LogKV("email", email)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:EMAIL_ADDRESS_BELONGS_TO_TENANT]-(e:Email) 
 		       WHERE e.rawEmail = $email OR e.email = $email RETURN e ORDER BY e.createdAt LIMIT 1`
@@ -165,8 +160,8 @@ func (r *emailReadRepository) GetFirstByEmail(ctx context.Context, tenant, email
 		"tenant": tenant,
 		"email":  email,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -177,26 +172,24 @@ func (r *emailReadRepository) GetFirstByEmail(ctx context.Context, tenant, email
 	})
 
 	if err != nil && err.Error() == "Result contains no more records" {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	} else if err != nil {
 		return nil, err
 	}
 
 	if dbRecord == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return dbRecord.(*dbtype.Node), err
 }
 
 func (r *emailReadRepository) GetAllEmailNodesForLinkedEntityIds(ctx context.Context, tenant string, entityType neo4jenum.EntityType, entityIds []string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailReadRepository.GetAllEmailNodesForLinkedEntityIds")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailReadRepository.GetAllEmailNodesForLinkedEntityIds")
+	defer spans.Finish()
 
 	cypher := ""
 	switch entityType {
@@ -215,8 +208,8 @@ func (r *emailReadRepository) GetAllEmailNodesForLinkedEntityIds(ctx context.Con
 		"entityIds": entityIds,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -235,10 +228,8 @@ func (r *emailReadRepository) GetAllEmailNodesForLinkedEntityIds(ctx context.Con
 }
 
 func (r *emailReadRepository) GetPrimaryEmailNodesForLinkedEntityIds(ctx context.Context, tenant string, entityType neo4jenum.EntityType, entityIds []string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailReadRepository.GetPrimaryEmailNodesForLinkedEntityIds")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailReadRepository.GetPrimaryEmailNodesForLinkedEntityIds")
+	defer spans.Finish()
 
 	cypher := ""
 	switch entityType {
@@ -257,8 +248,8 @@ func (r *emailReadRepository) GetPrimaryEmailNodesForLinkedEntityIds(ctx context
 		"entityIds": entityIds,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -277,13 +268,12 @@ func (r *emailReadRepository) GetPrimaryEmailNodesForLinkedEntityIds(ctx context
 }
 
 func (r *emailReadRepository) GetEmailsForValidation(ctx context.Context, delayFromLastUpdateInSeconds, delayFromLastValidationAttemptInMinutes, limit int) ([]TenantAndEmailId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailReadRepository.GetEmailsForValidation")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(
-		log.Int("delayFromLastUpdateInSeconds", delayFromLastUpdateInSeconds),
-		log.Int("delayFromLastValidationAttemptInMinutes", delayFromLastValidationAttemptInMinutes),
-		log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailReadRepository.GetEmailsForValidation")
+	defer spans.Finish()
+
+	spans.LogKV("delayFromLastUpdateInSeconds", delayFromLastUpdateInSeconds)
+	spans.LogKV("delayFromLastValidationAttemptInMinutes", delayFromLastValidationAttemptInMinutes)
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant {active:true})<-[:EMAIL_ADDRESS_BELONGS_TO_TENANT]-(e:Email)
 				WHERE
@@ -315,8 +305,8 @@ func (r *emailReadRepository) GetEmailsForValidation(ctx context.Context, delayF
 		"delayForRetryValidationInDays":           7,
 		"limit":                                   limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -339,16 +329,17 @@ func (r *emailReadRepository) GetEmailsForValidation(ctx context.Context, delayF
 				EmailId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *emailReadRepository) IsLinkedToEntityByEmailAddress(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, email, entityId string, entityType neo4jenum.EntityType) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailReadRepository.IsLinkedToEntityByEmailAddress")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("email", email), log.String("entityId", entityId), log.String("entityType", entityType.String()))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailReadRepository.IsLinkedToEntityByEmailAddress")
+	defer spans.Finish()
+
+	spans.LogKV("email", email)
+	spans.LogKV("entityId", entityId)
+	spans.LogKV("entityType", entityType.String())
 
 	cypher := ""
 	switch entityType {
@@ -370,8 +361,8 @@ func (r *emailReadRepository) IsLinkedToEntityByEmailAddress(ctx context.Context
 		"email":    email,
 		"entityId": entityId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -390,10 +381,11 @@ func (r *emailReadRepository) IsLinkedToEntityByEmailAddress(ctx context.Context
 }
 
 func (r *emailReadRepository) GetOrphanEmailNodes(ctx context.Context, limit, hoursFromLastUpdate int) ([]TenantAndEmailId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailReadRepository.GetOrphanEmailNodes")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit), log.Int("hoursFromLastUpdate", hoursFromLastUpdate))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailReadRepository.GetOrphanEmailNodes")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
+	spans.LogKV("hoursFromLastUpdate", hoursFromLastUpdate)
 
 	cypher := `MATCH (t:Tenant)<-[:EMAIL_ADDRESS_BELONGS_TO_TENANT]-(e:Email)
 				WHERE e.updatedAt < datetime() - duration({hours: $hoursFromLastUpdate})
@@ -407,8 +399,8 @@ func (r *emailReadRepository) GetOrphanEmailNodes(ctx context.Context, limit, ho
 		"hoursFromLastUpdate": hoursFromLastUpdate,
 		"limit":               limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -421,7 +413,7 @@ func (r *emailReadRepository) GetOrphanEmailNodes(ctx context.Context, limit, ho
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	output := make([]TenantAndEmailId, 0)
@@ -432,16 +424,15 @@ func (r *emailReadRepository) GetOrphanEmailNodes(ctx context.Context, limit, ho
 				EmailId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *emailReadRepository) IsOrphanEmail(ctx context.Context, tenant, emailId string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailReadRepository.IsOrphanEmail")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, emailId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailReadRepository.IsOrphanEmail")
+	defer spans.Finish()
+
+	spans.TagEntity(emailId)
 
 	cypher := `MATCH (:Tenant)<-[:EMAIL_ADDRESS_BELONGS_TO_TENANT]-(e:Email {id:$emailId})
 				OPTIONAL MATCH (e)--(other) 
@@ -452,8 +443,8 @@ func (r *emailReadRepository) IsOrphanEmail(ctx context.Context, tenant, emailId
 	params := map[string]any{
 		"emailId": emailId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -463,24 +454,22 @@ func (r *emailReadRepository) IsOrphanEmail(ctx context.Context, tenant, emailId
 		return utils.ExtractSingleRecordFirstValueAsType[bool](ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return false, err
 	}
 	return result.(bool), err
 }
 
 func (r *emailReadRepository) GetTestEmailForFlows(ctx context.Context, tenant string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailReadRepository.GetTestEmailForFlows")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailReadRepository.GetTestEmailForFlows")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`match (t:Tenant{name:$tenant})--(e:Email_%s) where e.rawEmail =~ ".*testcustomeros.com" return e.rawEmail`, tenant)
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -493,13 +482,13 @@ func (r *emailReadRepository) GetTestEmailForFlows(ctx context.Context, tenant s
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
 	if len(result.([]*db.Record)) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return "", nil
 	}
-	span.LogFields(log.String("result", result.([]*db.Record)[0].Values[0].(string)))
+	spans.LogKV("result", result.([]*db.Record)[0].Values[0].(string))
 	return result.([]*db.Record)[0].Values[0].(string), err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/email_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/email_write_repository.go
@@ -7,11 +7,10 @@ import (
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/constants"
@@ -60,12 +59,11 @@ func NewEmailWriteRepository(driver *neo4j.DriverWithContext, database string) E
 }
 
 func (r *emailWriteRepository) CreateEmail(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, emailId string, data EmailCreateFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.CreateEmail")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, emailId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.CreateEmail")
+	defer spans.Finish()
+
+	spans.TagEntity(emailId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant}) 
               MERGE (e:Email:Email_%s {id:$id})
@@ -81,8 +79,8 @@ func (r *emailWriteRepository) CreateEmail(ctx context.Context, tx *neo4j.Manage
 		"source":    utils.StringFirstNonEmpty(data.Source.String(), constants.SourceOpenline),
 		"createdAt": utils.NowIfZero(data.CreatedAt),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -92,19 +90,18 @@ func (r *emailWriteRepository) CreateEmail(ctx context.Context, tx *neo4j.Manage
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *emailWriteRepository) EmailValidated(ctx context.Context, tenant, emailId string, data data_fields.EmailValidationFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.EmailValidated")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, emailId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.EmailValidated")
+	defer spans.Finish()
+
+	spans.TagEntity(emailId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:EMAIL_ADDRESS_BELONGS_TO_TENANT]-(e:Email:Email_%s {id:$id})
 		 		SET e.email = CASE WHEN $email <> '' THEN $email ELSE e.email END,
@@ -165,22 +162,21 @@ func (r *emailWriteRepository) EmailValidated(ctx context.Context, tenant, email
 		"source":             neo4j_entity.DataSourceOpenline.String(),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *emailWriteRepository) LinkWithContact(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contactId, emailId string, primary bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.LinkWithContact")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, emailId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.LinkWithContact")
+	defer spans.Finish()
+
+	spans.TagEntity(emailId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact {id:$contactId}),
 				(t)<-[:EMAIL_ADDRESS_BELONGS_TO_TENANT]-(e:Email {id:$emailId})
@@ -197,8 +193,8 @@ func (r *emailWriteRepository) LinkWithContact(ctx context.Context, tx *neo4j.Ma
 		"emailId":   emailId,
 		"primary":   primary,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -208,18 +204,17 @@ func (r *emailWriteRepository) LinkWithContact(ctx context.Context, tx *neo4j.Ma
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *emailWriteRepository) LinkWithOrganization(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId, emailId string, primary bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.LinkWithOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, emailId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.LinkWithOrganization")
+	defer spans.Finish()
+
+	spans.TagEntity(emailId)
 
 	cypher := `
 		MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId}),
@@ -233,8 +228,8 @@ func (r *emailWriteRepository) LinkWithOrganization(ctx context.Context, tx *neo
 		"emailId":        emailId,
 		"primary":        primary,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -244,18 +239,17 @@ func (r *emailWriteRepository) LinkWithOrganization(ctx context.Context, tx *neo
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *emailWriteRepository) LinkWithUser(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, userId, emailId string, primary bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.LinkWithUser")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, emailId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.LinkWithUser")
+	defer spans.Finish()
+
+	spans.TagEntity(emailId)
 
 	cypher := `
 		MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User {id:$userId}),
@@ -269,8 +263,8 @@ func (r *emailWriteRepository) LinkWithUser(ctx context.Context, tx *neo4j.Manag
 		"emailId": emailId,
 		"primary": primary,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -280,18 +274,17 @@ func (r *emailWriteRepository) LinkWithUser(ctx context.Context, tx *neo4j.Manag
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *emailWriteRepository) CleanEmailValidation(ctx context.Context, tenant, emailId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.CleanEmailValidation")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, emailId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.CleanEmailValidation")
+	defer spans.Finish()
+
+	spans.TagEntity(emailId)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:EMAIL_ADDRESS_BELONGS_TO_TENANT]-(e:Email {id:$id})
 				WHERE e:Email_%s
@@ -323,23 +316,22 @@ func (r *emailWriteRepository) CleanEmailValidation(ctx context.Context, tenant,
 		"id":     emailId,
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *emailWriteRepository) UnlinkFromUser(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, usedId, email string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.UnlinkFromUser")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, usedId)
-	span.LogKV("email", email)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.UnlinkFromUser")
+	defer spans.Finish()
+
+	spans.TagEntity(usedId)
+	spans.LogKV("email", email)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User {id:$userId})-[rel:HAS]->(e:Email)
 				WHERE e.email = $email OR e.rawEmail = $email
@@ -350,8 +342,8 @@ func (r *emailWriteRepository) UnlinkFromUser(ctx context.Context, tx *neo4j.Man
 		"email":  email,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -361,19 +353,18 @@ func (r *emailWriteRepository) UnlinkFromUser(ctx context.Context, tx *neo4j.Man
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *emailWriteRepository) UnlinkFromContact(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contactId, email string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.UnlinkFromContact")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, contactId)
-	span.LogKV("email", email)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.UnlinkFromContact")
+	defer spans.Finish()
+
+	spans.TagEntity(contactId)
+	spans.LogKV("email", email)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact {id:$contactId})-[rel:HAS]->(e:Email)
 				WHERE e.email = $email OR e.rawEmail = $email
@@ -397,8 +388,8 @@ func (r *emailWriteRepository) UnlinkFromContact(ctx context.Context, tx *neo4j.
 		"email":     email,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -408,19 +399,18 @@ func (r *emailWriteRepository) UnlinkFromContact(ctx context.Context, tx *neo4j.
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *emailWriteRepository) UnlinkFromOrganization(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId, email string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.UnlinkFromOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, organizationId)
-	span.LogKV("email", email)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.UnlinkFromOrganization")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
+	spans.LogKV("email", email)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization {id:$organizationId})-[rel:HAS]->(e:Email)
 				WHERE e.email = $email OR e.rawEmail = $email
@@ -432,8 +422,8 @@ func (r *emailWriteRepository) UnlinkFromOrganization(ctx context.Context, tx *n
 		"email":          email,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -443,15 +433,15 @@ func (r *emailWriteRepository) UnlinkFromOrganization(ctx context.Context, tx *n
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *emailWriteRepository) DeleteOrphanEmail(ctx context.Context, tenant, emailId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.DeleteOrphanEmail")
-	defer span.Finish()
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.DeleteOrphanEmail")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[r:EMAIL_ADDRESS_BELONGS_TO_TENANT]-(e:Email {id:$id})
 				OPTIONAL MATCH (e)-[r2]-(d:Domain)
@@ -461,22 +451,21 @@ func (r *emailWriteRepository) DeleteOrphanEmail(ctx context.Context, tenant, em
 		"id":     emailId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *emailWriteRepository) SetPrimaryForEntity(ctx context.Context, tenant, entityId, email string, entityType model.EntityType) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.SetPrimaryForEntity")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogKV("entityId", entityId, "email", email, "entityType", entityType.String())
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.SetPrimaryForEntity")
+	defer spans.Finish()
+
+	spans.LogKV("entityId", entityId, "email", email, "entityType", entityType.String())
 
 	cypher := fmt.Sprintf(`MATCH (entity:%s {id:$entityId})-[rel:HAS]->(e:Email)
 				WHERE e.email = $email OR e.rawEmail = $email
@@ -492,21 +481,21 @@ func (r *emailWriteRepository) SetPrimaryForEntity(ctx context.Context, tenant, 
 		"email":    email,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *emailWriteRepository) SetDeliverableByEmailForAllTenants(ctx context.Context, email string, deliverable EmailDeliverableStatus) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailWriteRepository.SetDeliverableByEmailForAllTenants")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogKV("email", email, "deliverable", deliverable)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "EmailWriteRepository.SetDeliverableByEmailForAllTenants")
+	defer spans.Finish()
+
+	spans.LogKV("email", email, "deliverable", deliverable)
 
 	cypher := `MATCH (e:Email) WHERE e.email = $email OR e.rawEmail = $email
 				SET e.deliverable = $deliverable, e.updatedAt = datetime()`
@@ -515,12 +504,12 @@ func (r *emailWriteRepository) SetDeliverableByEmailForAllTenants(ctx context.Co
 		"deliverable": deliverable,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/external_system_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/external_system_read_repository.go
@@ -2,12 +2,11 @@ package neo4j_repository
 
 import (
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -35,11 +34,12 @@ func (r *externalSystemReadRepository) prepareReadSession(ctx context.Context) n
 }
 
 func (r *externalSystemReadRepository) GetFirstExternalIdForLinkedEntity(ctx context.Context, tenant, externalSystemId, entityId, entityLabel string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemReadRepository.GetFirstExternalIdForLinkedEntity")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("externalSystemId", externalSystemId), log.String("entityId", entityId), log.String("entityLabel", entityLabel))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ExternalSystemReadRepository.GetFirstExternalIdForLinkedEntity")
+	defer spans.Finish()
+
+	spans.LogKV("externalSystemId", externalSystemId)
+	spans.LogKV("entityId", entityId)
+	spans.LogKV("entityLabel", entityLabel)
 
 	cypher := fmt.Sprintf(`
 		MATCH (:Tenant {name:$tenant})<-[:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]-(ext:ExternalSystem {id:$externalSystemId})
@@ -50,8 +50,8 @@ func (r *externalSystemReadRepository) GetFirstExternalIdForLinkedEntity(ctx con
 		"externalSystemId": externalSystemId,
 		"entityId":         entityId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -64,12 +64,12 @@ func (r *externalSystemReadRepository) GetFirstExternalIdForLinkedEntity(ctx con
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]string))))
+	spans.LogKV("result.count", len(result.([]string)))
 	if len(result.([]string)) > 0 {
-		span.LogFields(log.String("result.externalId", result.([]string)[0]))
+		spans.LogKV("result.externalId", result.([]string)[0])
 		return result.([]string)[0], nil
 	} else {
 		return "", nil
@@ -77,11 +77,12 @@ func (r *externalSystemReadRepository) GetFirstExternalIdForLinkedEntity(ctx con
 }
 
 func (r *externalSystemReadRepository) GetAllExternalIdsForLinkedEntity(ctx context.Context, tenant, externalSystemId, entityId, entityLabel string) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemReadRepository.GetAllExternalIdsForLinkedEntity")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("externalSystemId", externalSystemId), log.String("entityId", entityId), log.String("entityLabel", entityLabel))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ExternalSystemReadRepository.GetAllExternalIdsForLinkedEntity")
+	defer spans.Finish()
+
+	spans.LogKV("externalSystemId", externalSystemId)
+	spans.LogKV("entityId", entityId)
+	spans.LogKV("entityLabel", entityLabel)
 
 	cypher := fmt.Sprintf(`
 		MATCH (:Tenant {name:$tenant})<-[:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]-(ext:ExternalSystem {id:$externalSystemId})
@@ -92,8 +93,8 @@ func (r *externalSystemReadRepository) GetAllExternalIdsForLinkedEntity(ctx cont
 		"entityId":         entityId,
 		"externalSystemId": externalSystemId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -106,25 +107,23 @@ func (r *externalSystemReadRepository) GetAllExternalIdsForLinkedEntity(ctx cont
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]string))))
+	spans.LogKV("result.count", len(result.([]string)))
 	return result.([]string), nil
 }
 
 func (r *externalSystemReadRepository) GetAllForTenant(ctx context.Context, tenant string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemReadRepository.GetAllForTenant")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ExternalSystemReadRepository.GetAllForTenant")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]-(ext:ExternalSystem) RETURN ext`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -137,18 +136,18 @@ func (r *externalSystemReadRepository) GetAllForTenant(ctx context.Context, tena
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), err
 }
 
 func (r *externalSystemReadRepository) GetFor(ctx context.Context, tenant string, ids []string, label string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemReadRepository.GetFor")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("label", label))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ExternalSystemReadRepository.GetFor")
+	defer spans.Finish()
+
+	spans.LogKV("label", label)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]-(e:ExternalSystem)<-[rel:IS_LINKED_WITH]-(n:%s)
 			WHERE n.id IN $ids RETURN e, rel, n.id order by e.id, rel.syncDate`, label)
@@ -157,8 +156,8 @@ func (r *externalSystemReadRepository) GetFor(ctx context.Context, tenant string
 		"ids":    ids,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/external_system_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/external_system_write_repository.go
@@ -2,12 +2,11 @@ package neo4j_repository
 
 import (
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -36,11 +35,11 @@ func (r *externalSystemWriteRepository) prepareWriteSession(ctx context.Context)
 }
 
 func (r *externalSystemWriteRepository) CreateIfNotExists(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, externalSystemId, externalSystemName string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemWriteRepository.CreateIfNotExists")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("externalSystemId", externalSystemId), log.String("externalSystemName", externalSystemName))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ExternalSystemWriteRepository.CreateIfNotExists")
+	defer spans.Finish()
+
+	spans.LogKV("externalSystemId", externalSystemId)
+	spans.LogKV("externalSystemName", externalSystemName)
 
 	cypher := fmt.Sprintf(`MATCH(t:Tenant {name:$tenant})
 							MERGE (t)<-[:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]-(e:ExternalSystem {id:$externalSystemId}) 
@@ -51,8 +50,8 @@ func (r *externalSystemWriteRepository) CreateIfNotExists(ctx context.Context, t
 		"externalSystemName": utils.FirstNotEmpty(externalSystemName, externalSystemId),
 		"now":                utils.Now(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -62,19 +61,19 @@ func (r *externalSystemWriteRepository) CreateIfNotExists(ctx context.Context, t
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *externalSystemWriteRepository) LinkWithEntity(ctx context.Context, tenant, linkedEntityId, linkedEntityNodeLabel string, externalSystem model.ExternalSystem) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemWriteRepository.LinkWithEntity")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("linkedEntityId", linkedEntityId), log.String("linkedEntityNodeLabel", linkedEntityNodeLabel))
-	tracing.LogObjectAsJson(span, "externalSystem", externalSystem)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ExternalSystemWriteRepository.LinkWithEntity")
+	defer spans.Finish()
+
+	spans.LogKV("linkedEntityId", linkedEntityId)
+	spans.LogKV("linkedEntityNodeLabel", linkedEntityNodeLabel)
+	spans.LogObjectAsJson("externalSystem", externalSystem)
 
 	session := r.prepareWriteSession(ctx)
 	defer session.Close(ctx)
@@ -86,12 +85,12 @@ func (r *externalSystemWriteRepository) LinkWithEntity(ctx context.Context, tena
 }
 
 func (r *externalSystemWriteRepository) LinkWithEntityInTx(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, linkedEntityId, linkedEntityNodeLabel string, externalSystem model.ExternalSystem) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemWriteRepository.LinkWithEntityInTx")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("linkedEntityId", linkedEntityId), log.String("linkedEntityNodeLabel", linkedEntityNodeLabel))
-	tracing.LogObjectAsJson(span, "externalSystem", externalSystem)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ExternalSystemWriteRepository.LinkWithEntityInTx")
+	defer spans.Finish()
+
+	spans.LogKV("linkedEntityId", linkedEntityId)
+	spans.LogKV("linkedEntityNodeLabel", linkedEntityNodeLabel)
+	spans.LogObjectAsJson("externalSystem", externalSystem)
 
 	cypher := fmt.Sprintf(`MATCH (n:%s {id:$entityId}),
 			(t:Tenant {name:$tenant})<-[:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]-(ext:ExternalSystem {id:$externalSystemId})
@@ -114,8 +113,8 @@ func (r *externalSystemWriteRepository) LinkWithEntityInTx(ctx context.Context, 
 		"syncDate":         utils.TimePtrAsAny(externalSystem.SyncDate),
 		"entityId":         linkedEntityId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -125,18 +124,19 @@ func (r *externalSystemWriteRepository) LinkWithEntityInTx(ctx context.Context, 
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *externalSystemWriteRepository) SetProperty(ctx context.Context, tenant, externalSystemId, propertyName string, propertyValue any) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemWriteRepository.SetProperty")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("externalSystemId", externalSystemId), log.String("propertyName", propertyName), log.Object("propertyValue", propertyValue))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ExternalSystemWriteRepository.SetProperty")
+	defer spans.Finish()
+
+	spans.LogKV("externalSystemId", externalSystemId)
+	spans.LogKV("propertyName", propertyName)
+	spans.LogObjectAsJson("propertyValue", propertyValue)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]-(e:ExternalSystem {id:$externalSystemId})
 		SET e.%s=$propertyValue, e.updatedAt=datetime()`, propertyName)
@@ -145,26 +145,24 @@ func (r *externalSystemWriteRepository) SetProperty(ctx context.Context, tenant,
 		"externalSystemId": externalSystemId,
 		"propertyValue":    propertyValue,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *externalSystemWriteRepository) SetPrimaryExternalId(ctx context.Context, tenant, externalSystemId string, externalId, linkedEntityNodeLabel, linkedEntityId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemWriteRepository.SetPrimaryExternalId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(
-		log.String("externalSystemId", externalSystemId),
-		log.String("externalId", externalId),
-		log.String("linkedEntityNodeLabel", linkedEntityNodeLabel),
-		log.String("linkedEntityId", linkedEntityId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ExternalSystemWriteRepository.SetPrimaryExternalId")
+	defer spans.Finish()
+
+	spans.LogKV("externalSystemId", externalSystemId)
+	spans.LogKV("externalId", externalId)
+	spans.LogKV("linkedEntityNodeLabel", linkedEntityNodeLabel)
+	spans.LogKV("linkedEntityId", linkedEntityId)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]-(e:ExternalSystem {id:$externalSystemId})
 		MATCH (n:%s {id:$linkedEntityId})
@@ -182,12 +180,12 @@ func (r *externalSystemWriteRepository) SetPrimaryExternalId(ctx context.Context
 		"linkedEntityId":   linkedEntityId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/flow_action_execution_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_action_execution_read_repository.go
@@ -7,14 +7,12 @@ import (
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type FlowActionExecutionReadRepository interface {
@@ -41,11 +39,10 @@ func NewFlowActionExecutionReadRepository(driver *neo4j.DriverWithContext, datab
 }
 
 func (r *flowActionExecutionReadRepositoryImpl) GetById(ctx context.Context, id string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.GetExecution")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.GetExecution")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -55,8 +52,8 @@ func (r *flowActionExecutionReadRepositoryImpl) GetById(ctx context.Context, id 
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -70,23 +67,22 @@ func (r *flowActionExecutionReadRepositoryImpl) GetById(ctx context.Context, id 
 	})
 
 	if err != nil && err.Error() == "Result contains no more records" {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 
 	return result.(*dbtype.Node), nil
 }
 
 func (r *flowActionExecutionReadRepositoryImpl) GetExecution(ctx context.Context, flowId, actionId, entityId string, entityType model.EntityType) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.GetExecution")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.GetExecution")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -99,8 +95,8 @@ func (r *flowActionExecutionReadRepositoryImpl) GetExecution(ctx context.Context
 		"entityType": entityType.String(),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -119,9 +115,8 @@ func (r *flowActionExecutionReadRepositoryImpl) GetExecution(ctx context.Context
 }
 
 func (r *flowActionExecutionReadRepositoryImpl) GetForParticipants(ctx context.Context, participantIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.GetForParticipants")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.GetForParticipants")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -131,8 +126,8 @@ func (r *flowActionExecutionReadRepositoryImpl) GetForParticipants(ctx context.C
 		"participantIds": participantIds,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, nil, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -143,7 +138,7 @@ func (r *flowActionExecutionReadRepositoryImpl) GetForParticipants(ctx context.C
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -151,9 +146,8 @@ func (r *flowActionExecutionReadRepositoryImpl) GetForParticipants(ctx context.C
 }
 
 func (r *flowActionExecutionReadRepositoryImpl) GetForEntity(ctx context.Context, tx *neo4j.ManagedTransaction, flowId, entityId string, entityType model.EntityType) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.GetForEntity")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.GetForEntity")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -165,8 +159,8 @@ func (r *flowActionExecutionReadRepositoryImpl) GetForEntity(ctx context.Context
 		"entityType": entityType.String(),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -177,7 +171,7 @@ func (r *flowActionExecutionReadRepositoryImpl) GetForEntity(ctx context.Context
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -185,17 +179,16 @@ func (r *flowActionExecutionReadRepositoryImpl) GetForEntity(ctx context.Context
 }
 
 func (r *flowActionExecutionReadRepositoryImpl) GetScheduledBefore(ctx context.Context, before time.Time) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.GetScheduledBefore")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.GetScheduledBefore")
+	defer spans.Finish()
 
 	cypher := `MATCH (f:Flow {status: 'ON'})-[:HAS]->(:FlowAction)-[:HAS_EXECUTION]->(fae:FlowActionExecution) where fae.status = 'SCHEDULED' and fae.scheduledAt < $before RETURN fae order by fae.scheduledAt limit 100`
 	params := map[string]any{
 		"before": before,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -208,17 +201,16 @@ func (r *flowActionExecutionReadRepositoryImpl) GetScheduledBefore(ctx context.C
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), nil
 }
 
 func (r *flowActionExecutionReadRepositoryImpl) GetByMailboxAndTimeInterval(ctx context.Context, tx *neo4j.ManagedTransaction, mailbox string, startTime, endTime time.Time) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.GetByMailboxAndTimeInterval")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.GetByMailboxAndTimeInterval")
+	defer spans.Finish()
 
 	cypher := `
 		MATCH (f:FlowActionExecution)
@@ -232,8 +224,8 @@ func (r *flowActionExecutionReadRepositoryImpl) GetByMailboxAndTimeInterval(ctx 
 		"endTime":   endTime,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -244,25 +236,26 @@ func (r *flowActionExecutionReadRepositoryImpl) GetByMailboxAndTimeInterval(ctx 
 	})
 
 	if err != nil && err.Error() == "Result contains no more records" {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 
 	return result.(*dbtype.Node), nil
 }
 
 func (r *flowActionExecutionReadRepositoryImpl) GetForEntityWithActionType(ctx context.Context, entityId string, entityType model.EntityType, actionType neo4jentity.FlowActionType) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.GetForEntityWithActionType")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.GetForEntityWithActionType")
+	defer spans.Finish()
 
-	span.LogFields(log.String("entityId", entityId), log.Object("entityType", entityType), log.Object("actionType", actionType))
+	spans.LogKV("entityId", entityId)
+	spans.LogObjectAsJson("entityType", entityType)
+	spans.LogObjectAsJson("actionType", actionType)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -276,8 +269,8 @@ func (r *flowActionExecutionReadRepositoryImpl) GetForEntityWithActionType(ctx c
 		"actionType": actionType,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, nil, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -287,21 +280,20 @@ func (r *flowActionExecutionReadRepositoryImpl) GetForEntityWithActionType(ctx c
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 
 	return result.([]*dbtype.Node), nil
 }
 
 func (r *flowActionExecutionReadRepositoryImpl) GetFirstSlotForMailbox(ctx context.Context, tx *neo4j.ManagedTransaction, mailbox string) (*time.Time, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.GetFirstSlotForMailbox")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.GetFirstSlotForMailbox")
+	defer spans.Finish()
 
-	span.LogFields(log.Object("mailbox", mailbox))
+	spans.LogKV("mailbox", mailbox)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -311,8 +303,8 @@ func (r *flowActionExecutionReadRepositoryImpl) GetFirstSlotForMailbox(ctx conte
 		"mailbox": mailbox,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if tx == nil {
 		session := utils.NewNeo4jReadSession(ctx, *r.driver)
@@ -350,11 +342,10 @@ func (r *flowActionExecutionReadRepositoryImpl) GetFirstSlotForMailbox(ctx conte
 }
 
 func (r *flowActionExecutionReadRepositoryImpl) GetLastScheduledForMailbox(ctx context.Context, tx *neo4j.ManagedTransaction, mailbox string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.GetLastScheduledForMailbox")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.GetLastScheduledForMailbox")
+	defer spans.Finish()
 
-	span.LogFields(log.String("mailbox", mailbox))
+	spans.LogKV("mailbox", mailbox)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -364,8 +355,8 @@ func (r *flowActionExecutionReadRepositoryImpl) GetLastScheduledForMailbox(ctx c
 		"mailbox": mailbox,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if tx == nil {
 		session := utils.NewNeo4jReadSession(ctx, *r.driver)
@@ -403,11 +394,12 @@ func (r *flowActionExecutionReadRepositoryImpl) GetLastScheduledForMailbox(ctx c
 }
 
 func (r *flowActionExecutionReadRepositoryImpl) CountEmailsPerMailboxPerDay(ctx context.Context, tx *neo4j.ManagedTransaction, mailbox string, startDate, endDate time.Time) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.CountEmailsPerMailboxPerDay")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.CountEmailsPerMailboxPerDay")
+	defer spans.Finish()
 
-	span.LogFields(log.String("mailbox", mailbox), log.Object("startDate", startDate), log.Object("endDate", endDate))
+	spans.LogKV("mailbox", mailbox)
+	spans.LogObjectAsJson("startDate", startDate)
+	spans.LogObjectAsJson("endDate", endDate)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -419,8 +411,8 @@ func (r *flowActionExecutionReadRepositoryImpl) CountEmailsPerMailboxPerDay(ctx 
 		"endDate":   endDate,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -437,26 +429,26 @@ func (r *flowActionExecutionReadRepositoryImpl) CountEmailsPerMailboxPerDay(ctx 
 			return queryResult.Single(ctx)
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return 0, err
 		}
 
 		count := queryResult.(*db.Record).Values[0].(int64)
-		span.LogFields(log.Int64("result", count))
+		spans.LogKV("result", count)
 		return count, nil
 	} else {
 		queryResult, err := (*tx).Run(ctx, cypher, params)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return 0, err
 		}
 		single, err := queryResult.Single(ctx)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return 0, err
 		}
 		count := single.Values[0].(int64)
-		span.LogFields(log.Int64("result", count))
+		spans.LogKV("result", count)
 		return count, nil
 	}
 }

--- a/packages/server/customer-os-neo4j-repository/repository/flow_action_execution_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_action_execution_write_repository.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -32,9 +30,8 @@ func NewFlowActionExecutionWriteRepository(driver *neo4j.DriverWithContext, data
 }
 
 func (r *flowActionExecutionWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.ManagedTransaction, entity *neo4j_entity.FlowActionExecutionEntity) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionWriteRepository.Merge")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionWriteRepository.Merge")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -89,8 +86,8 @@ func (r *flowActionExecutionWriteRepositoryImpl) Merge(ctx context.Context, tx *
 		"error":           entity.Error,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	queryResult, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		qr, err := tx.Run(ctx, cypher, params)
@@ -100,7 +97,7 @@ func (r *flowActionExecutionWriteRepositoryImpl) Merge(ctx context.Context, tx *
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, qr, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -108,9 +105,8 @@ func (r *flowActionExecutionWriteRepositoryImpl) Merge(ctx context.Context, tx *
 }
 
 func (r *flowActionExecutionWriteRepositoryImpl) RelinkWithActions(ctx context.Context) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionWriteRepository.RelinkWithActions")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionWriteRepository.RelinkWithActions")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -124,8 +120,8 @@ func (r *flowActionExecutionWriteRepositoryImpl) RelinkWithActions(ctx context.C
 		"tenant": tenant,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, nil, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -135,7 +131,7 @@ func (r *flowActionExecutionWriteRepositoryImpl) RelinkWithActions(ctx context.C
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -143,11 +139,10 @@ func (r *flowActionExecutionWriteRepositoryImpl) RelinkWithActions(ctx context.C
 }
 
 func (r *flowActionExecutionWriteRepositoryImpl) Delete(ctx context.Context, tx *neo4j.ManagedTransaction, id string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionWriteRepository.Delete")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionWriteRepository.Delete")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -158,8 +153,8 @@ func (r *flowActionExecutionWriteRepositoryImpl) Delete(ctx context.Context, tx 
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -169,7 +164,7 @@ func (r *flowActionExecutionWriteRepositoryImpl) Delete(ctx context.Context, tx 
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -177,11 +172,10 @@ func (r *flowActionExecutionWriteRepositoryImpl) Delete(ctx context.Context, tx 
 }
 
 func (r *flowActionExecutionWriteRepositoryImpl) DeleteScheduledForFlow(ctx context.Context, flowId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionWriteRepository.DeleteScheduledForFlow")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionWriteRepository.DeleteScheduledForFlow")
+	defer spans.Finish()
 
-	span.LogFields(log.String("flowId", flowId))
+	spans.LogKV("flowId", flowId)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -192,8 +186,8 @@ func (r *flowActionExecutionWriteRepositoryImpl) DeleteScheduledForFlow(ctx cont
 		"flowId": flowId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -206,7 +200,7 @@ func (r *flowActionExecutionWriteRepositoryImpl) DeleteScheduledForFlow(ctx cont
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 

--- a/packages/server/customer-os-neo4j-repository/repository/flow_action_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_action_read_repository.go
@@ -6,12 +6,10 @@ import (
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type FlowActionReadRepository interface {
@@ -34,12 +32,11 @@ func NewFlowActionReadRepository(driver *neo4j.DriverWithContext, database strin
 }
 
 func (r flowActionReadRepositoryImpl) GetList(ctx context.Context, flowIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionReadRepository.GetList")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionReadRepository.GetList")
+	defer spans.Finish()
 
 	if len(flowIds) > 0 {
-		span.LogFields(log.String("flowIds", fmt.Sprintf("%v", flowIds)))
+		spans.LogKV("flowIds", fmt.Sprintf("%v", flowIds))
 	}
 
 	tenant := common.GetTenantFromContext(ctx)
@@ -55,8 +52,8 @@ func (r flowActionReadRepositoryImpl) GetList(ctx context.Context, flowIds []str
 	}
 	cypher += "RETURN fa, f.id ORDER by fa.index"
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -69,10 +66,10 @@ func (r flowActionReadRepositoryImpl) GetList(ctx context.Context, flowIds []str
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	if len(result.([]*utils.DbNodeAndId)) == 0 {
 		return nil, nil
 	}
@@ -80,11 +77,10 @@ func (r flowActionReadRepositoryImpl) GetList(ctx context.Context, flowIds []str
 }
 
 func (r flowActionReadRepositoryImpl) GetById(ctx context.Context, id string) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionReadRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionReadRepository.GetById")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -94,8 +90,8 @@ func (r flowActionReadRepositoryImpl) GetById(ctx context.Context, id string) (*
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -117,11 +113,10 @@ func (r flowActionReadRepositoryImpl) GetById(ctx context.Context, id string) (*
 }
 
 func (r flowActionReadRepositoryImpl) GetStartAction(ctx context.Context, flowId string) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionReadRepository.GetStartAction")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionReadRepository.GetStartAction")
+	defer spans.Finish()
 
-	span.LogFields(log.String("flowId", flowId))
+	spans.LogKV("flowId", flowId)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -131,8 +126,8 @@ func (r flowActionReadRepositoryImpl) GetStartAction(ctx context.Context, flowId
 		"flowId": flowId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -154,11 +149,10 @@ func (r flowActionReadRepositoryImpl) GetStartAction(ctx context.Context, flowId
 }
 
 func (r flowActionReadRepositoryImpl) GetPrevious(ctx context.Context, actionId string) ([]*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionReadRepository.GetPrevious")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionReadRepository.GetPrevious")
+	defer spans.Finish()
 
-	span.LogFields(log.String("actionId", actionId))
+	spans.LogKV("actionId", actionId)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -169,8 +163,8 @@ func (r flowActionReadRepositoryImpl) GetPrevious(ctx context.Context, actionId 
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:BELONGS_TO_TENANT]-(previous:FlowAction_%s )-[:NEXT]->(current:FlowAction_%s {id: $actionId}) RETURN previous`, tenant, tenant)
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -183,10 +177,10 @@ func (r flowActionReadRepositoryImpl) GetPrevious(ctx context.Context, actionId 
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	if len(result.([]*dbtype.Node)) == 0 {
 		return nil, nil
 	}
@@ -194,11 +188,10 @@ func (r flowActionReadRepositoryImpl) GetPrevious(ctx context.Context, actionId 
 }
 
 func (r flowActionReadRepositoryImpl) GetNext(ctx context.Context, actionId string) ([]*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionReadRepository.GetNext")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionReadRepository.GetNext")
+	defer spans.Finish()
 
-	span.LogFields(log.String("actionId", actionId))
+	spans.LogKV("actionId", actionId)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -209,8 +202,8 @@ func (r flowActionReadRepositoryImpl) GetNext(ctx context.Context, actionId stri
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:BELONGS_TO_TENANT]-(:FlowAction_%s {id: $actionId})-[:NEXT]->(fa:FlowAction_%s) RETURN fa`, tenant, tenant)
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -223,10 +216,10 @@ func (r flowActionReadRepositoryImpl) GetNext(ctx context.Context, actionId stri
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	if len(result.([]*dbtype.Node)) == 0 {
 		return nil, nil
 	}
@@ -234,11 +227,10 @@ func (r flowActionReadRepositoryImpl) GetNext(ctx context.Context, actionId stri
 }
 
 func (r flowActionReadRepositoryImpl) GetFlowByActionId(ctx context.Context, id string) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionReadRepository.GetFlowByActionId")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionReadRepository.GetFlowByActionId")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -248,8 +240,8 @@ func (r flowActionReadRepositoryImpl) GetFlowByActionId(ctx context.Context, id 
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -271,11 +263,11 @@ func (r flowActionReadRepositoryImpl) GetFlowByActionId(ctx context.Context, id 
 }
 
 func (r flowActionReadRepositoryImpl) GetFlowByEntity(ctx context.Context, entityId string, entityType model.EntityType) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionReadRepository.GetFlowByEntity")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionReadRepository.GetFlowByEntity")
+	defer spans.Finish()
 
-	span.LogFields(log.String("entityId", entityId), log.String("entityType", entityType.String()))
+	spans.LogKV("entityId", entityId)
+	spans.LogKV("entityType", entityType.String())
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -286,8 +278,8 @@ func (r flowActionReadRepositoryImpl) GetFlowByEntity(ctx context.Context, entit
 		"entityType": entityType.String(),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/flow_action_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_action_write_repository.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -31,9 +29,8 @@ func NewFlowActionWriteRepository(driver *neo4j.DriverWithContext, database stri
 }
 
 func (r *flowActionWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.ManagedTransaction, input *neo4j_entity.FlowActionEntity) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionWriteRepository.Merge")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionWriteRepository.Merge")
+	defer spans.Finish()
 
 	onCreate := `ON CREATE SET
 				fa.createdAt = $createdAt,
@@ -113,8 +110,8 @@ func (r *flowActionWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.Man
 			%s
 			RETURN fa`, common.GetTenantFromContext(ctx), onCreate, onMatch)
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -131,7 +128,7 @@ func (r *flowActionWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.Man
 			return utils.ExtractSingleRecordFirstValueAsNode(ctx, qr, err)
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 
@@ -139,7 +136,7 @@ func (r *flowActionWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.Man
 	} else {
 		queryResult, err := (*tx).Run(ctx, cypher, params)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
@@ -147,11 +144,10 @@ func (r *flowActionWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.Man
 }
 
 func (r *flowActionWriteRepositoryImpl) DeleteForFlow(ctx context.Context, tx *neo4j.ManagedTransaction, id string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.DeleteForFlow")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.DeleteForFlow")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -162,8 +158,8 @@ func (r *flowActionWriteRepositoryImpl) DeleteForFlow(ctx context.Context, tx *n
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -173,7 +169,7 @@ func (r *flowActionWriteRepositoryImpl) DeleteForFlow(ctx context.Context, tx *n
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -181,11 +177,10 @@ func (r *flowActionWriteRepositoryImpl) DeleteForFlow(ctx context.Context, tx *n
 }
 
 func (r *flowActionWriteRepositoryImpl) Delete(ctx context.Context, id string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.Delete")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.Delete")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -196,8 +191,8 @@ func (r *flowActionWriteRepositoryImpl) Delete(ctx context.Context, id string) e
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -210,7 +205,7 @@ func (r *flowActionWriteRepositoryImpl) Delete(ctx context.Context, id string) e
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 

--- a/packages/server/customer-os-neo4j-repository/repository/flow_execution_settings_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_execution_settings_read_repository.go
@@ -3,13 +3,11 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type FlowExecutionSettingsReadRepository interface {
@@ -26,11 +24,11 @@ func NewFlowExecutionSettingsReadRepository(driver *neo4j.DriverWithContext, dat
 }
 
 func (r flowExecutionSettingsReadRepositoryImpl) GetForEntity(ctx context.Context, tx *neo4j.ManagedTransaction, flowId, entityId, entityType string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowReadRepository.GetForEntity")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowReadRepository.GetForEntity")
+	defer spans.Finish()
 
-	span.LogFields(log.String("flowId", flowId), log.String("entityId", entityId))
+	spans.LogKV("flowId", flowId)
+	spans.LogKV("entityId", entityId)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -42,8 +40,8 @@ func (r flowExecutionSettingsReadRepositoryImpl) GetForEntity(ctx context.Contex
 		"entityType": entityType,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)

--- a/packages/server/customer-os-neo4j-repository/repository/flow_execution_settings_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_execution_settings_write_repository.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -29,9 +27,8 @@ func NewFlowExecutionSettingsWriteRepository(driver *neo4j.DriverWithContext, da
 }
 
 func (r *flowExecutionSettingsWriteRepository) Merge(ctx context.Context, tx *neo4j.ManagedTransaction, entity *neo4j_entity.FlowExecutionSettingsEntity) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowExecutionSettingsWriteRepository.Merge")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowExecutionSettingsWriteRepository.Merge")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -65,8 +62,8 @@ func (r *flowExecutionSettingsWriteRepository) Merge(ctx context.Context, tx *ne
 		"userId":  entity.UserId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if tx == nil {
 		session := utils.NewNeo4jWriteSession(ctx, *r.driver)
@@ -80,7 +77,7 @@ func (r *flowExecutionSettingsWriteRepository) Merge(ctx context.Context, tx *ne
 			return utils.ExtractSingleRecordFirstValueAsNode(ctx, qr, err)
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 
@@ -88,7 +85,7 @@ func (r *flowExecutionSettingsWriteRepository) Merge(ctx context.Context, tx *ne
 	} else {
 		queryResult, err := (*tx).Run(ctx, cypher, params)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)

--- a/packages/server/customer-os-neo4j-repository/repository/flow_participant_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_participant_read_repository.go
@@ -6,13 +6,11 @@ import (
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -34,12 +32,11 @@ func NewFlowParticipantReadRepository(driver *neo4j.DriverWithContext, database 
 }
 
 func (r flowParticipantReadRepositoryImpl) GetList(ctx context.Context, flowIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowParticipantReadRepository.GetList")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowParticipantReadRepository.GetList")
+	defer spans.Finish()
 
 	if len(flowIds) > 0 {
-		span.LogFields(log.String("flowIds", fmt.Sprintf("%v", flowIds)))
+		spans.LogKV("flowIds", fmt.Sprintf("%v", flowIds))
 	}
 
 	tenant := common.GetTenantFromContext(ctx)
@@ -55,8 +52,8 @@ func (r flowParticipantReadRepositoryImpl) GetList(ctx context.Context, flowIds 
 	}
 	cypher += "RETURN fc, f.id"
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -69,10 +66,10 @@ func (r flowParticipantReadRepositoryImpl) GetList(ctx context.Context, flowIds 
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	if len(result.([]*utils.DbNodeAndId)) == 0 {
 		return nil, nil
 	}
@@ -80,9 +77,8 @@ func (r flowParticipantReadRepositoryImpl) GetList(ctx context.Context, flowIds 
 }
 
 func (r flowParticipantReadRepositoryImpl) CountWithStatus(ctx context.Context, flowId string, status neo4j_entity.FlowParticipantStatus) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowParticipantReadRepository.CountWithStatus")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowParticipantReadRepository.CountWithStatus")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -92,8 +88,8 @@ func (r flowParticipantReadRepositoryImpl) CountWithStatus(ctx context.Context, 
 		"flowId": flowId,
 		"status": status,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -109,16 +105,17 @@ func (r flowParticipantReadRepositoryImpl) CountWithStatus(ctx context.Context, 
 		return 0, err
 	}
 	organizationsCount := dbRecord.(*db.Record).Values[0].(int64)
-	span.LogFields(log.Int64("result", organizationsCount))
+	spans.LogKV("result", organizationsCount)
 	return organizationsCount, nil
 }
 
 func (r flowParticipantReadRepositoryImpl) Identify(ctx context.Context, flowId, entityId string, entityType model.EntityType) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowParticipantReadRepository.Identify")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowParticipantReadRepository.Identify")
+	defer spans.Finish()
 
-	span.LogFields(log.String("flowId", flowId), log.String("entityId", entityId), log.String("entityType", entityType.String()))
+	spans.LogKV("flowId", flowId)
+	spans.LogKV("entityId", entityId)
+	spans.LogKV("entityType", entityType.String())
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -130,8 +127,8 @@ func (r flowParticipantReadRepositoryImpl) Identify(ctx context.Context, flowId,
 		"entityType": entityType.String(),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -153,11 +150,10 @@ func (r flowParticipantReadRepositoryImpl) Identify(ctx context.Context, flowId,
 }
 
 func (r flowParticipantReadRepositoryImpl) GetById(ctx context.Context, id string) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowParticipantReadRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowParticipantReadRepository.GetById")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -167,8 +163,8 @@ func (r flowParticipantReadRepositoryImpl) GetById(ctx context.Context, id strin
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/flow_participant_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_participant_write_repository.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -32,9 +30,8 @@ func NewFlowParticipantWriteRepository(driver *neo4j.DriverWithContext, database
 }
 
 func (r *flowParticipantWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.ManagedTransaction, entity *neo4j_entity.FlowParticipantEntity) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowParticipantWriteRepository.Merge")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowParticipantWriteRepository.Merge")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`
 			MATCH (t:Tenant {name:$tenant})
@@ -65,8 +62,8 @@ func (r *flowParticipantWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4
 		"status":             entity.Status,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	queryResult, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		qr, err := tx.Run(ctx, cypher, params)
@@ -76,7 +73,7 @@ func (r *flowParticipantWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, qr, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -84,11 +81,10 @@ func (r *flowParticipantWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4
 }
 
 func (r *flowParticipantWriteRepositoryImpl) Delete(ctx context.Context, tx *neo4j.ManagedTransaction, id string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.Delete")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.Delete")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -99,8 +95,8 @@ func (r *flowParticipantWriteRepositoryImpl) Delete(ctx context.Context, tx *neo
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -110,7 +106,7 @@ func (r *flowParticipantWriteRepositoryImpl) Delete(ctx context.Context, tx *neo
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -118,11 +114,10 @@ func (r *flowParticipantWriteRepositoryImpl) Delete(ctx context.Context, tx *neo
 }
 
 func (r *flowParticipantWriteRepositoryImpl) MarkReadyContactsAsScheduled(ctx context.Context, tx *neo4j.ManagedTransaction, flowId string) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommonWriteRepository.MarkReadyContactsAsScheduled")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "CommonWriteRepository.MarkReadyContactsAsScheduled")
+	defer spans.Finish()
 
-	span.LogFields(log.String("flowId", flowId))
+	spans.LogKV("flowId", flowId)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -133,8 +128,8 @@ func (r *flowParticipantWriteRepositoryImpl) MarkReadyContactsAsScheduled(ctx co
 		"flowId": flowId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		qr, err := tx.Run(ctx, cypher, params)
@@ -144,7 +139,7 @@ func (r *flowParticipantWriteRepositoryImpl) MarkReadyContactsAsScheduled(ctx co
 		return utils.ExtractAllRecordsAsString(ctx, qr, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-neo4j-repository/repository/flow_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_read_repository.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type FlowReadRepository interface {
@@ -31,17 +29,16 @@ func NewFlowReadRepository(driver *neo4j.DriverWithContext, database string) Flo
 }
 
 func (r flowReadRepositoryImpl) GetList(ctx context.Context) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowReadRepository.GetList")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowReadRepository.GetList")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:BELONGS_TO_TENANT]-(f:Flow_%s) where not f.status = 'ARCHIVED' RETURN f`, common.GetTenantFromContext(ctx))
 	params := map[string]any{
 		"tenant": common.GetTenantFromContext(ctx),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -54,19 +51,18 @@ func (r flowReadRepositoryImpl) GetList(ctx context.Context) ([]*dbtype.Node, er
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), nil
 }
 
 func (r flowReadRepositoryImpl) GetWithParticipant(ctx context.Context, tx *neo4j.ManagedTransaction, flowParticipantId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowReadRepository.GetWithParticipant")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowReadRepository.GetWithParticipant")
+	defer spans.Finish()
 
-	span.LogFields(log.Object("flowParticipantId", flowParticipantId))
+	spans.LogObjectAsJson("flowParticipantId", flowParticipantId)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -77,8 +73,8 @@ func (r flowReadRepositoryImpl) GetWithParticipant(ctx context.Context, tx *neo4
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:BELONGS_TO_TENANT]-(f:Flow_%s)-[:HAS]->(fc:FlowParticipant_%s { id: $participantId }) RETURN f`, tenant, tenant)
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
@@ -99,11 +95,11 @@ func (r flowReadRepositoryImpl) GetWithParticipant(ctx context.Context, tx *neo4
 }
 
 func (r flowReadRepositoryImpl) GetFlowsForParticipants(ctx context.Context, entityIds []string, entityType model.EntityType) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowReadRepository.GetFlowsForParticipants")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowReadRepository.GetFlowsForParticipants")
+	defer spans.Finish()
 
-	span.LogFields(log.Object("entityIds", entityIds), log.Object("entityType", entityType))
+	spans.LogObjectAsJson("entityIds", entityIds)
+	spans.LogObjectAsJson("entityType", entityType)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -115,8 +111,8 @@ func (r flowReadRepositoryImpl) GetFlowsForParticipants(ctx context.Context, ent
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:BELONGS_TO_TENANT]-(f:Flow_%s)-[:HAS]->(fc:FlowParticipant_%s) where fc.entityType = $entityType and fc.entityId in $entityIds RETURN f, fc.entityId`, tenant, tenant)
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -129,19 +125,18 @@ func (r flowReadRepositoryImpl) GetFlowsForParticipants(ctx context.Context, ent
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r flowReadRepositoryImpl) GetListWithSender(ctx context.Context, senderIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowReadRepository.GetListWithSender")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowReadRepository.GetListWithSender")
+	defer spans.Finish()
 
-	span.LogFields(log.Object("senderIds", senderIds))
+	spans.LogObjectAsJson("senderIds", senderIds)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -153,8 +148,8 @@ func (r flowReadRepositoryImpl) GetListWithSender(ctx context.Context, senderIds
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:BELONGS_TO_TENANT]-(f:Flow_%s)-[:HAS]->(fs:FlowSender_%s) `, tenant, tenant)
 	cypher += "where fs.id in $senderIds RETURN f, fs.id"
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -167,27 +162,26 @@ func (r flowReadRepositoryImpl) GetListWithSender(ctx context.Context, senderIds
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r flowReadRepositoryImpl) GetById(ctx context.Context, id string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowReadRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowReadRepository.GetById")
+	defer spans.Finish()
 
-	tracing.LogObjectAsJson(span, "id", id)
+	spans.LogObjectAsJson("id", id)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:BELONGS_TO_TENANT]-(f:Flow_%s {id: $id}) RETURN f`, common.GetTenantFromContext(ctx))
 	params := map[string]any{
 		"tenant": common.GetTenantFromContext(ctx),
 		"id":     id,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/flow_sender_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_sender_read_repository.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type FlowSenderReadRepository interface {
@@ -29,12 +27,11 @@ func NewFlowSenderReadRepository(driver *neo4j.DriverWithContext, database strin
 }
 
 func (r flowSenderReadRepositoryImpl) GetList(ctx context.Context, flowIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowSenderReadRepository.GetList")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowSenderReadRepository.GetList")
+	defer spans.Finish()
 
 	if len(flowIds) > 0 {
-		span.LogFields(log.String("flowIds", fmt.Sprintf("%v", flowIds)))
+		spans.LogKV("flowIds", fmt.Sprintf("%v", flowIds))
 	}
 
 	tenant := common.GetTenantFromContext(ctx)
@@ -50,8 +47,8 @@ func (r flowSenderReadRepositoryImpl) GetList(ctx context.Context, flowIds []str
 	}
 	cypher += "RETURN fs, f.id"
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -64,10 +61,10 @@ func (r flowSenderReadRepositoryImpl) GetList(ctx context.Context, flowIds []str
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	if len(result.([]*utils.DbNodeAndId)) == 0 {
 		return nil, nil
 	}
@@ -75,11 +72,10 @@ func (r flowSenderReadRepositoryImpl) GetList(ctx context.Context, flowIds []str
 }
 
 func (r flowSenderReadRepositoryImpl) GetById(ctx context.Context, id string) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowSenderReadRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowSenderReadRepository.GetById")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -89,8 +85,8 @@ func (r flowSenderReadRepositoryImpl) GetById(ctx context.Context, id string) (*
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -112,11 +108,10 @@ func (r flowSenderReadRepositoryImpl) GetById(ctx context.Context, id string) (*
 }
 
 func (r flowSenderReadRepositoryImpl) GetFlowBySenderId(ctx context.Context, id string) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowSenderReadRepository.GetFlowBySenderId")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowSenderReadRepository.GetFlowBySenderId")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -126,8 +121,8 @@ func (r flowSenderReadRepositoryImpl) GetFlowBySenderId(ctx context.Context, id 
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -149,11 +144,10 @@ func (r flowSenderReadRepositoryImpl) GetFlowBySenderId(ctx context.Context, id 
 }
 
 func (r flowSenderReadRepositoryImpl) GetUsersUsedInFlows(ctx context.Context, userIds []string) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowSenderReadRepository.GetUsersUsedInFlows")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowSenderReadRepository.GetUsersUsedInFlows")
+	defer spans.Finish()
 
-	span.LogFields(log.Object("userIds", userIds))
+	spans.LogObjectAsJson("userIds", userIds)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -163,8 +157,8 @@ func (r flowSenderReadRepositoryImpl) GetUsersUsedInFlows(ctx context.Context, u
 		"userIds": userIds,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/flow_sender_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_sender_write_repository.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -30,9 +28,8 @@ func NewFlowSenderWriteRepository(driver *neo4j.DriverWithContext, database stri
 }
 
 func (r *flowSenderWriteRepositoryImpl) Merge(ctx context.Context, entity *neo4j_entity.FlowSenderEntity) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowSenderWriteRepository.Merge")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowSenderWriteRepository.Merge")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`
 			MATCH (t:Tenant {name:$tenant})
@@ -51,8 +48,8 @@ func (r *flowSenderWriteRepositoryImpl) Merge(ctx context.Context, entity *neo4j
 		"updatedAt": utils.NowIfZero(entity.UpdatedAt),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -72,11 +69,10 @@ func (r *flowSenderWriteRepositoryImpl) Merge(ctx context.Context, entity *neo4j
 }
 
 func (r *flowSenderWriteRepositoryImpl) Delete(ctx context.Context, id string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowSenderWriteRepository.Delete")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowSenderWriteRepository.Delete")
+	defer spans.Finish()
 
-	span.LogFields(log.String("id", id))
+	spans.LogKV("id", id)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -87,8 +83,8 @@ func (r *flowSenderWriteRepositoryImpl) Delete(ctx context.Context, id string) e
 		"id":     id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -101,7 +97,7 @@ func (r *flowSenderWriteRepositoryImpl) Delete(ctx context.Context, id string) e
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 

--- a/packages/server/customer-os-neo4j-repository/repository/flow_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/flow_write_repository.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -32,9 +30,8 @@ func NewFlowWriteRepository(driver *neo4j.DriverWithContext, database string) Fl
 }
 
 func (r *flowWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.ManagedTransaction, entity *neo4j_entity.FlowEntity) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowWriteRepository.Merge")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowWriteRepository.Merge")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`
 			MATCH (t:Tenant {name:$tenant})
@@ -89,8 +86,8 @@ func (r *flowWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.ManagedTr
 		"goalAchieved":   entity.GoalAchieved,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -107,7 +104,7 @@ func (r *flowWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.ManagedTr
 			return utils.ExtractSingleRecordFirstValueAsNode(ctx, qr, err)
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 
@@ -115,7 +112,7 @@ func (r *flowWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.ManagedTr
 	} else {
 		queryResult, err := (*tx).Run(ctx, cypher, params)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
@@ -123,9 +120,8 @@ func (r *flowWriteRepositoryImpl) Merge(ctx context.Context, tx *neo4j.ManagedTr
 }
 
 func (r *flowWriteRepositoryImpl) UpdateStatistics(ctx context.Context) ([]*utils.StringsWithTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowWriteRepository.UpdateStatistics")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowWriteRepository.UpdateStatistics")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant)<-[:BELONGS_TO_TENANT]-(f:Flow)-[:HAS]->(fp:FlowParticipant)
 WITH t, f, fp.status AS flowStatus, COUNT(fp.status) AS fs
@@ -155,8 +151,8 @@ RETURN collect(f.id), t.name`
 
 	params := map[string]any{}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -169,23 +165,22 @@ RETURN collect(f.id), t.name`
 		return utils.ExtractAllRecordsAsStringsWithTenant(ctx, r, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	flowsUpdated := result.([]*utils.StringsWithTenant)
 
 	for _, flowUpdated := range flowsUpdated {
-		span.LogFields(log.String("flowsUpdated."+flowUpdated.Tenant, fmt.Sprintf("%v", flowUpdated.Strings)))
+		spans.LogKV("flowsUpdated."+flowUpdated.Tenant, fmt.Sprintf("%v", flowUpdated.Strings))
 	}
 
 	return flowsUpdated, nil
 }
 
 func (r *flowWriteRepositoryImpl) UpdateFlowStatistics(ctx context.Context, tx *neo4j.ManagedTransaction, flowId string) ([]*utils.StringsWithTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowWriteRepository.UpdateFlowStatistics")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowWriteRepository.UpdateFlowStatistics")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -220,8 +215,8 @@ RETURN collect(f.id), t.name`, tenant, tenant)
 		"flowId": flowId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		r, err := tx.Run(ctx, cypher, params)
@@ -231,14 +226,14 @@ RETURN collect(f.id), t.name`, tenant, tenant)
 		return utils.ExtractAllRecordsAsStringsWithTenant(ctx, r, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	flowsUpdated := result.([]*utils.StringsWithTenant)
 
 	for _, flowUpdated := range flowsUpdated {
-		span.LogFields(log.String("flowsUpdated."+flowUpdated.Tenant, fmt.Sprintf("%v", flowUpdated.Strings)))
+		spans.LogKV("flowsUpdated."+flowUpdated.Tenant, fmt.Sprintf("%v", flowUpdated.Strings))
 	}
 
 	return flowsUpdated, nil

--- a/packages/server/customer-os-neo4j-repository/repository/industry_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/industry_read_repository.go
@@ -3,12 +3,11 @@ package neo4j_repository
 import (
 	context2 "context"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -31,10 +30,10 @@ func NewIndustryReadRepository(driver *neo4j.DriverWithContext, database string)
 }
 
 func (r *industryReadRepository) GetAllForOrganizationIds(ctx context.Context, tenant string, organizationIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IndustryReadRepository.GetAllForOrganizationIds")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("organizationIds", fmt.Sprintf("%v", organizationIds)))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IndustryReadRepository.GetAllForOrganizationIds")
+	defer spans.Finish()
+
+	spans.LogKV("organizationIds", fmt.Sprintf("%v", organizationIds))
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)-[:HAS_INDUSTRY]->(i:Industry) 
 				WHERE o.id in $organizationIds RETURN i, o.id`
@@ -44,8 +43,8 @@ func (r *industryReadRepository) GetAllForOrganizationIds(ctx context.Context, t
 		"organizationIds": organizationIds,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -55,17 +54,16 @@ func (r *industryReadRepository) GetAllForOrganizationIds(ctx context.Context, t
 		return utils.ExtractAllRecordsAsDbNodeAndId(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *industryReadRepository) GetInUseIndustries(ctx context2.Context, tenant string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IndustryReadRepository.GetInUseIndustries")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IndustryReadRepository.GetInUseIndustries")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization {hide:false})-[:HAS_INDUSTRY]->(i:Industry) 
 				RETURN DISTINCT i ORDER BY i.code`
@@ -74,8 +72,8 @@ func (r *industryReadRepository) GetInUseIndustries(ctx context2.Context, tenant
 		"tenant": tenant,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -85,26 +83,26 @@ func (r *industryReadRepository) GetInUseIndustries(ctx context2.Context, tenant
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), err
 }
 
 func (r *industryReadRepository) GetByCode(ctx context.Context, code string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IndustryReadRepository.GetByCode")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("code", code))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IndustryReadRepository.GetByCode")
+	defer spans.Finish()
+
+	spans.LogKV("code", code)
 
 	cypher := `MATCH (i:Industry {code:$code}) RETURN i`
 	params := map[string]any{
 		"code": code,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -117,7 +115,7 @@ func (r *industryReadRepository) GetByCode(ctx context.Context, code string) (*d
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if len(result.([]*dbtype.Node)) == 0 {

--- a/packages/server/customer-os-neo4j-repository/repository/industry_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/industry_write_repository.go
@@ -1,9 +1,9 @@
 package neo4j_repository
 
 import (
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/opentracing/opentracing-go"
+
 	"golang.org/x/net/context"
 )
 
@@ -24,10 +24,8 @@ func NewIndustryWriteRepository(driver *neo4j.DriverWithContext, database string
 }
 
 func (r *industryWriteRepository) ReplaceForOrganization(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId, industryCode string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IndustryWriteRepository.ReplaceForOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IndustryWriteRepository.ReplaceForOrganization")
+	defer spans.Finish()
 
 	cypher := `MATCH (o:Organization {id: $organizationId})-[:ORGANIZATION_BELONGS_TO_TENANT]->(t:Tenant {name: $tenant})
 				MATCH (i:Industry {code: $industryCode})
@@ -42,5 +40,5 @@ func (r *industryWriteRepository) ReplaceForOrganization(ctx context.Context, tx
 		"industryCode":   industryCode,
 	}
 
-	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, span)
+	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, spans)
 }

--- a/packages/server/customer-os-neo4j-repository/repository/interaction_event_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/interaction_event_read_repository.go
@@ -3,12 +3,10 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type InteractionEventReadRepository interface {
@@ -40,10 +38,10 @@ func (r *interactionEventReadRepository) prepareReadSession(ctx context.Context)
 }
 
 func (r *interactionEventReadRepository) GetAllForInteractionSessions(ctx context.Context, tenant string, ids []string, returnContent bool) ([]*utils.DbPropsAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventReadRepository.GetAllForInteractionSessions")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Bool("returnContent", returnContent))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventReadRepository.GetAllForInteractionSessions")
+	defer spans.Finish()
+
+	spans.LogKV("returnContent", returnContent)
 
 	cypherReturnFragment := "e {.*}"
 	if !returnContent {
@@ -56,7 +54,8 @@ func (r *interactionEventReadRepository) GetAllForInteractionSessions(ctx contex
 	params := map[string]any{
 		"ids": ids,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -75,10 +74,10 @@ func (r *interactionEventReadRepository) GetAllForInteractionSessions(ctx contex
 }
 
 func (r *interactionEventReadRepository) GetAllForMeetings(ctx context.Context, tenant string, ids []string, returnContent bool) ([]*utils.DbPropsAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventReadRepository.GetAllForMeetings")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Bool("returnContent", returnContent))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventReadRepository.GetAllForMeetings")
+	defer spans.Finish()
+
+	spans.LogKV("returnContent", returnContent)
 
 	cypherReturnFragment := "e {.*}"
 	if !returnContent {
@@ -91,7 +90,8 @@ func (r *interactionEventReadRepository) GetAllForMeetings(ctx context.Context, 
 	params := map[string]any{
 		"ids": ids,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -110,10 +110,10 @@ func (r *interactionEventReadRepository) GetAllForMeetings(ctx context.Context, 
 }
 
 func (r *interactionEventReadRepository) GetAllForIssues(ctx context.Context, tenant string, issueIds []string, returnContent bool) ([]*utils.DbPropsAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventReadRepository.GetAllForIssues")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Bool("returnContent", returnContent))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventReadRepository.GetAllForIssues")
+	defer spans.Finish()
+
+	spans.LogKV("returnContent", returnContent)
 
 	cypherReturnFragment := "e {.*}"
 	if !returnContent {
@@ -127,7 +127,8 @@ func (r *interactionEventReadRepository) GetAllForIssues(ctx context.Context, te
 		"tenant":   tenant,
 		"issueIds": issueIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -139,16 +140,15 @@ func (r *interactionEventReadRepository) GetAllForIssues(ctx context.Context, te
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	return result.([]*utils.DbPropsAndId), nil
 }
 
 func (r *interactionEventReadRepository) GetSentByFor(ctx context.Context, tenant string, ids []string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventReadRepository.GetSentByFor")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventReadRepository.GetSentByFor")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (ie:InteractionEvent)-[rel:SENT_BY]->(p:Email|PhoneNumber|User|Contact|Organization|JobRole) 
 		WHERE ie.id IN $ids AND ie:InteractionEvent_%s
@@ -156,7 +156,8 @@ func (r *interactionEventReadRepository) GetSentByFor(ctx context.Context, tenan
 	params := map[string]any{
 		"ids": ids,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -175,16 +176,16 @@ func (r *interactionEventReadRepository) GetSentByFor(ctx context.Context, tenan
 }
 
 func (r *interactionEventReadRepository) GetSentToFor(ctx context.Context, tenant string, ids []string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventReadRepository.GetSentToFor")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventReadRepository.GetSentToFor")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (ie:InteractionEvent)-[rel:SENT_TO]->(p:Email|PhoneNumber|User|Contact|Organization|JobRole) 
 		 WHERE ie.id IN $ids AND ie:InteractionEvent_%s RETURN p, rel, ie.id`, tenant)
 	params := map[string]any{
 		"ids": ids,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -202,10 +203,10 @@ func (r *interactionEventReadRepository) GetSentToFor(ctx context.Context, tenan
 }
 
 func (r *interactionEventReadRepository) GetReplyToFor(ctx context.Context, tenant string, ids []string, returnContent bool) ([]*utils.DbPropsAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventReadRepository.GetReplyToFor")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Bool("returnContent", returnContent))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventReadRepository.GetReplyToFor")
+	defer spans.Finish()
+
+	spans.LogKV("returnContent", returnContent)
 
 	cypherReturnFragment := "rie {.*}"
 	if !returnContent {
@@ -218,7 +219,8 @@ func (r *interactionEventReadRepository) GetReplyToFor(ctx context.Context, tena
 	params := map[string]any{
 		"ids": ids,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -237,16 +239,16 @@ func (r *interactionEventReadRepository) GetReplyToFor(ctx context.Context, tena
 }
 
 func (r *interactionEventReadRepository) GetInteractionEventByCustomerOSIdentifier(ctx context.Context, customerOSInternalIdentifier string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventReadRepository.GetInteractionEventByCustomerOSIdentifier")
-	defer span.Finish()
-	span.LogFields(log.String("customerOSInternalIdentifier", customerOSInternalIdentifier))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventReadRepository.GetInteractionEventByCustomerOSIdentifier")
+	defer spans.Finish()
+	spans.LogKV("customerOSInternalIdentifier", customerOSInternalIdentifier)
 
 	cypher := `MATCH (i:InteractionEvent {customerOSInternalIdentifier:$customerOSInternalIdentifier}) WHERE i:InteractionEvent RETURN i`
 	params := map[string]any{
 		"customerOSInternalIdentifier": customerOSInternalIdentifier,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -268,18 +270,17 @@ func (r *interactionEventReadRepository) GetInteractionEventByCustomerOSIdentifi
 }
 
 func (r *interactionEventReadRepository) InteractionEventSentByUser(ctx context.Context, tenant, interactionEventId string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventReadRepository.InteractionEventSentByUser")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, interactionEventId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventReadRepository.InteractionEventSentByUser")
+	defer spans.Finish()
+
+	spans.LogKV("interactionEventId", interactionEventId)
 
 	cypher := fmt.Sprintf(`MATCH (i:InteractionEvent {id:$id}) WHERE i:InteractionEvent_%s AND (i)-[:SENT_BY]->(:User) OR (i)-[:SENT_BY]->(:Email|PhoneNumber)--(:User) return count(i) > 0`, tenant)
 	params := map[string]any{
 		"id": interactionEventId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -292,26 +293,24 @@ func (r *interactionEventReadRepository) InteractionEventSentByUser(ctx context.
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return false, err
 	}
-	span.LogFields(log.Bool("result", result.(bool)))
+	spans.LogKV("result", result.(bool))
 	return result.(bool), nil
 }
 
 func (r *interactionEventReadRepository) GetInteractionEventIdByExternalId(ctx context.Context, tenant, externalSystemId, externalId string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventReadRepository.GetInteractionEventIdByExternalId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventReadRepository.GetInteractionEventIdByExternalId")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (ie:InteractionEvent_%s)-[IS_LINKED_WITH {externalId:$externalId}]-(e:ExternalSystem{id:$externalSystemId}) RETURN ie.id`, tenant)
 	params := map[string]any{
 		"externalId":       externalId,
 		"externalSystemId": externalSystemId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/interaction_event_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/interaction_event_write_repository.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"fmt"
 	commonmodel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/constants"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"time"
 )
 
@@ -62,12 +61,11 @@ func NewInteractionEventWriteRepository(driver *neo4j.DriverWithContext, databas
 }
 
 func (r *interactionEventWriteRepository) CreateInTx(ctx context.Context, tx neo4j.ManagedTransaction, tenant, interactionEventId string, data neo4jentity.InteractionEventEntity) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventWriteRepository.CreateInTx")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, interactionEventId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventWriteRepository.CreateInTx")
+	defer spans.Finish()
+
+	spans.LogKV("interactionEventId", interactionEventId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MERGE (i:InteractionEvent:InteractionEvent_%s {id:$interactionEventId}) 
 							ON CREATE SET 
@@ -109,12 +107,12 @@ func (r *interactionEventWriteRepository) CreateInTx(ctx context.Context, tx neo
 		"hide":               data.Hide,
 		"overwrite":          data.Source == constants.SourceOpenline,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := tx.Run(ctx, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -122,12 +120,11 @@ func (r *interactionEventWriteRepository) CreateInTx(ctx context.Context, tx neo
 }
 
 func (r *interactionEventWriteRepository) Update(ctx context.Context, tenant, interactionEventId string, data InteractionEventUpdateFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventWriteRepository.Update")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, interactionEventId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventWriteRepository.Update")
+	defer spans.Finish()
+
+	spans.LogKV("interactionEventId", interactionEventId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (i:InteractionEvent:InteractionEvent_%s {id:$interactionEventId})
 		 	SET	
@@ -152,23 +149,22 @@ func (r *interactionEventWriteRepository) Update(ctx context.Context, tenant, in
 		"hide":               data.Hide,
 		"overwrite":          data.Source == constants.SourceOpenline,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *interactionEventWriteRepository) MergeByExternalSystem(ctx context.Context, tx *neo4j.ManagedTransaction, tenant string, syncDate time.Time, message commonmodel.SaveEmailMessage, source, appSource string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventWriteRepository.MergeByExternalSystem")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogKV("source", source, "appSource", appSource)
-	tracing.LogObjectAsJson(span, "message", message)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventWriteRepository.MergeByExternalSystem")
+	defer spans.Finish()
+
+	spans.LogKV("source", source, "appSource", appSource)
+	spans.LogObjectAsJson("message", message)
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]-(e:ExternalSystem {id:$externalSystemId}) 
 		 MERGE (ie:InteractionEvent_%s {source:$source, channel:$channel})-[rel:IS_LINKED_WITH {externalId:$externalId}]->(e) 
@@ -210,8 +206,8 @@ func (r *interactionEventWriteRepository) MergeByExternalSystem(ctx context.Cont
 		params["contentType"] = "text/plain"
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	queryResult, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		qr, err := tx.Run(ctx, cypher, params)
@@ -221,7 +217,7 @@ func (r *interactionEventWriteRepository) MergeByExternalSystem(ctx context.Cont
 		return utils.ExtractSingleRecordFirstValueAsString(ctx, qr, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
 
@@ -229,12 +225,11 @@ func (r *interactionEventWriteRepository) MergeByExternalSystem(ctx context.Cont
 }
 
 func (r *interactionEventWriteRepository) LinkInteractionEventToSession(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, interactionEventId, interactionSessionId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventWriteRepository.LinkInteractionEventToSession")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, interactionEventId)
-	span.LogKV("interactionSessionId", interactionSessionId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventWriteRepository.LinkInteractionEventToSession")
+	defer spans.Finish()
+
+	spans.LogKV("interactionEventId", interactionEventId)
+	spans.LogKV("interactionSessionId", interactionSessionId)
 
 	cypher := fmt.Sprintf(`MATCH (ie:InteractionEvent_%s {id:$interactionEventId}) 
 		 MATCH (is:InteractionSession_%s {id:$interactionSessionId}) 
@@ -246,8 +241,8 @@ func (r *interactionEventWriteRepository) LinkInteractionEventToSession(ctx cont
 		"interactionSessionId": interactionSessionId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -257,18 +252,17 @@ func (r *interactionEventWriteRepository) LinkInteractionEventToSession(ctx cont
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *interactionEventWriteRepository) InteractionEventSentByEmail(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, interactionEventId, emailId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventWriteRepository.InteractionEventSentByEmail")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, interactionEventId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventWriteRepository.InteractionEventSentByEmail")
+	defer spans.Finish()
+
+	spans.LogKV("interactionEventId", interactionEventId)
 
 	cypher := fmt.Sprintf(`MATCH (ie:InteractionEvent_%s {id:$interactionEventId})
 		 MATCH (e:Email_%s {id: $emailId})
@@ -280,8 +274,8 @@ func (r *interactionEventWriteRepository) InteractionEventSentByEmail(ctx contex
 		"emailId":            emailId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -291,18 +285,17 @@ func (r *interactionEventWriteRepository) InteractionEventSentByEmail(ctx contex
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *interactionEventWriteRepository) InteractionEventSentToEmails(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, interactionEventId, sentType string, emailIds []string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventWriteRepository.InteractionEventSentToEmails")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, interactionEventId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionEventWriteRepository.InteractionEventSentToEmails")
+	defer spans.Finish()
+
+	spans.LogKV("interactionEventId", interactionEventId)
 
 	cypher := fmt.Sprintf(`MATCH (ie:InteractionEvent_%s {id:$interactionEventId})
 		 MATCH (e:Email_%s) WHERE e.id in $emailIds
@@ -315,8 +308,8 @@ func (r *interactionEventWriteRepository) InteractionEventSentToEmails(ctx conte
 		"emailIds":           emailIds,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -326,7 +319,7 @@ func (r *interactionEventWriteRepository) InteractionEventSentToEmails(ctx conte
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err

--- a/packages/server/customer-os-neo4j-repository/repository/interaction_session_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/interaction_session_read_repository.go
@@ -3,12 +3,10 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type InteractionSessionReadRepository interface {
@@ -31,18 +29,18 @@ func NewInteractionSessionReadRepository(driver *neo4j.DriverWithContext, databa
 }
 
 func (r *interactionSessionReadRepository) GetForInteractionEvent(ctx context.Context, tenant, interactionEventId string) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionSessionReadRepository.GetForInteractionEvent")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("interactionEventId", interactionEventId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionSessionReadRepository.GetForInteractionEvent")
+	defer spans.Finish()
+
+	spans.LogKV("interactionEventId", interactionEventId)
 
 	cypher := fmt.Sprintf(`MATCH (e:InteractionEvent_%s{id: $id})-[:PART_OF]->(s:InteractionSession_%s) 
 		 RETURN s`, tenant, tenant)
 	params := map[string]any{
 		"id": interactionEventId,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -64,11 +62,10 @@ func (r *interactionSessionReadRepository) GetForInteractionEvent(ctx context.Co
 }
 
 func (r *interactionSessionReadRepository) GetAllForInteractionEvents(ctx context.Context, tenant string, ids []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionSessionReadRepository.GetAllForInteractionEvents")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("ids", ids))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionSessionReadRepository.GetAllForInteractionEvents")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("ids", ids)
 
 	cypher := fmt.Sprintf(`MATCH (e:InteractionEvent)-[:PART_OF]->(s:InteractionSession_%s) 
 		 WHERE e.id IN $ids AND e:InteractionEvent_%s
@@ -76,7 +73,8 @@ func (r *interactionSessionReadRepository) GetAllForInteractionEvents(ctx contex
 	params := map[string]any{
 		"ids": ids,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -95,12 +93,11 @@ func (r *interactionSessionReadRepository) GetAllForInteractionEvents(ctx contex
 }
 
 func (r *interactionSessionReadRepository) GetByIdentifierAndChannel(ctx context.Context, tenant, identifier, channel string) (*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionSessionReadRepository.GetByIdentifierAndChannel")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.LogObjectAsJson(span, "identifier", identifier)
-	tracing.LogObjectAsJson(span, "channel", channel)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionSessionReadRepository.GetByIdentifierAndChannel")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("identifier", identifier)
+	spans.LogObjectAsJson("channel", channel)
 
 	cypher := fmt.Sprintf(`MATCH (i:InteractionSession_%s {identifier:$identifier, channel:$channel}) RETURN i LIMIT 1`, tenant)
 	params := map[string]any{
@@ -108,8 +105,8 @@ func (r *interactionSessionReadRepository) GetByIdentifierAndChannel(ctx context
 		"identifier": identifier,
 		"channel":    channel,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -131,9 +128,8 @@ func (r *interactionSessionReadRepository) GetByIdentifierAndChannel(ctx context
 }
 
 func (r *interactionSessionReadRepository) GetAttendedByParticipantsForInteractionSessions(ctx context.Context, tenant string, ids []string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionSessionReadRepository.GetAttendedByParticipantsForInteractionSessions")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionSessionReadRepository.GetAttendedByParticipantsForInteractionSessions")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/interaction_session_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/interaction_session_write_repository.go
@@ -7,11 +7,9 @@ import (
 
 	commonenum "github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
 	commonmodel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -34,12 +32,11 @@ func NewInteractionSessionWriteRepository(driver *neo4j.DriverWithContext, datab
 }
 
 func (r *interactionSessionWriteRepository) CreateInTx(ctx context.Context, tx neo4j.ManagedTransaction, tenant, interactionSessionId string, data neo4j_entity.InteractionSessionEntity) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionSessionWriteRepository.CreateInTx")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, interactionSessionId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionSessionWriteRepository.CreateInTx")
+	defer spans.Finish()
+
+	spans.LogKV("interactionSessionId", interactionSessionId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MERGE (i:InteractionSession:InteractionSession_%s {id:$interactionSessionId}) 
 							ON CREATE SET 
@@ -67,12 +64,12 @@ func (r *interactionSessionWriteRepository) CreateInTx(ctx context.Context, tx n
 		"status":               data.Status.String(),
 		"name":                 data.Name,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := tx.Run(ctx, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -80,11 +77,10 @@ func (r *interactionSessionWriteRepository) CreateInTx(ctx context.Context, tx n
 }
 
 func (r *interactionSessionWriteRepository) MergeByIdentifierAndChannel(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, identifier string, syncDate time.Time, message commonmodel.SaveEmailMessage, sessionType commonenum.InteractionSessionType, channel commonenum.InteractionSessionChannel, source, appSource string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionSessionWriteRepository.MergeByIdentifierAndChannel")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogKV("identifier", identifier, "channel", channel, "sessionType", sessionType, "source", source, "appSource", appSource)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InteractionSessionWriteRepository.MergeByIdentifierAndChannel")
+	defer spans.Finish()
+
+	spans.LogKV("identifier", identifier, "channel", channel, "sessionType", sessionType, "source", source, "appSource", appSource)
 
 	cypher := ""
 	if identifier == "" {
@@ -124,8 +120,8 @@ func (r *interactionSessionWriteRepository) MergeByIdentifierAndChannel(ctx cont
 		"channel":    channel,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	queryResult, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		qr, err := tx.Run(ctx, cypher, params)
@@ -135,7 +131,7 @@ func (r *interactionSessionWriteRepository) MergeByIdentifierAndChannel(ctx cont
 		return utils.ExtractSingleRecordFirstValueAsString(ctx, qr, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
 

--- a/packages/server/customer-os-neo4j-repository/repository/invoice_line_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/invoice_line_read_repository.go
@@ -1,13 +1,12 @@
 package neo4j_repository
 
 import (
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -34,11 +33,10 @@ func (r *invoiceLineReadRepository) prepareReadSession(ctx context.Context) neo4
 }
 
 func (r *invoiceLineReadRepository) GetAllForInvoice(ctx context.Context, tx *neo4j.ManagedTransaction, tenant string, invoiceId string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceLineReadRepository.GetAllForInvoice")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("invoiceId", invoiceId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceLineReadRepository.GetAllForInvoice")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice{id:$invoiceId})-[:HAS_INVOICE_LINE]->(il:InvoiceLine)
 		 RETURN il ORDER BY il.name`
@@ -46,8 +44,8 @@ func (r *invoiceLineReadRepository) GetAllForInvoice(ctx context.Context, tx *ne
 		"tenant":    tenant,
 		"invoiceId": invoiceId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -57,19 +55,18 @@ func (r *invoiceLineReadRepository) GetAllForInvoice(ctx context.Context, tx *ne
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), err
 }
 
 func (r *invoiceLineReadRepository) GetAllForInvoices(ctx context.Context, tenant string, ids []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceLineReadRepository.GetAllForInvoice")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("ids", ids))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceLineReadRepository.GetAllForInvoice")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("ids", ids)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)-[:HAS_INVOICE_LINE]->(il:InvoiceLine)
 		 WHERE i.id IN $ids 
@@ -78,8 +75,8 @@ func (r *invoiceLineReadRepository) GetAllForInvoices(ctx context.Context, tenan
 		"tenant": tenant,
 		"ids":    ids,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -92,19 +89,18 @@ func (r *invoiceLineReadRepository) GetAllForInvoices(ctx context.Context, tenan
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *invoiceLineReadRepository) GetLatestInvoiceLineWithInvoiceIdByServiceLineItemParentId(ctx context.Context, tenant, sliParentId string) (*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceLineReadRepository.GetLatestInvoiceLineWithInvoiceIdByServiceLineItemParentId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("sliParentId", sliParentId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceLineReadRepository.GetLatestInvoiceLineWithInvoiceIdByServiceLineItemParentId")
+	defer spans.Finish()
+
+	spans.LogKV("sliParentId", sliParentId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)-[:HAS_INVOICE_LINE]->(il:InvoiceLine)-[:INVOICED]->(sli:ServiceLineItem {parentId:$parentId})
 		WHERE NOT i.status IN $skipStatuses AND i.dryRun = false
@@ -114,8 +110,8 @@ func (r *invoiceLineReadRepository) GetLatestInvoiceLineWithInvoiceIdByServiceLi
 		"parentId":     sliParentId,
 		"skipStatuses": []string{neo4jenum.InvoiceStatusInitialized.String()},
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -128,10 +124,10 @@ func (r *invoiceLineReadRepository) GetLatestInvoiceLineWithInvoiceIdByServiceLi
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	if len(result.([]*utils.DbNodeAndId)) == 0 {
 		return nil, nil
 	}

--- a/packages/server/customer-os-neo4j-repository/repository/invoice_line_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/invoice_line_write_repository.go
@@ -3,12 +3,11 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"time"
 )
 
@@ -47,15 +46,14 @@ func NewInvoiceLineWriteRepository(driver *neo4j.DriverWithContext, database str
 }
 
 func (r *invoiceLineWriteRepository) CreateInvoiceLine(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, invoiceId, invoiceLineId string, data InvoiceLineCreateFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceLineWriteRepository.CreateInvoiceLine")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, invoiceLineId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceLineWriteRepository.CreateInvoiceLine")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceLineId", invoiceLineId)
 
 	if invoiceLineId == "" || invoiceId == "" {
 		err := fmt.Errorf("invoiceLineId or invoiceId is empty")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -104,14 +102,14 @@ func (r *invoiceLineWriteRepository) CreateInvoiceLine(ctx context.Context, tx *
 		"serviceLineItemParentId": data.ServiceLineItemParentId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/invoice_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/invoice_read_repository.go
@@ -5,14 +5,12 @@ import (
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -61,9 +59,8 @@ func (r *invoiceReadRepository) prepareReadSession(ctx context.Context) neo4j.Se
 }
 
 func (r *invoiceReadRepository) CountInvoices(ctx context.Context, tenant, filterString string, filterParams map[string]interface{}) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.CountInvoices")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.CountInvoices")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization_%s)-[:HAS_CONTRACT]->(c:Contract_%s)-[:HAS_INVOICE]->(i:Invoice_%s) 
 			%s
@@ -73,8 +70,8 @@ func (r *invoiceReadRepository) CountInvoices(ctx context.Context, tenant, filte
 	}
 	utils.MergeMapToMap(filterParams, params)
 
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -90,19 +87,19 @@ func (r *invoiceReadRepository) CountInvoices(ctx context.Context, tenant, filte
 		return 0, err
 	}
 	count := dbRecord.(*db.Record).Values[0].(int64)
-	span.LogFields(log.Int64("result - invoicesCount", count))
+	spans.LogKV("result.count", count)
 	return count, nil
 }
 
 func (r *invoiceReadRepository) GetPaginatedInvoices(ctx context.Context, tenant string, skip, limit int, filterCypher string, filterParams map[string]interface{}, sorting *utils.Cypher) (*utils.DbNodesWithTotalCount, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetPaginatedInvoices")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Int("skip", skip))
-	span.LogFields(log.Int("limit", limit))
-	span.LogFields(log.String("filterCypher", filterCypher))
-	span.LogFields(log.Object("filterParams", filterParams))
-	span.LogFields(log.Object("sorting", sorting))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetPaginatedInvoices")
+	defer spans.Finish()
+
+	spans.LogKV("skip", skip)
+	spans.LogKV("limit", limit)
+	spans.LogKV("filterCypher", filterCypher)
+	spans.LogObjectAsJson("filterParams", filterParams)
+	spans.LogObjectAsJson("sorting", sorting)
 
 	sortFragment := string(*sorting)
 	if sortFragment == "" {
@@ -133,8 +130,8 @@ func (r *invoiceReadRepository) GetPaginatedInvoices(ctx context.Context, tenant
 				 %s 
 				 RETURN count(i) as count`, tenant, tenant, tenant, filterCypher)
 
-		span.LogFields(log.String("countCypher", countCypher))
-		tracing.LogObjectAsJson(span, "countParams", countParams)
+		spans.LogKV("countCypher", countCypher)
+		spans.LogObjectAsJson("countParams", countParams)
 
 		queryResult, err := tx.Run(ctx, countCypher, countParams)
 		if err != nil {
@@ -152,8 +149,8 @@ func (r *invoiceReadRepository) GetPaginatedInvoices(ctx context.Context, tenant
 				 RETURN i
 				 SKIP $skip LIMIT $limit`, tenant, tenant, tenant, filterCypher, sortFragment)
 
-		span.LogFields(log.String("cypher", cypher))
-		tracing.LogObjectAsJson(span, "queryParams", queryParams)
+		spans.LogKV("cypher", cypher)
+		spans.LogObjectAsJson("queryParams", queryParams)
 
 		queryResult, err = tx.Run(ctx, cypher, queryParams)
 		if err != nil {
@@ -162,7 +159,7 @@ func (r *invoiceReadRepository) GetPaginatedInvoices(ctx context.Context, tenant
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	for _, v := range dbRecords.([]*neo4j.Record) {
@@ -172,18 +169,18 @@ func (r *invoiceReadRepository) GetPaginatedInvoices(ctx context.Context, tenant
 }
 
 func (r *invoiceReadRepository) GetInvoiceById(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, invoiceId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetInvoiceById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, invoiceId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetInvoiceById")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice {id:$id}) RETURN i`
 	params := map[string]any{
 		"tenant": tenant,
 		"id":     invoiceId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -193,27 +190,27 @@ func (r *invoiceReadRepository) GetInvoiceById(ctx context.Context, tx *neo4j.Ma
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *invoiceReadRepository) GetInvoicesByIds(ctx context.Context, tenant string, ids []string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetInvoicesByIds")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("ids", ids))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetInvoicesByIds")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("ids", ids)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice) WHERE i.id IN $ids RETURN i`
 	params := map[string]any{
 		"tenant": tenant,
 		"ids":    ids,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -226,10 +223,10 @@ func (r *invoiceReadRepository) GetInvoicesByIds(ctx context.Context, tenant str
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), nil
 }
 
@@ -263,17 +260,17 @@ func (r *invoiceReadRepository) GetAllNonDryRunInvoices(ctx context.Context, ten
 }
 
 func (r *invoiceReadRepository) GetInvoiceByIdAcrossAllTenants(ctx context.Context, invoiceId string) (*dbtype.Node, string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetInvoiceByIdAcrossAllTenants")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, invoiceId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetInvoiceByIdAcrossAllTenants")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := `MATCH (t:Tenant)<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice {id:$id}) RETURN i, t.name`
 	params := map[string]any{
 		"id": invoiceId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -283,33 +280,32 @@ func (r *invoiceReadRepository) GetInvoiceByIdAcrossAllTenants(ctx context.Conte
 		return utils.ExtractAllRecordsAsDbNodeAndTenant(ctx, queryResult, err)
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, "", err
 	}
 
 	convertedResult, _ := result.([]*utils.DbNodeAndTenant)
 	if len(convertedResult) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, "", nil
 	}
-	span.LogFields(log.Bool("result.found", true))
-	span.LogFields(log.String("result.tenant", convertedResult[0].Tenant))
+	spans.LogKV("result.found", true)
+	spans.LogKV("result.tenant", convertedResult[0].Tenant)
 	return convertedResult[0].Node, convertedResult[0].Tenant, err
 }
 
 func (r *invoiceReadRepository) GetInvoiceByNumber(ctx context.Context, tenant, invoiceNumber string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetInvoiceByNumber")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetInvoiceByNumber")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice {number:$number}) RETURN i limit 1`
 	params := map[string]any{
 		"tenant": tenant,
 		"number": invoiceNumber,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -320,19 +316,22 @@ func (r *invoiceReadRepository) GetInvoiceByNumber(ctx context.Context, tenant, 
 
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *invoiceReadRepository) GetInvoicesForPayNotifications(ctx context.Context, minutesFromCreate, minutesFromLastAttempt, lookbackWindow, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetInvoicesForPayNotifications")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Int("minutesFromCreate", minutesFromCreate), log.Int("minutesFromLastAttempt", minutesFromLastAttempt), log.Int("lookbackWindow", lookbackWindow), log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetInvoicesForPayNotifications")
+	defer spans.Finish()
+
+	spans.LogKV("minutesFromCreate", minutesFromCreate)
+	spans.LogKV("minutesFromLastAttempt", minutesFromLastAttempt)
+	spans.LogKV("lookbackWindow", lookbackWindow)
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (i:Invoice)-[:INVOICE_BELONGS_TO_TENANT]->(t:Tenant)
 			WHERE 
@@ -354,8 +353,8 @@ func (r *invoiceReadRepository) GetInvoicesForPayNotifications(ctx context.Conte
 			neo4jenum.InvoiceStatusDue.String(), neo4jenum.InvoiceStatusOverdue.String(), neo4jenum.InvoiceStatusPaymentProcessing.String(),
 		},
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -369,18 +368,20 @@ func (r *invoiceReadRepository) GetInvoicesForPayNotifications(ctx context.Conte
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *invoiceReadRepository) GetInvoicesForPastDueNotifications(ctx context.Context, tenant string, referenceTime time.Time, overdueDays, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetInvoicesForPastDueNotifications")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("referenceTime", referenceTime), log.Int("overdueDays", overdueDays), log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetInvoicesForPastDueNotifications")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("referenceTime", referenceTime)
+	spans.LogKV("overdueDays", overdueDays)
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (i:Invoice)-[:INVOICE_BELONGS_TO_TENANT]->(t:Tenant {name:$tenant})
 			WHERE 
@@ -402,8 +403,8 @@ func (r *invoiceReadRepository) GetInvoicesForPastDueNotifications(ctx context.C
 			neo4jenum.InvoiceStatusOverdue.String(),
 		},
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -417,19 +418,18 @@ func (r *invoiceReadRepository) GetInvoicesForPastDueNotifications(ctx context.C
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *invoiceReadRepository) CountNonDryRunInvoicesForContract(ctx context.Context, tenant, contractId string) (int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.CountNonDryRunInvoicesForContract")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
-	span.LogFields(log.String("contractId", contractId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.CountNonDryRunInvoicesForContract")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -440,25 +440,25 @@ func (r *invoiceReadRepository) CountNonDryRunInvoicesForContract(ctx context.Co
 			"tenant":     tenant,
 			"contractId": contractId,
 		}
-		span.LogFields(log.String("cypher", cypher))
-		tracing.LogObjectAsJson(span, "params", params)
+		spans.LogKV("cypher", cypher)
+		spans.LogObjectAsJson("params", params)
 
 		queryResult, err := tx.Run(ctx, cypher, params)
 		return utils.ExtractSingleRecordFirstValueAsType[int64](ctx, queryResult, err)
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return 0, err
 	}
-	span.LogFields(log.Int64("result.count", count.(int64)))
+	spans.LogKV("result.count", count.(int64))
 	return int(count.(int64)), nil
 }
 
 func (r *invoiceReadRepository) GetPreviousCycleInvoice(ctx context.Context, tenant, contractId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetPreviousCycleInvoice")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetPreviousCycleInvoice")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
 
 	cypher := `MATCH (c:Contract {id:$contractId})-[:HAS_INVOICE]->(i:Invoice)-[:INVOICE_BELONGS_TO_TENANT]->(:Tenant {name:$tenant})
 			WHERE i.dryRun = false AND i.offCycle = false
@@ -467,8 +467,8 @@ func (r *invoiceReadRepository) GetPreviousCycleInvoice(ctx context.Context, ten
 		"tenant":     tenant,
 		"contractId": contractId,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -479,23 +479,23 @@ func (r *invoiceReadRepository) GetPreviousCycleInvoice(ctx context.Context, ten
 
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *invoiceReadRepository) GetLastIssuedOnCycleInvoiceForContract(ctx context.Context, tenant, contractId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetLastIssuedOnCycleInvoiceForContract")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetLastIssuedOnCycleInvoiceForContract")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
 
 	cypher := `MATCH (c:Contract {id:$contractId})-[:HAS_INVOICE]->(i:Invoice)-[:INVOICE_BELONGS_TO_TENANT]->(:Tenant {name:$tenant})
 			WHERE i.dryRun = false AND i.offCycle = false
@@ -504,8 +504,8 @@ func (r *invoiceReadRepository) GetLastIssuedOnCycleInvoiceForContract(ctx conte
 		"tenant":     tenant,
 		"contractId": contractId,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -516,23 +516,23 @@ func (r *invoiceReadRepository) GetLastIssuedOnCycleInvoiceForContract(ctx conte
 
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *invoiceReadRepository) GetLastIssuedInvoiceForContract(ctx context.Context, tenant, contractId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetLastIssuedInvoiceForContract")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetLastIssuedInvoiceForContract")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
 
 	cypher := `MATCH (c:Contract {id:$contractId})-[:HAS_INVOICE]->(i:Invoice)-[:INVOICE_BELONGS_TO_TENANT]->(:Tenant {name:$tenant})
 			WHERE i.dryRun = false
@@ -541,8 +541,8 @@ func (r *invoiceReadRepository) GetLastIssuedInvoiceForContract(ctx context.Cont
 		"tenant":     tenant,
 		"contractId": contractId,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -553,23 +553,23 @@ func (r *invoiceReadRepository) GetLastIssuedInvoiceForContract(ctx context.Cont
 
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *invoiceReadRepository) GetFirstPreviewFilledInvoice(ctx context.Context, tenant, contractId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetFirstPreviewFilledInvoice")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetFirstPreviewFilledInvoice")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
 
 	cypher := `MATCH (c:Contract {id:$contractId})-[:HAS_INVOICE]->(i:Invoice)-[:INVOICE_BELONGS_TO_TENANT]->(:Tenant {name:$tenant})
 			WHERE i.dryRun = true AND i.preview = true AND i.status <> $statusInitialized AND i.number IS NOT NULL AND i.number <> ''
@@ -579,8 +579,8 @@ func (r *invoiceReadRepository) GetFirstPreviewFilledInvoice(ctx context.Context
 		"contractId":        contractId,
 		"statusInitialized": neo4jenum.InvoiceStatusInitialized.String(),
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -591,23 +591,23 @@ func (r *invoiceReadRepository) GetFirstPreviewFilledInvoice(ctx context.Context
 
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *invoiceReadRepository) GetExpiredDryRunInvoices(ctx context.Context, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetExpiredDryRunInvoices")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogKV("limit", limit)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetExpiredDryRunInvoices")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (i:Invoice)-[:INVOICE_BELONGS_TO_TENANT]->(t:Tenant)
 			WHERE 
@@ -620,8 +620,8 @@ func (r *invoiceReadRepository) GetExpiredDryRunInvoices(ctx context.Context, li
 		"now":   utils.Now(),
 		"limit": limit,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -635,18 +635,18 @@ func (r *invoiceReadRepository) GetExpiredDryRunInvoices(ctx context.Context, li
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *invoiceReadRepository) GetPreviewInvoicesForEndedContracts(ctx context.Context, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetPreviewInvoicesForEndedContracts")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogKV("limit", limit)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetPreviewInvoicesForEndedContracts")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (c:Contract)--(i:Invoice)-[:INVOICE_BELONGS_TO_TENANT]->(t:Tenant)
 			WHERE 
@@ -657,8 +657,8 @@ func (r *invoiceReadRepository) GetPreviewInvoicesForEndedContracts(ctx context.
 		"ended": neo4jenum.ContractStatusEnded.String(),
 		"limit": limit,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -672,18 +672,18 @@ func (r *invoiceReadRepository) GetPreviewInvoicesForEndedContracts(ctx context.
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *invoiceReadRepository) GetAllForContracts(ctx context.Context, tenant string, ids []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetAllForContracts")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("contractIds", ids))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetAllForContracts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("contractIds", ids)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)<-[:HAS_INVOICE]-(c:Contract) 
 			WHERE c.id IN $ids
@@ -692,8 +692,8 @@ func (r *invoiceReadRepository) GetAllForContracts(ctx context.Context, tenant s
 		"tenant": tenant,
 		"ids":    ids,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -706,18 +706,18 @@ func (r *invoiceReadRepository) GetAllForContracts(ctx context.Context, tenant s
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *invoiceReadRepository) GetAllForServiceLineItems(ctx context.Context, tenant string, ids []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetAllForServiceLineItems")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("sliIds", ids))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetAllForServiceLineItems")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("sliIds", ids)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)-[:HAS_INVOICE_LINE]->(:InvoiceLine)-[:INVOICED]->(sli:ServiceLineItem)
 			WHERE sli.id IN $ids
@@ -726,8 +726,8 @@ func (r *invoiceReadRepository) GetAllForServiceLineItems(ctx context.Context, t
 		"tenant": tenant,
 		"ids":    ids,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -740,18 +740,18 @@ func (r *invoiceReadRepository) GetAllForServiceLineItems(ctx context.Context, t
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *invoiceReadRepository) GetInvoicesForOverdue(ctx context.Context, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetInvoicesForOverdue")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetInvoicesForOverdue")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (i:Invoice)-[:INVOICE_BELONGS_TO_TENANT]->(t:Tenant)
 			WHERE 
@@ -763,8 +763,8 @@ func (r *invoiceReadRepository) GetInvoicesForOverdue(ctx context.Context, limit
 		"dueStatus": neo4jenum.InvoiceStatusDue.String(),
 		"limit":     limit,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -778,18 +778,18 @@ func (r *invoiceReadRepository) GetInvoicesForOverdue(ctx context.Context, limit
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *invoiceReadRepository) GetInvoicesForOnHold(ctx context.Context, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetInvoicesForOnHold")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetInvoicesForOnHold")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant)<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)<-[:HAS_INVOICE]-(c:Contract)
 			WHERE 
@@ -804,8 +804,8 @@ func (r *invoiceReadRepository) GetInvoicesForOnHold(ctx context.Context, limit 
 		"outOfContractStatus": neo4jenum.ContractStatusOutOfContract.String(),
 		"limit":               limit,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -819,18 +819,18 @@ func (r *invoiceReadRepository) GetInvoicesForOnHold(ctx context.Context, limit 
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *invoiceReadRepository) GetInvoicesForScheduled(ctx context.Context, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetInvoicesForScheduled")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetInvoicesForScheduled")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant)<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)<-[:HAS_INVOICE]-(c:Contract)
 			WHERE 
@@ -845,8 +845,8 @@ func (r *invoiceReadRepository) GetInvoicesForScheduled(ctx context.Context, lim
 		"outOfContractStatus": neo4jenum.ContractStatusOutOfContract.String(),
 		"limit":               limit,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -860,18 +860,19 @@ func (r *invoiceReadRepository) GetInvoicesForScheduled(ctx context.Context, lim
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *invoiceReadRepository) GetExpiredPaymentProcessingInvoices(ctx context.Context, paymentProcessingMaxDays, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetExpiredPaymentProcessingInvoices")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Int("limit", limit), log.Int("paymentProcessingMaxDays", paymentProcessingMaxDays))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetExpiredPaymentProcessingInvoices")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
+	spans.LogKV("paymentProcessingMaxDays", paymentProcessingMaxDays)
 
 	cypher := `MATCH (t:Tenant)<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)
 			WHERE 
@@ -885,8 +886,8 @@ func (r *invoiceReadRepository) GetExpiredPaymentProcessingInvoices(ctx context.
 		"paymentProcessingMaxDays": paymentProcessingMaxDays,
 		"limit":                    limit,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -900,17 +901,16 @@ func (r *invoiceReadRepository) GetExpiredPaymentProcessingInvoices(ctx context.
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *invoiceReadRepository) GetReadyInvoicesForFinalizedWebhook(ctx context.Context, limit int) ([]*utils.DbNodeAndTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetReadyInvoicesForFinalizedWebhook")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetReadyInvoicesForFinalizedWebhook")
+	defer spans.Finish()
 
 	cypher := `MATCH (c:Contract)-[:HAS_INVOICE]->(i:Invoice)-[:INVOICE_BELONGS_TO_TENANT]->(t:Tenant)
 			WHERE 
@@ -924,8 +924,8 @@ func (r *invoiceReadRepository) GetReadyInvoicesForFinalizedWebhook(ctx context.
 		"minutesFromLastUpdate": 15,
 		"limit":                 limit,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -939,18 +939,18 @@ func (r *invoiceReadRepository) GetReadyInvoicesForFinalizedWebhook(ctx context.
 
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndTenant))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndTenant)))
 	return result.([]*utils.DbNodeAndTenant), err
 }
 
 func (r *invoiceReadRepository) GetNonDryRunInvoicesForOrganization(ctx context.Context, tenant, organizationId string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetNonDryRunInvoicesForOrganization")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("organizationId", organizationId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetNonDryRunInvoicesForOrganization")
+	defer spans.Finish()
+
+	spans.LogKV("organizationId", organizationId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization {id:$organizationId})-[:HAS_CONTRACT]->(c:Contract)-[:HAS_INVOICE]->(i:Invoice)
 			WHERE i.dryRun = false AND i.status IN $acceptedStatuses
@@ -967,8 +967,8 @@ func (r *invoiceReadRepository) GetNonDryRunInvoicesForOrganization(ctx context.
 			neo4jenum.InvoiceStatusPaymentProcessing.String(),
 		},
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -981,17 +981,16 @@ func (r *invoiceReadRepository) GetNonDryRunInvoicesForOrganization(ctx context.
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), nil
 }
 
 func (r *invoiceReadRepository) GetUpcomingInvoices(ctx context.Context, tenant string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.GetUpcomingInvoices")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.GetUpcomingInvoices")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)
 			WHERE i.preview = true AND i.dryRun = true
@@ -999,8 +998,8 @@ func (r *invoiceReadRepository) GetUpcomingInvoices(ctx context.Context, tenant 
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1013,9 +1012,9 @@ func (r *invoiceReadRepository) GetUpcomingInvoices(ctx context.Context, tenant 
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/invoice_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/invoice_write_repository.go
@@ -3,13 +3,12 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"time"
 )
 
@@ -103,12 +102,11 @@ func NewInvoiceWriteRepository(driver *neo4j.DriverWithContext, database string)
 }
 
 func (r *invoiceWriteRepository) CreateInvoiceForContract(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, invoiceId string, data InvoiceCreateFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceWriteRepository.CreateInvoiceForContract")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, invoiceId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceWriteRepository.CreateInvoiceForContract")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract {id:$contractId})
 							MERGE (t)<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice {id:$invoiceId}) 
@@ -153,24 +151,23 @@ func (r *invoiceWriteRepository) CreateInvoiceForContract(ctx context.Context, t
 		"status":               data.Status.String(),
 		"note":                 data.Note,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *invoiceWriteRepository) FillInvoice(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, invoiceId string, data InvoiceFillFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceWriteRepository.FillInvoice")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, invoiceId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceWriteRepository.FillInvoice")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := fmt.Sprintf(`MATCH (i:Invoice_%s {id:$invoiceId}) 
 							SET 
@@ -244,24 +241,23 @@ func (r *invoiceWriteRepository) FillInvoice(ctx context.Context, tx *neo4j.Mana
 		"providerBankAccountOtherDetails":  data.ProviderBankAccountOtherDetails,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *invoiceWriteRepository) UpdateInvoice(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, invoiceId string, data InvoiceUpdateFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceWriteRepository.UpdateInvoice")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, invoiceId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceWriteRepository.UpdateInvoice")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice {id:$invoiceId})
 				SET i.updatedAt=datetime()`
@@ -284,24 +280,23 @@ func (r *invoiceWriteRepository) UpdateInvoice(ctx context.Context, tx *neo4j.Ma
 		params["paymentLinkValidUntil"] = utils.TimePtrAsAny(data.PaymentLinkValidUntil)
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *invoiceWriteRepository) InvoicePdfGenerated(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, invoiceId, repositoryFileId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoicingCycleWriteRepository.Update")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, invoiceId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoicingCycleWriteRepository.Update")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice_%s {id:$id}) 
 							SET 
@@ -313,24 +308,23 @@ func (r *invoiceWriteRepository) InvoicePdfGenerated(ctx context.Context, tx *ne
 		"repositoryFileId": repositoryFileId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *invoiceWriteRepository) MarkPayNotificationRequested(ctx context.Context, tenant, invoiceId string, requestedAt time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceWriteRepository.MarkPayNotificationRequested")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, invoiceId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceWriteRepository.MarkPayNotificationRequested")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice {id:$invoiceId})
 				SET i.techPayNotificationRequestedAt=$requestedAt`
@@ -339,22 +333,21 @@ func (r *invoiceWriteRepository) MarkPayNotificationRequested(ctx context.Contex
 		"invoiceId":   invoiceId,
 		"requestedAt": requestedAt,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *invoiceWriteRepository) SetPaidInvoiceNotificationSentAt(ctx context.Context, tenant, invoiceId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceWriteRepository.SetPaidInvoiceNotificationSentAt")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, invoiceId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceWriteRepository.SetPaidInvoiceNotificationSentAt")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice {id:$invoiceId})
 							WHERE i:Invoice_%s
@@ -365,22 +358,21 @@ func (r *invoiceWriteRepository) SetPaidInvoiceNotificationSentAt(ctx context.Co
 		"now":       utils.Now(),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *invoiceWriteRepository) SetVoidInvoiceNotificationSentAt(ctx context.Context, tenant, invoiceId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceWriteRepository.SetVoidInvoiceNotificationSentAt")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, invoiceId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceWriteRepository.SetVoidInvoiceNotificationSentAt")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice {id:$invoiceId})
 							WHERE i:Invoice_%s
@@ -391,22 +383,21 @@ func (r *invoiceWriteRepository) SetVoidInvoiceNotificationSentAt(ctx context.Co
 		"now":       utils.Now(),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *invoiceWriteRepository) SetPayInvoiceNotificationSentAt(ctx context.Context, tenant, invoiceId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceWriteRepository.SetPayInvoiceNotificationSentAt")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, invoiceId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceWriteRepository.SetPayInvoiceNotificationSentAt")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice {id:$invoiceId})
 							WHERE i:Invoice_%s
@@ -417,22 +408,22 @@ func (r *invoiceWriteRepository) SetPayInvoiceNotificationSentAt(ctx context.Con
 		"now":       utils.Now(),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *invoiceWriteRepository) DeletePreviewCycleInvoices(ctx context.Context, tenant, contractId, skipInvoiceId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.DeletePreviewCycleInvoices")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("contractId", contractId), log.String("skipInvoiceId", skipInvoiceId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.DeletePreviewCycleInvoices")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
+	spans.LogKV("skipInvoiceId", skipInvoiceId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract{id:$contractId})-[:HAS_INVOICE]->(i:Invoice {dryRun:true, preview: true, offCycle: false})
 							   WHERE i.id <> $skipInvoiceId
@@ -443,23 +434,23 @@ func (r *invoiceWriteRepository) DeletePreviewCycleInvoices(ctx context.Context,
 		"contractId":    contractId,
 		"skipInvoiceId": skipInvoiceId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *invoiceWriteRepository) DeletePreviewCycleInitializedInvoices(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contractId, skipInvoiceId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.DeletePreviewCycleInitializedInvoices")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("contractId", contractId), log.String("skipInvoiceId", skipInvoiceId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.DeletePreviewCycleInitializedInvoices")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
+	spans.LogKV("skipInvoiceId", skipInvoiceId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract{id:$contractId})-[:HAS_INVOICE]->(i:Invoice {dryRun:true, preview: true, offCycle: false})
 							   WHERE i.id <> $skipInvoiceId and i.status=$initializedStatus
@@ -471,24 +462,23 @@ func (r *invoiceWriteRepository) DeletePreviewCycleInitializedInvoices(ctx conte
 		"skipInvoiceId":     skipInvoiceId,
 		"initializedStatus": neo4jenum.InvoiceStatusInitialized.String(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *invoiceWriteRepository) DeleteDryRunInvoice(ctx context.Context, tenant, invoiceId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceReadRepository.DeleteDryRunInvoice")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("invoiceId", invoiceId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "InvoiceReadRepository.DeleteDryRunInvoice")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice {id:$invoiceId, dryRun:true})
 			   OPTIONAL MATCH (i)-[:HAS_INVOICE_LINE]->(il:InvoiceLine) 
@@ -497,12 +487,12 @@ func (r *invoiceWriteRepository) DeleteDryRunInvoice(ctx context.Context, tenant
 		"tenant":    tenant,
 		"invoiceId": invoiceId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err

--- a/packages/server/customer-os-neo4j-repository/repository/issue_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/issue_read_repository.go
@@ -3,13 +3,11 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type IssueReadRepository interface {
@@ -32,18 +30,16 @@ func NewIssueReadRepository(driver *neo4j.DriverWithContext, database string) Is
 }
 
 func (r *issueReadRepository) GetById(ctx context.Context, tenant, issueId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueRepository.GetById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueRepository.GetById")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue {id:$issueId}) RETURN i`
 	params := map[string]any{
 		"tenant":  tenant,
 		"issueId": issueId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -59,11 +55,11 @@ func (r *issueReadRepository) GetById(ctx context.Context, tenant, issueId strin
 }
 
 func (r *issueReadRepository) GetMatchedIssueId(ctx context.Context, tenant, externalSystem, externalId string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueRepository.GetMatchedIssueId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("externalSystem", externalSystem), log.String("externalId", externalId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueRepository.GetMatchedIssueId")
+	defer spans.Finish()
+
+	spans.LogKV("externalSystem", externalSystem)
+	spans.LogKV("externalId", externalId)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -76,7 +72,8 @@ func (r *issueReadRepository) GetMatchedIssueId(ctx context.Context, tenant, ext
 		"externalSystem":  externalSystem,
 		"issueExternalId": externalId,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	dbRecords, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -96,10 +93,8 @@ func (r *issueReadRepository) GetMatchedIssueId(ctx context.Context, tenant, ext
 }
 
 func (r *issueReadRepository) GetIssueIdByExternalId(ctx context.Context, tenant, externalId, externalSystemId string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueRepository.GetIssueIdByExternalId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueRepository.GetIssueIdByExternalId")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]-(e:ExternalSystem {id:$externalSystemId})
 					MATCH (t)<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue_%s)-[:IS_LINKED_WITH {externalId:$externalId}]->(e)
@@ -109,7 +104,8 @@ func (r *issueReadRepository) GetIssueIdByExternalId(ctx context.Context, tenant
 		"externalId":       externalId,
 		"externalSystemId": externalSystemId,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -128,9 +124,8 @@ func (r *issueReadRepository) GetIssueIdByExternalId(ctx context.Context, tenant
 }
 
 func (r *issueReadRepository) GetIssueCountByStatusForOrganization(ctx context.Context, tenant, organizationId string) (map[string]int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueReadRepository.GetIssueCountByStatusForOrganization")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueReadRepository.GetIssueCountByStatusForOrganization")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(:Organization {id:$organizationId})<-[:REPORTED_BY]-(i:Issue)
 			WITH DISTINCT i
@@ -139,7 +134,8 @@ func (r *issueReadRepository) GetIssueCountByStatusForOrganization(ctx context.C
 		"tenant":         tenant,
 		"organizationId": organizationId,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/issue_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/issue_write_repository.go
@@ -3,12 +3,10 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
 type IssueWriteRepository interface {
@@ -38,12 +36,11 @@ func NewIssueWriteRepository(driver *neo4j.DriverWithContext, database string) I
 }
 
 func (r *issueWriteRepository) Create(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, issueId string, data data_fields.IssueFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueWriteRepository.Create")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, issueId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueWriteRepository.Create")
+	defer spans.Finish()
+
+	spans.LogKV("issueId", issueId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})
 							MERGE (t)<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue {id:$issueId}) 
@@ -91,8 +88,8 @@ func (r *issueWriteRepository) Create(ctx context.Context, tx *neo4j.ManagedTran
 		"submittedByOrganizationId": utils.IfNotNilString(data.SubmittedByOrganizationId),
 		"submittedByUserId":         utils.IfNotNilString(data.SubmittedByUserId),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -100,19 +97,18 @@ func (r *issueWriteRepository) Create(ctx context.Context, tx *neo4j.ManagedTran
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *issueWriteRepository) Update(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, issueId string, data data_fields.IssueFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueWriteRepository.Create")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, issueId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueWriteRepository.Create")
+	defer spans.Finish()
+
+	spans.TagEntity(issueId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue {id:$issueId})
 		 	SET	i.updatedAt = datetime() `
@@ -142,8 +138,8 @@ func (r *issueWriteRepository) Update(ctx context.Context, tx *neo4j.ManagedTran
 		params["priority"] = *data.Priority
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -154,19 +150,18 @@ func (r *issueWriteRepository) Update(ctx context.Context, tx *neo4j.ManagedTran
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *issueWriteRepository) AddUserAssignee(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, issueId, userId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueWriteRepository.AddUserAssignee")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, issueId)
-	span.LogKV("userId", userId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueWriteRepository.AddUserAssignee")
+	defer spans.Finish()
+
+	spans.TagEntity(issueId)
+	spans.LogKV("userId", userId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue {id:$issueId}),
 				(t)<-[:USER_BELONGS_TO_TENANT]-(u:User {id:$userId})
@@ -177,8 +172,8 @@ func (r *issueWriteRepository) AddUserAssignee(ctx context.Context, tx *neo4j.Ma
 		"issueId": issueId,
 		"userId":  userId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -189,19 +184,18 @@ func (r *issueWriteRepository) AddUserAssignee(ctx context.Context, tx *neo4j.Ma
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *issueWriteRepository) AddUserFollower(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, issueId, userId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueWriteRepository.AddUserFollower")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, issueId)
-	span.LogFields(log.String("userId", userId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueWriteRepository.AddUserFollower")
+	defer spans.Finish()
+
+	spans.TagEntity(issueId)
+	spans.LogKV("userId", userId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue {id:$issueId}),
 				(t)<-[:USER_BELONGS_TO_TENANT]-(u:User {id:$userId})
@@ -212,8 +206,8 @@ func (r *issueWriteRepository) AddUserFollower(ctx context.Context, tx *neo4j.Ma
 		"issueId": issueId,
 		"userId":  userId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -224,19 +218,18 @@ func (r *issueWriteRepository) AddUserFollower(ctx context.Context, tx *neo4j.Ma
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *issueWriteRepository) RemoveUserAssignee(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, issueId, userId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueWriteRepository.RemoveUserAssignee")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, issueId)
-	span.LogFields(log.String("userId", userId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueWriteRepository.RemoveUserAssignee")
+	defer spans.Finish()
+
+	spans.TagEntity(issueId)
+	spans.LogKV("userId", userId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue {id:$issueId}),
 				(t)<-[:USER_BELONGS_TO_TENANT]-(u:User {id:$userId}),
@@ -248,8 +241,8 @@ func (r *issueWriteRepository) RemoveUserAssignee(ctx context.Context, tx *neo4j
 		"issueId": issueId,
 		"userId":  userId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -260,19 +253,18 @@ func (r *issueWriteRepository) RemoveUserAssignee(ctx context.Context, tx *neo4j
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *issueWriteRepository) RemoveUserFollower(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, issueId, userId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueWriteRepository.RemoveUserFollower")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, issueId)
-	span.LogFields(log.String("userId", userId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueWriteRepository.RemoveUserFollower")
+	defer spans.Finish()
+
+	spans.TagEntity(issueId)
+	spans.LogKV("userId", userId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue {id:$issueId}),
 				(t)<-[:USER_BELONGS_TO_TENANT]-(u:User {id:$userId}),
@@ -284,8 +276,8 @@ func (r *issueWriteRepository) RemoveUserFollower(ctx context.Context, tx *neo4j
 		"issueId": issueId,
 		"userId":  userId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -296,19 +288,18 @@ func (r *issueWriteRepository) RemoveUserFollower(ctx context.Context, tx *neo4j
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *issueWriteRepository) ReportedByOrganizationWithGroupId(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId, groupId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueWriteRepository.ReportedByOrganizationWithGroupId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("organizationId", organizationId))
-	span.LogFields(log.String("groupId", groupId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueWriteRepository.ReportedByOrganizationWithGroupId")
+	defer spans.Finish()
+
+	spans.LogKV("organizationId", organizationId)
+	spans.LogKV("groupId", groupId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization {id:$organizationId}) 
 			   OPTIONAL MATCH (t)<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue {groupId:$groupId}) 
@@ -318,8 +309,8 @@ func (r *issueWriteRepository) ReportedByOrganizationWithGroupId(ctx context.Con
 		"organizationId": organizationId,
 		"groupId":        groupId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -329,19 +320,18 @@ func (r *issueWriteRepository) ReportedByOrganizationWithGroupId(ctx context.Con
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *issueWriteRepository) RemoveReportedByOrganizationWithGroupId(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId, groupId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueWriteRepository.RemoveReportedByOrganizationWithGroupId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("organizationId", organizationId))
-	span.LogFields(log.String("groupId", groupId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueWriteRepository.RemoveReportedByOrganizationWithGroupId")
+	defer spans.Finish()
+
+	spans.LogKV("organizationId", organizationId)
+	spans.LogKV("groupId", groupId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization {id:$organizationId})<-[r:REPORTED_BY]-(i:Issue{groupId:$groupId}) 
 			   DELETE r`
@@ -350,8 +340,8 @@ func (r *issueWriteRepository) RemoveReportedByOrganizationWithGroupId(ctx conte
 		"organizationId": organizationId,
 		"groupId":        groupId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -361,15 +351,15 @@ func (r *issueWriteRepository) RemoveReportedByOrganizationWithGroupId(ctx conte
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *issueWriteRepository) LinkUnthreadIssuesToOrganizationByGroupId(ctx context.Context) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueWriteRepository.LinkUnthreadIssuesToOrganizationByGroupId")
-	defer span.Finish()
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "IssueWriteRepository.LinkUnthreadIssuesToOrganizationByGroupId")
+	defer spans.Finish()
 
 	cypher := `match (t:Tenant)<-[:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]-(e:ExternalSystem{id:"unthread"})<-[:IS_LINKED_WITH]-(i:Issue)
 			   with t, i
@@ -378,12 +368,12 @@ func (r *issueWriteRepository) LinkUnthreadIssuesToOrganizationByGroupId(ctx con
 			   MERGE (i)-[:REPORTED_BY]->(o)
 				SET o.updatedAt = datetime()`
 	params := map[string]any{}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/job_role_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/job_role_read_repository.go
@@ -3,12 +3,10 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type JobRoleReadRepository interface {
@@ -42,9 +40,8 @@ func NewJobRoleReadRepository(driver *neo4j.DriverWithContext, database string) 
 }
 
 func (r *jobRoleReadRepository) GetAllForContact(ctx context.Context, session neo4j.SessionWithContext, tenant, contactId string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.GetAllForContact")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.GetAllForContact")
+	defer spans.Finish()
 
 	records, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
 		queryResult, err := tx.Run(ctx, `
@@ -73,9 +70,8 @@ func (r *jobRoleReadRepository) GetAllForContact(ctx context.Context, session ne
 }
 
 func (r *jobRoleReadRepository) GetAllForContacts(ctx context.Context, tenant string, contactIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.GetAllForContacts")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.GetAllForContacts")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -101,9 +97,8 @@ func (r *jobRoleReadRepository) GetAllForContacts(ctx context.Context, tenant st
 }
 
 func (r *jobRoleReadRepository) GetAllForUsers(ctx context.Context, tenant string, userIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.GetAllForUsers")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.GetAllForUsers")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -129,9 +124,8 @@ func (r *jobRoleReadRepository) GetAllForUsers(ctx context.Context, tenant strin
 }
 
 func (r *jobRoleReadRepository) GetAllForOrganization(ctx context.Context, session neo4j.SessionWithContext, tenant, organizationId string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.GetAllForOrganization")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.GetAllForOrganization")
+	defer spans.Finish()
 
 	records, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
 		queryResult, err := tx.Run(ctx, `
@@ -160,9 +154,8 @@ func (r *jobRoleReadRepository) GetAllForOrganization(ctx context.Context, sessi
 }
 
 func (r *jobRoleReadRepository) GetAllForOrganizations(ctx context.Context, tenant string, organizationIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.GetAllForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.GetAllForOrganizations")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -188,9 +181,8 @@ func (r *jobRoleReadRepository) GetAllForOrganizations(ctx context.Context, tena
 }
 
 func (r *jobRoleReadRepository) ExistsForContactAndOrganization(ctx context.Context, tenant, contactId, organizationId string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.ExistsForContactAndOrganization")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.ExistsForContactAndOrganization")
+	defer spans.Finish()
 
 	cypher := `MATCH (c:Contact {id:$contactId})-[:CONTACT_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}),
 			  			(o:Organization {id:$organizationId})-[:ORGANIZATION_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}),
@@ -201,8 +193,8 @@ func (r *jobRoleReadRepository) ExistsForContactAndOrganization(ctx context.Cont
 		"organizationId": organizationId,
 		"tenant":         tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -217,14 +209,13 @@ func (r *jobRoleReadRepository) ExistsForContactAndOrganization(ctx context.Cont
 	if err != nil {
 		return false, err
 	}
-	span.LogFields(log.Bool("result.found", len(records.([]*neo4j.Record)) > 0))
+	spans.LogKV("result.found", len(records.([]*neo4j.Record)) > 0)
 	return len(records.([]*neo4j.Record)) > 0, err
 }
 
 func (r *jobRoleReadRepository) GetAllForContactWithOrganizationId(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contactId string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.GetAllForContactWithOrganizationId")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.GetAllForContactWithOrganizationId")
+	defer spans.Finish()
 
 	cypher := `MATCH (c:Contact {id:$contactId})-[:CONTACT_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}),
 			  			(c)-[:WORKS_AS]->(j:JobRole)-[:ROLE_IN]->(o:Organization)
@@ -234,8 +225,8 @@ func (r *jobRoleReadRepository) GetAllForContactWithOrganizationId(ctx context.C
 		"tenant":    tenant,
 	}
 
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
@@ -245,25 +236,24 @@ func (r *jobRoleReadRepository) GetAllForContactWithOrganizationId(ctx context.C
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *jobRoleReadRepository) GetByIds(ctx context.Context, tenant string, ids []string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.GetByIds")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.GetByIds")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (job:JobRole_%s) WHERE job.id IN $ids RETURN job`, tenant)
 	params := map[string]interface{}{
 		"ids": ids,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -276,18 +266,17 @@ func (r *jobRoleReadRepository) GetByIds(ctx context.Context, tenant string, ids
 		}
 	})
 	if err != nil {
-		span.LogFields(log.Int("result.count", 0))
+		spans.LogKV("result.count", 0)
 		return nil, err
 	}
 	nodes := result.([]*dbtype.Node)
-	span.LogFields(log.Int("result.count", len(nodes)))
+	spans.LogKV("result.count", len(nodes))
 	return nodes, err
 }
 
 func (r *jobRoleReadRepository) GetJobRoleForContactAndOrganization(ctx context.Context, tenant, contactId, organizationId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.GetJobRoleForContactAndOrganization")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.GetJobRoleForContactAndOrganization")
+	defer spans.Finish()
 
 	cypher := `MATCH (c:Contact {id:$contactId})-[:CONTACT_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}),
 			  	(o:Organization {id:$organizationId})-[:ORGANIZATION_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}),
@@ -298,8 +287,8 @@ func (r *jobRoleReadRepository) GetJobRoleForContactAndOrganization(ctx context.
 		"organizationId": organizationId,
 		"tenant":         tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -309,7 +298,7 @@ func (r *jobRoleReadRepository) GetJobRoleForContactAndOrganization(ctx context.
 		return utils.ExtractFirstRecordFirstValueAsDbNodePtr(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if result == nil {
@@ -319,9 +308,8 @@ func (r *jobRoleReadRepository) GetJobRoleForContactAndOrganization(ctx context.
 }
 
 func (r *jobRoleReadRepository) GetJobRoleForContactWithoutOrganization(ctx context.Context, tenant, contactId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.GetJobRoleForContactWithoutOrganization")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.GetJobRoleForContactWithoutOrganization")
+	defer spans.Finish()
 
 	cypher := `MATCH (c:Contact {id:$contactId})-[:CONTACT_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}),
 			  	(c)-[:WORKS_AS]->(j:JobRole)
@@ -331,8 +319,8 @@ func (r *jobRoleReadRepository) GetJobRoleForContactWithoutOrganization(ctx cont
 		"contactId": contactId,
 		"tenant":    tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -342,7 +330,7 @@ func (r *jobRoleReadRepository) GetJobRoleForContactWithoutOrganization(ctx cont
 		return utils.ExtractFirstRecordFirstValueAsDbNodePtr(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if result == nil {
@@ -352,17 +340,16 @@ func (r *jobRoleReadRepository) GetJobRoleForContactWithoutOrganization(ctx cont
 }
 
 func (r *jobRoleReadRepository) GetById(ctx context.Context, tenant string, id string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.GetById")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (job:JobRole_%s) WHERE job.id = $id RETURN job`, tenant)
 	params := map[string]interface{}{
 		"id": id,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -372,7 +359,7 @@ func (r *jobRoleReadRepository) GetById(ctx context.Context, tenant string, id s
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	return result.(*dbtype.Node), err

--- a/packages/server/customer-os-neo4j-repository/repository/job_role_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/job_role_write_repository.go
@@ -3,12 +3,10 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
 type JobRoleWriteRepository interface {
@@ -35,11 +33,11 @@ func NewJobRoleWriteRepository(driver *neo4j.DriverWithContext, database string)
 }
 
 func (r *jobRoleWriteRepository) LinkWithUser(ctx context.Context, tenant, userId, jobRoleId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleWriteRepository.LinkWithUser")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("userId", userId), log.String("jobRoleId", jobRoleId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleWriteRepository.LinkWithUser")
+	defer spans.Finish()
+
+	spans.LogKV("userId", userId)
+	spans.LogKV("jobRoleId", jobRoleId)
 
 	cypher := fmt.Sprintf(`MATCH (u:User_%s {id: $userId})
               MERGE (jr:JobRole:JobRole_%s {id: $jobRoleId})
@@ -49,23 +47,23 @@ func (r *jobRoleWriteRepository) LinkWithUser(ctx context.Context, tenant, userI
 		"userId":    userId,
 		"jobRoleId": jobRoleId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *jobRoleWriteRepository) LinkContactWithOrganization(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, jobRoleId, contactId, organizationId string, data data_fields.JobRoleFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleWriteRepository.LinkContactWithOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("contactId", contactId), log.String("organizationId", organizationId))
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleWriteRepository.LinkContactWithOrganization")
+	defer spans.Finish()
+
+	spans.LogKV("contactId", contactId)
+	spans.LogKV("organizationId", organizationId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (c:Contact {id:$contactId})-[:CONTACT_BELONGS_TO_TENANT]->(t:Tenant {name:$tenant}), 
 		  								(t)<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId}) 
@@ -98,27 +96,26 @@ func (r *jobRoleWriteRepository) LinkContactWithOrganization(ctx context.Context
 		"endedAt":        utils.TimePtrAsAny(data.EndedAt),
 		"primary":        utils.IfNotNilBool(data.Primary),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *jobRoleWriteRepository) CreateJobRoleForContact(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, jobRoleId, contactId string, data data_fields.JobRoleFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleWriteRepository.CreateJobRoleForContact")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("contactId", contactId))
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleWriteRepository.CreateJobRoleForContact")
+	defer spans.Finish()
+
+	spans.LogKV("contactId", contactId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (c:Contact {id:$contactId})-[:CONTACT_BELONGS_TO_TENANT]->(t:Tenant {name:$tenant})
 		 MERGE (c)-[:WORKS_AS]->(jr:JobRole {id:$jobRoleId}) 
@@ -147,24 +144,23 @@ func (r *jobRoleWriteRepository) CreateJobRoleForContact(ctx context.Context, tx
 		"endedAt":     utils.TimePtrAsAny(data.EndedAt),
 		"primary":     utils.IfNotNilBool(data.Primary),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *jobRoleWriteRepository) UpdateJobRoleDetails(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, roleId string, data data_fields.JobRoleFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.UpdateJobRoleDetails")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.UpdateJobRoleDetails")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (jr:JobRole_%s {id:$roleId})
 			SET jr.updatedAt=datetime()`, tenant)
@@ -202,24 +198,23 @@ func (r *jobRoleWriteRepository) UpdateJobRoleDetails(ctx context.Context, tx *n
 		params["endedAt"] = *data.EndedAt
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *jobRoleWriteRepository) DeleteJobRoleInTx(ctx context.Context, tx neo4j.ManagedTransaction, tenant, contactId, roleId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.DeleteJobRoleInTx")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.DeleteJobRoleInTx")
+	defer spans.Finish()
 
 	_, err := tx.Run(ctx, `
 			MATCH (c:Contact {id:$contactId})-[:CONTACT_BELONGS_TO_TENANT]->(t:Tenant {name:$tenant}),
@@ -234,9 +229,8 @@ func (r *jobRoleWriteRepository) DeleteJobRoleInTx(ctx context.Context, tx neo4j
 }
 
 func (r *jobRoleWriteRepository) SetOtherJobRolesForContactNonPrimaryInTx(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contactId, skipRoleId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.SetOtherJobRolesForContactNonPrimaryInTx")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.SetOtherJobRolesForContactNonPrimaryInTx")
+	defer spans.Finish()
 
 	cypher := `MATCH (c:Contact {id:$contactId})-[:CONTACT_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}),
 				 (c)-[:WORKS_AS]->(r:JobRole)
@@ -249,24 +243,23 @@ func (r *jobRoleWriteRepository) SetOtherJobRolesForContactNonPrimaryInTx(ctx co
 		"skipRoleId": skipRoleId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *jobRoleWriteRepository) LinkWithOrganization(ctx context.Context, tx *neo4j.ManagedTransaction, tenant string, roleId string, organizationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.LinkWithOrganization")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.LinkWithOrganization")
+	defer spans.Finish()
 
 	cypher := `MATCH (org:Organization {id:$organizationId})-[:ORGANIZATION_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}),
 					(r:JobRole {id:$roleId})<-[:WORKS_AS]-(c:Contact)-[:CONTACT_BELONGS_TO_TENANT]->(:Tenant {name:$tenant})
@@ -282,24 +275,23 @@ func (r *jobRoleWriteRepository) LinkWithOrganization(ctx context.Context, tx *n
 		"organizationId": organizationId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *jobRoleWriteRepository) SetJobRolePrimaryInTx(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, roleId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleRepository.SetJobRolePrimaryInTx")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "JobRoleRepository.SetJobRolePrimaryInTx")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (j:JobRole_%s {id:$roleId})
 			SET j.primary=true,
@@ -308,15 +300,15 @@ func (r *jobRoleWriteRepository) SetJobRolePrimaryInTx(ctx context.Context, tx *
 		"roleId": roleId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err

--- a/packages/server/customer-os-neo4j-repository/repository/linkedin_connection_request_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/linkedin_connection_request_read_repository.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"time"
 )
 
@@ -34,12 +33,12 @@ func NewLinkedinConnectionRequestReadRepository(driver *neo4j.DriverWithContext,
 }
 
 func (r *linkedinConnectionRequestReadRepository) GetPendingRequestByUserForSocialUrl(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, userId, socialUrl string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LinkedinConnectionRequestReadRepository.GetPendingRequestByUserForSocialUrl")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LinkedinConnectionRequestReadRepository.GetPendingRequestByUserForSocialUrl")
+	defer spans.Finish()
 
-	span.LogFields(log.String("tenant", tenant), log.String("userId", userId), log.String("socialUrl", socialUrl))
+	spans.LogKV("tenant", tenant)
+	spans.LogKV("userId", userId)
+	spans.LogKV("socialUrl", socialUrl)
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:BELONGS_TO_TENANT]-(l:LinkedinConnectionRequest_%s) where l.status = 'PENDING' and l.userId = $userId and l.socialUrl = $socialUrl return l`, tenant)
 
@@ -48,8 +47,8 @@ func (r *linkedinConnectionRequestReadRepository) GetPendingRequestByUserForSoci
 		"userId":    userId,
 		"socialUrl": socialUrl,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -60,7 +59,7 @@ func (r *linkedinConnectionRequestReadRepository) GetPendingRequestByUserForSoci
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -68,11 +67,10 @@ func (r *linkedinConnectionRequestReadRepository) GetPendingRequestByUserForSoci
 }
 
 func (r *linkedinConnectionRequestReadRepository) GetLastScheduledForUser(ctx context.Context, tx *neo4j.ManagedTransaction, userId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.GetLastScheduledForUser")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.GetLastScheduledForUser")
+	defer spans.Finish()
 
-	span.LogFields(log.Object("userId", userId))
+	spans.LogKV("userId", userId)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -82,8 +80,8 @@ func (r *linkedinConnectionRequestReadRepository) GetLastScheduledForUser(ctx co
 		"userId": userId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -103,11 +101,12 @@ func (r *linkedinConnectionRequestReadRepository) GetLastScheduledForUser(ctx co
 }
 
 func (r *linkedinConnectionRequestReadRepository) CountRequestsPerUserPerDay(ctx context.Context, tx *neo4j.ManagedTransaction, userId string, startDate, endDate time.Time) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowActionExecutionReadRepository.CountRequestsPerUserPerDay")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "FlowActionExecutionReadRepository.CountRequestsPerUserPerDay")
+	defer spans.Finish()
 
-	span.LogFields(log.String("userId", userId), log.Object("startDate", startDate), log.Object("endDate", endDate))
+	spans.LogKV("userId", userId)
+	spans.LogObjectAsJson("startDate", startDate)
+	spans.LogObjectAsJson("endDate", endDate)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -119,8 +118,8 @@ func (r *linkedinConnectionRequestReadRepository) CountRequestsPerUserPerDay(ctx
 		"endDate":   endDate,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	queryResult, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -131,11 +130,11 @@ func (r *linkedinConnectionRequestReadRepository) CountRequestsPerUserPerDay(ctx
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return 0, err
 	}
 
 	count := queryResult.(*db.Record).Values[0].(int64)
-	span.LogFields(log.Int64("result", count))
+	spans.LogKV("result", count)
 	return count, nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/linkedin_connection_request_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/linkedin_connection_request_write_repository.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -31,11 +29,10 @@ func NewLinkedinConnectionRequestWriteRepository(driver *neo4j.DriverWithContext
 }
 
 func (r *linkedinConnectionRequestWriteRepository) Save(ctx context.Context, tx *neo4j.ManagedTransaction, input *neo4j_entity.LinkedinConnectionRequest) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LinkedinConnectionRequestWriteRepository.Save")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LinkedinConnectionRequestWriteRepository.Save")
+	defer spans.Finish()
 
-	tracing.LogObjectAsJson(span, "input", input)
+	spans.LogObjectAsJson("input", input)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -65,12 +62,12 @@ func (r *linkedinConnectionRequestWriteRepository) Save(ctx context.Context, tx 
 			"scheduledAt":  input.ScheduledAt,
 			"status":       input.Status,
 		}
-		span.LogFields(log.String("cypher", cypher))
-		tracing.LogObjectAsJson(span, "params", params)
+		spans.LogKV("cypher", cypher)
+		spans.LogObjectAsJson("params", params)
 
 		_, err := tx.Run(ctx, cypher, params)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 

--- a/packages/server/customer-os-neo4j-repository/repository/location_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/location_read_repository.go
@@ -2,11 +2,10 @@ package neo4j_repository
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
 )
 
 type LocationReadRepository interface {
@@ -29,9 +28,8 @@ func NewLocationReadRepository(driver *neo4j.DriverWithContext, database string)
 }
 
 func (r *locationReadRepository) GetAllForContact(ctx context.Context, tenant, contactId string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationReadRepository.GetAllForContact")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LocationReadRepository.GetAllForContact")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -53,9 +51,8 @@ func (r *locationReadRepository) GetAllForContact(ctx context.Context, tenant, c
 }
 
 func (r *locationReadRepository) GetAllForContacts(ctx context.Context, tenant string, contactIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationReadRepository.GetAllForContacts")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LocationReadRepository.GetAllForContacts")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -81,9 +78,8 @@ func (r *locationReadRepository) GetAllForContacts(ctx context.Context, tenant s
 }
 
 func (r *locationReadRepository) GetAllForOrganization(ctx context.Context, tenant, organizationId string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationReadRepository.GetAllForOrganization")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LocationReadRepository.GetAllForOrganization")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -105,9 +101,8 @@ func (r *locationReadRepository) GetAllForOrganization(ctx context.Context, tena
 }
 
 func (r *locationReadRepository) GetAllForOrganizations(ctx context.Context, tenant string, organizationIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationReadRepository.GetAllForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LocationReadRepository.GetAllForOrganizations")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/location_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/location_write_repository.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/constants"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"time"
 )
 
@@ -65,12 +64,11 @@ func NewLocationWriteRepository(driver *neo4j.DriverWithContext, database string
 }
 
 func (r *locationRepository) CreateLocation(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, locationId string, data data_fields.LocationFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationWriteRepository.CreateLocation")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, locationId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LocationWriteRepository.CreateLocation")
+	defer spans.Finish()
+
+	spans.TagEntity(locationId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant}) 
 		 MERGE (t)<-[:LOCATION_BELONGS_TO_TENANT]-(l:Location:Location_%s {id:$id}) 
@@ -130,25 +128,24 @@ func (r *locationRepository) CreateLocation(ctx context.Context, tx *neo4j.Manag
 		"timeZone":      data.TimeZone,
 		"utcOffset":     data.UtcOffset,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *locationRepository) UpdateLocation(ctx context.Context, tenant, locationId string, data LocationUpdateFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationWriteRepository.UpdateLocation")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, locationId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LocationWriteRepository.UpdateLocation")
+	defer spans.Finish()
+
+	spans.TagEntity(locationId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:LOCATION_BELONGS_TO_TENANT]-(l:Location {id:$id})
 			WHERE l:Location_%s
@@ -199,22 +196,21 @@ func (r *locationRepository) UpdateLocation(ctx context.Context, tenant, locatio
 		"utcOffset":    data.AddressDetails.UtcOffset,
 		"overwrite":    data.Source == constants.SourceOpenline,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *locationRepository) FailLocationValidation(ctx context.Context, tenant, locationId, validationError string, validatedAt time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationWriteRepository.FailLocationValidation")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, locationId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LocationWriteRepository.FailLocationValidation")
+	defer spans.Finish()
+
+	spans.TagEntity(locationId)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:LOCATION_BELONGS_TO_TENANT]-(l:Location:Location_%s {id:$id})
 		 		SET l.validationError = $validationError,
@@ -226,22 +222,21 @@ func (r *locationRepository) FailLocationValidation(ctx context.Context, tenant,
 		"validationError": validationError,
 		"validatedAt":     validatedAt,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *locationRepository) LocationValidated(ctx context.Context, tenant, locationId string, data AddressDetails, validatedAt time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationWriteRepository.LocationValidated")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, locationId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LocationWriteRepository.LocationValidated")
+	defer spans.Finish()
+
+	spans.TagEntity(locationId)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -292,23 +287,22 @@ func (r *locationRepository) LocationValidated(ctx context.Context, tenant, loca
 		"timeZone":        data.TimeZone,
 		"utcOffset":       data.UtcOffset,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *locationRepository) LinkWithOrganization(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId, locationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationWriteRepository.LinkWithOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, locationId)
-	span.LogFields(log.String("organizationId", organizationId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LocationWriteRepository.LinkWithOrganization")
+	defer spans.Finish()
+
+	spans.TagEntity(locationId)
+	spans.LogKV("organizationId", organizationId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization {id:$organizationId}),
 				(t)<-[:LOCATION_BELONGS_TO_TENANT]-(l:Location {id:$locationId})
@@ -319,25 +313,24 @@ func (r *locationRepository) LinkWithOrganization(ctx context.Context, tx *neo4j
 		"locationId":     locationId,
 		"organizationId": organizationId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *locationRepository) LinkWithContact(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contactId, locationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationWriteRepository.LinkWithContact")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, locationId)
-	span.LogFields(log.String("contactId", contactId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LocationWriteRepository.LinkWithContact")
+	defer spans.Finish()
+
+	spans.TagEntity(locationId)
+	spans.LogKV("contactId", contactId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact {id:$contactId}),
 				(t)<-[:LOCATION_BELONGS_TO_TENANT]-(l:Location {id:$locationId})
@@ -348,14 +341,14 @@ func (r *locationRepository) LinkWithContact(ctx context.Context, tx *neo4j.Mana
 		"locationId": locationId,
 		"contactId":  contactId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/log_entry_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/log_entry_read_repository.go
@@ -2,12 +2,11 @@ package neo4j_repository
 
 import (
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -32,18 +31,17 @@ func (r *logEntryReadRepository) prepareReadSession(ctx context.Context) neo4j.S
 }
 
 func (r *logEntryReadRepository) GetById(ctx context.Context, tenant, id string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LogEntryReadRepository.GetById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, id)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LogEntryReadRepository.GetById")
+	defer spans.Finish()
+
+	spans.TagEntity(id)
 
 	cypher := fmt.Sprintf(`MATCH (l:LogEntry {id:$id}) WHERE l:LogEntry_%s return l`, tenant)
 	params := map[string]any{
 		"id": id,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -53,10 +51,10 @@ func (r *logEntryReadRepository) GetById(ctx context.Context, tenant, id string)
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/log_entry_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/log_entry_write_repository.go
@@ -3,12 +3,10 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
 type LogEntryWriteRepository interface {
@@ -29,12 +27,11 @@ func NewLogEntryWriteRepository(driver *neo4j.DriverWithContext, database string
 }
 
 func (r *logEntryWriteRepository) CreateInTx(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, logEntryId string, data data_fields.LogEntryFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LogEntryWriteRepository.CreateInTx")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, logEntryId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LogEntryWriteRepository.CreateInTx")
+	defer spans.Finish()
+
+	spans.TagEntity(logEntryId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization {id:$orgId})
 							MERGE (l:LogEntry {id:$logEntryId})<-[:LOGGED]-(o)
@@ -68,25 +65,24 @@ func (r *logEntryWriteRepository) CreateInTx(ctx context.Context, tx *neo4j.Mana
 		"contentType":  utils.IfNotNilString(data.ContentType),
 		"authorUserId": utils.IfNotNilString(data.AuthorUserId),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *logEntryWriteRepository) UpdateInTx(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, logEntryId string, data data_fields.LogEntryFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LogEntryWriteRepository.UpdateInTx")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, logEntryId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "LogEntryWriteRepository.UpdateInTx")
+	defer spans.Finish()
+
+	spans.TagEntity(logEntryId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (l:LogEntry_%s {id:$logEntryId}) SET l.updatedAt=datetime()`, tenant)
 	params := map[string]any{
@@ -106,8 +102,8 @@ func (r *logEntryWriteRepository) UpdateInTx(ctx context.Context, tx *neo4j.Mana
 		cypher += ", l.contentType=$contentType"
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -118,7 +114,7 @@ func (r *logEntryWriteRepository) UpdateInTx(ctx context.Context, tx *neo4j.Mana
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err

--- a/packages/server/customer-os-neo4j-repository/repository/markdown_event_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/markdown_event_write_repository.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -31,12 +29,11 @@ func NewMarkdownEventWriteRepository(driver *neo4j.DriverWithContext, database s
 }
 
 func (r *markdownEventWriteRepository) CreateInTx(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, markdownEventId string, data data_fields.MarkdownEventFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MarkdownEventWriteRepository.CreateInTx")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, markdownEventId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "MarkdownEventWriteRepository.CreateInTx")
+	defer spans.Finish()
+
+	spans.TagEntity(markdownEventId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization {id:$orgId})
 							MERGE (m:MarkdownEvent {id:$markdownEventId})<-[:HAS_MARKDOWN_EVENT]-(o)
@@ -64,8 +61,8 @@ func (r *markdownEventWriteRepository) CreateInTx(ctx context.Context, tx *neo4j
 	} else {
 		params["source"] = neo4j_entity.DataSourceOpenline.String()
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -75,7 +72,7 @@ func (r *markdownEventWriteRepository) CreateInTx(ctx context.Context, tx *neo4j
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err

--- a/packages/server/customer-os-neo4j-repository/repository/opportunity_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/opportunity_read_repository.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type TenantAndOpportunityId struct {
@@ -36,10 +34,10 @@ type opportunityReadRepository struct {
 }
 
 func (r *opportunityReadRepository) GetPreviousClosedWonRenewalOpportunityForContract(ctx context.Context, tenant, contractId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityReadRepository.GetPreviousClosedWonRenewalOpportunityForContract")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("contractId", contractId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityReadRepository.GetPreviousClosedWonRenewalOpportunityForContract")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract {id:$contractId})-[:HAS_OPPORTUNITY]->(op:RenewalOpportunity)
 				WHERE op.internalStage=$internalStage AND op.renewedAt < $now
@@ -50,25 +48,25 @@ func (r *opportunityReadRepository) GetPreviousClosedWonRenewalOpportunityForCon
 		"now":           utils.Now(),
 		"internalStage": enum.OpportunityInternalStageClosedWon.String(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
 
 	result, err := session.Run(ctx, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	if result.Next(ctx) {
 		node := result.Record().Values[0].(dbtype.Node)
-		span.LogFields(log.Bool("result.found", true))
+		spans.LogKV("result.found", true)
 		return &node, nil
 	}
 
-	span.LogFields(log.Bool("result.found", false))
+	spans.LogKV("result.found", false)
 	return nil, nil
 }
 
@@ -84,17 +82,17 @@ func (r *opportunityReadRepository) prepareReadSession(ctx context.Context) neo4
 }
 
 func (r *opportunityReadRepository) GetOpportunityById(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, opportunityId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityReadRepository.GetOpportunityById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, opportunityId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityReadRepository.GetOpportunityById")
+	defer spans.Finish()
+
+	spans.TagEntity(opportunityId)
 
 	cypher := fmt.Sprintf(`MATCH (op:Opportunity {id:$id}) WHERE op:Opportunity_%s RETURN op`, tenant)
 	params := map[string]any{
 		"id": opportunityId,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
@@ -104,18 +102,18 @@ func (r *opportunityReadRepository) GetOpportunityById(ctx context.Context, tx *
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *opportunityReadRepository) GetActiveRenewalOpportunityForContract(ctx context.Context, tenant, contractId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityReadRepository.GetActiveRenewalOpportunityForContract")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("contractId", contractId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityReadRepository.GetActiveRenewalOpportunityForContract")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract {id:$contractId})-[:ACTIVE_RENEWAL]->(op:RenewalOpportunity)
 				WHERE op.internalStage=$internalStage
@@ -125,34 +123,34 @@ func (r *opportunityReadRepository) GetActiveRenewalOpportunityForContract(ctx c
 		"contractId":    contractId,
 		"internalStage": enum.OpportunityInternalStageOpen.String(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
 
 	result, err := session.Run(ctx, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	if result.Next(ctx) {
 		node := result.Record().Values[0].(dbtype.Node)
-		span.LogFields(log.Bool("result.found", true))
+		spans.LogKV("result.found", true)
 		return &node, nil
 	}
 
-	span.LogFields(log.Bool("result.found", false))
+	spans.LogKV("result.found", false)
 	return nil, nil
 }
 
 func (r *opportunityReadRepository) GetActiveRenewalOpportunitiesForOrganization(ctx context.Context, tenant, organizationId string, includeDraftContracts bool) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityReadRepository.GetActiveRenewalOpportunitiesForOrganization")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("organizationId", organizationId))
-	span.LogFields(log.Bool("includeDraftContracts", includeDraftContracts))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityReadRepository.GetActiveRenewalOpportunitiesForOrganization")
+	defer spans.Finish()
+
+	spans.LogKV("organizationId", organizationId)
+	spans.LogKV("includeDraftContracts", includeDraftContracts)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId})-[:HAS_CONTRACT]->(c:Contract)-[:ACTIVE_RENEWAL]->(op:Opportunity)
 				WHERE op:RenewalOpportunity AND op.internalStage=$internalStage AND (c.status<>$draftStatus OR $includeDraftContracts)
@@ -164,8 +162,8 @@ func (r *opportunityReadRepository) GetActiveRenewalOpportunitiesForOrganization
 		"draftStatus":           enum.ContractStatusDraft.String(),
 		"includeDraftContracts": includeDraftContracts,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -178,18 +176,18 @@ func (r *opportunityReadRepository) GetActiveRenewalOpportunitiesForOrganization
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), nil
 }
 
 func (r *opportunityReadRepository) GetRenewalOpportunitiesForClosingAsLost(ctx context.Context, limit int) ([]TenantAndOpportunityId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractRepository.GetRenewalOpportunitiesForClosingAsLost")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractRepository.GetRenewalOpportunitiesForClosingAsLost")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant)<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract)-[:ACTIVE_RENEWAL]->(op:RenewalOpportunity)
 				WHERE 
@@ -204,8 +202,8 @@ func (r *opportunityReadRepository) GetRenewalOpportunitiesForClosingAsLost(ctx 
 		"internalStageOpen": enum.OpportunityInternalStageOpen.String(),
 		"limit":             limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -229,14 +227,13 @@ func (r *opportunityReadRepository) GetRenewalOpportunitiesForClosingAsLost(ctx 
 				OpportunityId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *opportunityReadRepository) GetForContracts(ctx context.Context, tenant string, contractIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityRepository.GetForContracts")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityRepository.GetForContracts")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract)-[:HAS_OPPORTUNITY]->(op:Opportunity)
 			WHERE c.id IN $contractIds
@@ -245,7 +242,8 @@ func (r *opportunityReadRepository) GetForContracts(ctx context.Context, tenant 
 		"tenant":      tenant,
 		"contractIds": contractIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -264,9 +262,8 @@ func (r *opportunityReadRepository) GetForContracts(ctx context.Context, tenant 
 }
 
 func (r *opportunityReadRepository) GetForOrganizations(ctx context.Context, tenant string, organizationIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityRepository.GetForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityRepository.GetForOrganizations")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization)-[:HAS_OPPORTUNITY]->(op:Opportunity)
 			WHERE org.id IN $orgIds
@@ -275,8 +272,8 @@ func (r *opportunityReadRepository) GetForOrganizations(ctx context.Context, ten
 		"tenant": tenant,
 		"orgIds": organizationIds,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -295,9 +292,8 @@ func (r *opportunityReadRepository) GetForOrganizations(ctx context.Context, ten
 }
 
 func (r *opportunityReadRepository) GetForTasks(ctx context.Context, tenant string, taskIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityRepository.GetForTasks")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityRepository.GetForTasks")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task)-[:LINKED_TO]->(op:Opportunity)
 			WHERE tsk.id IN $taskIds
@@ -306,8 +302,8 @@ func (r *opportunityReadRepository) GetForTasks(ctx context.Context, tenant stri
 		"tenant":  tenant,
 		"taskIds": taskIds,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -322,14 +318,13 @@ func (r *opportunityReadRepository) GetForTasks(ctx context.Context, tenant stri
 	if err != nil {
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *opportunityReadRepository) GetPaginatedOpportunitiesLinkedToAnOrganization(ctx context.Context, tenant string, skip, limit int) (*utils.DbNodesWithTotalCount, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityRepository.GetPaginatedOpportunitiesLinkedToAnOrganization")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityRepository.GetPaginatedOpportunitiesLinkedToAnOrganization")
+	defer spans.Finish()
 
 	dbNodesWithTotalCount := new(utils.DbNodesWithTotalCount)
 
@@ -344,10 +339,10 @@ func (r *opportunityReadRepository) GetPaginatedOpportunitiesLinkedToAnOrganizat
 		"skip":   skip,
 		"limit":  limit,
 	}
-	span.LogFields(log.String("countCypher", countCypher))
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
-	tracing.LogObjectAsJson(span, "countParams", countParams)
+	spans.LogKV("countCypher", countCypher)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
+	spans.LogObjectAsJson("countParams", countParams)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -367,12 +362,12 @@ func (r *opportunityReadRepository) GetPaginatedOpportunitiesLinkedToAnOrganizat
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	for _, v := range dbRecords.([]*neo4j.Record) {
 		dbNodesWithTotalCount.Nodes = append(dbNodesWithTotalCount.Nodes, utils.NodePtr(v.Values[0].(neo4j.Node)))
 	}
-	span.LogFields(log.Int("result.count", len(dbNodesWithTotalCount.Nodes)))
+	spans.LogKV("result.count", len(dbNodesWithTotalCount.Nodes))
 	return dbNodesWithTotalCount, nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/opportunity_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/opportunity_write_repository.go
@@ -3,12 +3,11 @@ package neo4j_repository
 import (
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 	"time"
 )
@@ -57,12 +56,11 @@ func NewOpportunityWriteRepository(driver *neo4j.DriverWithContext, database str
 }
 
 func (r *opportunityWriteRepository) Save(ctx context.Context, txx *neo4j.ManagedTransaction, tenant, opportunityId string, data data_fields.OpportunityFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityWriteRepository.Save")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, opportunityId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityWriteRepository.Save")
+	defer spans.Finish()
+
+	spans.TagEntity(opportunityId)
+	spans.LogObjectAsJson("data", data)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, txx, func(tx neo4j.ManagedTransaction) (any, error) {
 
@@ -82,12 +80,12 @@ func (r *opportunityWriteRepository) Save(ctx context.Context, txx *neo4j.Manage
 			"source":        data.Source,
 		}
 
-		span.LogFields(log.String("cypherCreate", cypherCreate))
-		tracing.LogObjectAsJson(span, "paramsCreate", paramsCreate)
+		spans.LogKV("cypherCreate", cypherCreate)
+		spans.LogObjectAsJson("paramsCreate", paramsCreate)
 
 		_, err := tx.Run(ctx, cypherCreate, paramsCreate)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 
@@ -143,12 +141,12 @@ func (r *opportunityWriteRepository) Save(ctx context.Context, txx *neo4j.Manage
 			paramsUpdate["likelihoodRate"] = *data.LikelihoodRate
 		}
 
-		span.LogFields(log.String("cypherUpdate", cypherUpdate))
-		tracing.LogObjectAsJson(span, "paramsUpdate", paramsUpdate)
+		spans.LogKV("cypherUpdate", cypherUpdate)
+		spans.LogObjectAsJson("paramsUpdate", paramsUpdate)
 
 		_, err = tx.Run(ctx, cypherUpdate, paramsUpdate)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 
@@ -159,12 +157,11 @@ func (r *opportunityWriteRepository) Save(ctx context.Context, txx *neo4j.Manage
 }
 
 func (r *opportunityWriteRepository) ReplaceOwner(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, opportunityId, userId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityWriteRepository.ReplaceOwner")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, opportunityId)
-	span.LogFields(log.String("userId", userId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityWriteRepository.ReplaceOwner")
+	defer spans.Finish()
+
+	spans.TagEntity(opportunityId)
+	spans.LogKV("userId", userId)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant}), (op:Opportunity:Opportunity_%s {id:$opportunityId})
 			WITH op, t
@@ -182,15 +179,15 @@ func (r *opportunityWriteRepository) ReplaceOwner(ctx context.Context, tx *neo4j
 		"now":           utils.Now(),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -198,11 +195,10 @@ func (r *opportunityWriteRepository) ReplaceOwner(ctx context.Context, tx *neo4j
 }
 
 func (r *opportunityWriteRepository) RemoveOwner(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, opportunityId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityWriteRepository.RemoveOwner")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, opportunityId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityWriteRepository.RemoveOwner")
+	defer spans.Finish()
+
+	spans.TagEntity(opportunityId)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:OPPORTUNITY_BELONGS_TO_TENANT]-(op:Opportunity:Opportunity_%s {id:$opportunityId})<-[rel:OWNS]-(:User_%s)
 				SET op.updatedAt=datetime()
@@ -212,15 +208,15 @@ func (r *opportunityWriteRepository) RemoveOwner(ctx context.Context, tx *neo4j.
 		"opportunityId": opportunityId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -228,16 +224,15 @@ func (r *opportunityWriteRepository) RemoveOwner(ctx context.Context, tx *neo4j.
 }
 
 func (r *opportunityWriteRepository) CreateRenewal(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, opportunityId string, data data_fields.OpportunityFields) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityWriteRepository.CreateRenewal")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, opportunityId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityWriteRepository.CreateRenewal")
+	defer spans.Finish()
+
+	spans.TagEntity(opportunityId)
+	spans.LogObjectAsJson("data", data)
 
 	if !data.IsRenewal() {
 		err := fmt.Errorf("opportunity is not a renewal opportunity")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return false, err
 	}
 
@@ -283,8 +278,8 @@ func (r *opportunityWriteRepository) CreateRenewal(ctx context.Context, tx *neo4
 		params["renewalLikelihood"] = ""
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -294,21 +289,20 @@ func (r *opportunityWriteRepository) CreateRenewal(ctx context.Context, tx *neo4
 		return utils.ExtractSingleRecordFirstValueAsType[bool](ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
-		span.LogFields(log.Bool("result.created", false))
+		spans.TraceError(err)
+		spans.LogKV("result.created", false)
 		return false, err
 	}
-	span.LogFields(log.Bool("result.created", result.(bool)))
+	spans.LogKV("result.created", result.(bool))
 	return result.(bool), nil
 }
 
 func (r *opportunityWriteRepository) UpdateRenewal(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, opportunityId string, data data_fields.OpportunityFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityWriteRepository.UpdateRenewal")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, opportunityId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityWriteRepository.UpdateRenewal")
+	defer spans.Finish()
+
+	spans.TagEntity(opportunityId)
+	spans.LogObjectAsJson("data", data)
 
 	params := map[string]any{
 		"tenant":        tenant,
@@ -341,15 +335,15 @@ func (r *opportunityWriteRepository) UpdateRenewal(ctx context.Context, tx *neo4
 		params["renewalAdjustedRate"] = data.RenewalAdjustedRate
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -357,11 +351,10 @@ func (r *opportunityWriteRepository) UpdateRenewal(ctx context.Context, tx *neo4
 }
 
 func (r *opportunityWriteRepository) CloseWon(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, opportunityId string, closedAt time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityWriteRepository.CloseWon")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, opportunityId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityWriteRepository.CloseWon")
+	defer spans.Finish()
+
+	spans.TagEntity(opportunityId)
 
 	cypher := fmt.Sprintf(`MATCH (op:Opportunity {id:$opportunityId}) 
 							WHERE op:Opportunity_%s AND op.internalStage <> $internalStage
@@ -379,14 +372,14 @@ func (r *opportunityWriteRepository) CloseWon(ctx context.Context, tx *neo4j.Man
 		"internalStage": enum.OpportunityInternalStageClosedWon.String(),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -394,11 +387,10 @@ func (r *opportunityWriteRepository) CloseWon(ctx context.Context, tx *neo4j.Man
 }
 
 func (r *opportunityWriteRepository) CloseLost(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, opportunityId string, closedAt time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityWriteRepository.CloseLost")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, opportunityId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityWriteRepository.CloseLost")
+	defer spans.Finish()
+
+	spans.TagEntity(opportunityId)
 
 	cypher := fmt.Sprintf(`MATCH (op:Opportunity {id:$opportunityId}) 
 							WHERE op:Opportunity_%s AND op.internalStage <> $internalStage
@@ -415,15 +407,15 @@ func (r *opportunityWriteRepository) CloseLost(ctx context.Context, tx *neo4j.Ma
 		"internalStage": enum.OpportunityInternalStageClosedLost,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		return nil, err
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -431,11 +423,10 @@ func (r *opportunityWriteRepository) CloseLost(ctx context.Context, tx *neo4j.Ma
 }
 
 func (r *opportunityWriteRepository) MarkRenewalRequested(ctx context.Context, tenant, opportunityId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractWriteRepository.MarkRenewalRequested")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, opportunityId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContractWriteRepository.MarkRenewalRequested")
+	defer spans.Finish()
+
+	spans.TagEntity(opportunityId)
 
 	cypher := fmt.Sprintf(`MATCH (op:Opportunity {id:$opportunityId})
 				WHERE op:Opportunity_%s
@@ -444,22 +435,21 @@ func (r *opportunityWriteRepository) MarkRenewalRequested(ctx context.Context, t
 		"opportunityId": opportunityId,
 		"now":           utils.Now(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *opportunityWriteRepository) Archive(ctx context.Context, tenant, opportunityId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityWriteRepository.Archive")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, opportunityId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OpportunityWriteRepository.Archive")
+	defer spans.Finish()
+
+	spans.TagEntity(opportunityId)
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:OPPORTUNITY_BELONGS_TO_TENANT]-(op:Opportunity {id:$opportunityId}) 
 							WHERE op:Opportunity_%s
@@ -472,12 +462,12 @@ func (r *opportunityWriteRepository) Archive(ctx context.Context, tenant, opport
 		"opportunityId": opportunityId,
 		"tenant":        tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/organization_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/organization_read_repository.go
@@ -7,13 +7,11 @@ import (
 	"time"
 
 	commonenum "github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 )
@@ -91,18 +89,16 @@ func (r *organizationReadRepository) prepareReadSession(ctx context.Context) neo
 }
 
 func (r *organizationReadRepository) CountByTenant(ctx context.Context, tenant string) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.CountByTenant")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.CountByTenant")
+	defer spans.Finish()
 
 	cypher := `MATCH (org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}) where org.hide = false
 			RETURN count(org)`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("query", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -118,24 +114,23 @@ func (r *organizationReadRepository) CountByTenant(ctx context.Context, tenant s
 		return 0, err
 	}
 	organizationsCount := dbRecord.(*db.Record).Values[0].(int64)
-	span.LogFields(log.Int64("result", organizationsCount))
+	spans.LogKV("result", organizationsCount)
 	return organizationsCount, nil
 }
 
 func (r *organizationReadRepository) GetOrganization(ctx context.Context, tenant, organizationId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, organizationId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganization")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$id}) RETURN org`
 	params := map[string]any{
 		"tenant": tenant,
 		"id":     organizationId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -148,19 +143,18 @@ func (r *organizationReadRepository) GetOrganization(ctx context.Context, tenant
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *organizationReadRepository) GetOrganizationIdsConnectedToInteractionEvent(ctx context.Context, tenant, interactionEventId string) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationIdsConnectedToInteractionEvent")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("interactionEventId", interactionEventId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationIdsConnectedToInteractionEvent")
+	defer spans.Finish()
+
+	spans.LogKV("interactionEventId", interactionEventId)
 
 	cypher := fmt.Sprintf(`MATCH (ie:InteractionEvent_%s {id:$interactionEventId}),
 				(t:Tenant {name:$tenant})
@@ -178,8 +172,8 @@ func (r *organizationReadRepository) GetOrganizationIdsConnectedToInteractionEve
 		"tenant":             tenant,
 		"interactionEventId": interactionEventId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -192,19 +186,18 @@ func (r *organizationReadRepository) GetOrganizationIdsConnectedToInteractionEve
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]string))))
+	spans.LogKV("result.count", len(result.([]string)))
 	return result.([]string), err
 }
 
 func (r *organizationReadRepository) GetOrganizationByOpportunityId(ctx context.Context, tenant, opportunityId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationByOpportunityId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("opportunityId", opportunityId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationByOpportunityId")
+	defer spans.Finish()
+
+	spans.LogKV("opportunityId", opportunityId)
 
 	cypher := `MATCH (op:Opportunity {id:$id})
 				MATCH (t:Tenant {name:$tenant})
@@ -216,8 +209,8 @@ func (r *organizationReadRepository) GetOrganizationByOpportunityId(ctx context.
 		"tenant": tenant,
 		"id":     opportunityId,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("query", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -230,25 +223,24 @@ func (r *organizationReadRepository) GetOrganizationByOpportunityId(ctx context.
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	records := result.([]*dbtype.Node)
 	if len(records) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	} else {
-		span.LogFields(log.Bool("result.found", true))
+		spans.LogKV("result.found", true)
 		return records[0], nil
 	}
 }
 
 func (r *organizationReadRepository) GetOrganizationByContactId(ctx context.Context, tenant, contactId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationByContactId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("contactId", contactId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationByContactId")
+	defer spans.Finish()
+
+	spans.LogKV("contactId", contactId)
 
 	cypher := `MATCH (org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(t:Tenant {name:$tenant}), 
 				(t)<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact {id:$contactId})
@@ -258,8 +250,8 @@ func (r *organizationReadRepository) GetOrganizationByContactId(ctx context.Cont
 		"tenant":    tenant,
 		"contactId": contactId,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("query", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -272,25 +264,24 @@ func (r *organizationReadRepository) GetOrganizationByContactId(ctx context.Cont
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	records := result.([]*dbtype.Node)
 	if len(records) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	} else {
-		span.LogFields(log.Bool("result.found", true))
+		spans.LogKV("result.found", true)
 		return records[0], nil
 	}
 }
 
 func (r *organizationReadRepository) GetOrganizationByContractId(ctx context.Context, tenant, contractId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationByContractId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("contractId", contractId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationByContractId")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization)-[:HAS_CONTRACT]->(c:Contract {id:$id})
 			RETURN org limit 1`
@@ -298,8 +289,8 @@ func (r *organizationReadRepository) GetOrganizationByContractId(ctx context.Con
 		"tenant": tenant,
 		"id":     contractId,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("query", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -312,25 +303,24 @@ func (r *organizationReadRepository) GetOrganizationByContractId(ctx context.Con
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	records := result.([]*dbtype.Node)
 	if len(records) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	} else {
-		span.LogFields(log.Bool("result.found", true))
+		spans.LogKV("result.found", true)
 		return records[0], nil
 	}
 }
 
 func (r *organizationReadRepository) GetOrganizationByInvoiceId(ctx context.Context, tenant, invoiceId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationByInvoiceId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("invoiceId", invoiceId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationByInvoiceId")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceId", invoiceId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(inv:Invoice {id:$invoiceId})<-[:HAS_INVOICE]-(c:Contract)<-[:HAS_CONTRACT]-(org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(t)
 			RETURN org`
@@ -338,8 +328,8 @@ func (r *organizationReadRepository) GetOrganizationByInvoiceId(ctx context.Cont
 		"tenant":    tenant,
 		"invoiceId": invoiceId,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -352,25 +342,24 @@ func (r *organizationReadRepository) GetOrganizationByInvoiceId(ctx context.Cont
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	records := result.([]*dbtype.Node)
 	if len(records) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	} else {
-		span.LogFields(log.Bool("result.found", true))
+		spans.LogKV("result.found", true)
 		return records[0], nil
 	}
 }
 
 func (r *organizationReadRepository) GetOrganizationByCustomerOsId(ctx context.Context, tenant, customerOsId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationByCustomerOsId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("customerOsId", customerOsId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationByCustomerOsId")
+	defer spans.Finish()
+
+	spans.LogKV("customerOsId", customerOsId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {customerOsId:$customerOsId})
 			RETURN org`
@@ -378,8 +367,8 @@ func (r *organizationReadRepository) GetOrganizationByCustomerOsId(ctx context.C
 		"tenant":       tenant,
 		"customerOsId": customerOsId,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -392,23 +381,22 @@ func (r *organizationReadRepository) GetOrganizationByCustomerOsId(ctx context.C
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *organizationReadRepository) GetOrganizationByIdOrCustomerOsId(ctx context.Context, tenant, id string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationByIdOrCustomerOsId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("id", id))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationByIdOrCustomerOsId")
+	defer spans.Finish()
+
+	spans.LogKV("id", id)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization)
 			WHERE org.customerOsId = $id OR org.id = $id RETURN org`
@@ -416,8 +404,8 @@ func (r *organizationReadRepository) GetOrganizationByIdOrCustomerOsId(ctx conte
 		"tenant": tenant,
 		"id":     id,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -430,31 +418,30 @@ func (r *organizationReadRepository) GetOrganizationByIdOrCustomerOsId(ctx conte
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *organizationReadRepository) GetOrganizationByReferenceId(ctx context.Context, tenant, referenceId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationByReferenceId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("referenceId", referenceId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationByReferenceId")
+	defer spans.Finish()
+
+	spans.LogKV("referenceId", referenceId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {referenceId:$referenceId}) RETURN org`
 	params := map[string]any{
 		"tenant":      tenant,
 		"referenceId": referenceId,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -467,30 +454,30 @@ func (r *organizationReadRepository) GetOrganizationByReferenceId(ctx context.Co
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *organizationReadRepository) GetOrganizationByDomain(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, domain string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationByDomain")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("domain", domain))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationByDomain")
+	defer spans.Finish()
+
+	spans.LogKV("domain", domain)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)-[:HAS_DOMAIN]->(d:Domain{domain:$domain}) RETURN o limit 1`
 	params := map[string]any{
 		"tenant": tenant,
 		"domain": domain,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -503,23 +490,22 @@ func (r *organizationReadRepository) GetOrganizationByDomain(ctx context.Context
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	if len(result.([]*dbtype.Node)) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.([]*dbtype.Node)[0], err
 }
 
 func (r *organizationReadRepository) GetOrganizationBySocialUrl(ctx context.Context, tenant, socialUrl string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationBySocialUrl")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogKV("socialUrl", socialUrl)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationBySocialUrl")
+	defer spans.Finish()
+
+	spans.LogKV("socialUrl", socialUrl)
 
 	if socialUrl == "" || socialUrl == "/" {
 		return nil, nil
@@ -533,7 +519,7 @@ func (r *organizationReadRepository) GetOrganizationBySocialUrl(ctx context.Cont
 		urlWithoutSlash = socialUrl
 		urlWithSlash = socialUrl + "/"
 	}
-	span.LogKV("urlWithoutSlash", urlWithoutSlash, "urlWithSlash", urlWithSlash)
+	spans.LogKV("urlWithoutSlash", urlWithoutSlash, "urlWithSlash", urlWithSlash)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)-[:HAS]->(s:Social)
 				WHERE s.url = $urlWithoutSlash OR s.url = $urlWithSlash
@@ -555,7 +541,7 @@ func (r *organizationReadRepository) GetOrganizationBySocialUrl(ctx context.Cont
 		}
 	})
 	if err != nil && err.Error() == "Result contains no more records" {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 	if err != nil {
@@ -563,22 +549,22 @@ func (r *organizationReadRepository) GetOrganizationBySocialUrl(ctx context.Cont
 	}
 
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 
 	return result.(*dbtype.Node), err
 }
 
 func (r *organizationReadRepository) GetOrganizationsByLinkedIn(ctx context.Context, tenant, url, alias, externalId string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationsByLinkedIn")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("url", url), log.String("alias", alias), log.String("externalId", externalId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationsByLinkedIn")
+	defer spans.Finish()
+
+	spans.LogKV("url", url, "alias", alias, "externalId", externalId)
 
 	if !strings.Contains(url, "linkedin.com") {
-		span.LogFields(log.Int("result.count", 0))
+		spans.LogKV("result.count", 0)
 		return nil, nil
 	}
 
@@ -610,8 +596,8 @@ func (r *organizationReadRepository) GetOrganizationsByLinkedIn(ctx context.Cont
 		"externalId":   externalId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -624,20 +610,19 @@ func (r *organizationReadRepository) GetOrganizationsByLinkedIn(ctx context.Cont
 		}
 	})
 	if err != nil {
-		span.LogFields(log.Int("result.count", 0))
+		spans.LogKV("result.count", 0)
 		return nil, err
 	}
 	nodes := result.([]*dbtype.Node)
-	span.LogFields(log.Int("result.count", len(nodes)))
+	spans.LogKV("result.count", len(nodes))
 	return nodes, err
 }
 
 func (r *organizationReadRepository) GetForApiCache(ctx context.Context, tenant string, skip, limit int) ([]map[string]interface{}, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetForApiCache")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("skip", skip), log.Object("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetForApiCache")
+	defer spans.Finish()
+
+	spans.LogKV("skip", skip, "limit", limit)
 
 	cypher := ` MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization) 
 				WHERE o.hide = false
@@ -665,8 +650,8 @@ func (r *organizationReadRepository) GetForApiCache(ctx context.Context, tenant 
 		"limit":  limit,
 	}
 
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -679,7 +664,7 @@ func (r *organizationReadRepository) GetForApiCache(ctx context.Context, tenant 
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -714,10 +699,8 @@ func (r *organizationReadRepository) GetForApiCache(ctx context.Context, tenant 
 }
 
 func (r *organizationReadRepository) GetPatchesForApiCache(ctx context.Context, tenant string, lastPatchTimestamp time.Time) ([]map[string]interface{}, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetPatchesForApiCache")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetPatchesForApiCache")
+	defer spans.Finish()
 
 	cypher := ` MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)
 				where o.updatedAt > $lastPatchTimestamp
@@ -755,8 +738,8 @@ func (r *organizationReadRepository) GetPatchesForApiCache(ctx context.Context, 
 		"lastPatchTimestamp": lastPatchTimestamp,
 	}
 
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -769,7 +752,7 @@ func (r *organizationReadRepository) GetPatchesForApiCache(ctx context.Context, 
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -804,11 +787,10 @@ func (r *organizationReadRepository) GetPatchesForApiCache(ctx context.Context, 
 }
 
 func (r *organizationReadRepository) GetAllForInvoices(ctx context.Context, tenant string, invoiceIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetAllForInvoices")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("invoiceIds", invoiceIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetAllForInvoices")
+	defer spans.Finish()
+
+	spans.LogKV("invoiceIds", invoiceIds)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:INVOICE_BELONGS_TO_TENANT]-(i:Invoice)<-[:HAS_INVOICE]-(:Contract)<-[:HAS_CONTRACT]-(o:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(t)
 				WHERE i.id IN $invoiceIds
@@ -818,8 +800,8 @@ func (r *organizationReadRepository) GetAllForInvoices(ctx context.Context, tena
 		"invoiceIds": invoiceIds,
 	}
 
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -834,16 +816,15 @@ func (r *organizationReadRepository) GetAllForInvoices(ctx context.Context, tena
 	if err != nil {
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *organizationReadRepository) GetAllForContracts(ctx context.Context, tenant string, contractIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetAllForContracts")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("contractIds", contractIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetAllForContracts")
+	defer spans.Finish()
+
+	spans.LogKV("contractIds", contractIds)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)-[:HAS_CONTRACT]->(c:Contract)
 				WHERE c.id IN $contractIds
@@ -853,8 +834,8 @@ func (r *organizationReadRepository) GetAllForContracts(ctx context.Context, ten
 		"contractIds": contractIds,
 	}
 
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -869,16 +850,15 @@ func (r *organizationReadRepository) GetAllForContracts(ctx context.Context, ten
 	if err != nil {
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *organizationReadRepository) GetAllForSlackChannels(ctx context.Context, tenant string, slackChannelIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetAllForSlackChannels")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("slackChannelIds", slackChannelIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetAllForSlackChannels")
+	defer spans.Finish()
+
+	spans.LogKV("slackChannelIds", slackChannelIds)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})-[:ORGANIZATION_BELONGS_TO_TENANT]->(o:Organization)
 				WHERE o.slackChannelId IN $slackChannelIds
@@ -888,8 +868,8 @@ func (r *organizationReadRepository) GetAllForSlackChannels(ctx context.Context,
 		"slackChannelIds": slackChannelIds,
 	}
 
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -904,16 +884,15 @@ func (r *organizationReadRepository) GetAllForSlackChannels(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *organizationReadRepository) GetAllForOpportunities(ctx context.Context, tenant string, opportunityIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetAllForOpportunities")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("opportunityIds", opportunityIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetAllForOpportunities")
+	defer spans.Finish()
+
+	spans.LogKV("opportunityIds", opportunityIds)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization)-[:HAS_OPPORTUNITY]->(op:Opportunity)
 				WHERE op.id IN $opportunityIds
@@ -923,8 +902,8 @@ func (r *organizationReadRepository) GetAllForOpportunities(ctx context.Context,
 		"opportunityIds": opportunityIds,
 	}
 
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -939,15 +918,15 @@ func (r *organizationReadRepository) GetAllForOpportunities(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeAndId)))
 	return result.([]*utils.DbNodeAndId), err
 }
 
 func (r *organizationReadRepository) GetOrganizationsForUpdateNextRenewalDate(ctx context.Context, limit int) ([]TenantAndOrganizationId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationsForUpdateNextRenewalDate")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationsForUpdateNextRenewalDate")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
 
 	cypher := `MATCH (t:Tenant)<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization)-[:HAS_CONTRACT]-(c:Contract)-[:ACTIVE_RENEWAL]->(op:RenewalOpportunity) 
 				WITH t, org, collect(c) as contracts, collect(op) as ops 
@@ -960,8 +939,8 @@ func (r *organizationReadRepository) GetOrganizationsForUpdateNextRenewalDate(ct
 		"liveStatus": neo4jenum.ContractStatusLive.String(),
 		"limit":      limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -984,15 +963,16 @@ func (r *organizationReadRepository) GetOrganizationsForUpdateNextRenewalDate(ct
 				OrganizationId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *organizationReadRepository) GetOrganizationsWithWebsiteAndWithoutDomains(ctx context.Context, limit, delayInMinutes int) ([]TenantAndOrganizationId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationsWithWebsiteAndWithoutDomains")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit), log.Int("delayInMinutes", delayInMinutes))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationsWithWebsiteAndWithoutDomains")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
+	spans.LogKV("delayInMinutes", delayInMinutes)
 
 	cypher := `MATCH (t:Tenant)<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization) 
 				WHERE NOT (org)-[:HAS_DOMAIN]->(:Domain) AND 
@@ -1007,8 +987,8 @@ func (r *organizationReadRepository) GetOrganizationsWithWebsiteAndWithoutDomain
 		"limit":          limit,
 		"delayInMinutes": delayInMinutes,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1031,15 +1011,16 @@ func (r *organizationReadRepository) GetOrganizationsWithWebsiteAndWithoutDomain
 				OrganizationId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *organizationReadRepository) GetOrganizationsForEnrichByDomain(ctx context.Context, limit, delayInMinutes int) ([]TenantAndOrganizationIdExtended, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationsForEnrichByDomain")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit), log.Int("delayInMinutes", delayInMinutes))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationsForEnrichByDomain")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
+	spans.LogKV("delayInMinutes", delayInMinutes)
 
 	cypher := `MATCH (t:Tenant {active:true})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization)-[:HAS_DOMAIN]->(d:Domain {primary:true})
 				WHERE 	org.enrichedAt IS NULL AND
@@ -1056,8 +1037,8 @@ func (r *organizationReadRepository) GetOrganizationsForEnrichByDomain(ctx conte
 		"delayInMinutes": delayInMinutes,
 		"maxAttempts":    1,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1081,15 +1062,16 @@ func (r *organizationReadRepository) GetOrganizationsForEnrichByDomain(ctx conte
 				Param1:         v.Values[2].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *organizationReadRepository) GetOrganizationsForUpdateLastTouchpoint(ctx context.Context, limit, delayFromPreviousCheckMin int) ([]TenantAndOrganizationId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationsForUpdateLastTouchpoint")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit), log.Int("delayFromPreviousCheckMin", delayFromPreviousCheckMin))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationsForUpdateLastTouchpoint")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
+	spans.LogKV("delayFromPreviousCheckMin", delayFromPreviousCheckMin)
 
 	cypher := `MATCH (t:Tenant {active:true})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization)
 				WHERE org.hide = false AND
@@ -1102,8 +1084,8 @@ func (r *organizationReadRepository) GetOrganizationsForUpdateLastTouchpoint(ctx
 		"limit":                     limit,
 		"delayFromPreviousCheckMin": delayFromPreviousCheckMin,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1126,15 +1108,16 @@ func (r *organizationReadRepository) GetOrganizationsForUpdateLastTouchpoint(ctx
 				OrganizationId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *organizationReadRepository) GetOrganizationsForIcpCheck(ctx context.Context, tenants []string, limit, delayFromPreviousCheckMin int) ([]TenantAndOrganizationId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationsForIcpCheck")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit), log.Int("delayFromPreviousCheckMin", delayFromPreviousCheckMin))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationsForIcpCheck")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
+	spans.LogKV("delayFromPreviousCheckMin", delayFromPreviousCheckMin)
 
 	cypher := `MATCH (t:Tenant {active:true})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization)
 				WHERE t.name IN $tenants AND 
@@ -1156,8 +1139,8 @@ func (r *organizationReadRepository) GetOrganizationsForIcpCheck(ctx context.Con
 		"icpNotSet":                 commonenum.IcpNotSet.String(),
 		"leadStage":                 neo4jenum.Lead.String(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1180,16 +1163,15 @@ func (r *organizationReadRepository) GetOrganizationsForIcpCheck(ctx context.Con
 				OrganizationId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *organizationReadRepository) GetPrimaryOrganizationsWithJobRoleForContacts(ctx context.Context, tenant string, contactIds []string) ([]*utils.DbNodePairAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetPrimaryOrganizationsWithJobRoleForContacts")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("contactIds", contactIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetPrimaryOrganizationsWithJobRoleForContacts")
+	defer spans.Finish()
+
+	spans.LogKV("contactIds", contactIds)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)-[:WORKS_AS]->(j:JobRole {primary:true})-[:ROLE_IN]->(o:Organization)
 				WHERE c.id IN $contactIds AND o.hide = false
@@ -1199,8 +1181,8 @@ func (r *organizationReadRepository) GetPrimaryOrganizationsWithJobRoleForContac
 		"contactIds": contactIds,
 	}
 
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1212,16 +1194,15 @@ func (r *organizationReadRepository) GetPrimaryOrganizationsWithJobRoleForContac
 	if err != nil {
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodePairAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodePairAndId)))
 	return result.([]*utils.DbNodePairAndId), err
 }
 
 func (r *organizationReadRepository) GetHiddenOrganizationIds(ctx context.Context, tenant string, hiddenAfter time.Time) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetHiddenOrganizationIds")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("hiddenAfter", hiddenAfter.String()))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetHiddenOrganizationIds")
+	defer spans.Finish()
+
+	spans.LogKV("hiddenAfter", hiddenAfter.String())
 
 	cypher := `MATCH (org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}) 
 				WHERE org.hide = true AND org.hiddenAt > $hiddenAfter
@@ -1230,8 +1211,8 @@ func (r *organizationReadRepository) GetHiddenOrganizationIds(ctx context.Contex
 		"tenant":      tenant,
 		"hiddenAfter": hiddenAfter,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1244,19 +1225,18 @@ func (r *organizationReadRepository) GetHiddenOrganizationIds(ctx context.Contex
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]string))))
+	spans.LogKV("result.count", len(result.([]string)))
 	return result.([]string), err
 }
 
 func (r *organizationReadRepository) GetMergedOrganizationIds(ctx context.Context, tenant string, mergedAfter time.Time) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetMergedOrganizationIds")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("mergedAfter", mergedAfter.String()))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetMergedOrganizationIds")
+	defer spans.Finish()
+
+	spans.LogKV("mergedAfter", mergedAfter.String())
 
 	cypher := `MATCH (org:MergedOrganization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}) 
 				WHERE org.updatedAt >= $mergedAfter
@@ -1265,8 +1245,8 @@ func (r *organizationReadRepository) GetMergedOrganizationIds(ctx context.Contex
 		"tenant":      tenant,
 		"mergedAfter": mergedAfter,
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1279,18 +1259,16 @@ func (r *organizationReadRepository) GetMergedOrganizationIds(ctx context.Contex
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]string))))
+	spans.LogKV("result.count", len(result.([]string)))
 	return result.([]string), err
 }
 
 func (r *organizationReadRepository) GetOrganizationsWithEmail(ctx context.Context, tenant, email string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactReadRepository.GetOrganizationsWithEmail")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ContactReadRepository.GetOrganizationsWithEmail")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -1312,16 +1290,15 @@ func (r *organizationReadRepository) GetOrganizationsWithEmail(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), err
 }
 
 func (r *organizationReadRepository) GetActiveOrganizationIdsByDomain(ctx context.Context, tenant string, domains []string) (map[string]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetActiveOrganizationIdsByDomain")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("domains", strings.Join(domains, ",")))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetActiveOrganizationIdsByDomain")
+	defer spans.Finish()
+
+	spans.LogKV("domains", strings.Join(domains, ","))
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)-[:HAS_DOMAIN]->(d:Domain)
 				WHERE d.domain IN $domains AND o.hide = false
@@ -1330,8 +1307,8 @@ func (r *organizationReadRepository) GetActiveOrganizationIdsByDomain(ctx contex
 		"tenant":  tenant,
 		"domains": domains,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1344,7 +1321,7 @@ func (r *organizationReadRepository) GetActiveOrganizationIdsByDomain(ctx contex
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	output := make(map[string]string)
@@ -1355,10 +1332,8 @@ func (r *organizationReadRepository) GetActiveOrganizationIdsByDomain(ctx contex
 }
 
 func (r *organizationReadRepository) GetLinkedSubOrganizations(ctx context.Context, tenant string, parentOrganizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetLinkedSubOrganizations")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetLinkedSubOrganizations")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(parent:Organization)<-[rel:%s]-(org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(t)
 								WHERE parent.id IN $parentOrganizationIds
@@ -1367,8 +1342,8 @@ func (r *organizationReadRepository) GetLinkedSubOrganizations(ctx context.Conte
 		"tenant":                tenant,
 		"parentOrganizationIds": parentOrganizationIds,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1387,11 +1362,8 @@ func (r *organizationReadRepository) GetLinkedSubOrganizations(ctx context.Conte
 }
 
 func (r *organizationReadRepository) GetLinkedParentOrganizations(ctx context.Context, tenant string, organizationIds []string, relationName string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetLinkedParentOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetLinkedParentOrganizations")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(sub:Organization)-[rel:%s]->(org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(t)
 			WHERE sub.id IN $organizationIds
@@ -1401,8 +1373,8 @@ func (r *organizationReadRepository) GetLinkedParentOrganizations(ctx context.Co
 		"organizationIds": organizationIds,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1421,9 +1393,8 @@ func (r *organizationReadRepository) GetLinkedParentOrganizations(ctx context.Co
 }
 
 func (r *organizationReadRepository) GetOrganizationsByDomainAcrossAllTenants(ctx context.Context, domain string) ([]TenantAndOrganizationId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationsByDomainAcrossAllTenants")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationsByDomainAcrossAllTenants")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {active:true})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization)-[:HAS_DOMAIN]->(d:Domain {domain:$domain})
 				RETURN t.name, org.id`
@@ -1431,8 +1402,8 @@ func (r *organizationReadRepository) GetOrganizationsByDomainAcrossAllTenants(ct
 	params := map[string]any{
 		"domain": domain,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1455,16 +1426,15 @@ func (r *organizationReadRepository) GetOrganizationsByDomainAcrossAllTenants(ct
 				OrganizationId: v.Values[1].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *organizationReadRepository) GetOrganizationsByStage(ctx context.Context, tenant string, stage neo4jenum.OrganizationStage) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetOrganizationsByStage")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("stage", stage.String()))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetOrganizationsByStage")
+	defer spans.Finish()
+
+	spans.LogKV("stage", stage.String())
 
 	cypher := `MATCH (org:Organization)-[:ORGANIZATION_BELONGS_TO_TENANT]->(:Tenant {name:$tenant})
 			WHERE org.hide = false AND org.stage = $stage
@@ -1473,8 +1443,8 @@ func (r *organizationReadRepository) GetOrganizationsByStage(ctx context.Context
 		"tenant": tenant,
 		"stage":  stage.String(),
 	}
-	span.LogFields(log.String("query", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -1487,11 +1457,11 @@ func (r *organizationReadRepository) GetOrganizationsByStage(ctx context.Context
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 
 	return result.([]*dbtype.Node), nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/organization_with_filters_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/organization_with_filters_read_repository.go
@@ -2,13 +2,12 @@ package neo4j_repository
 
 import (
 	"context"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+
 	"strings"
 )
 
@@ -70,11 +69,10 @@ func (r *organizationWithFiltersReadRepository) prepareReadSession(ctx context.C
 }
 
 func (r *organizationWithFiltersReadRepository) GetFilteredOrganizationIds(ctx context.Context, tenant string, filter *model.Filter) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationReadRepository.GetFilteredOrganizationIds")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.LogObjectAsJson(span, "filter", filter)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationReadRepository.GetFilteredOrganizationIds")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("filter", filter)
 
 	params := map[string]any{
 		"tenant": tenant,
@@ -190,8 +188,8 @@ func (r *organizationWithFiltersReadRepository) GetFilteredOrganizationIds(ctx c
 	params = utils.MergeMaps(params, locationFilterParams)
 	params = utils.MergeMaps(params, socialFilterParams)
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -204,10 +202,10 @@ func (r *organizationWithFiltersReadRepository) GetFilteredOrganizationIds(ctx c
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
-		span.LogFields(log.Int("result.count", 0))
+		spans.TraceError(err)
+		spans.LogKV("result.count", 0)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]string))))
+	spans.LogKV("result.count", len(result.([]string)))
 	return result.([]string), err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/organization_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/organization_write_repository.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/enum"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/constants"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 	"strings"
 	"time"
@@ -53,14 +52,12 @@ func NewOrganizationWriteRepository(driver *neo4j.DriverWithContext, database st
 }
 
 func (r *organizationWriteRepository) Save(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId string, data data_fields.OrganizationFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.Save")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.Save")
+	defer spans.Finish()
 
-	span.SetTag(tracing.SpanTagEntityId, organizationId)
+	spans.TagEntity(organizationId)
 
-	tracing.LogObjectAsJson(span, "data", data)
+	spans.LogObjectAsJson("data", data)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 
@@ -84,12 +81,12 @@ func (r *organizationWriteRepository) Save(ctx context.Context, tx *neo4j.Manage
 			"lastTouchpointType": neo4jenum.TouchpointTypeActionCreated.String(),
 		}
 
-		span.LogFields(log.String("cypherCreate", cypherCreate))
-		tracing.LogObjectAsJson(span, "paramsCreate", paramsCreate)
+		spans.LogKV("cypherCreate", cypherCreate)
+		spans.LogObjectAsJson("paramsCreate", paramsCreate)
 
 		_, err := tx.Run(ctx, cypherCreate, paramsCreate)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 
@@ -215,12 +212,12 @@ func (r *organizationWriteRepository) Save(ctx context.Context, tx *neo4j.Manage
 		}
 		cypherUpdate += `org.updatedAt = datetime()`
 
-		span.LogFields(log.String("cypherUpdate", cypherUpdate))
-		tracing.LogObjectAsJson(span, "paramsUpdate", paramsUpdate)
+		spans.LogKV("cypherUpdate", cypherUpdate)
+		spans.LogObjectAsJson("paramsUpdate", paramsUpdate)
 
 		_, err = tx.Run(ctx, cypherUpdate, paramsUpdate)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 
@@ -231,11 +228,10 @@ func (r *organizationWriteRepository) Save(ctx context.Context, tx *neo4j.Manage
 }
 
 func (r *organizationWriteRepository) LinkWithDomain(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId, domain string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.LinkWithDomain")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, organizationId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.LinkWithDomain")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
 
 	cypher := `MATCH (d:Domain {domain: $domain}) 
 				MATCH (t:Tenant {name: $tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id: $organizationId})
@@ -252,27 +248,26 @@ func (r *organizationWriteRepository) LinkWithDomain(ctx context.Context, tx *ne
 		"organizationId": organizationId,
 		"domain":         strings.ToLower(domain),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
 		resultWithContext, err := tx.Run(ctx, cypher, params)
 		return utils.ExtractSingleRecordFirstValueAsType[bool](ctx, resultWithContext, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return false, err
 	}
-	span.LogFields(log.Bool("result", result.(bool)))
+	spans.LogKV("result", result.(bool))
 	return result.(bool), err
 }
 
 func (r *organizationWriteRepository) UnlinkDomain(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId, domain string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.UnlinkDomain")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, organizationId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.UnlinkDomain")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId})
 		 MATCH (org)-[rel:HAS_DOMAIN]->(d:Domain {domain:$domain})
@@ -283,26 +278,25 @@ func (r *organizationWriteRepository) UnlinkDomain(ctx context.Context, tx *neo4
 		"organizationId": organizationId,
 		"domain":         strings.ToLower(domain),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	return nil
 }
 
 func (r *organizationWriteRepository) ReplaceOwner(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId, userId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.ReplaceOwner")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.ReplaceOwner")
+	defer spans.Finish()
 
-	span.LogFields(log.String("organizationId", organizationId), log.String("userId", userId))
+	spans.LogKV("organizationId", organizationId)
+	spans.LogKV("userId", userId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId})
 			OPTIONAL MATCH (:User)-[rel:OWNS]->(org)
@@ -320,14 +314,14 @@ func (r *organizationWriteRepository) ReplaceOwner(ctx context.Context, tx *neo4
 		"source":         constants.SourceOpenline,
 		"now":            utils.Now(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 
 		_, err := tx.Run(ctx, cypher, params)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 
@@ -335,7 +329,7 @@ func (r *organizationWriteRepository) ReplaceOwner(ctx context.Context, tx *neo4
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -343,12 +337,11 @@ func (r *organizationWriteRepository) ReplaceOwner(ctx context.Context, tx *neo4
 }
 
 func (r *organizationWriteRepository) SetVisibility(ctx context.Context, tenant, organizationId string, hide bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.SetVisibility")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, organizationId)
-	span.LogFields(log.Bool("hide", hide))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.SetVisibility")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
+	spans.LogKV("hide", hide)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$id})
 			WHERE org:Organization_%s
@@ -361,22 +354,23 @@ func (r *organizationWriteRepository) SetVisibility(ctx context.Context, tenant,
 		"hide":   hide,
 		"now":    utils.Now(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *organizationWriteRepository) UpdateLastTouchpoint(ctx context.Context, tenant, organizationId string, touchpointAt *time.Time, touchpointId, touchpointType string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.UpdateLastTouchpoint")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("organizationId", organizationId), log.String("touchpointId", touchpointId), log.Object("touchpointAt", touchpointAt))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.UpdateLastTouchpoint")
+	defer spans.Finish()
+
+	spans.LogKV("organizationId", organizationId)
+	spans.LogKV("touchpointId", touchpointId)
+	spans.LogKV("touchpointAt", touchpointAt)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId})
 		 SET 	org.updatedAt = CASE WHEN org.lastTouchpointId <> $touchpointId THEN datetime() ELSE org.updatedAt END,
@@ -390,23 +384,22 @@ func (r *organizationWriteRepository) UpdateLastTouchpoint(ctx context.Context, 
 		"touchpointId":   touchpointId,
 		"touchpointType": touchpointType,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *organizationWriteRepository) SetCustomerOsIdIfMissing(ctx context.Context, tenant, organizationId, customerOsId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.SetCustomerOsIdIfMissing")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, organizationId)
-	span.LogFields(log.String("customerOsId", customerOsId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.SetCustomerOsIdIfMissing")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
+	spans.LogKV("customerOsId", customerOsId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId})
 		 SET org.customerOsId = CASE WHEN (org.customerOsId IS NULL OR org.customerOsId = '') AND $customerOsId <> '' THEN $customerOsId ELSE org.customerOsId END,
@@ -416,23 +409,23 @@ func (r *organizationWriteRepository) SetCustomerOsIdIfMissing(ctx context.Conte
 		"organizationId": organizationId,
 		"customerOsId":   customerOsId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *organizationWriteRepository) LinkWithParentOrganization(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, subOrganizationId, parentOrganizationId, subOrganizationType string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.LinkWithParentOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, subOrganizationId)
-	span.LogFields(log.String("parentOrganizationId", parentOrganizationId), log.String("subOrganizationType", subOrganizationType))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.LinkWithParentOrganization")
+	defer spans.Finish()
+
+	spans.TagEntity(subOrganizationId)
+	spans.LogKV("parentOrganizationId", parentOrganizationId)
+	spans.LogKV("subOrganizationType", subOrganizationType)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(parent:Organization {id:$parentOrganizationId}),
 		 			(t)<-[:ORGANIZATION_BELONGS_TO_TENANT]-(sub:Organization {id:$subOrganizationId}) 
@@ -447,26 +440,25 @@ func (r *organizationWriteRepository) LinkWithParentOrganization(ctx context.Con
 		"parentOrganizationId": parentOrganizationId,
 		"type":                 subOrganizationType,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	return nil
 }
 
 func (r *organizationWriteRepository) UnlinkParentOrganization(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, subOrganizationId, parentOrganizationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.UnlinkParentOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, subOrganizationId)
-	span.LogFields(log.String("parentOrganizationId", parentOrganizationId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.UnlinkParentOrganization")
+	defer spans.Finish()
+
+	spans.TagEntity(subOrganizationId)
+	spans.LogKV("parentOrganizationId", parentOrganizationId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(parent:Organization {id:$parentOrganizationId})<-[rel:SUBSIDIARY_OF]-(sub:Organization {id:$subOrganizationId})-[:ORGANIZATION_BELONGS_TO_TENANT]->(t)
 		 		DELETE rel
@@ -477,25 +469,24 @@ func (r *organizationWriteRepository) UnlinkParentOrganization(ctx context.Conte
 		"subOrganizationId":    subOrganizationId,
 		"parentOrganizationId": parentOrganizationId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	return nil
 }
 
 func (r *organizationWriteRepository) UpdateArr(ctx context.Context, tenant, organizationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.UpdateArr")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, organizationId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.UpdateArr")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
 
 	cypher := `MATCH (t:Tenant {name: $tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id: $organizationId})
 				OPTIONAL MATCH (org)-[:HAS_CONTRACT]->(c:Contract) WHERE c.status <> $statusDraft
@@ -508,23 +499,24 @@ func (r *organizationWriteRepository) UpdateArr(ctx context.Context, tenant, org
 		"organizationId": organizationId,
 		"statusDraft":    neo4jenum.ContractStatusDraft.String(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *organizationWriteRepository) UpdateRenewalSummary(ctx context.Context, tenant, organizationId string, likelihood *string, likelihoodOrder *int64, nextRenewalDate *time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.UpdateRenewalSummary")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, organizationId)
-	span.LogFields(log.String("likelihood", utils.IfNotNilString(likelihood)), log.Object("likelihoodOrder", likelihoodOrder), log.Object("nextRenewalDate", nextRenewalDate))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.UpdateRenewalSummary")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
+	spans.LogKV("likelihood", utils.IfNotNilString(likelihood))
+	spans.LogKV("likelihoodOrder", likelihoodOrder)
+	spans.LogKV("nextRenewalDate", nextRenewalDate)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId})
 				SET org.derivedRenewalLikelihood = $derivedRenewalLikelihood,
@@ -539,23 +531,22 @@ func (r *organizationWriteRepository) UpdateRenewalSummary(ctx context.Context, 
 		"derivedNextRenewalAt":          utils.TimePtrAsAny(nextRenewalDate),
 		"now":                           utils.Now(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *organizationWriteRepository) WebScrapeRequested(ctx context.Context, tenant, organizationId, url string, attempt int64, requestedAt time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.WebScrapeRequested")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, organizationId)
-	span.LogFields(log.String("url", url))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.WebScrapeRequested")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
+	spans.LogKV("url", url)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId})
 		 	SET org.webScrapeLastRequestedAt=$requestedAt, 
@@ -568,22 +559,21 @@ func (r *organizationWriteRepository) WebScrapeRequested(ctx context.Context, te
 		"attempt":        attempt,
 		"requestedAt":    requestedAt,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *organizationWriteRepository) UpdateOnboardingStatus(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId string, data data_fields.OrganizationOnboardingStatusFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.UpdateOnboardingStatus")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, organizationId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.UpdateOnboardingStatus")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId})
 				SET org.onboardingUpdatedAt = CASE WHEN org.onboardingStatus IS NULL OR (org.onboardingStatus <> $status AND $status IS NULL) THEN datetime() ELSE org.onboardingUpdatedAt END,
@@ -603,26 +593,26 @@ func (r *organizationWriteRepository) UpdateOnboardingStatus(ctx context.Context
 		params["status"] = nil
 		params["statusOrder"] = nil
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		return tx.Run(ctx, cypher, params)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	return nil
 }
 
 func (r *organizationWriteRepository) UpdateTimeProperty(ctx context.Context, tenant, organizationId, property string, value *time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.UpdateTimeProperty")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, organizationId)
-	span.LogFields(log.String("property", property), log.Object("value", value))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.UpdateTimeProperty")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
+	spans.LogKV("property", property)
+	spans.LogObjectAsJson("value", value)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name: $tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id: $organizationId})
 			SET org.%s = $value`, property)
@@ -632,23 +622,23 @@ func (r *organizationWriteRepository) UpdateTimeProperty(ctx context.Context, te
 		"property":       property,
 		"value":          utils.TimePtrAsAny(value),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *organizationWriteRepository) UpdateFloatProperty(ctx context.Context, tenant, organizationId, property string, value float64) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.UpdateFloatProperty")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, organizationId)
-	span.LogFields(log.String("property", property), log.Float64("value", value))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.UpdateFloatProperty")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
+	spans.LogKV("property", property)
+	spans.LogKV("value", value)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name: $tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id: $organizationId})
 			SET org.%s = $value`, property)
@@ -658,23 +648,23 @@ func (r *organizationWriteRepository) UpdateFloatProperty(ctx context.Context, t
 		"property":       property,
 		"value":          value,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *organizationWriteRepository) UpdateStringProperty(ctx context.Context, tenant, organizationId, property string, value string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.UpdateFloatProperty")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, organizationId)
-	span.LogFields(log.String("property", property), log.String("value", value))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.UpdateFloatProperty")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
+	spans.LogKV("property", property)
+	spans.LogKV("value", value)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name: $tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id: $organizationId})
 			SET org.%s = $value`, property)
@@ -684,20 +674,19 @@ func (r *organizationWriteRepository) UpdateStringProperty(ctx context.Context, 
 		"property":       property,
 		"value":          value,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *organizationWriteRepository) Archive(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationRepository.Delete")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationRepository.Delete")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (org:Organization {id:$organizationId})-[currentRel:ORGANIZATION_BELONGS_TO_TENANT]->(t:Tenant {name:$tenant})
 			MERGE (org)-[newRel:ARCHIVED]->(t)
@@ -710,14 +699,14 @@ func (r *organizationWriteRepository) Archive(ctx context.Context, tx *neo4j.Man
 		"now":            utils.Now(),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	span.LogFields(log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 
 		_, err := tx.Run(ctx, cypher, params)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 
@@ -725,7 +714,7 @@ func (r *organizationWriteRepository) Archive(ctx context.Context, tx *neo4j.Man
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -733,11 +722,10 @@ func (r *organizationWriteRepository) Archive(ctx context.Context, tx *neo4j.Man
 }
 
 func (r *organizationWriteRepository) ResetEnrichAttempts(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.ResetEnrichAttempts")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, organizationId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.ResetEnrichAttempts")
+	defer spans.Finish()
+
+	spans.TagEntity(organizationId)
 
 	cypher := `MATCH (t:Tenant {name: $tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization {id: $organizationId})
 	WHERE o.enrichedAt IS NULL
@@ -746,8 +734,8 @@ func (r *organizationWriteRepository) ResetEnrichAttempts(ctx context.Context, t
 		"tenant":         tenant,
 		"organizationId": organizationId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -757,17 +745,15 @@ func (r *organizationWriteRepository) ResetEnrichAttempts(ctx context.Context, t
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *organizationWriteRepository) RefreshContactCountByOrgId(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, organizationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.RefreshContactCountByOrgId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.RefreshContactCountByOrgId")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId})
 			WITH org
@@ -780,8 +766,8 @@ func (r *organizationWriteRepository) RefreshContactCountByOrgId(ctx context.Con
 		"organizationId": organizationId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -791,17 +777,15 @@ func (r *organizationWriteRepository) RefreshContactCountByOrgId(ctx context.Con
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *organizationWriteRepository) RefreshContactCountByContactId(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, contactId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationWriteRepository.RefreshContactCountByContactId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "OrganizationWriteRepository.RefreshContactCountByContactId")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(:Contact {id:$contactId})--(:JobRole)--(org:Organization)
 			WITH org
@@ -814,8 +798,8 @@ func (r *organizationWriteRepository) RefreshContactCountByContactId(ctx context
 		"contactId": contactId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -825,7 +809,7 @@ func (r *organizationWriteRepository) RefreshContactCountByContactId(ctx context
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err

--- a/packages/server/customer-os-neo4j-repository/repository/phone_number_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/phone_number_read_repository.go
@@ -2,14 +2,13 @@ package neo4j_repository
 
 import (
 	"fmt"
+	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -39,18 +38,17 @@ func (r *phoneNumberReadRepository) prepareReadSession(ctx context.Context) neo4
 }
 
 func (r *phoneNumberReadRepository) GetPhoneNumberIdIfExists(ctx context.Context, tenant, phoneNumber string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberReadRepository.GetPhoneNumberIdIfExists")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("phoneNumber", phoneNumber))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberReadRepository.GetPhoneNumberIdIfExists")
+	defer spans.Finish()
+
+	spans.LogKV("phoneNumber", phoneNumber)
 
 	cypher := fmt.Sprintf(`MATCH (p:PhoneNumber_%s) WHERE p.e164 = $phoneNumber OR p.rawPhoneNumber = $phoneNumber RETURN p.id LIMIT 1`, tenant)
 	params := map[string]any{
 		"phoneNumber": phoneNumber,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -63,23 +61,22 @@ func (r *phoneNumberReadRepository) GetPhoneNumberIdIfExists(ctx context.Context
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
 	if len(result.([]*db.Record)) == 0 {
-		span.LogFields(log.String("result", ""))
+		spans.LogKV("result", "")
 		return "", nil
 	}
-	span.LogFields(log.String("result", result.([]*db.Record)[0].Values[0].(string)))
+	spans.LogKV("result", result.([]*db.Record)[0].Values[0].(string))
 	return result.([]*db.Record)[0].Values[0].(string), err
 }
 
 func (r *phoneNumberReadRepository) GetCountryCodeA2ForPhoneNumber(ctx context.Context, tenant, phoneNumberId string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberReadRepository.GetCountryCodeA2ForPhoneNumber")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, phoneNumberId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberReadRepository.GetCountryCodeA2ForPhoneNumber")
+	defer spans.Finish()
+
+	spans.TagEntity(phoneNumberId)
 
 	cypher := `MATCH (p:PhoneNumber {id:$phoneNumberId})-[:PHONE_NUMBER_BELONGS_TO_TENANT]->(t:Tenant {name:$tenant})
 				OPTIONAL MATCH (p)-[:LINKED_TO]->(c:Country)
@@ -89,8 +86,8 @@ func (r *phoneNumberReadRepository) GetCountryCodeA2ForPhoneNumber(ctx context.C
 		"tenant":        tenant,
 		"phoneNumberId": phoneNumberId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -103,27 +100,26 @@ func (r *phoneNumberReadRepository) GetCountryCodeA2ForPhoneNumber(ctx context.C
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
-	span.LogFields(log.String("result", result.(string)))
+	spans.LogKV("result", result.(string))
 	return result.(string), nil
 }
 
 func (r *phoneNumberReadRepository) GetById(ctx context.Context, tenant, phoneNumberId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberReadRepository.GetById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("phoneNumberId", phoneNumberId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberReadRepository.GetById")
+	defer spans.Finish()
+
+	spans.LogKV("phoneNumberId", phoneNumberId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:PHONE_NUMBER_BELONGS_TO_TENANT]-(p:PhoneNumber {id:$phoneNumberId}) return p`
 	params := map[string]any{
 		"tenant":        tenant,
 		"phoneNumberId": phoneNumberId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -142,10 +138,8 @@ func (r *phoneNumberReadRepository) GetById(ctx context.Context, tenant, phoneNu
 }
 
 func (r *phoneNumberReadRepository) GetAllForLinkedEntityIds(ctx context.Context, tenant string, entityType neo4jenum.EntityType, entityIds []string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberReadRepository.GetAllForLinkedEntityIds")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberReadRepository.GetAllForLinkedEntityIds")
+	defer spans.Finish()
 
 	cypher := ""
 	switch entityType {
@@ -164,8 +158,8 @@ func (r *phoneNumberReadRepository) GetAllForLinkedEntityIds(ctx context.Context
 		"entityIds": entityIds,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -184,16 +178,15 @@ func (r *phoneNumberReadRepository) GetAllForLinkedEntityIds(ctx context.Context
 }
 
 func (r *phoneNumberReadRepository) Exists(ctx context.Context, tenant string, e164 string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberReadRepository.Exists")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberReadRepository.Exists")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf("MATCH (p:PhoneNumber_%s) WHERE p.e164 = $e164 OR p.rawPhoneNumber = $e164 RETURN p LIMIT 1", tenant)
 	params := map[string]any{
 		"e164": e164,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -213,16 +206,15 @@ func (r *phoneNumberReadRepository) Exists(ctx context.Context, tenant string, e
 }
 
 func (r *phoneNumberReadRepository) GetByPhoneNumber(ctx context.Context, tenant, e164 string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberReadRepository.GetByPhoneNumber")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberReadRepository.GetByPhoneNumber")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf("MATCH (p:PhoneNumber_%s) WHERE p.e164 = $e164 OR p.rawPhoneNumber = $e164 RETURN p LIMIT 1", tenant)
 	params := map[string]any{
 		"e164": e164,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/phone_number_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/phone_number_write_repository.go
@@ -2,13 +2,12 @@ package neo4j_repository
 
 import (
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+
 	"golang.org/x/net/context"
 	"time"
 )
@@ -53,12 +52,11 @@ func NewPhoneNumberWriteRepository(driver *neo4j.DriverWithContext, database str
 }
 
 func (r *phoneNumberWriteRepository) CreatePhoneNumber(ctx context.Context, tenant, phoneNumberId string, data PhoneNumberCreateFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberWriteRepository.CreatePhoneNumber")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, phoneNumberId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberWriteRepository.CreatePhoneNumber")
+	defer spans.Finish()
+
+	spans.TagEntity(phoneNumberId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant}) 
 		 MERGE (t)<-[:PHONE_NUMBER_BELONGS_TO_TENANT]-(p:PhoneNumber:PhoneNumber_%s {id:$id}) 
@@ -77,22 +75,21 @@ func (r *phoneNumberWriteRepository) CreatePhoneNumber(ctx context.Context, tena
 		"createdAt":      data.CreatedAt,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *phoneNumberWriteRepository) UpdatePhoneNumber(ctx context.Context, tenant, phoneNumberId, rawPhoneNumber, source string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberWriteRepository.UpdatePhoneNumber")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, phoneNumberId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberWriteRepository.UpdatePhoneNumber")
+	defer spans.Finish()
+
+	spans.TagEntity(phoneNumberId)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:PHONE_NUMBER_BELONGS_TO_TENANT]-(p:PhoneNumber {id:$id})
 				WHERE p:PhoneNumber_%s
@@ -103,22 +100,21 @@ func (r *phoneNumberWriteRepository) UpdatePhoneNumber(ctx context.Context, tena
 		"tenant":         tenant,
 		"rawPhoneNumber": rawPhoneNumber,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *phoneNumberWriteRepository) FailPhoneNumberValidation(ctx context.Context, tenant, phoneNumberId, validationError string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberWriteRepository.FailPhoneNumberValidation")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, phoneNumberId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberWriteRepository.FailPhoneNumberValidation")
+	defer spans.Finish()
+
+	spans.TagEntity(phoneNumberId)
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:PHONE_NUMBER_BELONGS_TO_TENANT]-(p:PhoneNumber {id:$id})
 				WHERE p:PhoneNumber_%s
@@ -130,23 +126,22 @@ func (r *phoneNumberWriteRepository) FailPhoneNumberValidation(ctx context.Conte
 		"tenant":          tenant,
 		"validationError": validationError,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *phoneNumberWriteRepository) PhoneNumberValidated(ctx context.Context, tenant, phoneNumberId string, data PhoneNumberValidateFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberWriteRepository.PhoneNumberValidated")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, phoneNumberId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberWriteRepository.PhoneNumberValidated")
+	defer spans.Finish()
+
+	spans.TagEntity(phoneNumberId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:PHONE_NUMBER_BELONGS_TO_TENANT]-(p:PhoneNumber {id:$id})
 				WHERE p:PhoneNumber_%s
@@ -181,22 +176,21 @@ func (r *phoneNumberWriteRepository) PhoneNumberValidated(ctx context.Context, t
 		"appSource":       data.AppSource,
 		"source":          data.Source,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *phoneNumberWriteRepository) LinkWithContact(ctx context.Context, tenant, contactId, phoneNumberId, label string, primary bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberWriteRepository.LinkWithContact")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, phoneNumberId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberWriteRepository.LinkWithContact")
+	defer spans.Finish()
+
+	spans.TagEntity(phoneNumberId)
 
 	cypher := `
 		MATCH (t:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact {id:$contactId}),
@@ -212,22 +206,21 @@ func (r *phoneNumberWriteRepository) LinkWithContact(ctx context.Context, tenant
 		"label":         label,
 		"primary":       primary,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *phoneNumberWriteRepository) LinkWithOrganization(ctx context.Context, tenant, organizationId, phoneNumberId, label string, primary bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberWriteRepository.LinkWithOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, phoneNumberId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberWriteRepository.LinkWithOrganization")
+	defer spans.Finish()
+
+	spans.TagEntity(phoneNumberId)
 
 	cypher := `
 		MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId}),
@@ -243,22 +236,21 @@ func (r *phoneNumberWriteRepository) LinkWithOrganization(ctx context.Context, t
 		"label":          label,
 		"primary":        primary,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *phoneNumberWriteRepository) LinkWithUser(ctx context.Context, tenant, userId, phoneNumberId, label string, primary bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberWriteRepository.LinkWithUser")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, phoneNumberId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberWriteRepository.LinkWithUser")
+	defer spans.Finish()
+
+	spans.TagEntity(phoneNumberId)
 
 	cypher := `
 		MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User {id:$userId}),
@@ -274,22 +266,21 @@ func (r *phoneNumberWriteRepository) LinkWithUser(ctx context.Context, tenant, u
 		"label":         label,
 		"primary":       primary,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *phoneNumberWriteRepository) CleanPhoneNumberValidation(ctx context.Context, tenant, phoneNumberId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberWriteRepository.CleanPhoneNumberValidation")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, phoneNumberId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberWriteRepository.CleanPhoneNumberValidation")
+	defer spans.Finish()
+
+	spans.TagEntity(phoneNumberId)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:PHONE_NUMBER_BELONGS_TO_TENANT]-(p:PhoneNumber {id:$id})
 				WHERE p:PhoneNumber_%s
@@ -301,20 +292,19 @@ func (r *phoneNumberWriteRepository) CleanPhoneNumberValidation(ctx context.Cont
 		"id":     phoneNumberId,
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *phoneNumberWriteRepository) RemoveRelationship(ctx context.Context, entityType commonModel.EntityType, tenant, entityId, phoneNumber string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberWriteRepository.RemoveRelationship")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberWriteRepository.RemoveRelationship")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -336,8 +326,8 @@ func (r *phoneNumberWriteRepository) RemoveRelationship(ctx context.Context, ent
 		"phoneNumber": phoneNumber,
 		"tenant":      tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if _, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -350,9 +340,8 @@ func (r *phoneNumberWriteRepository) RemoveRelationship(ctx context.Context, ent
 }
 
 func (r *phoneNumberWriteRepository) RemoveRelationshipById(ctx context.Context, entityType commonModel.EntityType, tenant, entityId, phoneNumberId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberWriteRepository.RemoveRelationshipById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "PhoneNumberWriteRepository.RemoveRelationshipById")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -373,8 +362,8 @@ func (r *phoneNumberWriteRepository) RemoveRelationshipById(ctx context.Context,
 		"phoneNumberId": phoneNumberId,
 		"tenant":        tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if _, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)

--- a/packages/server/customer-os-neo4j-repository/repository/reminder_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/reminder_read_repository.go
@@ -5,12 +5,10 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"time"
 
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type ReminderReadRepository interface {
@@ -36,9 +34,8 @@ func NewReminderReadRepository(driver *neo4j.DriverWithContext, database string)
 }
 
 func (r *reminderReadRepository) GetReminderById(ctx context.Context, id string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ReminderReadRepository.GetReminderById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ReminderReadRepository.GetReminderById")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -47,8 +44,8 @@ func (r *reminderReadRepository) GetReminderById(ctx context.Context, id string)
 		"tenant": tenant,
 		"id":     id,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -59,18 +56,17 @@ func (r *reminderReadRepository) GetReminderById(ctx context.Context, id string)
 
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *reminderReadRepository) GetRemindersOrderByDueDateAsc(ctx context.Context, organizationId string, dismissed *bool) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ReminderReadRepository.GetRemindersOrderByDueDateAsc")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ReminderReadRepository.GetRemindersOrderByDueDateAsc")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -88,8 +84,8 @@ func (r *reminderReadRepository) GetRemindersOrderByDueDateAsc(ctx context.Conte
 		"tenant":         tenant,
 		"organizationId": organizationId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -99,25 +95,24 @@ func (r *reminderReadRepository) GetRemindersOrderByDueDateAsc(ctx context.Conte
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), nil
 }
 
 func (r *reminderReadRepository) GetReadyToSend(ctx context.Context, dueDate time.Time) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ReminderReadRepository.GetReadyToSend")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ReminderReadRepository.GetReadyToSend")
+	defer spans.Finish()
 
 	cypher := `MATCH (r:Reminder) WHERE r.dismissed = false and r.sent = false AND r.dueDate <= $dueDate RETURN r ORDER BY r.dueDate ASC`
 
 	params := map[string]any{
 		"dueDate": dueDate,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -127,9 +122,9 @@ func (r *reminderReadRepository) GetReadyToSend(ctx context.Context, dueDate tim
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/reminder_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/reminder_write_repository.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
 type ReminderUpdateFields struct {
@@ -41,11 +40,10 @@ func NewReminderWriteRepository(driver *neo4j.DriverWithContext, database string
 }
 
 func (r *reminderWriteRepository) CreateReminder(ctx context.Context, tenant, id, userId, organizationId, content string, createdAt, dueDate time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ReminderWriteRepository.CreateReminder")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, id)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ReminderWriteRepository.CreateReminder")
+	defer spans.Finish()
+
+	spans.TagEntity(id)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})
 				MERGE (t)<-[:REMINDER_BELONGS_TO_TENANT]-(r:Reminder {id:$id})
@@ -82,17 +80,16 @@ func (r *reminderWriteRepository) CreateReminder(ctx context.Context, tenant, id
 	}
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *reminderWriteRepository) UpdateReminder(ctx context.Context, tenant, id string, data ReminderUpdateFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ReminderWriteRepository.UpdateReminder")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, id)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ReminderWriteRepository.UpdateReminder")
+	defer spans.Finish()
+
+	spans.TagEntity(id)
 
 	if data.Content == nil && data.DueDate == nil && data.Dismissed == nil {
 		return nil
@@ -123,17 +120,16 @@ func (r *reminderWriteRepository) UpdateReminder(ctx context.Context, tenant, id
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *reminderWriteRepository) DeleteReminder(ctx context.Context, tenant, id string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ReminderWriteRepository.DeleteReminder")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, id)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ReminderWriteRepository.DeleteReminder")
+	defer spans.Finish()
+
+	spans.TagEntity(id)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:REMINDER_BELONGS_TO_TENANT]-(r:Reminder {id:$id})
 				DETACH DELETE r`
@@ -144,7 +140,7 @@ func (r *reminderWriteRepository) DeleteReminder(ctx context.Context, tenant, id
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/service_line_item_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/service_line_item_read_repository.go
@@ -3,12 +3,11 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"time"
 )
 
@@ -39,11 +38,10 @@ func (r *serviceLineItemReadRepository) prepareReadSession(ctx context.Context) 
 }
 
 func (r *serviceLineItemReadRepository) GetServiceLineItemsForContract(ctx context.Context, tenant, contractId string) ([]*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemReadRepository.GetServiceLineItemsForContract")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("contractId", contractId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemReadRepository.GetServiceLineItemsForContract")
+	defer spans.Finish()
+
+	spans.LogKV("contractId", contractId)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract {id:$contractId})-[:HAS_SERVICE]->(sli:ServiceLineItem)
 							WHERE sli:ServiceLineItem_%s
@@ -52,8 +50,8 @@ func (r *serviceLineItemReadRepository) GetServiceLineItemsForContract(ctx conte
 		"tenant":     tenant,
 		"contractId": contractId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -66,19 +64,18 @@ func (r *serviceLineItemReadRepository) GetServiceLineItemsForContract(ctx conte
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*neo4j.Node))))
+	spans.LogKV("result.count", len(result.([]*neo4j.Node)))
 	return result.([]*neo4j.Node), nil
 }
 
 func (r *serviceLineItemReadRepository) GetServiceLineItemsForContracts(ctx context.Context, tenant string, contractIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemRepository.GetServiceLineItemsForContracts")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("contractIds", contractIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemRepository.GetServiceLineItemsForContracts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("contractIds", contractIds)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract)-[:HAS_SERVICE]->(sli:ServiceLineItem)
 			WHERE c.id IN $contractIds and sli:ServiceLineItem_%s
@@ -87,7 +84,8 @@ func (r *serviceLineItemReadRepository) GetServiceLineItemsForContracts(ctx cont
 		"tenant":      tenant,
 		"contractIds": contractIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -106,11 +104,10 @@ func (r *serviceLineItemReadRepository) GetServiceLineItemsForContracts(ctx cont
 }
 
 func (r *serviceLineItemReadRepository) GetServiceLineItemsForInvoiceLines(ctx context.Context, tenant string, invoiceLineIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemRepository.GetServiceLineItemsForInvoiceLines")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("invoiceLineIds", invoiceLineIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemRepository.GetServiceLineItemsForInvoiceLines")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("invoiceLineIds", invoiceLineIds)
 
 	cypher := fmt.Sprintf(`MATCH (il:InvoiceLine)-[:INVOICED]->(sli:ServiceLineItem)
 			WHERE il.id IN $invoiceLineIds and sli:ServiceLineItem_%s
@@ -119,7 +116,8 @@ func (r *serviceLineItemReadRepository) GetServiceLineItemsForInvoiceLines(ctx c
 		"tenant":         tenant,
 		"invoiceLineIds": invoiceLineIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -138,11 +136,10 @@ func (r *serviceLineItemReadRepository) GetServiceLineItemsForInvoiceLines(ctx c
 }
 
 func (r *serviceLineItemReadRepository) GetServiceLineItemsByParentId(ctx context.Context, tenant, sliParentId string) ([]*neo4j.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemReadRepository.GetServiceLineItemsByParentId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("sliParentId", sliParentId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemReadRepository.GetServiceLineItemsByParentId")
+	defer spans.Finish()
+
+	spans.LogKV("sliParentId", sliParentId)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract)-[:HAS_SERVICE]->(sli:ServiceLineItem {parentId:$parentId})
 							WHERE sli:ServiceLineItem_%s
@@ -151,8 +148,8 @@ func (r *serviceLineItemReadRepository) GetServiceLineItemsByParentId(ctx contex
 		"tenant":   tenant,
 		"parentId": sliParentId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -165,26 +162,25 @@ func (r *serviceLineItemReadRepository) GetServiceLineItemsByParentId(ctx contex
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*neo4j.Node))))
+	spans.LogKV("result.count", len(result.([]*neo4j.Node)))
 	return result.([]*neo4j.Node), nil
 }
 
 func (r *serviceLineItemReadRepository) GetServiceLineItemById(ctx context.Context, tenant, serviceLineItemId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemReadRepository.GetServiceLineItemById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, serviceLineItemId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemReadRepository.GetServiceLineItemById")
+	defer spans.Finish()
+
+	spans.TagEntity(serviceLineItemId)
 
 	cypher := fmt.Sprintf(`MATCH (sli:ServiceLineItem {id:$id}) WHERE sli:ServiceLineItem_%s RETURN sli`, tenant)
 	params := map[string]any{
 		"id": serviceLineItemId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -197,19 +193,19 @@ func (r *serviceLineItemReadRepository) GetServiceLineItemById(ctx context.Conte
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *serviceLineItemReadRepository) GetLatestServiceLineItemByParentId(ctx context.Context, tenant, serviceLineItemParentId string, beforeDate *time.Time) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemReadRepository.GetLatestServiceLineItemByParentId")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("serviceLineItemParentId", serviceLineItemParentId), log.Object("beforeDate", beforeDate))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemReadRepository.GetLatestServiceLineItemByParentId")
+	defer spans.Finish()
+
+	spans.LogKV("serviceLineItemParentId", serviceLineItemParentId)
+	spans.LogObjectAsJson("beforeDate", beforeDate)
 
 	params := map[string]any{
 		"tenant":   tenant,
@@ -222,8 +218,8 @@ func (r *serviceLineItemReadRepository) GetLatestServiceLineItemByParentId(ctx c
 	}
 	cypher += ` RETURN sli ORDER BY sli.startedAt DESC LIMIT 1`
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -236,26 +232,25 @@ func (r *serviceLineItemReadRepository) GetLatestServiceLineItemByParentId(ctx c
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *serviceLineItemReadRepository) WasServiceLineItemInvoiced(ctx context.Context, tenant, serviceLineItemId string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemReadRepository.WasServiceLineItemInvoiced")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, serviceLineItemId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemReadRepository.WasServiceLineItemInvoiced")
+	defer spans.Finish()
+
+	spans.TagEntity(serviceLineItemId)
 
 	cypher := fmt.Sprintf(`MATCH (sli:ServiceLineItem {id:$id})<-[:INVOICED]-(il:InvoiceLine)--(i:Invoice {dryRun:false}) WHERE sli:ServiceLineItem_%s RETURN count(sli)`, tenant)
 	params := map[string]any{
 		"id": serviceLineItemId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -265,14 +260,14 @@ func (r *serviceLineItemReadRepository) WasServiceLineItemInvoiced(ctx context.C
 		return utils.ExtractSingleRecordFirstValueAsType[int64](ctx, queryResult, err)
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return false, err
 	}
 	if result.(int64) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return false, nil
 	}
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return true, nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/service_line_item_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/service_line_item_write_repository.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"time"
 )
 
@@ -33,12 +32,11 @@ func NewServiceLineItemWriteRepository(driver *neo4j.DriverWithContext, database
 }
 
 func (r *serviceLineItemWriteRepository) CreateForContract(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, serviceLineItemId string, data data_fields.SLIFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemWriteRepository.CreateForContract")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, serviceLineItemId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemWriteRepository.CreateForContract")
+	defer spans.Finish()
+
+	spans.TagEntity(serviceLineItemId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract {id:$contractId})
 							MERGE (c)-[:HAS_SERVICE]->(sli:ServiceLineItem {id:$serviceLineItemId})
@@ -82,8 +80,8 @@ func (r *serviceLineItemWriteRepository) CreateForContract(ctx context.Context, 
 		params["billed"] = ""
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -91,19 +89,18 @@ func (r *serviceLineItemWriteRepository) CreateForContract(ctx context.Context, 
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *serviceLineItemWriteRepository) Update(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, serviceLineItemId string, data data_fields.SLIFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemWriteRepository.Update")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, serviceLineItemId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemWriteRepository.Update")
+	defer spans.Finish()
+
+	spans.TagEntity(serviceLineItemId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (sli:ServiceLineItem_%s {id:$serviceLineItemId})
 							SET sli.updatedAt=datetime()`, tenant)
@@ -142,8 +139,8 @@ func (r *serviceLineItemWriteRepository) Update(ctx context.Context, tx *neo4j.M
 		params["comments"] = *data.Comments
 		cypher += `, sli.comments = $comments`
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -151,18 +148,17 @@ func (r *serviceLineItemWriteRepository) Update(ctx context.Context, tx *neo4j.M
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *serviceLineItemWriteRepository) Delete(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, serviceLineItemId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemWriteRepository.Delete")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag(tracing.SpanTagEntityId, serviceLineItemId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemWriteRepository.Delete")
+	defer spans.Finish()
+
+	spans.TagEntity(serviceLineItemId)
 
 	cypher := `MATCH (sli:ServiceLineItem {id:$serviceLineItemId})<-[:HAS_SERVICE]-(c:Contract)-[:CONTRACT_BELONGS_TO_TENANT]->(t:Tenant {name:$tenant})
 							WHERE sli:ServiceLineItem
@@ -174,8 +170,8 @@ func (r *serviceLineItemWriteRepository) Delete(ctx context.Context, tx *neo4j.M
 		"serviceLineItemId": serviceLineItemId,
 		"now":               utils.Now(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -183,19 +179,19 @@ func (r *serviceLineItemWriteRepository) Delete(ctx context.Context, tx *neo4j.M
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *serviceLineItemWriteRepository) Close(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, serviceLineItemId string, endedAt time.Time, isCanceled bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemWriteRepository.Close")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, serviceLineItemId)
-	span.LogFields(log.Object("endedAt", endedAt), log.Bool("isCanceled", isCanceled))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemWriteRepository.Close")
+	defer spans.Finish()
+
+	spans.TagEntity(serviceLineItemId)
+	spans.LogObjectAsJson("endedAt", endedAt)
+	spans.LogKV("isCanceled", isCanceled)
 
 	params := map[string]any{
 		"serviceLineItemId": serviceLineItemId,
@@ -209,8 +205,8 @@ func (r *serviceLineItemWriteRepository) Close(ctx context.Context, tx *neo4j.Ma
 		params["isCanceled"] = isCanceled
 		cypher += `, sli.isCanceled = $isCanceled`
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -218,18 +214,17 @@ func (r *serviceLineItemWriteRepository) Close(ctx context.Context, tx *neo4j.Ma
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *serviceLineItemWriteRepository) AdjustEndDates(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, parentId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemWriteRepository.AdjustEndDates")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.SetTag("parentId", parentId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "ServiceLineItemWriteRepository.AdjustEndDates")
+	defer spans.Finish()
+
+	spans.LogKV("parentId", parentId)
 
 	cypher := fmt.Sprintf(`MATCH (sli:ServiceLineItem {parentId: $parentId})
 									WHERE sli:ServiceLineItem_%s
@@ -249,8 +244,8 @@ func (r *serviceLineItemWriteRepository) AdjustEndDates(ctx context.Context, tx 
 	params := map[string]any{
 		"parentId": parentId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -258,7 +253,7 @@ func (r *serviceLineItemWriteRepository) AdjustEndDates(ctx context.Context, tx 
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err

--- a/packages/server/customer-os-neo4j-repository/repository/social_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/social_read_repository.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type TenantSocialIdAndEntityId struct {
@@ -43,10 +41,10 @@ func (r *socialReadRepository) prepareReadSession(ctx context.Context) neo4j.Ses
 }
 
 func (r *socialReadRepository) GetById(ctx context.Context, tenant, socialId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialReadRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, socialId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "SocialReadRepository.GetById")
+	defer spans.Finish()
+
+	spans.TagEntity(socialId)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -55,8 +53,8 @@ func (r *socialReadRepository) GetById(ctx context.Context, tenant, socialId str
 	params := map[string]any{
 		"socialId": socialId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
@@ -66,17 +64,19 @@ func (r *socialReadRepository) GetById(ctx context.Context, tenant, socialId str
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *socialReadRepository) GetDuplicatedSocialsForEntityType(ctx context.Context, linkedEntityNodeLabel string, minutesSinceLastUpdate, limit int) ([]TenantSocialIdAndEntityId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialReadRepository.GetDuplicatedSocialsForEntityType")
-	defer span.Finish()
-	span.LogFields(log.String("linkedEntityNodeLabel", linkedEntityNodeLabel), log.Int("minutesSinceLastUpdate", minutesSinceLastUpdate), log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "SocialReadRepository.GetDuplicatedSocialsForEntityType")
+	defer spans.Finish()
+	spans.LogKV("linkedEntityNodeLabel", linkedEntityNodeLabel)
+	spans.LogKV("minutesSinceLastUpdate", minutesSinceLastUpdate)
+	spans.LogKV("limit", limit)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant)--(e:%s)-[:HAS]->(s:Social)
 					WHERE s.updatedAt < datetime() - duration({minutes: $minutesSinceLastUpdate})
@@ -88,8 +88,8 @@ func (r *socialReadRepository) GetDuplicatedSocialsForEntityType(ctx context.Con
 		"minutesSinceLastUpdate": minutesSinceLastUpdate,
 		"limit":                  limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -114,14 +114,16 @@ func (r *socialReadRepository) GetDuplicatedSocialsForEntityType(ctx context.Con
 				SocialId:       v.Values[2].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *socialReadRepository) GetEmptySocialsForEntityType(ctx context.Context, linkedEntityNodeLabel string, minutesSinceLastUpdate, limit int) ([]TenantSocialIdAndEntityId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialReadRepository.GetDuplicatedSocialsForEntityType")
-	defer span.Finish()
-	span.LogFields(log.String("linkedEntityNodeLabel", linkedEntityNodeLabel), log.Int("minutesSinceLastUpdate", minutesSinceLastUpdate), log.Int("limit", limit))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "SocialReadRepository.GetDuplicatedSocialsForEntityType")
+	defer spans.Finish()
+	spans.LogKV("linkedEntityNodeLabel", linkedEntityNodeLabel)
+	spans.LogKV("minutesSinceLastUpdate", minutesSinceLastUpdate)
+	spans.LogKV("limit", limit)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant)--(e:%s)-[:HAS]->(s:Social)
 					WHERE s.updatedAt < datetime() - duration({minutes: $minutesSinceLastUpdate})
@@ -131,8 +133,8 @@ func (r *socialReadRepository) GetEmptySocialsForEntityType(ctx context.Context,
 		"minutesSinceLastUpdate": minutesSinceLastUpdate,
 		"limit":                  limit,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -157,14 +159,13 @@ func (r *socialReadRepository) GetEmptySocialsForEntityType(ctx context.Context,
 				SocialId:       v.Values[2].(string),
 			})
 	}
-	span.LogFields(log.Int("result.count", len(output)))
+	spans.LogKV("result.count", len(output))
 	return output, nil
 }
 
 func (r *socialReadRepository) GetAllForEntities(ctx context.Context, tenant string, linkedEntityType neo4jenum.EntityType, linkedEntityIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialReadRepository.GetAllForEntities")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "SocialReadRepository.GetAllForEntities")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -176,8 +177,8 @@ func (r *socialReadRepository) GetAllForEntities(ctx context.Context, tenant str
 		"entityIds": linkedEntityIds,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
@@ -190,14 +191,13 @@ func (r *socialReadRepository) GetAllForEntities(ctx context.Context, tenant str
 		return nil, err
 	}
 	dbNodeAndIds := result.([]*utils.DbNodeAndId)
-	span.LogFields(log.Int("result.count", len(dbNodeAndIds)))
+	spans.LogKV("result.count", len(dbNodeAndIds))
 	return dbNodeAndIds, err
 }
 
 func (r *socialReadRepository) GetAllLinkedinForEntities(ctx context.Context, tenant string, linkedEntityType neo4jenum.EntityType, linkedEntityIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialReadRepository.GetAllLinkedinForEntities")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "SocialReadRepository.GetAllLinkedinForEntities")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -209,8 +209,8 @@ func (r *socialReadRepository) GetAllLinkedinForEntities(ctx context.Context, te
 		"entityIds": linkedEntityIds,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		if queryResult, err := tx.Run(ctx, cypher, params); err != nil {
@@ -220,10 +220,10 @@ func (r *socialReadRepository) GetAllLinkedinForEntities(ctx context.Context, te
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	dbNodeAndIds := result.([]*utils.DbNodeAndId)
-	span.LogFields(log.Int("result.count", len(dbNodeAndIds)))
+	spans.LogKV("result.count", len(dbNodeAndIds))
 	return dbNodeAndIds, err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/social_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/social_write_repository.go
@@ -3,13 +3,12 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"time"
 )
 
@@ -44,12 +43,12 @@ func NewSocialWriteRepository(driver *neo4j.DriverWithContext, database string) 
 }
 
 func (r *socialWriteRepository) MergeSocialForEntity(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, linkedEntityId, linkedEntityNodeLabel string, data SocialFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialWriteRepository.MergeSocialForEntity")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("linkedEntityId", linkedEntityId), log.String("linkedEntityNodeLabel", linkedEntityNodeLabel))
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "SocialWriteRepository.MergeSocialForEntity")
+	defer spans.Finish()
+
+	spans.LogKV("linkedEntityId", linkedEntityId)
+	spans.LogKV("linkedEntityNodeLabel", linkedEntityNodeLabel)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`
 		MATCH (e:%s {id:$entityId})
@@ -82,8 +81,8 @@ func (r *socialWriteRepository) MergeSocialForEntity(ctx context.Context, tx *ne
 		"source":         data.SourceFields.Source,
 		"appSource":      data.SourceFields.AppSource,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -93,18 +92,17 @@ func (r *socialWriteRepository) MergeSocialForEntity(ctx context.Context, tx *ne
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *socialWriteRepository) PermanentlyDelete(ctx context.Context, tenant, socialId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialWriteRepository.PermanentlyDelete")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, socialId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "SocialWriteRepository.PermanentlyDelete")
+	defer spans.Finish()
+
+	spans.TagEntity(socialId)
 
 	cypher := fmt.Sprintf(
 		`MATCH (soc:Social_%s {id:$socialId})<-[r:HAS]-(n:Organization|Contact|MergedContact|MergedOrganization)
@@ -115,15 +113,16 @@ func (r *socialWriteRepository) PermanentlyDelete(ctx context.Context, tenant, s
 		"socialId": socialId,
 	}
 
-	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, span)
+	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, spans)
 }
 
 func (r *socialWriteRepository) RemoveSocialForEntityById(ctx context.Context, tenant, linkedEntityId, linkedEntityNodeLabel, socialId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialWriteRepository.RemoveSocialForEntityById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("linkedEntityId", linkedEntityId), log.String("linkedEntityNodeLabel", linkedEntityNodeLabel), log.String("socialId", socialId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "SocialWriteRepository.RemoveSocialForEntityById")
+	defer spans.Finish()
+
+	spans.LogKV("linkedEntityId", linkedEntityId)
+	spans.LogKV("linkedEntityNodeLabel", linkedEntityNodeLabel)
+	spans.LogKV("socialId", socialId)
 
 	// delete social only if has no other relations
 	cypher := fmt.Sprintf(`
@@ -137,15 +136,16 @@ func (r *socialWriteRepository) RemoveSocialForEntityById(ctx context.Context, t
 		"socialId": socialId,
 	}
 
-	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, span)
+	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, spans)
 }
 
 func (r *socialWriteRepository) RemoveSocialForEntityByUrl(ctx context.Context, tenant, linkedEntityId, linkedEntityNodeLabel, socialUrl string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialWriteRepository.RemoveSocialForEntityByUrl")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("linkedEntityId", linkedEntityId), log.String("linkedEntityNodeLabel", linkedEntityNodeLabel), log.String("socialUrl", socialUrl))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "SocialWriteRepository.RemoveSocialForEntityByUrl")
+	defer spans.Finish()
+
+	spans.LogKV("linkedEntityId", linkedEntityId)
+	spans.LogKV("linkedEntityNodeLabel", linkedEntityNodeLabel)
+	spans.LogKV("socialUrl", socialUrl)
 
 	// delete social only if has no other relations
 	cypher := fmt.Sprintf(`
@@ -159,15 +159,14 @@ func (r *socialWriteRepository) RemoveSocialForEntityByUrl(ctx context.Context, 
 		"url":      socialUrl,
 	}
 
-	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, span)
+	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, spans)
 }
 
 func (r *socialWriteRepository) Update(ctx context.Context, tenant, socialId, url string, alias, externalId *string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialWriteRepository.Update")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, socialId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "SocialWriteRepository.Update")
+	defer spans.Finish()
+
+	spans.TagEntity(socialId)
 
 	params := map[string]any{
 		"id":  socialId,
@@ -189,8 +188,8 @@ func (r *socialWriteRepository) Update(ctx context.Context, tenant, socialId, ur
 				SET n.updatedAt = datetime()
 			RETURN DISTINCT soc`
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/state_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/state_read_repository.go
@@ -2,11 +2,10 @@ package neo4j_repository
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type StateReadRepository interface {
@@ -26,9 +25,9 @@ func NewStateReadRepository(driver *neo4j.DriverWithContext, database string) St
 }
 
 func (r *stateReadRepository) GetStatesByCountryId(ctx context.Context, countryId string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserRepository.FindFirstUserWithRolesByEmail")
-	defer span.Finish()
-	span.LogFields(log.String("countryId", countryId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "StateReadRepository.GetStatesByCountryId")
+	defer spans.Finish()
+	spans.LogKV("countryId", countryId)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/tag_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/tag_read_repository.go
@@ -2,13 +2,12 @@ package neo4j_repository
 
 import (
 	"fmt"
+	commonmodel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	commonmodel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -40,19 +39,18 @@ func (r *tagReadRepository) prepareReadSession(ctx context.Context) neo4j.Sessio
 }
 
 func (r *tagReadRepository) GetById(ctx context.Context, tenant, tagId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagReadRepository.GetById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("tagId", tagId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagReadRepository.GetById")
+	defer spans.Finish()
+
+	spans.LogKV("tagId", tagId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:TAG_BELONGS_TO_TENANT]-(tag:Tag {id:$tagId}) return tag`
 	params := map[string]any{
 		"tenant": tenant,
 		"tagId":  tagId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -68,18 +66,16 @@ func (r *tagReadRepository) GetById(ctx context.Context, tenant, tagId string) (
 }
 
 func (r *tagReadRepository) GetAll(ctx context.Context, tenant string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagRepository.GetAll")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagRepository.GetAll")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:TAG_BELONGS_TO_TENANT]-(tag:Tag)
 			RETURN tag ORDER BY tag.name`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -89,20 +85,19 @@ func (r *tagReadRepository) GetAll(ctx context.Context, tenant string) ([]*dbtyp
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), err
 }
 
 func (r *tagReadRepository) GetForIssues(ctx context.Context, tenant string, issueIds []string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagReadRepository.GetForIssues")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("issueIds", issueIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagReadRepository.GetForIssues")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("issueIds", issueIds)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ISSUE_BELONGS_TO_TENANT]-(i:Issue)-[rel:TAGGED]->(tag:Tag)-[:TAG_BELONGS_TO_TENANT]->(t)
 			WHERE i.id IN $issueIds
@@ -123,11 +118,11 @@ func (r *tagReadRepository) GetForIssues(ctx context.Context, tenant string, iss
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeWithRelationAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeWithRelationAndId)))
 	if len(result.([]*utils.DbNodeWithRelationAndId)) == 0 {
 		return nil, nil
 	}
@@ -135,11 +130,10 @@ func (r *tagReadRepository) GetForIssues(ctx context.Context, tenant string, iss
 }
 
 func (r *tagReadRepository) GetForLogEntries(ctx context.Context, tenant string, logEntryIds []string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagReadRepository.GetForLogEntries")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("logEntryIds", logEntryIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagReadRepository.GetForLogEntries")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("logEntryIds", logEntryIds)
 
 	cypher := fmt.Sprintf(`MATCH (l:LogEntry)-[rel:TAGGED]->(tag:Tag)-[:TAG_BELONGS_TO_TENANT]->(t:Tenant {name:$tenant})
 			WHERE l.id IN $logEntryIds AND l:LogEntry_%s
@@ -160,11 +154,11 @@ func (r *tagReadRepository) GetForLogEntries(ctx context.Context, tenant string,
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeWithRelationAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeWithRelationAndId)))
 	if len(result.([]*utils.DbNodeWithRelationAndId)) == 0 {
 		return nil, nil
 	}
@@ -172,11 +166,10 @@ func (r *tagReadRepository) GetForLogEntries(ctx context.Context, tenant string,
 }
 
 func (r *tagReadRepository) GetForContacts(ctx context.Context, tenant string, contactIds []string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagReadRepository.GetForContacts")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("contactIds", contactIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagReadRepository.GetForContacts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("contactIds", contactIds)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact)-[rel:TAGGED]->(tag:Tag)-[:TAG_BELONGS_TO_TENANT]->(t)
 			WHERE c.id IN $contactIds
@@ -197,11 +190,11 @@ func (r *tagReadRepository) GetForContacts(ctx context.Context, tenant string, c
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeWithRelationAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeWithRelationAndId)))
 	if len(result.([]*utils.DbNodeWithRelationAndId)) == 0 {
 		return nil, nil
 	}
@@ -209,11 +202,10 @@ func (r *tagReadRepository) GetForContacts(ctx context.Context, tenant string, c
 }
 
 func (r *tagReadRepository) GetForOrganizations(ctx context.Context, tenant string, organizationIds []string) ([]*utils.DbNodeWithRelationAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagReadRepository.GetForOrganizations")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.Object("organizationIds", organizationIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagReadRepository.GetForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("organizationIds", organizationIds)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)-[rel:TAGGED]->(tag:Tag)-[:TAG_BELONGS_TO_TENANT]->(t)
 			WHERE o.id IN $organizationIds
@@ -234,11 +226,11 @@ func (r *tagReadRepository) GetForOrganizations(ctx context.Context, tenant stri
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*utils.DbNodeWithRelationAndId))))
+	spans.LogKV("result.count", len(result.([]*utils.DbNodeWithRelationAndId)))
 	if len(result.([]*utils.DbNodeWithRelationAndId)) == 0 {
 		return nil, nil
 	}
@@ -246,11 +238,10 @@ func (r *tagReadRepository) GetForOrganizations(ctx context.Context, tenant stri
 }
 
 func (r *tagReadRepository) GetAllByEntityType(ctx context.Context, tenant string, entityType commonmodel.EntityType) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagRepository.GetAll")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("entityType", entityType.String()))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagRepository.GetAll")
+	defer spans.Finish()
+
+	spans.LogKV("entityType", entityType.String())
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:TAG_BELONGS_TO_TENANT]-(tag:Tag {entityType:$entityType})
 			RETURN tag ORDER BY tag.name`
@@ -258,8 +249,8 @@ func (r *tagReadRepository) GetAllByEntityType(ctx context.Context, tenant strin
 		"tenant":     tenant,
 		"entityType": entityType.String(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -269,20 +260,20 @@ func (r *tagReadRepository) GetAllByEntityType(ctx context.Context, tenant strin
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, resultWithContext, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), err
 }
 
 func (r *tagReadRepository) GetByEntityTypeAndName(ctx context.Context, tenant string, entityType commonmodel.EntityType, name string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagReadRepository.GetByEntityTypeAndName")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("entityType", entityType.String()), log.String("name", name))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagReadRepository.GetByEntityTypeAndName")
+	defer spans.Finish()
+
+	spans.LogKV("entityType", entityType.String())
+	spans.LogKV("name", name)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:TAG_BELONGS_TO_TENANT]-(tag:Tag {entityType:$entityType, name:$name})
 			RETURN tag`
@@ -291,8 +282,8 @@ func (r *tagReadRepository) GetByEntityTypeAndName(ctx context.Context, tenant s
 		"entityType": entityType.String(),
 		"name":       name,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -305,9 +296,9 @@ func (r *tagReadRepository) GetByEntityTypeAndName(ctx context.Context, tenant s
 		return nil, err
 	}
 	if dbRecords == nil || len(dbRecords.([]*dbtype.Node)) == 0 {
-		span.LogFields(log.String("result", "not found"))
+		spans.LogKV("result", "not found")
 		return nil, nil
 	}
-	span.LogFields(log.String("result", "found"))
+	spans.LogKV("result", "found")
 	return dbRecords.([]*dbtype.Node)[0], err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/tag_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/tag_write_repository.go
@@ -3,14 +3,12 @@ package neo4j_repository
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 )
 
 type TagWriteRepository interface {
@@ -34,9 +32,8 @@ func NewTagWriteRepository(driver *neo4j.DriverWithContext, database string) Tag
 }
 
 func (r *tagWriteRepository) Merge(ctx context.Context, tx *neo4j.ManagedTransaction, tenant string, tag neo4jentity.TagEntity) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagWriteRepository.Merge")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagWriteRepository.Merge")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -61,19 +58,19 @@ func (r *tagWriteRepository) Merge(ctx context.Context, tx *neo4j.ManagedTransac
 		"colorCode":  tag.ColorCode,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -81,11 +78,12 @@ func (r *tagWriteRepository) Merge(ctx context.Context, tx *neo4j.ManagedTransac
 }
 
 func (r *tagWriteRepository) LinkTagByIdToEntity(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, tagId, entityId string, entityType model.EntityType) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagWriteRepository.LinkTagByIdToEntity")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("tagId", tagId), log.String("entityId", entityId), log.String("entityType", entityType.String()))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagWriteRepository.LinkTagByIdToEntity")
+	defer spans.Finish()
+
+	spans.LogKV("tagId", tagId)
+	spans.LogKV("entityId", entityId)
+	spans.LogKV("entityType", entityType.String())
 
 	cypher := fmt.Sprintf(`
 		MATCH (e:%s {id:$entityId}),
@@ -101,19 +99,19 @@ func (r *tagWriteRepository) LinkTagByIdToEntity(ctx context.Context, tx *neo4j.
 		"entityId": entityId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -121,11 +119,12 @@ func (r *tagWriteRepository) LinkTagByIdToEntity(ctx context.Context, tx *neo4j.
 }
 
 func (r *tagWriteRepository) UnlinkTagByIdFromEntity(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, tagId, entityId string, entityType model.EntityType) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagWriteRepository.UnlinkTagByIdFromEntity")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("tagId", tagId), log.String("entityId", entityId), log.String("entityType", entityType.String()))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagWriteRepository.UnlinkTagByIdFromEntity")
+	defer spans.Finish()
+
+	spans.LogKV("tagId", tagId)
+	spans.LogKV("entityId", entityId)
+	spans.LogKV("entityType", entityType.String())
 
 	cypher := fmt.Sprintf(`
 		MATCH (t:Tenant {name:$tenant})<-[:TAG_BELONGS_TO_TENANT]-(tag:Tag {id:$id})<-[rel:TAGGED]-(e:%s {id:$entityId})
@@ -137,19 +136,19 @@ func (r *tagWriteRepository) UnlinkTagByIdFromEntity(ctx context.Context, tx *ne
 		"entityId": entityId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, err
 		}
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -157,11 +156,10 @@ func (r *tagWriteRepository) UnlinkTagByIdFromEntity(ctx context.Context, tx *ne
 }
 
 func (r *tagWriteRepository) UnlinkAllAndDelete(ctx context.Context, tenant, tagId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagWriteRepository.UnlinkAllAndDelete")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("tagId", tagId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagWriteRepository.UnlinkAllAndDelete")
+	defer spans.Finish()
+
+	spans.LogKV("tagId", tagId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:TAG_BELONGS_TO_TENANT]-(tag:Tag {id:$tagId}) DETACH DELETE tag`
 	params := map[string]any{
@@ -169,15 +167,14 @@ func (r *tagWriteRepository) UnlinkAllAndDelete(ctx context.Context, tenant, tag
 		"tagId":  tagId,
 	}
 
-	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, span)
+	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, spans)
 }
 
 func (r *tagWriteRepository) Update(ctx context.Context, tenant, tagId string, name, colorCode *string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagWriteRepository.UpdateName")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.TagEntity(span, tagId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TagWriteRepository.UpdateName")
+	defer spans.Finish()
+
+	spans.TagEntity(tagId)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:TAG_BELONGS_TO_TENANT]-(tag:Tag {id:$tagId})
 				SET tag.updatedAt=datetime()`
@@ -194,5 +191,5 @@ func (r *tagWriteRepository) Update(ctx context.Context, tenant, tagId string, n
 		params["colorCode"] = *colorCode
 	}
 
-	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, span)
+	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, spans)
 }

--- a/packages/server/customer-os-neo4j-repository/repository/task_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/task_read_repository.go
@@ -7,13 +7,11 @@ import (
 	"sync"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 const (
@@ -54,10 +52,10 @@ func NewTaskReadRepository(driver *neo4j.DriverWithContext, database string) Tas
 }
 
 func (r *taskReadRepository) GetById(ctx context.Context, tenant, taskId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskReadRepository.GetById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, taskId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskReadRepository.GetById")
+	defer spans.Finish()
+
+	spans.TagEntity(taskId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task {id:$taskId})
 				RETURN tsk`
@@ -66,8 +64,8 @@ func (r *taskReadRepository) GetById(ctx context.Context, tenant, taskId string)
 		"taskId": taskId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -83,10 +81,10 @@ func (r *taskReadRepository) GetById(ctx context.Context, tenant, taskId string)
 }
 
 func (r *taskReadRepository) GetAllByIds(ctx context.Context, tenant string, ids []string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskReadRepository.GetAllByIds")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "ids", ids)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskReadRepository.GetAllByIds")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("ids", ids)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task)
 				WHERE tsk.id IN $ids
@@ -96,8 +94,8 @@ func (r *taskReadRepository) GetAllByIds(ctx context.Context, tenant string, ids
 		"ids":    ids,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -107,17 +105,16 @@ func (r *taskReadRepository) GetAllByIds(ctx context.Context, tenant string, ids
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(dbRecords.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(dbRecords.([]*dbtype.Node)))
 	return dbRecords.([]*dbtype.Node), err
 }
 
 func (r *taskReadRepository) CountByTenant(ctx context.Context, tenant string) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskReadRepository.CountByTenant")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskReadRepository.CountByTenant")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task)
 				WHERE tsk.hide = false OR tsk.hide IS NULL
@@ -126,8 +123,8 @@ func (r *taskReadRepository) CountByTenant(ctx context.Context, tenant string) (
 		"tenant": tenant,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -144,20 +141,20 @@ func (r *taskReadRepository) CountByTenant(ctx context.Context, tenant string) (
 		return record.Values[0].(int64), nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return 0, err
 	}
-	span.LogFields(log.Int64("result", count.(int64)))
+	spans.LogKV("result", count.(int64))
 	return count.(int64), nil
 }
 
 func (r *taskReadRepository) SearchTasks(ctx context.Context, tenant string, limit int, where *model.Filter, sort *model.SortBy) (*utils.StringsWithTotalCount, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskReadRepository.SearchTasks")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Int("limit", limit))
-	tracing.LogObjectAsJson(span, "where", where)
-	tracing.LogObjectAsJson(span, "sort", sort)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskReadRepository.SearchTasks")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
+	spans.LogObjectAsJson("where", where)
+	spans.LogObjectAsJson("sort", sort)
 
 	taskFilterCypher, taskFilterParams := "", make(map[string]interface{})
 	userAuthorFilterCypher, userAuthorFilterParams := "", make(map[string]interface{})
@@ -376,13 +373,12 @@ func (r *taskReadRepository) SearchTasks(ctx context.Context, tenant string, lim
 
 	wg.Add(1)
 	go func(ctx context.Context, result *utils.StringsWithTotalCount) {
-		span, ctx := opentracing.StartSpanFromContext(ctx, "TaskReadRepository.SearchTasks.CountQuery")
-		defer span.Finish()
+		spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskReadRepository.SearchTasks.CountQuery")
+		defer spans.Finish()
 		defer wg.Done()
-		tracing.SetDefaultServiceSpanTags(ctx, span)
 
-		tracing.LogObjectAsJson(span, "params", params)
-		span.LogFields(log.String("countQuery", countQuery))
+		spans.LogObjectAsJson("params", params)
+		spans.LogKV("countQuery", countQuery)
 
 		session := utils.NewNeo4jReadSession(ctx, *r.driver)
 		defer session.Close(ctx)
@@ -397,7 +393,7 @@ func (r *taskReadRepository) SearchTasks(ctx context.Context, tenant string, lim
 		})
 
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			setError(err)
 			return
 		}
@@ -407,13 +403,12 @@ func (r *taskReadRepository) SearchTasks(ctx context.Context, tenant string, lim
 
 	wg.Add(1)
 	go func(ctx context.Context, result *utils.StringsWithTotalCount) {
-		span, ctx := opentracing.StartSpanFromContext(ctx, "TaskReadRepository.SearchTasks.SelectQuery")
-		defer span.Finish()
+		spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskReadRepository.SearchTasks.SelectQuery")
+		defer spans.Finish()
 		defer wg.Done()
-		tracing.SetDefaultServiceSpanTags(ctx, span)
 
-		tracing.LogObjectAsJson(span, "params", params)
-		span.LogFields(log.String("selectQuery", selectQuery))
+		spans.LogObjectAsJson("params", params)
+		spans.LogKV("selectQuery", selectQuery)
 
 		session := utils.NewNeo4jReadSession(ctx, *r.driver)
 		defer session.Close(ctx)
@@ -428,7 +423,7 @@ func (r *taskReadRepository) SearchTasks(ctx context.Context, tenant string, lim
 		})
 
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			setError(err)
 			return
 		}
@@ -442,7 +437,8 @@ func (r *taskReadRepository) SearchTasks(ctx context.Context, tenant string, lim
 		return nil, firstErr
 	}
 
-	span.LogFields(log.Int("result.count", len(stringsWithTotalCount.Strings)), log.Int64("result.totalCount", stringsWithTotalCount.Count))
+	spans.LogKV("result.count", len(stringsWithTotalCount.Strings))
+	spans.LogKV("result.totalCount", stringsWithTotalCount.Count)
 
 	return stringsWithTotalCount, nil
 }
@@ -478,10 +474,10 @@ func createTimeFilter(filter *model.Filter, cypherFilter *utils.CypherFilter, ne
 }
 
 func (r *taskReadRepository) GetTasksForOpportunities(ctx context.Context, tenant string, opportunityIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskReadRepository.GetTasksForOpportunities")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "opportunityIds", opportunityIds)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskReadRepository.GetTasksForOpportunities")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("opportunityIds", opportunityIds)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task)-[:LINKED_TO]->(opp:Opportunity)
 				WHERE opp.id IN $opportunityIds
@@ -492,8 +488,8 @@ func (r *taskReadRepository) GetTasksForOpportunities(ctx context.Context, tenan
 		"opportunityIds": opportunityIds,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -506,19 +502,19 @@ func (r *taskReadRepository) GetTasksForOpportunities(ctx context.Context, tenan
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	dbNodeAndIds := result.([]*utils.DbNodeAndId)
-	span.LogFields(log.Int("result.count", len(dbNodeAndIds)))
+	spans.LogKV("result.count", len(dbNodeAndIds))
 	return dbNodeAndIds, err
 }
 
 func (r *taskReadRepository) GetHiddenTasks(ctx context.Context, hiddenDaysAgo int) ([]string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskReadRepository.GetHiddenTasks")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogKV("hiddenDaysAgo", hiddenDaysAgo)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskReadRepository.GetHiddenTasks")
+	defer spans.Finish()
+
+	spans.LogKV("hiddenDaysAgo", hiddenDaysAgo)
 
 	cypher := `MATCH (:Tenant)<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task)
 				WHERE tsk.hide = true AND tsk.hiddenAt < datetime() - duration({days:$hiddenDaysAgo})
@@ -527,8 +523,8 @@ func (r *taskReadRepository) GetHiddenTasks(ctx context.Context, hiddenDaysAgo i
 		"hiddenDaysAgo": hiddenDaysAgo,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -542,11 +538,11 @@ func (r *taskReadRepository) GetHiddenTasks(ctx context.Context, hiddenDaysAgo i
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogKV("result.count", len(result.([]string)))
+	spans.LogKV("result.count", len(result.([]string)))
 	return result.([]string), nil
 
 }

--- a/packages/server/customer-os-neo4j-repository/repository/task_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/task_write_repository.go
@@ -6,10 +6,8 @@ import (
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
 )
 
 type TaskWriteRepository interface {
@@ -35,11 +33,11 @@ func NewTaskWriteRepository(driver *neo4j.DriverWithContext, database string) Ta
 }
 
 func (r *taskWriteRepository) Create(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, taskId string, data data_fields.TaskFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskWriteRepository.Create")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, taskId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskWriteRepository.Create")
+	defer spans.Finish()
+
+	spans.TagEntity(taskId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})
 							MERGE (t)<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task {id:$taskId}) 
@@ -73,15 +71,15 @@ func (r *taskWriteRepository) Create(ctx context.Context, tx *neo4j.ManagedTrans
 		"hide":            false,
 	}
 
-	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, span)
+	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, spans)
 }
 
 func (r *taskWriteRepository) Update(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, taskId string, data data_fields.TaskFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskWriteRepository.Update")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, taskId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskWriteRepository.Update")
+	defer spans.Finish()
+
+	spans.TagEntity(taskId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task {id:$taskId})
 		 	SET	tsk.updatedAt = datetime() `
@@ -107,15 +105,15 @@ func (r *taskWriteRepository) Update(ctx context.Context, tx *neo4j.ManagedTrans
 		params["dueAt"] = utils.TimePtrAsAny(data.DueAt)
 	}
 
-	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, span)
+	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, spans)
 }
 
 func (r *taskWriteRepository) SetOpportunities(ctx context.Context, tx *neo4j.ManagedTransaction, tenant string, taskId string, opportunityIds []string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskWriteRepository.SetOpportunities")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, taskId)
-	tracing.LogObjectAsJson(span, "opportunityIds", opportunityIds)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskWriteRepository.SetOpportunities")
+	defer spans.Finish()
+
+	spans.TagEntity(taskId)
+	spans.LogObjectAsJson("opportunityIds", opportunityIds)
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task {id:$taskId})
 				OPTIONAL MATCH (tsk)-[r:LINKED_TO]->(o:Opportunity)
@@ -132,15 +130,15 @@ func (r *taskWriteRepository) SetOpportunities(ctx context.Context, tx *neo4j.Ma
 		"opportunityIds": opportunityIds,
 	}
 
-	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, span)
+	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, spans)
 }
 
 func (r *taskWriteRepository) SetUserAssignees(ctx context.Context, tx *neo4j.ManagedTransaction, tenant string, taskId string, userIds []string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskWriteRepository.SetUserAssignees")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, taskId)
-	tracing.LogObjectAsJson(span, "userIds", userIds)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskWriteRepository.SetUserAssignees")
+	defer spans.Finish()
+
+	spans.TagEntity(taskId)
+	spans.LogObjectAsJson("userIds", userIds)
 
 	cypher := fmt.Sprintf(`MATCH (:Tenant {name:$tenant})<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task {id:$taskId})
 				OPTIONAL MATCH (tsk)-[r:ASSIGNED_TO]->(u:User)
@@ -160,14 +158,14 @@ func (r *taskWriteRepository) SetUserAssignees(ctx context.Context, tx *neo4j.Ma
 		"userIds": userIds,
 	}
 
-	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, span)
+	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, spans)
 }
 
 func (r *taskWriteRepository) Hide(ctx context.Context, tx *neo4j.ManagedTransaction, tenant string, taskId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskWriteRepository.Hide")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagEntity(span, taskId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskWriteRepository.Hide")
+	defer spans.Finish()
+
+	spans.TagEntity(taskId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task {id:$taskId})
 		SET tsk.hide = true, tsk.hiddenAt = datetime()`
@@ -176,14 +174,14 @@ func (r *taskWriteRepository) Hide(ctx context.Context, tx *neo4j.ManagedTransac
 		"taskId": taskId,
 	}
 
-	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, span)
+	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, spans)
 }
 
 func (r *taskWriteRepository) PermanentDeleteHiddenTasks(ctx context.Context, tx *neo4j.ManagedTransaction, taskIds []string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskWriteRepository.PermanentDeleteHiddenTasks")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "taskIds", taskIds)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TaskWriteRepository.PermanentDeleteHiddenTasks")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("taskIds", taskIds)
 
 	cypher := `MATCH (:Tenant)<-[:TASK_BELONGS_TO_TENANT]-(tsk:Task)
 		WHERE tsk.hide = true AND tsk.id IN $taskIds
@@ -192,7 +190,7 @@ func (r *taskWriteRepository) PermanentDeleteHiddenTasks(ctx context.Context, tx
 		"taskIds": taskIds,
 	}
 
-	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, span)
+	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, spans)
 }
 
 func (r *taskWriteRepository) AddOpportunity(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, taskId, opportunityId string) error {
@@ -210,5 +208,5 @@ func (r *taskWriteRepository) AddOpportunity(ctx context.Context, tx *neo4j.Mana
 		"opportunityId": opportunityId,
 	}
 
-	return LogAndExecuteWriteQueryInTxV2(ctx, tx, r.driver, r.database, cypher, params, spans)
+	return LogAndExecuteWriteQueryInTx(ctx, tx, r.driver, r.database, cypher, params, spans)
 }

--- a/packages/server/customer-os-neo4j-repository/repository/tenant_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/tenant_read_repository.go
@@ -3,12 +3,10 @@ package neo4j_repository
 import (
 	"context"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type TenantReadRepository interface {
@@ -42,14 +40,14 @@ func (r *tenantReadRepository) prepareReadSession(ctx context.Context) neo4j.Ses
 }
 
 func (r *tenantReadRepository) GetAll(ctx context.Context) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantReadRepository.GetAll")
-	defer span.Finish()
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantReadRepository.GetAll")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant) return t`
 	params := map[string]any{}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -59,18 +57,18 @@ func (r *tenantReadRepository) GetAll(ctx context.Context) ([]*dbtype.Node, erro
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), nil
 }
 
 func (r *tenantReadRepository) TenantExists(ctx context.Context, tenantName string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantRepository.TenantExists")
-	defer span.Finish()
-	span.LogFields(log.String("tenantName", tenantName))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantRepository.TenantExists")
+	defer spans.Finish()
+	spans.LogKV("tenantName", tenantName)
 
 	session := (*r.driver).NewSession(
 		ctx,
@@ -103,17 +101,15 @@ func (r *tenantReadRepository) TenantExists(ctx context.Context, tenantName stri
 }
 
 func (r *tenantReadRepository) GetTenantByName(ctx context.Context, tenant string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantReadRepository.GetTenantByName")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantReadRepository.GetTenantByName")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant}) RETURN t`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -128,26 +124,24 @@ func (r *tenantReadRepository) GetTenantByName(ctx context.Context, tenant strin
 	}
 
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *tenantReadRepository) GetTenantByNameIgnoreCase(ctx context.Context, tenant string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantReadRepository.GetTenantByNameIgnoreCase")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantReadRepository.GetTenantByNameIgnoreCase")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant) where lower(t.name) = lower($tenant)  RETURN t`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -162,18 +156,17 @@ func (r *tenantReadRepository) GetTenantByNameIgnoreCase(ctx context.Context, te
 	}
 
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *tenantReadRepository) GetTenantForWorkspaceProvider(ctx context.Context, workspaceName, workspaceProvider string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantReadRepository.GetTenantForWorkspaceProvider")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantReadRepository.GetTenantForWorkspaceProvider")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant)-[:HAS_WORKSPACE]->(w:Workspace)
 			WHERE w.name=$name AND w.provider=$provider
@@ -183,8 +176,8 @@ func (r *tenantReadRepository) GetTenantForWorkspaceProvider(ctx context.Context
 		"provider": workspaceProvider,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -202,18 +195,17 @@ func (r *tenantReadRepository) GetTenantForWorkspaceProvider(ctx context.Context
 	}
 
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *tenantReadRepository) GetTenantForWorkspace(ctx context.Context, workspaceName string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantReadRepository.GetTenantForWorkspace")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantReadRepository.GetTenantForWorkspace")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant)-[:HAS_WORKSPACE]->(w:Workspace)
 			WHERE w.name=$name 
@@ -222,8 +214,8 @@ func (r *tenantReadRepository) GetTenantForWorkspace(ctx context.Context, worksp
 		"name": workspaceName,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -237,25 +229,25 @@ func (r *tenantReadRepository) GetTenantForWorkspace(ctx context.Context, worksp
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
-	tracing.LogObjectAsJson(span, "result", result.(*dbtype.Node))
+	spans.LogKV("result.found", true)
+	spans.LogObjectAsJson("result", result.(*dbtype.Node))
 	return result.(*dbtype.Node), nil
 }
 
 func (r *tenantReadRepository) GetTenantForUserEmail(ctx context.Context, email string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantReadRepository.GetTenantForUserEmail")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.String("email", email))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantReadRepository.GetTenantForUserEmail")
+	defer spans.Finish()
+
+	spans.LogKV("email", email)
 
 	cypher := `MATCH (t:Tenant)<-[:USER_BELONGS_TO_TENANT]-(:User)-[:HAS]->(e:Email)
 		WHERE e.email=$email OR e.rawEmail=$email
@@ -263,8 +255,8 @@ func (r *tenantReadRepository) GetTenantForUserEmail(ctx context.Context, email 
 	params := map[string]any{
 		"email": email,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -281,27 +273,25 @@ func (r *tenantReadRepository) GetTenantForUserEmail(ctx context.Context, email 
 	}
 
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *tenantReadRepository) GetTenantSettings(ctx context.Context, tenant string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantReadRepository.GetTenantSettings")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantReadRepository.GetTenantSettings")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})-[:HAS_SETTINGS]->(ts:TenantSettings)
 			RETURN ts`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -316,27 +306,25 @@ func (r *tenantReadRepository) GetTenantSettings(ctx context.Context, tenant str
 	}
 
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *tenantReadRepository) GetTenantBillingProfiles(ctx context.Context, tenant string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantReadRepository.GetTenantBillingProfiles")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantReadRepository.GetTenantBillingProfiles")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})-[:HAS_BILLING_PROFILE]->(tbp:TenantBillingProfile)
 			RETURN tbp ORDER BY tbp.createdAt ASC`
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -350,7 +338,7 @@ func (r *tenantReadRepository) GetTenantBillingProfiles(ctx context.Context, ten
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	if result == nil {
 		return nil, nil
 	}
@@ -358,10 +346,8 @@ func (r *tenantReadRepository) GetTenantBillingProfiles(ctx context.Context, ten
 }
 
 func (r *tenantReadRepository) GetTenantBillingProfileById(ctx context.Context, tenant, id string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantReadRepository.GetTenantBillingProfileById")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantReadRepository.GetTenantBillingProfileById")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})-[:HAS_BILLING_PROFILE]->(tbp:TenantBillingProfile {id:$id})
 			RETURN tbp`
@@ -369,8 +355,8 @@ func (r *tenantReadRepository) GetTenantBillingProfileById(ctx context.Context, 
 		"tenant": tenant,
 		"id":     id,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -381,20 +367,21 @@ func (r *tenantReadRepository) GetTenantBillingProfileById(ctx context.Context, 
 	})
 
 	if err != nil {
-		tracing.TraceErr(span, err)
-		span.LogFields(log.Bool("result.found", false))
+		spans.TraceError(err)
+		spans.LogKV("result.found", false)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *tenantReadRepository) GetTenantsForOnboardingCheck(ctx context.Context, limit, delayFromPreviousCheckHours int) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantReadRepository.GetTenantsForOnboardingCheck")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	span.LogFields(log.Int("limit", limit), log.Int("delayFromPreviousCheckHours", delayFromPreviousCheckHours))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantReadRepository.GetTenantsForOnboardingCheck")
+	defer spans.Finish()
+
+	spans.LogKV("limit", limit)
+	spans.LogKV("delayFromPreviousCheckHours", delayFromPreviousCheckHours)
 
 	cypher := `MATCH (t:Tenant)
 			WHERE t.active = true
@@ -408,8 +395,8 @@ func (r *tenantReadRepository) GetTenantsForOnboardingCheck(ctx context.Context,
 		"delayFromCreationMin":        15,
 		"delayFromPreviousCheckHours": delayFromPreviousCheckHours,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -423,7 +410,7 @@ func (r *tenantReadRepository) GetTenantsForOnboardingCheck(ctx context.Context,
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	if result == nil {
 		return nil, nil
 	}

--- a/packages/server/customer-os-neo4j-repository/repository/tenant_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/tenant_write_repository.go
@@ -5,14 +5,12 @@ import (
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	commonmodel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type TenantWriteRepository interface {
@@ -41,11 +39,10 @@ func NewTenantWriteRepository(driver *neo4j.DriverWithContext, database string) 
 }
 
 func (r *tenantWriteRepository) CreateTenantIfNotExistAndReturn(ctx context.Context, tx neo4j.ManagedTransaction, tenant neo4jentity.TenantEntity) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantWriteRepository.CreateTenantIfNotExistAndReturn")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant.Name)
-	tracing.LogObjectAsJson(span, "inputTenantEntity", tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantWriteRepository.CreateTenantIfNotExistAndReturn")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("inputTenantEntity", tenant)
 
 	cypher := `MERGE (t:Tenant {name:$name}) 
 		 ON CREATE SET 
@@ -71,12 +68,12 @@ func (r *tenantWriteRepository) CreateTenantIfNotExistAndReturn(ctx context.Cont
 		"enrichContacts":    true,
 		"currency":          enum.CurrencyUSD.String(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	queryResult, err := tx.Run(ctx, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -84,10 +81,8 @@ func (r *tenantWriteRepository) CreateTenantIfNotExistAndReturn(ctx context.Cont
 }
 
 func (r *tenantWriteRepository) CreateTenantBillingProfile(ctx context.Context, tenant string, data data_fields.TenantBillingProfileFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantWriteRepository.CreateTenantBillingProfile")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantWriteRepository.CreateTenantBillingProfile")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})
 							MERGE (t)-[:HAS_BILLING_PROFILE]->(tbp:TenantBillingProfile {id:$billingProfileId}) 
@@ -134,22 +129,21 @@ func (r *tenantWriteRepository) CreateTenantBillingProfile(ctx context.Context, 
 		"canPayWithBankTransfer": utils.IfNotNilBool(data.CanPayWithBankTransfer),
 		"check":                  utils.IfNotNilBool(data.Check),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *tenantWriteRepository) UpdateTenantBillingProfile(ctx context.Context, tenant string, data data_fields.TenantBillingProfileFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantWriteRepository.UpdateTenantBillingProfile")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantWriteRepository.UpdateTenantBillingProfile")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("data", data)
 
 	cypher := `MATCH (:Tenant {name:$tenant})-[:HAS_BILLING_PROFILE]->(tbp:TenantBillingProfile {id:$billingProfileId}) 
 							SET tbp.updatedAt=datetime()
@@ -220,22 +214,21 @@ func (r *tenantWriteRepository) UpdateTenantBillingProfile(ctx context.Context, 
 		params["check"] = *data.Check
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *tenantWriteRepository) UpdateTenantSettings(ctx context.Context, tenant string, data data_fields.TenantSettingsFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantWriteRepository.UpdateTenantSettings")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantWriteRepository.UpdateTenantSettings")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("data", data)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})
 				MERGE (t)-[:HAS_SETTINGS]->(ts:TenantSettings {tenant:$tenant})
@@ -272,22 +265,21 @@ func (r *tenantWriteRepository) UpdateTenantSettings(ctx context.Context, tenant
 		params["workspaceLogoKey"] = *data.WorkspaceLogoKey
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *tenantWriteRepository) HardDeleteTenant(ctx context.Context, tenant string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantWriteRepository.HardDelete")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	tracing.LogObjectAsJson(span, "tenant", tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantWriteRepository.HardDelete")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("tenant", tenant)
 
 	nodeWithTenantSuffix := []string{
 		commonmodel.NodeLabelTenantBillingProfile,
@@ -336,7 +328,7 @@ func (r *tenantWriteRepository) HardDeleteTenant(ctx context.Context, tenant str
 	for _, nodeLabel := range nodeWithTenantSuffix {
 		err := utils.ExecuteWriteQuery(ctx, *r.driver, fmt.Sprintf(`MATCH (n:%s_%s) DETACH DELETE n`, nodeLabel, tenant), nil)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 	}
@@ -344,28 +336,28 @@ func (r *tenantWriteRepository) HardDeleteTenant(ctx context.Context, tenant str
 	//drop TenantSettings
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, `MATCH (t:TenantSettings{tenant: $tenant}) DETACH DELETE t`, map[string]any{"tenant": tenant})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	//drop TenantMetadata
 	err = utils.ExecuteWriteQuery(ctx, *r.driver, `MATCH (t:TenantMetadata{tenantName: $tenant}) DETACH DELETE t`, map[string]any{"tenant": tenant})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	//drop External systems
 	err = utils.ExecuteWriteQuery(ctx, *r.driver, `MATCH (e:ExternalSystem)-[r:EXTERNAL_SYSTEM_BELONGS_TO_TENANT]->(t:Tenant{name: $tenant}) DELETE r, e`, map[string]any{"tenant": tenant})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	//drop workspaces
 	err = utils.ExecuteWriteQuery(ctx, *r.driver, `MATCH (w:Workspace)<-[r:HAS_WORKSPACE]-(t:Tenant{name: $tenant}) DELETE r, w`, map[string]any{"tenant": tenant})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -375,14 +367,14 @@ func (r *tenantWriteRepository) HardDeleteTenant(ctx context.Context, tenant str
 					with au, r, t
 					delete r`, map[string]any{"tenant": tenant})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	//drop tenant
 	err = utils.ExecuteWriteQuery(ctx, *r.driver, `MATCH (t:Tenant{name: $tenant}) DELETE t`, map[string]any{"tenant": tenant})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -390,10 +382,8 @@ func (r *tenantWriteRepository) HardDeleteTenant(ctx context.Context, tenant str
 }
 
 func (r *tenantWriteRepository) MarkOnboardingChecked(ctx context.Context, tenant string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantWriteRepository.MarkOnboardingChecked")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TenantWriteRepository.MarkOnboardingChecked")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})
 				SET t.techOnboardingCheckedAt=datetime()
@@ -401,5 +391,5 @@ func (r *tenantWriteRepository) MarkOnboardingChecked(ctx context.Context, tenan
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, span)
+	return LogAndExecuteWriteQuery(ctx, *r.driver, cypher, params, spans)
 }

--- a/packages/server/customer-os-neo4j-repository/repository/timeline_event_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/timeline_event_read_repository.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/pkg/errors"
 	"time"
 )
@@ -54,18 +53,17 @@ func (r *timelineEventReadRepository) prepareReadSession(ctx context.Context) ne
 }
 
 func (r *timelineEventReadRepository) GetTimelineEvent(ctx context.Context, tenant, id string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventReadRepository.GetTimelineEventsWithIds")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("id", id))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TimelineEventReadRepository.GetTimelineEventsWithIds")
+	defer spans.Finish()
+
+	spans.LogKV("id", id)
 
 	cypher := fmt.Sprintf(`MATCH (a:TimelineEvent{id: $id}) WHERE a:TimelineEvent_%s RETURN a`, tenant)
 	params := map[string]any{
 		"id": id,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -76,20 +74,19 @@ func (r *timelineEventReadRepository) GetTimelineEvent(ctx context.Context, tena
 			return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 		}
 	})
-	span.LogFields(log.Bool("result.found", result != nil))
+	spans.LogKV("result.found", result != nil)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	return result.(*dbtype.Node), nil
 }
 
 func (r *timelineEventReadRepository) CalculateAndGetLastTouchPoint(ctx context.Context, tenant, organizationId string) (*time.Time, string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventReadRepository.CalculateAndGetLastTouchPoint")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("organizationId", organizationId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TimelineEventReadRepository.CalculateAndGetLastTouchPoint")
+	defer spans.Finish()
+
+	spans.LogKV("organizationId", organizationId)
 
 	params := map[string]any{
 		"tenant":                                  tenant,
@@ -143,8 +140,8 @@ func (r *timelineEventReadRepository) CalculateAndGetLastTouchPoint(ctx context.
 		} 
 		RETURN coalesce(timelineEvent.startedAt, timelineEvent.createdAt), timelineEvent.id ORDER BY coalesce(timelineEvent.startedAt, timelineEvent.createdAt) DESC LIMIT 1`
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -157,7 +154,7 @@ func (r *timelineEventReadRepository) CalculateAndGetLastTouchPoint(ctx context.
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, "", err
 	}
 
@@ -168,7 +165,7 @@ func (r *timelineEventReadRepository) CalculateAndGetLastTouchPoint(ctx context.
 			return utils.TimePtr(t), records.([]*neo4j.Record)[0].Values[1].(string), nil
 		} else {
 			err = errors.New(fmt.Sprintf("Value %v associated to timeline event id %s is not of type time.Time", records.([]*neo4j.Record)[0].Values[0], records.([]*neo4j.Record)[0].Values[1].(string)))
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return nil, "", nil
 		}
 	}
@@ -176,11 +173,12 @@ func (r *timelineEventReadRepository) CalculateAndGetLastTouchPoint(ctx context.
 }
 
 func (r *timelineEventReadRepository) GetTimelineEventsForContact(ctx context.Context, tenant, contactId string, startingDate time.Time, size int, labels []string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventRepository.GetTimelineEventsForContact")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("contactId", contactId), log.String("startingDate", startingDate.String()), log.Int("size", size))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TimelineEventRepository.GetTimelineEventsForContact")
+	defer spans.Finish()
+
+	spans.LogKV("contactId", contactId)
+	spans.LogKV("startingDate", startingDate.String())
+	spans.LogKV("size", size)
 
 	params := map[string]any{
 		"tenant":       tenant,
@@ -221,8 +219,8 @@ func (r *timelineEventReadRepository) GetTimelineEventsForContact(ctx context.Co
 		" RETURN distinct timelineEvent ORDER BY coalesce(timelineEvent.startedAt, timelineEvent.createdAt) DESC LIMIT $size",
 		filterByTypeCypherFragment, filterByTypeCypherFragment)
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -247,11 +245,10 @@ func (r *timelineEventReadRepository) GetTimelineEventsForContact(ctx context.Co
 }
 
 func (r *timelineEventReadRepository) GetTimelineEventsTotalCountForContact(ctx context.Context, tenant string, contactId string, labels []string) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventRepository.GetTimelineEventsTotalCountForContact")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("contactId", contactId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TimelineEventRepository.GetTimelineEventsTotalCountForContact")
+	defer spans.Finish()
+
+	spans.LogKV("contactId", contactId)
 
 	params := map[string]any{
 		"tenant":      tenant,
@@ -288,8 +285,8 @@ func (r *timelineEventReadRepository) GetTimelineEventsTotalCountForContact(ctx 
 		" RETURN count(distinct timelineEvent)",
 		filterByTypeCypherFragment, filterByTypeCypherFragment)
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -308,11 +305,12 @@ func (r *timelineEventReadRepository) GetTimelineEventsTotalCountForContact(ctx 
 }
 
 func (r *timelineEventReadRepository) GetTimelineEventsForOrganization(ctx context.Context, tenant, organizationId string, startingDate time.Time, size int, labels []string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventRepository.GetTimelineEventsForOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("organizationId", organizationId), log.String("startingDate", startingDate.String()), log.Int("size", size))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TimelineEventRepository.GetTimelineEventsForOrganization")
+	defer spans.Finish()
+
+	spans.LogKV("organizationId", organizationId)
+	spans.LogKV("startingDate", startingDate.String())
+	spans.LogKV("size", size)
 
 	params := map[string]any{
 		"tenant":                        tenant,
@@ -395,8 +393,8 @@ func (r *timelineEventReadRepository) GetTimelineEventsForOrganization(ctx conte
 		" RETURN distinct timelineEvent ORDER BY coalesce(timelineEvent.startedAt, timelineEvent.createdAt) DESC LIMIT $size",
 		filterByTypeCypherFragment, filterByTypeCypherFragment, filterByTypeCypherFragment, filterByTypeCypherFragment, filterByTypeCypherFragment, filterByTypeCypherFragment)
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -421,11 +419,10 @@ func (r *timelineEventReadRepository) GetTimelineEventsForOrganization(ctx conte
 }
 
 func (r *timelineEventReadRepository) GetTimelineEventsTotalCountForOrganization(ctx context.Context, tenant string, organizationId string, labels []string) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventRepository.GetTimelineEventsTotalCountForOrganization")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
-	span.LogFields(log.String("organizationId", organizationId))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TimelineEventRepository.GetTimelineEventsTotalCountForOrganization")
+	defer spans.Finish()
+
+	spans.LogKV("organizationId", organizationId)
 
 	params := map[string]any{
 		"tenant":                        tenant,
@@ -500,8 +497,8 @@ func (r *timelineEventReadRepository) GetTimelineEventsTotalCountForOrganization
 		" RETURN count(distinct timelineEvent)",
 		filterByTypeCypherFragment, filterByTypeCypherFragment, filterByTypeCypherFragment, filterByTypeCypherFragment, filterByTypeCypherFragment, filterByTypeCypherFragment)
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -520,17 +517,15 @@ func (r *timelineEventReadRepository) GetTimelineEventsTotalCountForOrganization
 }
 
 func (r *timelineEventReadRepository) GetTimelineEventsWithIds(ctx context.Context, tenant string, ids []string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventRepository.GetTimelineEventsWithIds")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "TimelineEventRepository.GetTimelineEventsWithIds")
+	defer spans.Finish()
 
 	cypher := fmt.Sprintf(`MATCH (a:TimelineEvent) WHERE a.id in $ids AND a:TimelineEvent_%s RETURN a`, tenant)
 	params := map[string]any{
 		"ids": ids,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)

--- a/packages/server/customer-os-neo4j-repository/repository/user_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/user_read_repository.go
@@ -2,17 +2,15 @@ package neo4j_repository
 
 import (
 	"fmt"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"strings"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -78,17 +76,16 @@ func (r *userReadRepository) prepareReadSession(ctx context.Context) neo4j.Sessi
 }
 
 func (r *userReadRepository) GetAllForTenant(ctx context.Context, tenant string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetAllForTenant")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetAllForTenant")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User) RETURN u `
 	params := map[string]any{
 		"tenant": tenant,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -103,28 +100,27 @@ func (r *userReadRepository) GetAllForTenant(ctx context.Context, tenant string)
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	for _, v := range dbRecords.([]*neo4j.Record) {
 		dbNodes = append(dbNodes, utils.NodePtr(v.Values[0].(neo4j.Node)))
 	}
-	span.LogFields(log.Int("result.count", len(dbNodes)))
+	spans.LogKV("result.count", len(dbNodes))
 	return dbNodes, nil
 }
 
 func (r *userReadRepository) GetByIds(ctx context.Context, tenant string, ids []string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetByIds")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetByIds")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User) where u.id in $ids RETURN u`
 	params := map[string]any{
 		"tenant": tenant,
 		"ids":    ids,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -140,30 +136,29 @@ func (r *userReadRepository) GetByIds(ctx context.Context, tenant string, ids []
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	for _, v := range dbRecords.([]*neo4j.Record) {
 		dbNodes = append(dbNodes, utils.NodePtr(v.Values[0].(neo4j.Node)))
 	}
-	span.LogFields(log.Int("result.count", len(dbNodes)))
+	spans.LogKV("result.count", len(dbNodes))
 	return dbNodes, nil
 }
 
 func (r *userReadRepository) GetUserById(ctx context.Context, tenant, userId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetUserById")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetUserById")
+	defer spans.Finish()
 
-	span.LogFields(log.String("userId", userId))
+	spans.LogKV("userId", userId)
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User {id:$id}) RETURN u`
 	params := map[string]any{
 		"tenant": tenant,
 		"id":     userId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -182,17 +177,16 @@ func (r *userReadRepository) GetUserById(ctx context.Context, tenant, userId str
 }
 
 func (u *userReadRepository) FindPlatformOwners(ctx context.Context) ([]*AuthenticatedUserInTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.FindPlatformOwners")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.FindPlatformOwners")
+	defer spans.Finish()
 
 	cypher := `MATCH (e:Email)-[:HAS{primary:true}]-(u:User)-[:AUTHENTICATED_BY]->(au:AuthenticationUser)-[:HAS_WORKSPACE]->(t:Tenant{name:"customerosai"}), (au)--(a:Authentication{provider:"google"})
 			WHERE 'PLATFORM_OWNER' in u.roles
 			RETURN t.name, au.id, u.id, u.roles, e.rawEmail, u.firstName, u.lastName ORDER BY u.createdAt ASC`
 	params := map[string]any{}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *u.driver)
 	defer session.Close(ctx)
@@ -205,7 +199,7 @@ func (u *userReadRepository) FindPlatformOwners(ctx context.Context) ([]*Authent
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -247,9 +241,8 @@ func (u *userReadRepository) FindPlatformOwners(ctx context.Context) ([]*Authent
 }
 
 func (u *userReadRepository) FindAllUsersWithRolesByEmail(ctx context.Context, email string) ([]*AuthenticatedUserInTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.FindAllUsersWithRoles")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.FindAllUsersWithRoles")
+	defer spans.Finish()
 
 	cypher := `MATCH (e:Email)<-[:HAS]-(u:User)-[:AUTHENTICATED_BY]->(au:AuthenticationUser)-[:HAS_WORKSPACE]->(t:Tenant)
 			WHERE e.email=$email OR e.rawEmail=$email
@@ -257,8 +250,8 @@ func (u *userReadRepository) FindAllUsersWithRolesByEmail(ctx context.Context, e
 	params := map[string]any{
 		"email": email,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *u.driver)
 	defer session.Close(ctx)
@@ -271,7 +264,7 @@ func (u *userReadRepository) FindAllUsersWithRolesByEmail(ctx context.Context, e
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -307,10 +300,10 @@ func (u *userReadRepository) FindAllUsersWithRolesByEmail(ctx context.Context, e
 }
 
 func (u *userReadRepository) GetCurrentTenantByUserEmail(ctx context.Context, email string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetCurrentTenantByUserEmail")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.String("email", email))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetCurrentTenantByUserEmail")
+	defer spans.Finish()
+
+	spans.LogKV("email", email)
 
 	cypher := `MATCH (e:Email)<-[:HAS]-(u:User)-[:AUTHENTICATED_BY]->(au:AuthenticationUser)-[:HAS_WORKSPACE]->(t:Tenant)
 				WHERE toLower(e.email)=$email OR toLower(e.rawEmail)=$email
@@ -321,8 +314,8 @@ func (u *userReadRepository) GetCurrentTenantByUserEmail(ctx context.Context, em
 		"email": strings.ToLower(email),
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *u.driver)
 	defer session.Close(ctx)
@@ -335,26 +328,25 @@ func (u *userReadRepository) GetCurrentTenantByUserEmail(ctx context.Context, em
 		return utils.ExtractAllRecordsAsString(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
 
 	if len(records.([]string)) == 0 {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return "", nil
 	}
-	span.LogFields(log.Bool("result.found", true))
-	span.LogFields(log.String("result.tenant", records.([]string)[0]))
+	spans.LogKV("result.found", true)
+	spans.LogKV("result.tenant", records.([]string)[0])
 	return records.([]string)[0], nil
 }
 
 func (u *userReadRepository) FindFirstUserWithRolesByEmail(ctx context.Context, tenant, email string) (*AuthenticatedUserInTenant, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.FindFirstUserWithRolesByEmail")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.FindFirstUserWithRolesByEmail")
+	defer spans.Finish()
 
-	span.LogFields(log.String("email", email))
-	span.LogFields(log.String("tenant", tenant))
+	spans.LogKV("email", email)
+	spans.LogKV("tenant", tenant)
 
 	cypher := fmt.Sprintf(`
 			MATCH (e:Email_%s)<-[:HAS]-(u:User_%s)-[:AUTHENTICATED_BY]->(au:AuthenticationUser)-[:HAS_WORKSPACE]->(t:Tenant {name: $tenant})
@@ -364,8 +356,8 @@ func (u *userReadRepository) FindFirstUserWithRolesByEmail(ctx context.Context, 
 		"email":  strings.ToLower(email),
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *u.driver)
 	defer session.Close(ctx)
@@ -378,10 +370,10 @@ func (u *userReadRepository) FindFirstUserWithRolesByEmail(ctx context.Context, 
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogKV("result.count", len(records.([]*neo4j.Record)))
+	spans.LogKV("result.count", len(records.([]*neo4j.Record)))
 	if len(records.([]*neo4j.Record)) > 0 {
 		authenticatedUserId := records.([]*neo4j.Record)[0].Values[1].(string)
 		userId := records.([]*neo4j.Record)[0].Values[2].(string)
@@ -398,7 +390,7 @@ func (u *userReadRepository) FindFirstUserWithRolesByEmail(ctx context.Context, 
 			UserId:              userId,
 			Roles:               roles,
 		}
-		tracing.LogObjectAsJson(span, "result", output)
+		spans.LogObjectAsJson("result", output)
 		return &output, nil
 	} else {
 		return nil, nil
@@ -414,9 +406,8 @@ func (u *userReadRepository) toStringList(values []interface{}) []string {
 }
 
 func (r *userReadRepository) GetAuthenticatedUserInTenant(ctx context.Context, authUserId, email string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetAuthenticatedUserInTenant")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetAuthenticatedUserInTenant")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -428,8 +419,8 @@ func (r *userReadRepository) GetAuthenticatedUserInTenant(ctx context.Context, a
 		"email":      strings.ToLower(email),
 		"authUserId": authUserId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -442,23 +433,22 @@ func (r *userReadRepository) GetAuthenticatedUserInTenant(ctx context.Context, a
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *userReadRepository) GetFirstUserByEmail(ctx context.Context, tenant, email string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetFirstUserByEmail")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetFirstUserByEmail")
+	defer spans.Finish()
 
 	cypher := `MATCH (:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)-[:HAS]->(e:Email) 
 			WHERE e.email=$email OR e.rawEmail=$email
@@ -467,8 +457,8 @@ func (r *userReadRepository) GetFirstUserByEmail(ctx context.Context, tenant, em
 		"tenant": tenant,
 		"email":  email,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -481,23 +471,22 @@ func (r *userReadRepository) GetFirstUserByEmail(ctx context.Context, tenant, em
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *userReadRepository) FindTestUser(ctx context.Context) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.FindTestUser")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.FindTestUser")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -507,8 +496,8 @@ func (r *userReadRepository) FindTestUser(ctx context.Context) (*dbtype.Node, er
 	params := map[string]any{
 		"tenant": tenant,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -521,23 +510,22 @@ func (r *userReadRepository) FindTestUser(ctx context.Context) (*dbtype.Node, er
 		}
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
 	if result == nil {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *userReadRepository) GetAllOwnersForOrganizations(ctx context.Context, tenant string, organizationIDs []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetAllOwnersForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetAllOwnersForOrganizations")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(o:Organization)<-[:OWNS]-(u:User)-[:USER_BELONGS_TO_TENANT]->(t)
 			WHERE o.id IN $organizationIds
@@ -546,8 +534,8 @@ func (r *userReadRepository) GetAllOwnersForOrganizations(ctx context.Context, t
 		"tenant":          tenant,
 		"organizationIds": organizationIDs,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -566,17 +554,16 @@ func (r *userReadRepository) GetAllOwnersForOrganizations(ctx context.Context, t
 }
 
 func (r *userReadRepository) GetOwnerForOrganization(ctx context.Context, tenant, organizationId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetOwnerForOrganization")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetOwnerForOrganization")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:ORGANIZATION_BELONGS_TO_TENANT]-(org:Organization {id:$organizationId})<-[:OWNS]-(u:User) RETURN u`
 	params := map[string]any{
 		"tenant":         tenant,
 		"organizationId": organizationId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareReadSession(ctx)
 	defer session.Close(ctx)
@@ -599,9 +586,8 @@ func (r *userReadRepository) GetOwnerForOrganization(ctx context.Context, tenant
 }
 
 func (r *userReadRepository) GetOwnerForContact(parentCtx context.Context, tenant, contactId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetOwnerForContact")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetOwnerForContact")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTACT_BELONGS_TO_TENANT]-(c:Contact {id:$contactId})<-[:OWNS]-(u:User)
 			RETURN u`
@@ -610,8 +596,8 @@ func (r *userReadRepository) GetOwnerForContact(parentCtx context.Context, tenan
 		"contactId": contactId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, nil, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -621,22 +607,21 @@ func (r *userReadRepository) GetOwnerForContact(parentCtx context.Context, tenan
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 	})
 	if err != nil && err.Error() == "Result contains no more records" {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *userReadRepository) GetCreatorForNote(parentCtx context.Context, tenant, noteId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetCreatorForNote")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetCreatorForNote")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)-[:CREATED]->(n:Note {id:$noteId})
 			RETURN u`
@@ -645,8 +630,8 @@ func (r *userReadRepository) GetCreatorForNote(parentCtx context.Context, tenant
 		"noteId": noteId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, nil, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -656,22 +641,21 @@ func (r *userReadRepository) GetCreatorForNote(parentCtx context.Context, tenant
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 	})
 	if err != nil && err.Error() == "Result contains no more records" {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *userReadRepository) GetPaginatedCustomerUsers(parentCtx context.Context, tenant string, skip, limit int, filter *utils.CypherFilter, sort *utils.CypherSort) (*utils.DbNodesWithTotalCount, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetPaginatedCustomerUsers")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetPaginatedCustomerUsers")
+	defer spans.Finish()
 
 	dbNodesWithTotalCount := new(utils.DbNodesWithTotalCount)
 
@@ -715,21 +699,21 @@ func (r *userReadRepository) GetPaginatedCustomerUsers(parentCtx context.Context
 		return queryResult.Collect(ctx)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	for _, v := range dbRecords.([]*neo4j.Record) {
 		dbNodesWithTotalCount.Nodes = append(dbNodesWithTotalCount.Nodes, utils.NodePtr(v.Values[0].(neo4j.Node)))
 	}
-	span.LogFields(log.Int("result.count", len(dbNodesWithTotalCount.Nodes)))
+	spans.LogKV("result.count", len(dbNodesWithTotalCount.Nodes))
 	return dbNodesWithTotalCount, nil
 }
 
 func (r *userReadRepository) GetUsersByEmailIds(parentCtx context.Context, tenant string, emailIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetUsersByEmailIds")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.LogObjectAsJson(span, "emailIds", emailIds)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetUsersByEmailIds")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("emailIds", emailIds)
 	cypher := ` MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)-[:HAS]->(e:Email)-[:EMAIL_ADDRESS_BELONGS_TO_TENANT]->(t)
 			WHERE e.id IN $emailIds
 			RETURN u, e.id as emailId ORDER BY u.firstName, u.lastName`
@@ -737,8 +721,8 @@ func (r *userReadRepository) GetUsersByEmailIds(parentCtx context.Context, tenan
 		"tenant":   tenant,
 		"emailIds": emailIds,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -789,9 +773,8 @@ func (r *userReadRepository) GetUsersByEmailAddresses(ctx context.Context, tenan
 }
 
 func (r *userReadRepository) GetAllForPhoneNumbers(parentCtx context.Context, tenant string, phoneNumberIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetAllForPhoneNumbers")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetAllForPhoneNumbers")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -817,9 +800,8 @@ func (r *userReadRepository) GetAllForPhoneNumbers(parentCtx context.Context, te
 }
 
 func (r *userReadRepository) GetAllOwnersForOpportunities(parentCtx context.Context, tenant string, opportunityIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetAllOwnersForOpportunities")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetAllOwnersForOpportunities")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)-[:OWNS]->(op:Opportunity)
 			WHERE op.id IN $opportunityIds
@@ -828,7 +810,8 @@ func (r *userReadRepository) GetAllOwnersForOpportunities(parentCtx context.Cont
 		"tenant":         tenant,
 		"opportunityIds": opportunityIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -847,9 +830,8 @@ func (r *userReadRepository) GetAllOwnersForOpportunities(parentCtx context.Cont
 }
 
 func (r *userReadRepository) GetAllCreatorsForOpportunities(parentCtx context.Context, tenant string, opportunityIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetAllCreatorsForOpportunities")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetAllCreatorsForOpportunities")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)<-[:CREATED_BY]-(op:Opportunity)
 			WHERE op.id IN $opportunityIds
@@ -858,7 +840,8 @@ func (r *userReadRepository) GetAllCreatorsForOpportunities(parentCtx context.Co
 		"tenant":         tenant,
 		"opportunityIds": opportunityIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -877,9 +860,8 @@ func (r *userReadRepository) GetAllCreatorsForOpportunities(parentCtx context.Co
 }
 
 func (r *userReadRepository) GetAllCreatorsForServiceLineItems(parentCtx context.Context, tenant string, serviceLineItemIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetAllCreatorsForServiceLineItems")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetAllCreatorsForServiceLineItems")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)<-[:CREATED_BY]-(sli:ServiceLineItem)
 			WHERE sli.id IN serviceLineItemIds
@@ -888,7 +870,8 @@ func (r *userReadRepository) GetAllCreatorsForServiceLineItems(parentCtx context
 		"tenant":             tenant,
 		"serviceLineItemIds": serviceLineItemIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -907,9 +890,8 @@ func (r *userReadRepository) GetAllCreatorsForServiceLineItems(parentCtx context
 }
 
 func (r *userReadRepository) GetAllCreatorsForContracts(parentCtx context.Context, tenant string, contractIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetAllCreatorsForContracts")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetAllCreatorsForContracts")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)<-[:CREATED_BY]-(c:Contract)
 			WHERE c.id IN $contractIds
@@ -918,7 +900,8 @@ func (r *userReadRepository) GetAllCreatorsForContracts(parentCtx context.Contex
 		"tenant":      tenant,
 		"contractIds": contractIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -937,9 +920,8 @@ func (r *userReadRepository) GetAllCreatorsForContracts(parentCtx context.Contex
 }
 
 func (r *userReadRepository) GetAllCreatorsForTasks(ctx context.Context, tenant string, taskIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetAllCreatorsForTasks")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetAllCreatorsForTasks")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)<-[:CREATED_BY]-(tsk:Task)
 			WHERE tsk.id IN $taskIds
@@ -948,7 +930,8 @@ func (r *userReadRepository) GetAllCreatorsForTasks(ctx context.Context, tenant 
 		"tenant":  tenant,
 		"taskIds": taskIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -967,9 +950,8 @@ func (r *userReadRepository) GetAllCreatorsForTasks(ctx context.Context, tenant 
 }
 
 func (r *userReadRepository) GetAllAssigneesForTasks(ctx context.Context, tenant string, taskIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetAllAssigneesForTasks")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetAllAssigneesForTasks")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)<-[:ASSIGNED_TO]-(tsk:Task)
 			WHERE tsk.id IN $taskIds
@@ -978,7 +960,8 @@ func (r *userReadRepository) GetAllAssigneesForTasks(ctx context.Context, tenant
 		"tenant":  tenant,
 		"taskIds": taskIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -997,15 +980,15 @@ func (r *userReadRepository) GetAllAssigneesForTasks(ctx context.Context, tenant
 }
 
 func (r *userReadRepository) GetAllAuthorsForLogEntries(parentCtx context.Context, tenant string, logEntryIDs []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetAllAuthorsForLogEntries")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("logEntryIDs", logEntryIDs))
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetAllAuthorsForLogEntries")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("logEntryIDs", logEntryIDs)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)<-[:CREATED_BY]-(l:LogEntry_%s)
 			WHERE l.id IN $logEntryIDs
 			RETURN u, l.id as logEntryId`, tenant)
-	span.LogFields(log.String("cypher", cypher))
+	spans.LogKV("cypher", cypher)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -1028,10 +1011,10 @@ func (r *userReadRepository) GetAllAuthorsForLogEntries(parentCtx context.Contex
 }
 
 func (r *userReadRepository) GetAllAuthorsForComments(parentCtx context.Context, tenant string, commentIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetAllAuthorsForComments")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("commentIds", commentIds))
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetAllAuthorsForComments")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("commentIds", commentIds)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)<-[:CREATED_BY]-(c:Comment_%s)
 			WHERE c.id IN $commentIds
@@ -1040,7 +1023,8 @@ func (r *userReadRepository) GetAllAuthorsForComments(parentCtx context.Context,
 		"tenant":     tenant,
 		"commentIds": commentIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -1059,10 +1043,10 @@ func (r *userReadRepository) GetAllAuthorsForComments(parentCtx context.Context,
 }
 
 func (r *userReadRepository) GetAllSendersForFlowSenders(ctx context.Context, tenant string, flowSenderIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetAllSendersForFlowSenders")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("flowSenderIds", flowSenderIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetAllSendersForFlowSenders")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("flowSenderIds", flowSenderIds)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)<-[:HAS]-(fs:FlowSender_%s)
 			WHERE fs.id IN $flowSenderIds
@@ -1071,7 +1055,8 @@ func (r *userReadRepository) GetAllSendersForFlowSenders(ctx context.Context, te
 		"tenant":        tenant,
 		"flowSenderIds": flowSenderIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -1090,10 +1075,10 @@ func (r *userReadRepository) GetAllSendersForFlowSenders(ctx context.Context, te
 }
 
 func (r *userReadRepository) GetUsersConnectedForContacts(ctx context.Context, tenant string, contactsIds []string) ([]*utils.DbNodeAndId, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetUsersConnectedForContacts")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("contactsIds", contactsIds))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetUsersConnectedForContacts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("contactsIds", contactsIds)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)<-[:CONNECTED_WITH]-(c:Contact_%s)
 			WHERE c.id IN $contactsIds
@@ -1102,7 +1087,8 @@ func (r *userReadRepository) GetUsersConnectedForContacts(ctx context.Context, t
 		"tenant":      tenant,
 		"contactsIds": contactsIds,
 	}
-	span.LogFields(log.String("cypher", cypher), log.Object("params", params))
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -1121,9 +1107,8 @@ func (r *userReadRepository) GetUsersConnectedForContacts(ctx context.Context, t
 }
 
 func (r *userReadRepository) GetDistinctOrganizationOwners(parentCtx context.Context, tenant string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetDistinctOrganizationOwners")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetDistinctOrganizationOwners")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -1148,15 +1133,15 @@ func (r *userReadRepository) GetDistinctOrganizationOwners(parentCtx context.Con
 }
 
 func (r *userReadRepository) GetUsers(ctx context.Context, tenant string, ids []string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserReadRepository.GetUsers")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("ids", ids))
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserReadRepository.GetUsers")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("ids", ids)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User)
 			WHERE u.id IN $ids
 			RETURN u`
-	span.LogFields(log.String("cypher", cypher))
+	spans.LogKV("cypher", cypher)
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver, utils.WithDatabaseName(r.database))
 	defer session.Close(ctx)
@@ -1178,9 +1163,8 @@ func (r *userReadRepository) GetUsers(ctx context.Context, tenant string, ids []
 }
 
 func (r *userReadRepository) GetOwnerForContract(parentCtx context.Context, tenant, contractId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetOwnerForContract")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetOwnerForContract")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:CONTRACT_BELONGS_TO_TENANT]-(c:Contract {id:$contractId})<-[:OWNS]-(u:User)
 			RETURN u`
@@ -1189,8 +1173,8 @@ func (r *userReadRepository) GetOwnerForContract(parentCtx context.Context, tena
 		"contractId": contractId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, nil, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -1200,22 +1184,21 @@ func (r *userReadRepository) GetOwnerForContract(parentCtx context.Context, tena
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 	})
 	if err != nil && err.Error() == "Result contains no more records" {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }
 
 func (r *userReadRepository) GetOwnerForReminder(parentCtx context.Context, tenant, reminderId string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserReadRepository.GetOwnerForReminder")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
+	spans, ctx := telemetry.StartNeo4jSpan(parentCtx, "UserReadRepository.GetOwnerForReminder")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:REMINDER_BELONGS_TO_TENANT]-(r:Reminder {id:$reminderId})-[:REMINDER_BELONGS_TO_USER]->(u:User)
 			RETURN u`
@@ -1224,8 +1207,8 @@ func (r *userReadRepository) GetOwnerForReminder(parentCtx context.Context, tena
 		"reminderId": reminderId,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := utils.ExecuteReadInTransaction(ctx, r.driver, r.database, nil, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
@@ -1235,14 +1218,14 @@ func (r *userReadRepository) GetOwnerForReminder(parentCtx context.Context, tena
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, queryResult, err)
 	})
 	if err != nil && err.Error() == "Result contains no more records" {
-		span.LogFields(log.Bool("result.found", false))
+		spans.LogKV("result.found", false)
 		return nil, nil
 	}
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Bool("result.found", true))
+	spans.LogKV("result.found", true)
 	return result.(*dbtype.Node), nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/user_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/user_write_repository.go
@@ -5,11 +5,10 @@ import (
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+
 	"golang.org/x/net/context"
 )
 
@@ -48,11 +47,11 @@ func (r *userWriteRepository) prepareWriteSession(ctx context.Context) neo4j.Ses
 }
 
 func (r *userWriteRepository) CreateUserInTx(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, userId string, data data_fields.UserFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserWriteRepository.CreateUserInTx")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, userId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserWriteRepository.CreateUserInTx")
+	defer spans.Finish()
+
+	spans.TagEntity(userId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := fmt.Sprintf(`MATCH (t:Tenant {name:$tenant}) 
 		 MERGE (t)<-[:USER_BELONGS_TO_TENANT]-(u:User:User_%s {id:$id}) 
@@ -87,8 +86,8 @@ func (r *userWriteRepository) CreateUserInTx(ctx context.Context, tx *neo4j.Mana
 		"source":          utils.IfNotNilString(data.Source),
 		"appSource":       utils.IfNotNilString(data.AppSource),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		_, err := tx.Run(ctx, cypher, params)
@@ -98,18 +97,18 @@ func (r *userWriteRepository) CreateUserInTx(ctx context.Context, tx *neo4j.Mana
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *userWriteRepository) UpdateUserInTx(ctx context.Context, tx *neo4j.ManagedTransaction, tenant, userId string, data data_fields.UserFields) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserWriteRepository.UpdateUser")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, userId)
-	tracing.LogObjectAsJson(span, "data", data)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserWriteRepository.UpdateUser")
+	defer spans.Finish()
+
+	spans.TagEntity(userId)
+	spans.LogObjectAsJson("data", data)
 
 	cypher := `MATCH (t:Tenant {name:$tenant})<-[:USER_BELONGS_TO_TENANT]-(u:User {id:$id}) SET u.updatedAt=datetime()`
 	params := map[string]any{
@@ -166,8 +165,8 @@ func (r *userWriteRepository) UpdateUserInTx(ctx context.Context, tx *neo4j.Mana
 		cypher += ", u.onboardingMailstackStepCompleted=$onboardingMailstackStepCompleted"
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := r.prepareWriteSession(ctx)
 	defer session.Close(ctx)
@@ -180,32 +179,32 @@ func (r *userWriteRepository) UpdateUserInTx(ctx context.Context, tx *neo4j.Mana
 		return nil, nil
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 
 	return err
 }
 
 func (r *userWriteRepository) AddRole(c context.Context, userId, role string) error {
-	span, ctx := opentracing.StartSpanFromContext(c, "UserWriteRepository.AddRole")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, userId)
-	span.LogFields(log.String("role", role))
+	spans, ctx := telemetry.StartNeo4jSpan(c, "UserWriteRepository.AddRole")
+	defer spans.Finish()
+
+	spans.TagEntity(userId)
+	spans.LogKV("role", role)
 
 	session := r.prepareWriteSession(ctx)
 	defer session.Close(ctx)
 
 	tx, err := session.BeginTransaction(ctx)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	defer tx.Close(ctx)
 
 	err = r.AddRoleInTx(ctx, tx, userId, role)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		_ = tx.Rollback(ctx)
 		return err
 	}
@@ -213,7 +212,7 @@ func (r *userWriteRepository) AddRole(c context.Context, userId, role string) er
 	err = tx.Commit(ctx)
 
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -221,11 +220,11 @@ func (r *userWriteRepository) AddRole(c context.Context, userId, role string) er
 }
 
 func (r *userWriteRepository) AddRoleInTx(c context.Context, tx neo4j.ManagedTransaction, userId, role string) error {
-	span, ctx := opentracing.StartSpanFromContext(c, "UserWriteRepository.AddRoleInTx")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, userId)
-	span.LogFields(log.String("role", role))
+	spans, ctx := telemetry.StartNeo4jSpan(c, "UserWriteRepository.AddRoleInTx")
+	defer spans.Finish()
+
+	spans.TagEntity(userId)
+	spans.LogKV("role", role)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -243,22 +242,22 @@ func (r *userWriteRepository) AddRoleInTx(c context.Context, tx neo4j.ManagedTra
 		"role":   role,
 		"userId": userId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	if err := utils.ExecuteQueryInTx(ctx, tx, cypher, params); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	return nil
 }
 
 func (r *userWriteRepository) RemoveRole(c context.Context, tenant, userId, role string) error {
-	span, ctx := opentracing.StartSpanFromContext(c, "UserWriteRepository.RemoveRole")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, userId)
-	span.LogFields(log.String("role", role))
+	spans, ctx := telemetry.StartNeo4jSpan(c, "UserWriteRepository.RemoveRole")
+	defer spans.Finish()
+
+	spans.TagEntity(userId)
+	spans.LogKV("role", role)
 
 	cypher := `MATCH (u:User {id:$userId})-[:USER_BELONGS_TO_TENANT]->(:Tenant {name:$tenant}) 
 		 	SET u.roles = [item IN u.roles WHERE item <> $role],
@@ -268,21 +267,21 @@ func (r *userWriteRepository) RemoveRole(c context.Context, tenant, userId, role
 		"role":   role,
 		"userId": userId,
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
 func (r *userWriteRepository) RegisterLogin(ctx context.Context, tenant, userId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserWriteRepository.RegisterLogin")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, userId)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "UserWriteRepository.RegisterLogin")
+	defer spans.Finish()
+
+	spans.TagEntity(userId)
 
 	cypher := `MATCH (u:User {id:$userId})-[:USER_BELONGS_TO_TENANT]->(:Tenant {name:$tenant})
 			SET u.lastLogin = $now,
@@ -292,12 +291,12 @@ func (r *userWriteRepository) RegisterLogin(ctx context.Context, tenant, userId 
 		"tenant": tenant,
 		"now":    utils.Now(),
 	}
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, *r.driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }

--- a/packages/server/customer-os-neo4j-repository/repository/utils.go
+++ b/packages/server/customer-os-neo4j-repository/repository/utils.go
@@ -5,55 +5,15 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"time"
 )
-
-func WaitForNodeCreatedInNeo4j(ctx context.Context, repositories *Repositories, id, nodeLabel string, span opentracing.Span) {
-	operation := func() error {
-		found, findErr := repositories.CommonReadRepository.ExistsById(ctx, common.GetTenantFromContext(ctx), id, nodeLabel)
-		if findErr != nil {
-			return findErr
-		}
-		if !found {
-			return errors.New(fmt.Sprintf("Node %s with id %s not found in Neo4j", nodeLabel, id))
-		}
-		return nil
-	}
-
-	err := backoff.Retry(operation, utils.BackOffConfig(100*time.Millisecond, 1.5, 1*time.Second, 5*time.Second, 10))
-	if err != nil {
-		span.LogFields(log.Bool("result.created", false))
-	} else {
-		span.LogFields(log.Bool("result.created", true))
-	}
-}
-
-func WaitForNodeCreatedInNeo4jWithConfig(ctx context.Context, span opentracing.Span, repositories *Repositories, id, nodeLabel string, maxWaitTime time.Duration) {
-	operation := func() error {
-		found, findErr := repositories.CommonReadRepository.ExistsById(ctx, common.GetTenantFromContext(ctx), id, nodeLabel)
-		if findErr != nil {
-			return findErr
-		}
-		if !found {
-			return errors.New(fmt.Sprintf("Node %s with id %s not found in Neo4j", nodeLabel, id))
-		}
-		return nil
-	}
-
-	err := backoff.Retry(operation, utils.BackOffConfig(250*time.Millisecond, 1, 500*time.Millisecond, maxWaitTime, 50))
-	if err != nil {
-		span.LogFields(log.Bool("result.created", false))
-	} else {
-		span.LogFields(log.Bool("result.created", true))
-	}
-}
 
 func WaitForNodeDeletedFromNeo4j(ctx context.Context, repositories *Repositories, id, nodeLabel string, span opentracing.Span) {
 	operation := func() error {
@@ -75,33 +35,19 @@ func WaitForNodeDeletedFromNeo4j(ctx context.Context, repositories *Repositories
 	}
 }
 
-func LogAndExecuteWriteQuery(ctx context.Context, driver neo4j.DriverWithContext, cypher string, params map[string]any, span opentracing.Span) error {
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+func LogAndExecuteWriteQuery(ctx context.Context, driver neo4j.DriverWithContext, cypher string, params map[string]any, spans *telemetry.Spans) error {
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	err := utils.ExecuteWriteQuery(ctx, driver, cypher, params)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 	}
 	return err
 }
 
-func LogAndExecuteWriteQueryInTx(ctx context.Context, tx *neo4j.ManagedTransaction, driver *neo4j.DriverWithContext, database, cypher string, params map[string]any, span opentracing.Span) error {
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
-
-	_, err := utils.ExecuteWriteInTransaction(ctx, driver, database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
-		_, err := tx.Run(ctx, cypher, params)
-		return nil, err
-	})
-	if err != nil {
-		tracing.TraceErr(span, err)
-	}
-	return err
-}
-
-func LogAndExecuteWriteQueryInTxV2(ctx context.Context, tx *neo4j.ManagedTransaction, driver *neo4j.DriverWithContext, database, cypher string, params map[string]any, spans *telemetry.Spans) error {
-	spans.LogFields(log.String("cypher", cypher))
+func LogAndExecuteWriteQueryInTx(ctx context.Context, tx *neo4j.ManagedTransaction, driver *neo4j.DriverWithContext, database, cypher string, params map[string]any, spans *telemetry.Spans) error {
+	spans.LogKV("cypher", cypher)
 	spans.LogObjectAsJson("params", params)
 
 	_, err := utils.ExecuteWriteInTransaction(ctx, driver, database, tx, func(tx neo4j.ManagedTransaction) (any, error) {

--- a/packages/server/customer-os-neo4j-repository/repository/workspace_read_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/workspace_read_repository.go
@@ -3,12 +3,10 @@ package neo4j_repository
 import (
 	"context"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type WorkspaceReadRepository interface {
@@ -30,10 +28,8 @@ func NewWorkspaceReadRepository(driver *neo4j.DriverWithContext, database string
 }
 
 func (r *workspaceReadRepository) GetAllForTenant(ctx context.Context, tenant string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WorkspaceReadRepository.GetAllForTenant")
-	defer span.Finish()
-
-	span.SetTag(tracing.SpanTagTenant, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "WorkspaceReadRepository.GetAllForTenant")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -43,26 +39,24 @@ func (r *workspaceReadRepository) GetAllForTenant(ctx context.Context, tenant st
 		"tenant": tenant,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
 		queryResult, err := tx.Run(ctx, cypher, params)
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), nil
 }
 
 func (r *workspaceReadRepository) GetByName(ctx context.Context, tenant, name string) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WorkspaceReadRepository.GetByName")
-	defer span.Finish()
-
-	span.SetTag(tracing.SpanTagTenant, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "WorkspaceReadRepository.GetByName")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -86,17 +80,16 @@ func (r *workspaceReadRepository) GetByName(ctx context.Context, tenant, name st
 }
 
 func (r *workspaceReadRepository) GetByNameCrossTenant(ctx context.Context, name string) ([]*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WorkspaceReadRepository.GetByNameCrossTenant")
-	defer span.Finish()
-	tracing.TagComponentNeo4jRepository(span)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "WorkspaceReadRepository.GetByNameCrossTenant")
+	defer spans.Finish()
 
 	cypher := `MATCH (t:Tenant)--(w:Workspace{name:$workspaceName}) return w`
 	params := map[string]any{
 		"workspaceName": name,
 	}
 
-	span.LogFields(log.String("cypher", cypher))
-	tracing.LogObjectAsJson(span, "params", params)
+	spans.LogKV("cypher", cypher)
+	spans.LogObjectAsJson("params", params)
 
 	session := utils.NewNeo4jWriteSession(ctx, *r.driver)
 	defer session.Close(ctx)
@@ -106,11 +99,11 @@ func (r *workspaceReadRepository) GetByNameCrossTenant(ctx context.Context, name
 		return utils.ExtractAllRecordsFirstValueAsDbNodePtrs(ctx, queryResult, err)
 	})
 	if err != nil {
-		span.LogFields(log.Bool("result.found", false))
-		tracing.TraceErr(span, err)
+		spans.LogKV("result.found", false)
+		spans.TraceError(err)
 		return nil, err
 	}
 
-	span.LogFields(log.Int("result.count", len(result.([]*dbtype.Node))))
+	spans.LogKV("result.count", len(result.([]*dbtype.Node)))
 	return result.([]*dbtype.Node), nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/workspace_write_repository.go
+++ b/packages/server/customer-os-neo4j-repository/repository/workspace_write_repository.go
@@ -2,13 +2,11 @@ package neo4j_repository
 
 import (
 	"context"
-	"github.com/opentracing/opentracing-go/log"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
 
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 )
@@ -30,10 +28,8 @@ func NewWorkspaceWriteRepository(driver *neo4j.DriverWithContext, database strin
 }
 
 func (r *workspaceWriteRepository) Merge(ctx context.Context, tx *neo4j.ManagedTransaction, tenant string, workspace neo4j_entity.WorkspaceEntity) (*dbtype.Node, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WorkspaceWriteRepository.Merge")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	tracing.TagTenant(span, tenant)
+	spans, ctx := telemetry.StartNeo4jSpan(ctx, "WorkspaceWriteRepository.Merge")
+	defer spans.Finish()
 
 	cypher := `
 				MATCH (t:Tenant {name: $tenant}) 
@@ -55,8 +51,8 @@ func (r *workspaceWriteRepository) Merge(ctx context.Context, tx *neo4j.ManagedT
 		"source":    utils.StringFirstNonEmpty(workspace.Source.String(), neo4j_entity.DataSourceOpenline.String()),
 		"appSource": workspace.AppSource,
 	}
-	tracing.LogObjectAsJson(span, "params", params)
-	span.LogFields(log.String("cypher", cypher))
+	spans.LogObjectAsJson("params", params)
+	spans.LogKV("cypher", cypher)
 
 	queryResult, err := utils.ExecuteWriteInTransaction(ctx, r.driver, r.database, tx, func(tx neo4j.ManagedTransaction) (any, error) {
 		qr, err := tx.Run(ctx, cypher, params)
@@ -66,7 +62,7 @@ func (r *workspaceWriteRepository) Merge(ctx context.Context, tx *neo4j.ManagedT
 		return utils.ExtractSingleRecordFirstValueAsNode(ctx, qr, err)
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `opentracing` with `telemetry` for tracing in Neo4j repository methods, updating span management and logging across multiple files.
> 
>   - **Tracing Updates**:
>     - Replace `opentracing` with `telemetry` for span management in methods across multiple files.
>     - Update span creation and logging in `tenant_read_repository.go`, `tenant_write_repository.go`, `timeline_event_read_repository.go`, `user_read_repository.go`, `user_write_repository.go`, `utils.go`, and `workspace_read_repository.go`.
>     - Ensure consistent logging of `cypher` queries and parameters using `spans.LogKV` and `spans.LogObjectAsJson`.
>   - **Error Handling**:
>     - Use `spans.TraceError` for error logging instead of `tracing.TraceErr`.
>   - **Miscellaneous**:
>     - Remove unused `opentracing` imports and related code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for ab5acfd0da50390b4cc5efb35f0e8932ebe8a227. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->