### PR TITLE
patch: handle snitcher company not found

### DIFF
--- a/packages/server/customer-os-common-module/services/enrichment/ip_identity.go
+++ b/packages/server/customer-os-common-module/services/enrichment/ip_identity.go
@@ -25,7 +25,6 @@ const (
 func (s *enrichmentService) IPIdentity(ctx context.Context, ip string) (*interfaces.SnitcherResponse, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "EnrichmentService.IPIdentity")
 	defer spans.Finish()
-
 	spans.LogKV("ip", ip)
 
 	// check cache if ip exists
@@ -115,9 +114,10 @@ func (s *enrichmentService) callSnitcher(ctx context.Context, ip string) (*inter
 
 	// Check status code
 	spans.LogKV("response.statusCode", resp.StatusCode)
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		// expected status codes 200 - company found, 404 - company not found
 		spans.LogKV("result.rawSnitcherResponse", string(responseBody))
-		return nil, nil, fmt.Errorf("snitcher API returned non-200 status code: %d", resp.StatusCode)
+		return nil, nil, fmt.Errorf("snitcher API returned unexpected status code: %d", resp.StatusCode)
 	}
 
 	// Validate and compact JSON


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle HTTP 404 status code in `callSnitcher` function in `ip_identity.go` to manage 'company not found' responses from Snitcher API.
> 
>   - **Behavior**:
>     - Update `callSnitcher` in `ip_identity.go` to handle HTTP 404 status code from Snitcher API as expected, indicating 'company not found'.
>     - Logs unexpected status codes and returns an error for non-200 and non-404 responses.
>   - **Misc**:
>     - Remove unnecessary newline in `IPIdentity` function in `ip_identity.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 9caf34e319bbeef6117f92dd42869f798e03efc9. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->