### PR TITLE
patch: check personal email provider on registration

### DIFF
--- a/packages/server/customer-os-api/rest/private/registration.go
+++ b/packages/server/customer-os-api/rest/private/registration.go
@@ -41,7 +41,7 @@ import (
 
 func RML(s *cosapi_services.Services) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		contextWithTimeout, cancel := common_utils.GetContextWithTimeout(context.Background(), 30*time.Second)
+		contextWithTimeout, cancel := common_utils.GetContextWithTimeout(c.Request.Context(), 30*time.Second)
 		defer cancel()
 
 		spans, ctx := telemetry.StartRestSpan(contextWithTimeout, "RML")
@@ -151,12 +151,7 @@ func RML(s *cosapi_services.Services) gin.HandlerFunc {
 
 func PML(s *cosapi_services.Services) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// todo move to server init?
-		personalEmailProviders, err := s.Repositories.PostgresRepositories.PersonalEmailProviderRepository.GetPersonalEmailProviders(c.Request.Context())
-		if err != nil {
-			panic(err)
-		}
-		contextWithTimeout, cancel := common_utils.GetContextWithTimeout(context.Background(), 30*time.Second)
+		contextWithTimeout, cancel := common_utils.GetContextWithTimeout(c.Request.Context(), 30*time.Second)
 		defer cancel()
 
 		spans, ctx := telemetry.StartRestSpan(contextWithTimeout, "PML")
@@ -171,6 +166,8 @@ func PML(s *cosapi_services.Services) gin.HandlerFunc {
 			})
 			return
 		}
+
+		var err error
 
 		if signInRequest.Code != "" {
 			magicLink, err = s.Repositories.PostgresRepositories.MagicLinkRepository.GetByCode(ctx, signInRequest.Code)
@@ -197,7 +194,7 @@ func PML(s *cosapi_services.Services) gin.HandlerFunc {
 			})
 		}
 
