### PR TITLE
fix postgres query check

### DIFF
--- a/packages/runner/integrity-checker/postgres-integrity-checker-queries.json
+++ b/packages/runner/integrity-checker/postgres-integrity-checker-queries.json
@@ -5,7 +5,7 @@
       "queries": [
         {
           "name": "Meeting scheduling records with non-existent tenants",
-          "query": "SELECT COUNT(*) FROM meeting_booking_events ms WHERE NOT EXISTS (SELECT 1 FROM tenant t WHERE t.id = ms.tenant_id)"
+          "query": "SELECT COUNT(*) FROM meeting_booking_events ms WHERE NOT EXISTS (SELECT 1 FROM tenant t WHERE t.name = ms.tenant)"
         }
       ]
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes query in `postgres-integrity-checker-queries.json` to compare `t.name` with `ms.tenant` for non-existent tenant check.
> 
>   - **Query Fix**:
>     - In `postgres-integrity-checker-queries.json`, updated query in `MeetingBookingEvent` group to compare `t.name` with `ms.tenant` instead of `t.id` with `ms.tenant_id` for checking non-existent tenants.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 4d5a6901eba97d7a08a473a591566534d3f480cc. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->