### PR TITLE
patch: early stop processing identify agent if domain not found

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_identify_web_visitor.go
@@ -299,7 +299,7 @@ func (c *IdentifyWebsiteVisitorCapability) tryIdentifyFromEnrichment(
 		if err != nil {
 			return enum.CapabilityExecutionError, *result, errors.Wrap(err, "failed to publish web visitor not identified event")
 		}
-		return enum.CapabilityExecutionCompleted, *result, nil
+		return enum.CapabilityExecutionStop, *result, nil
 	}
 
 	// Update the web session with identified domain


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change return status to `enum.CapabilityExecutionStop` in `tryIdentifyFromEnrichment` when domain is not found.
> 
>   - **Behavior**:
>     - In `tryIdentifyFromEnrichment` in `capability_identify_web_visitor.go`, change return status to `enum.CapabilityExecutionStop` when domain is not found, instead of `enum.CapabilityExecutionCompleted`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for a8b729917b3eaeadb54cc8626d5c2f74bea454bc. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->