### PR TITLE
patch: set operation name as span tag for filtering

### DIFF
--- a/packages/server/customer-os-common-module/telemetry/helpers.go
+++ b/packages/server/customer-os-common-module/telemetry/helpers.go
@@ -143,6 +143,7 @@ func StartSpan(ctx context.Context, operationName string, opts ...SpanOptions) (
 	} else {
 		ctx, otelSpan = tracer.Start(ctx, operationName)
 	}
+	otelSpan.SetAttributes(attribute.String("name", operationName))
 
 	setDefaultServiceSpanAttributes(ctx, otelSpan)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `operationName` as a span attribute in `StartSpan()` for OpenTelemetry spans in `helpers.go`.
> 
>   - **Behavior**:
>     - Adds `operationName` as a span attribute `name` in `StartSpan()` in `helpers.go` for OpenTelemetry spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for f7d80a51784bd4bcbd773de0ffbc6ace439daf42. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->