### PR TITLE
reschedule meeting by event id

### DIFF
--- a/packages/server/customer-os-api/graphql/resolver/cache.resolvers_it_test.go
+++ b/packages/server/customer-os-api/graphql/resolver/cache.resolvers_it_test.go
@@ -121,7 +121,7 @@ func TestQueryGlobalCache_Has_Logo(t *testing.T) {
 	})
 
 	neo4jtest.CreateTenantSettings(ctx, driver, tenantName, neo4jentity.TenantSettingsEntity{
-		LogoRepositoryFileId: "1",
+		WorkspaceLogoKey: "path/to/logo.png",
 	})
 	neo4jt.CreateAttachment(ctx, driver, tenantName, neo4jentity.AttachmentEntity{
 		Id:     "1",

--- a/packages/server/customer-os-api/rest/public/calendar.go
+++ b/packages/server/customer-os-api/rest/public/calendar.go
@@ -52,6 +52,7 @@ type bookMeetingRequest struct {
 	Email      string `json:"email"`
 	Phone      string `json:"phone"`
 	Reason     string `json:"reason"`
+	EventId    string `json:"eventId"`
 }
 
 type timezoneResponse struct {
@@ -62,7 +63,6 @@ type timezoneResponse struct {
 type cancelMeetingRequest struct {
 	CalendarId string `json:"calendarId"`
 	EventId    string `json:"eventId"`
-	Email      string `json:"email"` //previously used, to be removed
 }
 
 type BookedMeetingResponse struct {
@@ -365,7 +365,7 @@ func BookMeeting(s *cosapi_services.Services) gin.HandlerFunc {
 		spans.TagTenant(meetingBookingEvent.Tenant)
 
 		// Create meeting
-		bookMeetingResult, err := s.CommonServices.MeetingService.BookMeeting(ctx, meetingBookingEvent.ID, *startTime, request.Timezone, request.Name, request.Email, request.Phone, "", false)
+		bookMeetingResult, err := s.CommonServices.MeetingService.BookMeeting(ctx, meetingBookingEvent.ID, *startTime, request.Timezone, request.Name, request.Email, request.Phone, "")
 		if err != nil {
 			s.Log.Error("Failed to create meeting: %v", err)
 			if errors.Is(err, coserrors.ErrSlotNotAvailable) {
@@ -496,6 +496,12 @@ func RescheduleMeeting(s *cosapi_services.Services) gin.HandlerFunc {
 			return
 		}
 
+		// Event id is required
+		if request.EventId == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "missing eventId in request"})
+			return
+		}
+
 		// Calendar id is required
 		if request.CalendarId == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "missing calendarId in request"})
@@ -525,7 +531,7 @@ func RescheduleMeeting(s *cosapi_services.Services) gin.HandlerFunc {
 		spans.TagTenant(meetingBookingEvent.Tenant)
 
 		// Create meeting
-		bookMeetingResult, err := s.CommonServices.MeetingService.RescheduleMeeting(ctx, meetingBookingEvent.ID, *startTime, request.Timezone, request.Email, request.Name, request.Phone, request.Reason)
+		bookMeetingResult, err := s.CommonServices.MeetingService.RescheduleMeeting(ctx, meetingBookingEvent.ID, *startTime, request.Timezone, request.Email, request.Name, request.Phone, request.Reason, request.EventId)
 		if err != nil {
 			s.Log.Error("Failed to reschedule meeting: %v", err)
 			if errors.Is(err, coserrors.ErrSlotNotAvailable) {
@@ -533,7 +539,7 @@ func RescheduleMeeting(s *cosapi_services.Services) gin.HandlerFunc {
 			} else if errors.Is(err, coserrors.ErrEmailNotDeliverable) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "Email address is not deliverable. Please provide a valid email address."})
 			} else if errors.Is(err, coserrors.ErrMeetingNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "Active meeting for this email not found"})
+				c.JSON(http.StatusNotFound, gin.H{"error": "Calendar event not found"})
 			} else {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to reschedule meeting"})
 			}

--- a/packages/server/customer-os-common-module/interfaces/meeting.go
+++ b/packages/server/customer-os-common-module/interfaces/meeting.go
@@ -50,7 +50,7 @@ type MeetingService interface {
 	GetCalendarAvailability(ctx context.Context, meetingBookingEventID string, startTime time.Time, endTime time.Time, timezone string) (*CalendarAvailabilityResult, error)
 	GetAvailableCalendarParticipantEmailsForTimeRange(ctx context.Context, meetingBookingEventID string, startTime, endTime time.Time) ([]string, error)
 
-	BookMeeting(ctx context.Context, meetingBookingEventID string, startTime time.Time, timezone, name, email, phone, reason string, isReschedule bool) (*BookMeetingResult, error)
+	BookMeeting(ctx context.Context, meetingBookingEventID string, startTime time.Time, timezone, name, email, phone, reason string) (*BookMeetingResult, error)
 	CancelMeeting(ctx context.Context, meetingBookingEventID, eventID string) error
-	RescheduleMeeting(ctx context.Context, meetingBookingEventID string, startTime time.Time, timezone, clientEmail, clientName, clientPhone, rescheduleReason string) (*BookMeetingResult, error)
+	RescheduleMeeting(ctx context.Context, meetingBookingEventID string, startTime time.Time, timezone, clientEmail, clientName, clientPhone, rescheduleReason, eventID string) (*BookMeetingResult, error)
 }

--- a/packages/server/customer-os-common-module/services/meeting/service.go
+++ b/packages/server/customer-os-common-module/services/meeting/service.go
@@ -783,7 +783,7 @@ func (s *meetingService) GetAvailableCalendarParticipantEmailsForTimeRange(ctx c
 }
 
 // BookMeeting implements interfaces.MeetingService
-func (s *meetingService) BookMeeting(ctx context.Context, meetingBookingEventID string, startTime time.Time, timezone, clientName, clientEmail, clientPhone, reason string, isReschedule bool) (*interfaces.BookMeetingResult, error) {
+func (s *meetingService) BookMeeting(ctx context.Context, meetingBookingEventID string, startTime time.Time, timezone, clientName, clientEmail, clientPhone, reason string) (*interfaces.BookMeetingResult, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.BookMeeting")
 	defer spans.Finish()
 	spans.LogObjectAsJson("request", map[string]interface{}{
@@ -794,7 +794,6 @@ func (s *meetingService) BookMeeting(ctx context.Context, meetingBookingEventID 
 		"clientEmail":           clientEmail,
 		"clientPhone":           clientPhone,
 		"reason":                reason,
-		"isReschedule":          isReschedule,
 	})
 
 	// validate tenant
@@ -817,37 +816,6 @@ func (s *meetingService) BookMeeting(ctx context.Context, meetingBookingEventID 
 
 	if timezone == "" {
 		timezone = postgresEntity.DefaultTimezone
-	}
-
-	if !isReschedule {
-		// check if meeting already exists
-		existingMeetingBookedEvent, err := s.getMeetingBookedEvent(ctx, meetingBookingEventID, clientEmail)
-		if err != nil {
-			spans.TraceError(err)
-			return nil, fmt.Errorf("failed to check if meeting already exists: %v", err)
-		}
-		if existingMeetingBookedEvent != nil {
-			startTimeInTimeZone, err := utils.GetTimeInTimeZone(existingMeetingBookedEvent.StartTime, timezone)
-			if err != nil {
-				spans.TraceError(err)
-				startTimeInTimeZone = existingMeetingBookedEvent.StartTime
-			}
-			endTimeInTimeZone, err := utils.GetTimeInTimeZone(existingMeetingBookedEvent.EndTime, timezone)
-			if err != nil {
-				spans.TraceError(err)
-				endTimeInTimeZone = existingMeetingBookedEvent.EndTime
-			}
-			result := interfaces.BookMeetingResult{
-				StartTime: startTimeInTimeZone,
-				EndTime:   endTimeInTimeZone,
-				HostEmail: existingMeetingBookedEvent.HostEmail,
-				HostName:  existingMeetingBookedEvent.HostName,
-				EventID:   existingMeetingBookedEvent.NylasEventID,
-			}
-
-			spans.LogObjectAsJson("result", result)
-			return &result, coserrors.ErrMeetingAlreadyExists
-		}
 	}
 
 	// validate client email address
@@ -1072,7 +1040,7 @@ func (s *meetingService) cancelBookedMeeting(ctx context.Context, meetingBookedE
 }
 
 // RescheduleMeeting implements interfaces.MeetingService
-func (s *meetingService) RescheduleMeeting(ctx context.Context, meetingBookingEventID string, startTime time.Time, timezone, clientEmail, clientName, clientPhone, rescheduleReason string) (*interfaces.BookMeetingResult, error) {
+func (s *meetingService) RescheduleMeeting(ctx context.Context, meetingBookingEventID string, startTime time.Time, timezone, clientEmail, clientName, clientPhone, rescheduleReason, eventID string) (*interfaces.BookMeetingResult, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.RescheduleMeeting")
 	defer spans.Finish()
 	spans.LogObjectAsJson("request", map[string]interface{}{
@@ -1083,6 +1051,7 @@ func (s *meetingService) RescheduleMeeting(ctx context.Context, meetingBookingEv
 		"clientName":            clientName,
 		"clientPhone":           clientPhone,
 		"rescheduleReason":      rescheduleReason,
+		"eventID":               eventID,
 	})
 
 	// validate tenant
@@ -1093,18 +1062,20 @@ func (s *meetingService) RescheduleMeeting(ctx context.Context, meetingBookingEv
 	}
 	tenant := common.GetTenantFromContext(ctx)
 
-	meetingBookedEvent, err := s.postgres.MeetingBookedEventRepository.GetActiveFirstUpcomingByMeetingBookingEventIDAndClientEmail(ctx, tenant, meetingBookingEventID, clientEmail)
+	meetingBookedEvent, err := s.postgres.MeetingBookedEventRepository.GetByEventID(ctx, tenant, meetingBookingEventID, eventID)
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to get meeting booked event: %v", err)
 	}
 	if meetingBookedEvent == nil {
-		spans.LogKV("meetingBookedEventId", "not-found")
-	} else {
-		spans.LogKV("meetingBookedEventId", meetingBookedEvent.ID)
+		return nil, coserrors.ErrMeetingNotFound
 	}
 
-	bookedMeeting, err := s.BookMeeting(ctx, meetingBookingEventID, startTime, timezone, clientName, clientEmail, clientPhone, rescheduleReason, true)
+	if meetingBookedEvent.ClientEmail != clientEmail {
+		return nil, fmt.Errorf("meeting event does not match given email")
+	}
+
+	bookedMeeting, err := s.BookMeeting(ctx, meetingBookingEventID, startTime, timezone, clientName, clientEmail, clientPhone, rescheduleReason)
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to book meeting: %v", err)
@@ -1133,14 +1104,16 @@ func (s *meetingService) RescheduleMeeting(ctx context.Context, meetingBookingEv
 
 // get meeting booked event by meeting booking event id and client email
 // also check nylas event id, if not found cancel the event
-func (s *meetingService) getMeetingBookedEvent(ctx context.Context, meetingBookingEventID, clientEmail string) (*postgresEntity.MeetingBookedEvent, error) {
+func (s *meetingService) cancelMeetingIfNylasEventNotFoundOrCancelled(ctx context.Context, meetingBookingEventID, eventID string) (*postgresEntity.MeetingBookedEvent, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.getMeetingBookedEvent")
 	defer spans.Finish()
+	spans.LogKV("meetingBookingEventID", meetingBookingEventID)
+	spans.LogKV("eventID", eventID)
 
 	tenant := common.GetTenantFromContext(ctx)
 
 	// check if meeting already exists
-	existingMeetingBookedEvent, err := s.postgres.MeetingBookedEventRepository.GetActiveFirstUpcomingByMeetingBookingEventIDAndClientEmail(ctx, tenant, meetingBookingEventID, clientEmail)
+	existingMeetingBookedEvent, err := s.postgres.MeetingBookedEventRepository.GetByEventID(ctx, tenant, meetingBookingEventID, eventID)
 	if err != nil {
 		spans.TraceError(err)
 		return nil, fmt.Errorf("failed to check if meeting already exists: %v", err)
@@ -1155,7 +1128,7 @@ func (s *meetingService) getMeetingBookedEvent(ctx context.Context, meetingBooki
 		spans.TraceError(err)
 	}
 	if nylasEvent == nil || nylasEvent.Data.Status == "cancelled" {
-		err = s.CancelMeeting(ctx, meetingBookingEventID, clientEmail)
+		err = s.CancelMeeting(ctx, meetingBookingEventID, eventID)
 		if err != nil {
 			spans.TraceError(err)
 		}

--- a/packages/server/customer-os-postgres-repository/repository/meeting_booked_event_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/meeting_booked_event_repository.go
@@ -5,17 +5,15 @@ import (
 	"errors"
 
 	telemetry "github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
+	postgresEntity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	"gorm.io/gorm"
 )
 
 type MeetingBookedEventRepository interface {
-	Create(ctx context.Context, meetingBookedEvent *postgres_entity.MeetingBookedEvent) error
+	Create(ctx context.Context, meetingBookedEvent *postgresEntity.MeetingBookedEvent) error
 	Cancel(ctx context.Context, id string) error
-	DeleteByConditions(ctx context.Context, conditions *postgres_entity.MeetingBookedEvent) error
-	GetByEventID(ctx context.Context, tenant, meetingBookingEventID, eventID string) (*postgres_entity.MeetingBookedEvent, error)
-	GetActiveFirstUpcomingByMeetingBookingEventIDAndClientEmail(ctx context.Context, tenant, meetingBookingEventID, clientEmail string) (*postgres_entity.MeetingBookedEvent, error)
+	DeleteByConditions(ctx context.Context, conditions *postgresEntity.MeetingBookedEvent) error
+	GetByEventID(ctx context.Context, tenant, meetingBookingEventID, eventID string) (*postgresEntity.MeetingBookedEvent, error)
 }
 
 type meetingBookedEventRepository struct {
@@ -26,32 +24,11 @@ func NewMeetingBookedEventRepository(gormDb *gorm.DB) MeetingBookedEventReposito
 	return &meetingBookedEventRepository{gormDb: gormDb}
 }
 
-func (r *meetingBookedEventRepository) Create(ctx context.Context, meetingBookedEvent *postgres_entity.MeetingBookedEvent) error {
+func (r *meetingBookedEventRepository) Create(ctx context.Context, meetingBookedEvent *postgresEntity.MeetingBookedEvent) error {
 	spans, _ := telemetry.StartPostgresSpan(ctx, "MeetingBookedEventRepository.Create")
 	defer spans.Finish()
 
 	return r.gormDb.Create(meetingBookedEvent).Error
-}
-
-func (r *meetingBookedEventRepository) GetActiveFirstUpcomingByMeetingBookingEventIDAndClientEmail(ctx context.Context, tenant, meetingBookingEventID, clientEmail string) (*postgres_entity.MeetingBookedEvent, error) {
-	spans, _ := telemetry.StartPostgresSpan(ctx, "MeetingBookedEventRepository.GetActiveFirstUpcomingByMeetingBookingEventIDAndClientEmail")
-	defer spans.Finish()
-	spans.LogKV("meetingBookingEventID", meetingBookingEventID)
-	spans.LogKV("clientEmail", clientEmail)
-
-	var meetingBookedEvent postgres_entity.MeetingBookedEvent
-	err := r.gormDb.Where("tenant = ? AND meeting_booking_event_id = ? AND client_email = ? AND canceled = false AND start_time > ?", tenant, meetingBookingEventID, clientEmail, utils.Now()).
-		Order("start_time ASC").
-		First(&meetingBookedEvent).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
-		spans.TraceError(err)
-		return nil, err
-	}
-
-	return &meetingBookedEvent, nil
 }
 
 func (r *meetingBookedEventRepository) Cancel(ctx context.Context, id string) error {
@@ -59,15 +36,15 @@ func (r *meetingBookedEventRepository) Cancel(ctx context.Context, id string) er
 	defer spans.Finish()
 	spans.TagEntity(id)
 
-	return r.gormDb.Model(&postgres_entity.MeetingBookedEvent{}).Where("id = ?", id).Update("canceled", true).Error
+	return r.gormDb.Model(&postgresEntity.MeetingBookedEvent{}).Where("id = ?", id).Update("canceled", true).Error
 }
 
-func (r *meetingBookedEventRepository) DeleteByConditions(ctx context.Context, conditions *postgres_entity.MeetingBookedEvent) error {
+func (r *meetingBookedEventRepository) DeleteByConditions(ctx context.Context, conditions *postgresEntity.MeetingBookedEvent) error {
 	spans, _ := telemetry.StartPostgresSpan(ctx, "MeetingBookedEventRepository.DeleteByConditions")
 	defer spans.Finish()
 	spans.LogObjectAsJson("conditions", conditions)
 
-	query := r.gormDb.Model(&postgres_entity.MeetingBookedEvent{})
+	query := r.gormDb.Model(&postgresEntity.MeetingBookedEvent{})
 
 	// Build where conditions based on provided fields
 	if conditions.Tenant != "" {
@@ -83,16 +60,16 @@ func (r *meetingBookedEventRepository) DeleteByConditions(ctx context.Context, c
 		query = query.Where("start_time = ?", conditions.StartTime)
 	}
 
-	return query.Delete(&postgres_entity.MeetingBookedEvent{}).Error
+	return query.Delete(&postgresEntity.MeetingBookedEvent{}).Error
 }
 
-func (r *meetingBookedEventRepository) GetByEventID(ctx context.Context, tenant, meetingBookingEventID, eventID string) (*postgres_entity.MeetingBookedEvent, error) {
+func (r *meetingBookedEventRepository) GetByEventID(ctx context.Context, tenant, meetingBookingEventID, eventID string) (*postgresEntity.MeetingBookedEvent, error) {
 	spans, _ := telemetry.StartPostgresSpan(ctx, "MeetingBookedEventRepository.GetByEventID")
 	defer spans.Finish()
 	spans.LogKV("meetingBookingEventID", meetingBookingEventID)
 	spans.LogKV("eventID", eventID)
 
-	var meetingBookedEvent postgres_entity.MeetingBookedEvent
+	var meetingBookedEvent postgresEntity.MeetingBookedEvent
 	err := r.gormDb.Where("tenant = ? AND meeting_booking_event_id = ? AND nylas_event_id = ?", tenant, meetingBookingEventID, eventID).First(&meetingBookedEvent).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance meeting rescheduling by using event IDs for identification and validation across API and service layers.
> 
>   - **Behavior**:
>     - `RescheduleMeeting` in `calendar.go` now requires `eventId` and checks for its presence, returning a 400 error if missing.
>     - `RescheduleMeeting` in `service.go` now uses `eventId` to fetch and validate meetings, ensuring the event matches the given email.
>     - `CancelMeeting` in `service.go` and `calendar.go` now uses `eventId` to identify meetings.
>   - **Interfaces**:
>     - `RescheduleMeeting` and `CancelMeeting` in `meeting.go` updated to include `eventId` parameter.
>   - **Repository**:
>     - `GetByEventID` in `meeting_booked_event_repository.go` now fetches meetings using `eventId`.
>   - **Misc**:
>     - Removed `isReschedule` parameter from `BookMeeting` in `meeting.go` and `service.go`.
>     - Updated error messages in `calendar.go` for better clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 8549ecef14a442002c625c086518d5d19c6cbefb. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->