### PR TITLE
patch: send into retry flow if domain not available for org yet in le…

### DIFF
--- a/packages/server/customer-os-common-module/services/agent_capability/capability_gather_company_intelligence.go
+++ b/packages/server/customer-os-common-module/services/agent_capability/capability_gather_company_intelligence.go
@@ -121,7 +121,7 @@ func (c *GatherCompanyIntelligenceCapability) Execute(ctx context.Context, execu
 		return enum.CapabilityExecutionError, result, err
 	}
 	if primaryDomain == "" {
-		return enum.CapabilityExecutionError, result, coserrors.ErrCapabilityMissingPrimaryDomainForOrganization
+		return enum.CapabilityExecutionRetry, result, coserrors.ErrCapabilityMissingPrimaryDomainForOrganization
 	}
 	company, err := c.postgresRepositories.GlobalOrganizationRepository.GetByPrimaryDomain(ctx, primaryDomain)
 	if err != nil {


### PR DESCRIPTION
…ad agent
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `Execute()` in `GatherCompanyIntelligenceCapability` to retry when primary domain is missing.
> 
>   - **Behavior**:
>     - In `Execute()` of `GatherCompanyIntelligenceCapability`, change return status to `CapabilityExecutionRetry` when `primaryDomain` is empty, instead of `CapabilityExecutionError`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for accadd097d7ca4e75eaf57a9fce5488a52354400. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->