### PR TITLE
patch: revert header

### DIFF
--- a/packages/server/apigator/main.go
+++ b/packages/server/apigator/main.go
@@ -175,12 +175,6 @@ func validate(
 			return
 		}
 
-		// ✅ Skip for bypass paths (set by NGINX, never by client)
-		if c.GetHeader("X-Internal-Bypass") == "true" {
-			c.Status(http.StatusOK)
-			return
-		}
-
 		if isIntrospectionQuery(c.Request) {
 			c.Next()
 			return


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts bypass behavior for `X-Internal-Bypass` header in `validate()` in `main.go`.
> 
>   - **Behavior**:
>     - Removes bypass for requests with `X-Internal-Bypass` header in `validate()` in `main.go`. Previously, these requests were automatically given `http.StatusOK` without further processing.
>   - **Misc**:
>     - No other changes or refactoring were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 0c72b62da8c37e24d4c09835b6df6c9ddbd0a226. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->