### PR TITLE
patch: fix nats startup

### DIFF
--- a/packages/server/customer-os-common-module/services/organization/service.go
+++ b/packages/server/customer-os-common-module/services/organization/service.go
@@ -49,6 +49,7 @@ func NewOrganizationService(log logger.Logger,
 ) interfaces.OrganizationService {
 	return &organizationService{
 		log:             log,
+		natsConn:        natsConn,
 		postgres:        postgres,
 		neo4j:           neo4j,
 		events:          events,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes NATS startup by initializing `natsConn` in `NewOrganizationService` in `service.go`.
> 
>   - **Behavior**:
>     - Fixes NATS startup by ensuring `natsConn` is initialized in `NewOrganizationService` in `service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 132643e78a496cb5d980d98063bd74818ee848e2. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->