### PR TITLE
Upload file from url

### DIFF
--- a/packages/server/customer-os-api/rest/files/files.go
+++ b/packages/server/customer-os-api/rest/files/files.go
@@ -184,7 +184,7 @@ func (h *FileHandler) UploadWorkspaceLogo() gin.HandlerFunc {
 		}
 
 		// Get the public URL
-		publicUrl := h.services.CommonServices.MediaService.GetR2PublicURL(storageKey)
+		publicUrl := h.services.CommonServices.MediaService.GetR2ImagePublicURL(storageKey)
 
 		err = h.services.CommonServices.TenantSettingsService.UpdateTenantSettings(ctx, data_fields.TenantSettingsFields{
 			WorkspaceLogoKey: &storageKey,

--- a/packages/server/customer-os-api/server/route_registry.go
+++ b/packages/server/customer-os-api/server/route_registry.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"strings"
-
 	commoncaches "github.com/customeros/customeros/packages/server/customer-os-common-module/caches"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/security"
 	"github.com/gin-gonic/gin"
@@ -76,14 +74,6 @@ func registerRoute(ctx context.Context, r *gin.Engine, config RouteConfig) {
 		)
 
 	case RouteFiles:
-		if strings.Contains(config.path, "workspace-logo") {
-			middlewares = append(middlewares,
-				security.ApiKeyCheckerHTTP(
-					config.services.Repositories.PostgresRepositories.TenantWebhookApiKeyRepository,
-					config.services.Cfg.App.AppKey,
-					security.WithCache(config.cache),
-				))
-		}
 		middlewares = append(middlewares,
 			config.services.JWTService.GetJWTTenantUserEnhancer(),
 			enrichContextMiddleware(constants.AppSourceCustomerOsApiRest),

--- a/packages/server/customer-os-common-module/interfaces/media.go
+++ b/packages/server/customer-os-common-module/interfaces/media.go
@@ -14,5 +14,5 @@ type MediaService interface {
 
 	UploadImageDataToR2(ctx context.Context, data []byte, r2FilePath, fileName string, generateNewFileName bool) (string, error)
 
-	GetR2PublicURL(storageKey string) string
+	GetR2ImagePublicURL(storageKey string) string
 }

--- a/packages/server/customer-os-common-module/services/media/service.go
+++ b/packages/server/customer-os-common-module/services/media/service.go
@@ -3,10 +3,12 @@ package media
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
+	"io"
 	"net/http"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
@@ -188,6 +190,80 @@ func (s *mediaService) UploadImageDataToR2(ctx context.Context, data []byte, r2F
 	return storageKey, nil
 }
 
+func (s *mediaService) UploadImageToR2(ctx context.Context, imageURL string, r2FilePath string, generateNewFileName bool) (string, error) {
+	spans, ctx := telemetry.StartServiceSpan(ctx, "MediaService.UploadImageToR2")
+	defer spans.Finish()
+	spans.LogKV("imageURL", imageURL)
+	spans.LogKV("r2FilePath", r2FilePath)
+	spans.LogKV("generateNewFileName", generateNewFileName)
+
+	if imageURL == "" {
+		err := errors.New("imageURL cannot be empty")
+		spans.TraceError(err)
+		return "", err
+	}
+	if r2FilePath == "" {
+		err := errors.New("r2FilePath cannot be empty")
+		spans.TraceError(err)
+		return "", err
+	}
+
+	// Get the image from the URL
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+	if err != nil {
+		spans.TraceError(err)
+		return "", err
+	}
+
+	// Add User-Agent to avoid being blocked
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
+	req.Header.Set("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+
+	// Send the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		spans.TraceError(err)
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// Check if request was successful
+	if resp.StatusCode != http.StatusOK {
+		spans.LogKV("response.statusCode", resp.StatusCode)
+		switch {
+		case resp.StatusCode == http.StatusNotFound:
+			return "", coserrors.ErrResourceNotFound
+		case resp.StatusCode == http.StatusForbidden:
+			return "", coserrors.ErrResourceForbidden
+		default:
+			err := errors.New("failed to download image")
+			spans.TraceError(err)
+			return "", err
+		}
+	}
+
+	// Read the entire response body
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		spans.TraceError(err)
+		return "", errors.Wrap(err, "failed to read image data")
+	}
+
+	// Extract filename from URL
+	fileName := filepath.Base(imageURL)
+	if fileName == "" || fileName == "." {
+		// If we can't get a filename from URL, generate one with extension based on content type
+		contentType := resp.Header.Get("Content-Type")
+		ext := detectExtension(contentType, imageURL)
+		fileName = "image" + ext
+	}
+
+	// Upload to R2 using the existing method
+	return s.UploadImageDataToR2(ctx, data, r2FilePath, fileName, generateNewFileName)
+}
+
 // detectExtension determines the appropriate file extension based on content type
 // and falls back to extracting from URL if content type is not recognized
 func detectExtension(contentType, url string) string {
@@ -239,6 +315,6 @@ func getContentTypeFromExtension(fileName string) string {
 	}
 }
 
-func (s *mediaService) GetR2PublicURL(storageKey string) string {
+func (s *mediaService) GetR2ImagePublicURL(storageKey string) string {
 	return s.r2ImageStoragePublic.GetPublicURL(storageKey)
 }

--- a/packages/server/customer-os-common-module/services/storage/helpers.go
+++ b/packages/server/customer-os-common-module/services/storage/helpers.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/constants"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/clients/aws_client"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
@@ -33,5 +34,6 @@ func NewR2StorageService(accountID, accessKeyID, accessKeySecret, bucketName str
 	return NewStorageService(r2Client, StorageConfig{
 		BucketName: bucketName,
 		IsPublic:   isPublic,
+		CDNDomain:  constants.R2ImagesCDN,
 	})
 }

--- a/packages/server/customer-os-common-module/services/storage/service.go
+++ b/packages/server/customer-os-common-module/services/storage/service.go
@@ -89,7 +89,7 @@ func (s *ObjectStorageService) Delete(ctx context.Context, key string) error {
 func (s *ObjectStorageService) GetPublicURL(key string) string {
 	// Use CDN domain if provided
 	if s.cdnDomain != "" {
-		return "https://" + s.cdnDomain + "/" + key
+		return s.cdnDomain + key
 	}
 
 	return ""


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `UploadImageToR2()` to upload images from URLs to R2 storage, updates interfaces, and modifies route middleware.
> 
>   - **New Functionality**:
>     - Adds `UploadImageToR2()` in `service.go` to upload images from a URL to R2 storage.
>     - Handles empty `imageURL` and `r2FilePath` cases, logs errors, and returns specific errors for HTTP status codes.
>   - **Interface Changes**:
>     - Renames `GetR2PublicURL()` to `GetR2ImagePublicURL()` in `media.go`.
>   - **Route and Middleware**:
>     - Removes `ApiKeyCheckerHTTP` middleware for `RouteFiles` in `route_registry.go`.
>   - **Storage Service**:
>     - Updates `GetPublicURL()` in `service.go` to use `cdnDomain` directly for public URLs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 51d9ff8fb9600ce7ddf543849749f85e6c5131d7. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->