### PR TITLE
patch: remove migration cmd

### DIFF
--- a/packages/server/core-crm/main.go
+++ b/packages/server/core-crm/main.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"os"
 
 	"github.com/customeros/customeros/packages/server/core-crm/internal/config"
 	"github.com/customeros/customeros/packages/server/core-crm/internal/database"
@@ -11,14 +9,6 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Println("Usage: go run <command>")
-		fmt.Println("Commands:")
-		fmt.Println("  migrate   Run database migrations")
-		fmt.Println("  server    Start the application server")
-		os.Exit(1)
-	}
-
 	cfg, err := config.InitConfig()
 	if err != nil {
 		log.Fatalf("Config initialization failed: %v", err)
@@ -43,43 +33,17 @@ func main() {
 		log.Fatalf("Warehouse database initialization failed: %v", err)
 	}
 
-	switch os.Args[1] {
-	case "migrate":
-		// Run Mailstack database migrations
-		// err := repository.MigrateInboxDB(cfg.InboxDatabaseConfig, inboxDB)
-		// if err != nil {
-		// 	log.Fatalf("Inbox database migration failed: %v", err)
-		// }
-		// log.Println("Inbox database migration completed successfully")
-		//
-		// // Run DataWarehouse migrations
-		// err = repository.MigrateDataWarehouse(cfg.DataWarehouseConfig, warehouseDB)
-		// if err != nil {
-		// 	log.Fatalf("Warehouse database migration failed: %v", err)
-		// }
-		// log.Println("Warehouse database migration completed successfully")
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	log.Println("Core CRM starting up...")
 
-	case "server":
-		log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
-		log.Println("Core CRM starting up...")
+	srv, err := server.NewServer(cfg, warehouseDB)
+	if err != nil {
+		log.Fatalf("Server setup failed: %v", err)
+	}
 
-		srv, err := server.NewServer(cfg, warehouseDB)
-		if err != nil {
-			log.Fatalf("Server setup failed: %v", err)
-		}
-
-		// Start the server
-		err = srv.Run()
-		if err != nil {
-			log.Fatalf("Server startup failed: %v", err)
-		}
-
-	default:
-		fmt.Printf("Unknown command: %s\n", os.Args[1])
-		fmt.Println("Usage: go run <command>")
-		fmt.Println("Commands:")
-		fmt.Println("  migrate   Run database migrations")
-		fmt.Println("  server    Start the application server")
-		os.Exit(1)
+	// Start the server
+	err = srv.Run()
+	if err != nil {
+		log.Fatalf("Server startup failed: %v", err)
 	}
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove migration command and related logic from `main.go` in `core-crm`.
> 
>   - **Behavior**:
>     - Removes command-line argument parsing for `migrate` and `server` commands in `main.go`.
>     - Deletes migration logic for Mailstack and DataWarehouse databases.
>     - Retains server setup and startup logic.
>   - **Imports**:
>     - Removes unused imports `fmt` and `os` from `main.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 82d9acef9a64e5bcc17619fc2f2642d5e9de1c68. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->