### PR TITLE
patch: default meeting booking event fields

### DIFF
--- a/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/nylas.resolvers.go
@@ -96,7 +96,7 @@ func (r *mutationResolver) NylasConnect(ctx context.Context, input model.NylasCo
 			BookOptionMinNoticeMins:             240,
 			BookOptionDaysInAdvance:             30,
 			BookOptionBufferBetweenMeetingsMins: 15,
-			ShowLogo:                            false,
+			ShowLogo:                            true,
 			EmailNotificationEnabled:            true,
 		}
 		_, err = r.Services.Repositories.PostgresRepositories.MeetingBookingEventRepository.Save(ctx, &defaultMeetingBookingEventEntity)

--- a/packages/server/customer-os-postgres-repository/entity/meeting_booking_event.go
+++ b/packages/server/customer-os-postgres-repository/entity/meeting_booking_event.go
@@ -66,10 +66,10 @@ type MeetingBookingEvent struct {
 	BookOptionDaysInAdvance             int64 `gorm:"column:book_option_days_in_advance;not null;default:0" json:"bookOptionDaysInAdvance"`
 	BookOptionMinNoticeMins             int64 `gorm:"column:book_option_min_notice_mins;not null;default:0" json:"bookOptionMinNoticeMins"`
 
-	EmailNotificationEnabled        bool                                `gorm:"column:email_notification_enabled;not null;default:false" json:"emailNotificationEnabled"`
+	EmailNotificationEnabled        bool                                `gorm:"column:email_notification_enabled;not null;default:true" json:"emailNotificationEnabled"`
 	Location                        string                              `gorm:"column:location;size:255;not null;default:''" json:"location"`
 	AssignmentMethod                enum.MeetingBookingAssignmentMethod `gorm:"column:assignment_method;size:255;not null;default:''" json:"assignmentMethod"`
-	ShowLogo                        bool                                `gorm:"column:show_logo;not null;default:false" json:"showLogo"`
+	ShowLogo                        bool                                `gorm:"column:show_logo;not null;default:true" json:"showLogo"`
 	BookingConfirmationRedirectLink string                              `gorm:"column:booking_confirmation_redirect_link;size:255;not null;default:''" json:"bookingConfirmationRedirectLink"`
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set default `ShowLogo` and `EmailNotificationEnabled` to `true` for meeting booking events.
> 
>   - **Behavior**:
>     - Change default `ShowLogo` to `true` in `NylasConnect` in `nylas.resolvers.go`.
>     - Change default `EmailNotificationEnabled` to `true` in `MeetingBookingEvent` in `meeting_booking_event.go`.
>   - **Entities**:
>     - Update `MeetingBookingEvent` to set `ShowLogo` and `EmailNotificationEnabled` defaults to `true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for aa61c3a78e74eecc78805f9f54ebec008b79e9f7. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->