### PR TITLE
patch: add tracing to call logs

### DIFF
--- a/packages/server/customer-os-postgres-repository/entity/api_log.go
+++ b/packages/server/customer-os-postgres-repository/entity/api_log.go
@@ -11,12 +11,12 @@ type APICallLog struct {
 	Method       string         `gorm:"column:method;type:varchar(255);not null"`
 	URL          string         `gorm:"column:url;type:varchar(255);not null"`
 	RequestID    string         `gorm:"column:request_id;type:varchar(55);not null"`
-	RequestBody  []byte         `gorm:"column:request_body;type:bytea;not null"`
+	RequestBody  []byte         `gorm:"column:request_body;type:bytea"`
 	Timestamp    time.Time      `gorm:"column:timestamp;type:timestamptz;not null"`
 	Duration     int            `gorm:"column:duration;type:int;not null"`
 	StatusCode   *int           `gorm:"column:status_code;type:int;not null"`
 	ResponseBody *[]byte        `gorm:"column:response_body;type:bytea"`
-	ErrorMessage *string        `gorm:"column:error_message;type:text;not null"`
+	ErrorMessage *string        `gorm:"column:error_message;type:text"`
 }
 
 func (APICallLog) TableName() string {

--- a/packages/server/customer-os-postgres-repository/repository/api_log_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/api_log_repository.go
@@ -43,7 +43,12 @@ func (r *apiCallLogRepository) Create(ctx context.Context, log *postgres_entity.
 		log.ID = utils.GenerateNanoIdWithPrefix("api", 21)
 	}
 
-	return r.write.WithContext(ctx).Create(log).Error
+	err := r.write.WithContext(ctx).Create(log).Error
+	if err != nil {
+		span.TraceError(err)
+		return err
+	}
+	return nil
 }
 
 func (r *apiCallLogRepository) GetByID(ctx context.Context, id string) (*postgres_entity.APICallLog, error) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add error tracing to `Create` method and allow nullable fields in `APICallLog`.
> 
>   - **Behavior**:
>     - `Create` method in `api_log_repository.go` now logs errors using `span.TraceError()` before returning them.
>   - **Models**:
>     - `APICallLog` struct in `api_log.go` now allows `RequestBody` and `ErrorMessage` to be nullable by removing `not null` constraints.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f05965a3f5a03f734ba904339c563c554459c140. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->