### PR TITLE
patch: fix tracing for snitcher calls

### DIFF
--- a/packages/server/customer-os-common-module/services/enrichment/ip_identity.go
+++ b/packages/server/customer-os-common-module/services/enrichment/ip_identity.go
@@ -28,7 +28,7 @@ func (s *enrichmentService) IPIdentity(ctx context.Context, ip string) (*interfa
 
 	spans.LogKV("ip", ip)
 
-	// check caching
+	// check cache if ip exists
 	results, err := s.postgres.CacheIPIdentifyRepository.FindByIP(ctx, ip, CACHE_LOOKBACK_DAYS)
 	if err != nil {
 		spans.TraceError(err)
@@ -37,7 +37,7 @@ func (s *enrichmentService) IPIdentity(ctx context.Context, ip string) (*interfa
 
 	if results != nil && results.SnitcherData != "" && results.Domain != "" {
 		var snitcherResponse interfaces.SnitcherResponse
-		err := json.Unmarshal([]byte(results.SnitcherData), &snitcherResponse)
+		err = json.Unmarshal([]byte(results.SnitcherData), &snitcherResponse)
 		if err != nil {
 			return nil, fmt.Errorf("error unmarshaling snitcher response: %w", err)
 		}
@@ -72,7 +72,6 @@ func (s *enrichmentService) IPIdentity(ctx context.Context, ip string) (*interfa
 func (s *enrichmentService) callSnitcher(ctx context.Context, ip string) (*interfaces.SnitcherResponse, *string, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "EnrichmentService.callSnitcher")
 	defer spans.Finish()
-
 	spans.LogKV("ip", ip)
 
 	// validate if snitcher is configured
@@ -81,6 +80,8 @@ func (s *enrichmentService) callSnitcher(ctx context.Context, ip string) (*inter
 		spans.TraceError(err)
 		return nil, nil, err
 	}
+	spans.LogKV("snitcher.url", s.config.SnitcherConfig.Url)
+	spans.LogKV("snitcher.apiKey", utils.Mask(s.config.SnitcherConfig.ApiKey))
 
 	// Create POST request with context
 	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/company/find?ip=%s", s.config.SnitcherConfig.Url, ip), nil)
@@ -129,7 +130,7 @@ func (s *enrichmentService) callSnitcher(ctx context.Context, ip string) (*inter
 
 	// Parse the response
 	var snitcherResponse interfaces.SnitcherResponse
-	if err := json.Unmarshal(responseBody, &snitcherResponse); err != nil {
+	if err = json.Unmarshal(responseBody, &snitcherResponse); err != nil {
 		spans.TraceError(err)
 		spans.LogKV("json.response.parsing", string(responseBody))
 		return nil, nil, fmt.Errorf("failed to parse snitcher response: %w", err)

--- a/packages/server/customer-os-postgres-repository/repository/cache_ip_identify.go
+++ b/packages/server/customer-os-postgres-repository/repository/cache_ip_identify.go
@@ -2,9 +2,8 @@ package postgres_repository
 
 import (
 	"context"
-	"time"
-
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 
@@ -25,7 +24,7 @@ func NewCacheIPIdentifyRepository(gormDb *gorm.DB) CacheIPIdentifyRepository {
 }
 
 func (r *cacheIPIdentifyRepository) Create(ctx context.Context, ipData postgres_entity.CacheIPIdentify) error {
-	spans, ctx := telemetry.StartPostgresSpan(ctx, "CacheSnitcherRepository.Create")
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "cacheIPIdentifyRepository.Create")
 	defer spans.Finish()
 	spans.LogObjectAsJson("ipData", ipData)
 
@@ -45,11 +44,11 @@ func (r *cacheIPIdentifyRepository) Create(ctx context.Context, ipData postgres_
 }
 
 func (r *cacheIPIdentifyRepository) FindByIP(ctx context.Context, ip string, cacheLookBackInDays int) (*postgres_entity.CacheIPIdentify, error) {
-	spans, ctx := telemetry.StartPostgresSpan(ctx, "CacheSnitcherRepository.FindByIP")
+	spans, ctx := telemetry.StartPostgresSpan(ctx, "cacheIPIdentifyRepository.FindByIP")
 	defer spans.Finish()
 	spans.LogKV("ip", ip, "cacheLookBackInDays", cacheLookBackInDays)
 
-	lookBackDate := time.Now().AddDate(0, 0, -cacheLookBackInDays)
+	lookBackDate := utils.Now().AddDate(0, 0, -cacheLookBackInDays)
 
 	var result postgres_entity.CacheIPIdentify
 	err := r.db.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances tracing and logging for Snitcher API calls and cache operations, with telemetry span renaming and error handling improvements.
> 
>   - **Tracing and Logging Enhancements**:
>     - In `ip_identity.go`, added logging for `snitcher.url` and masked `snitcher.apiKey` in `callSnitcher()`.
>     - Improved error handling and logging in `IPIdentity()` and `callSnitcher()`.
>   - **Telemetry Span Renaming**:
>     - Renamed telemetry spans in `cache_ip_identify.go` from `CacheSnitcherRepository` to `cacheIPIdentifyRepository`.
>   - **Miscellaneous**:
>     - Fixed variable assignment in `ip_identity.go` for JSON unmarshalling errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 332cabf380b3fb72b03ee3700124af3ea51515cc. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->