-		signIn(ctx, s, c, signInRequest, personalEmailProviders, s.Cfg)
+		signIn(ctx, s, c, signInRequest, s.Cfg)
 
 		err = s.Repositories.PostgresRepositories.MagicLinkRepository.Delete(ctx, magicLink.ID)
 		if err != nil {
@@ -210,19 +207,14 @@ func PML(s *cosapi_services.Services) gin.HandlerFunc {
 
 func Signin(s *cosapi_services.Services) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		contextWithTimeout, cancel := common_utils.GetContextWithTimeout(context.Background(), 30*time.Second)
+		contextWithTimeout, cancel := common_utils.GetContextWithTimeout(c.Request.Context(), 30*time.Second)
 		defer cancel()
-
-		personalEmailProviders, err := s.Repositories.PostgresRepositories.PersonalEmailProviderRepository.GetPersonalEmailProviders(contextWithTimeout)
-		if err != nil {
-			panic(err)
-		}
 
 		spans, ctx := telemetry.StartRestSpan(contextWithTimeout, "Signin")
 		defer spans.Finish()
 
 		var signInRequest SignInRequest
-		if err = c.BindJSON(&signInRequest); err != nil {
+		if err := c.BindJSON(&signInRequest); err != nil {
 			spans.TraceError(err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"result": fmt.Sprintf("unable to parse json: %v", err.Error()),
@@ -230,11 +222,11 @@ func Signin(s *cosapi_services.Services) gin.HandlerFunc {
 			return
 		}
 
-		signIn(ctx, s, c, signInRequest, personalEmailProviders, s.Cfg)
+		signIn(ctx, s, c, signInRequest, s.Cfg)
 	}
 }
 
-func signIn(ctx context.Context, services *cosapi_services.Services, ginContext *gin.Context, signInRequest SignInRequest, personalEmailProviders []postgres_entity.PersonalEmailProvider, config *config.Config) {
+func signIn(ctx context.Context, services *cosapi_services.Services, ginContext *gin.Context, signInRequest SignInRequest, config *config.Config) {
 	spans, ctx := telemetry.StartRestSpan(ctx, "signIn")
 	defer spans.Finish()
 
@@ -372,20 +364,11 @@ func signIn(ctx context.Context, services *cosapi_services.Services, ginContext 
 			}
 
 			if tenants == nil || len(tenants) == 0 {
+				isPersonalEmail = services.CommonServices.EmailService.IsPersonalEmailProvider(ctx, signInRequest.LoggedInEmail)
+				spans.LogKV("isPersonalEmail", isPersonalEmail)
 
 				domain := common_utils.ExtractDomain(signInRequest.LoggedInEmail)
 				spans.LogKV("domainExtractedFromEmail", domain)
-
-				// check if the user is using a personal email provider
-				for _, personalEmailProviderItem := range personalEmailProviders {
-					domainLowercase := strings.ToLower(strings.TrimSpace(domain))
-					personalEmailProviderDomainLowercase := strings.ToLower(strings.TrimSpace(personalEmailProviderItem.ProviderDomain))
-					if domainLowercase == personalEmailProviderDomainLowercase {
-						isPersonalEmail = true
-						break
-					}
-				}
-				spans.LogKV("isPersonalEmail", isPersonalEmail)
 
 				if !isPersonalEmail {
 					tenantWithWorkspace, err := services.Repositories.Neo4jRepositories.TenantReadRepository.GetTenantForWorkspace(ctx, domain)

--- a/packages/server/customer-os-common-module/interfaces/email.go
+++ b/packages/server/customer-os-common-module/interfaces/email.go
@@ -27,6 +27,8 @@ type EmailService interface {
 	GetPrimaryEmailsForEntityIds(ctx context.Context, entityType model.EntityType, entityIds []string) (*neo4j_entity.EmailEntities, error)
 	UpdateEmailValidationDetails(ctx context.Context, emailId string, validationFields data_fields.EmailValidationFields) error
 	RequestEmailValidation(ctx context.Context, emailId string) error
+
+	IsPersonalEmailProvider(ctx context.Context, email string) bool
 }
 
 type EmailFields struct {

--- a/packages/server/customer-os-common-module/services/email/service.go
+++ b/packages/server/customer-os-common-module/services/email/service.go
@@ -3,13 +3,17 @@ package email
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/caches"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/customeros/mailsherpa/mailvalidate"
 	"github.com/opentracing/opentracing-go/log"
 
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
 	neo4j_repository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
-	neo4jrepository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
+	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 
 	"github.com/pkg/errors"
 
@@ -27,19 +31,23 @@ import (
 
 type emailService struct {
 	neo4j         *neo4j_repository.Repositories
+	postgres      *postgres_repository.Repositories
 	events        *events.EventsService
 	contact       interfaces.ContactService
 	org           interfaces.OrganizationService
 	domainService interfaces.DomainService
+	cache         *caches.Cache
 }
 
-func NewEmailService(neo4j *neo4j_repository.Repositories, events *events.EventsService, contact interfaces.ContactService, org interfaces.OrganizationService, domainService interfaces.DomainService) interfaces.EmailService {
+func NewEmailService(neo4j *neo4j_repository.Repositories, postgres *postgres_repository.Repositories, events *events.EventsService, contact interfaces.ContactService, org interfaces.OrganizationService, domainService interfaces.DomainService, cache *caches.Cache) interfaces.EmailService {
 	return &emailService{
 		neo4j:         neo4j,
+		postgres:      postgres,
 		events:        events,
 		contact:       contact,
 		org:           org,
 		domainService: domainService,
+		cache:         cache,
 	}
 }
 
@@ -104,7 +112,7 @@ func (s *emailService) Merge(ctx context.Context, txWithPostCommit *utils.TxWith
 				spans.TraceError(err)
 				return nil, err
 			}
-			err = s.neo4j.EmailWriteRepository.CreateEmail(ctx, txWithPostCommit.Tx, tenant, emailId, neo4jrepository.EmailCreateFields{
+			err = s.neo4j.EmailWriteRepository.CreateEmail(ctx, txWithPostCommit.Tx, tenant, emailId, neo4j_repository.EmailCreateFields{
 				RawEmail:  emailFields.Email,
 				CreatedAt: createdAt,
 				Source:    emailFields.Source,
@@ -649,4 +657,58 @@ func (s *emailService) RequestEmailValidation(ctx context.Context, emailId strin
 		spans.TraceError(errors.Wrap(err, "Error publishing email validation request"))
 	}
 	return err
+}
+
+func (s *emailService) IsPersonalEmailProvider(ctx context.Context, emailAddress string) bool {
+	spans, ctx := telemetry.StartServiceSpan(ctx, "EmailService.IsPersonalEmailProvider")
+	defer spans.Finish()
+
+	spans.LogKV("emailAddress", emailAddress)
+	emailAddress = strings.ToLower(emailAddress)
+
+	emailValidation := mailvalidate.ValidateEmailSyntax(emailAddress)
+
+	// check if personal email providers are loaded in cache
+	personalEmailProviders := s.cache.GetPersonalEmailProviders()
+	if len(personalEmailProviders) == 0 {
+		// get personal email providers from personal_email_providers table
+		personalEmailProviderEntities, err := s.postgres.PersonalEmailProviderRepository.GetPersonalEmailProviders(ctx)
+		if err != nil {
+			spans.TraceError(err)
+			return false
+		}
+		// convert to slice of strings
+		personalEmailProviders = make([]string, 0, len(personalEmailProviderEntities))
+		for _, v := range personalEmailProviderEntities {
+			personalEmailProviders = append(personalEmailProviders, v.ProviderDomain)
+		}
+		// set personal email providers in cache
+		s.cache.SetPersonalEmailProviders(personalEmailProviders)
+	}
+
+	domain := utils.ExtractDomain(emailAddress)
+	if s.cache.IsPersonalEmailProvider(domain) {
+		spans.LogFields(log.Bool("result.isPersonalEmailProvider", true))
+		return true
+	}
+
+	if emailValidation.IsFreeAccount {
+		spans.LogFields(log.Bool("result.IsFreeAccount", true))
+		return true
+	}
+
+	if emailValidation.IsSystemGenerated {
+		spans.LogFields(log.Bool("result.IsSystemGenerated", true))
+		return true
+	}
+
+	// domain of the email address is not top level domain
+	if emailValidation.Domain != domain {
+		spans.LogFields(log.Bool("result.nonTopLevelDomain", true))
+		return true
+	}
+
+	spans.LogFields(log.Bool("result.isPersonalEmailProvider", false))
+	return false
+
 }

--- a/packages/server/customer-os-common-module/services/init.go
+++ b/packages/server/customer-os-common-module/services/init.go
@@ -280,7 +280,7 @@ func InitCommonServices(
 
 	// Complex dependencies (ordered by dependency chain)
 	authenticationImpl := authentication.NewAuthenticationService(neo4jRepositories, nil, nil)
-	emailImpl := email.NewEmailService(neo4jRepositories, eventsImpl, nil, nil, nil)
+	emailImpl := email.NewEmailService(neo4jRepositories, postgresRepositories, eventsImpl, nil, nil, nil, cacheImpl)
 	jobroleImpl := jobrole.NewJobRoleService(neo4jRepositories, eventsImpl, nil)
 	issueImpl := issue.NewIssueService(log, neo4jRepositories, eventsImpl, nil)
 	contactImpl := contact.NewContactService(log, neo4jRepositories, eventsImpl, domainImpl, emailImpl, nil, jobroleImpl, nil, nil)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `IsPersonalEmailProvider` to `EmailService` and updates registration to block personal email domains.
> 
>   - **Behavior**:
>     - Adds `IsPersonalEmailProvider` method to `EmailService` to check if an email is from a personal provider.
>     - Updates registration logic in `registration.go` to prevent tenant registration with personal emails.
>     - Uses request context in `GetContextWithTimeout()` in `registration.go`.
>   - **Services**:
>     - Updates `EmailService` constructor in `service.go` to include `postgres` and `cache` dependencies.
>     - Initializes `EmailService` with `IsPersonalEmailProvider` in `init.go`.
>   - **Misc**:
>     - Removes redundant personal email provider checks in `registration.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for eaa51fb26edf034785db8ef648a9714573e14afd. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->