### PR TITLE
patch:Refactor table view definitions to include userId parameter

### DIFF
--- a/packages/server/customer-os-api/graphql/resolver/view.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/view.resolvers.go
@@ -279,7 +279,7 @@ func (r *queryResolver) TableViewDefs(ctx context.Context) ([]*model.TableViewDe
 		// check if shared presets exist
 		hasSharedPreset := table_view.CheckSharedPresetsExist(tableViewDefinitions)
 
-		for _, def := range table_view.DefaultTableViewDefinitions(hasSharedPreset) {
+		for _, def := range table_view.DefaultTableViewDefinitions(hasSharedPreset, userId) {
 			def.Tenant = tenant
 			def.UserId = userId
 			r.Services.Repositories.PostgresRepositories.TableViewDefinitionRepository.CreateTableViewDefinition(ctx, def)
@@ -489,7 +489,7 @@ func (r *queryResolver) TableViewDefs(ctx context.Context) ([]*model.TableViewDe
 		}
 	}
 	if !tasksFound {
-		tvDef, err := table_view.DefaultTableViewDefinitionTasks()
+		tvDef, err := table_view.DefaultTableViewDefinitionMyTasks(userId)
 		if err != nil {
 			spans.TraceError(pkgerrors.Wrap(err, "Failed to create default table view definition for tasks"))
 		} else {
@@ -499,6 +499,7 @@ func (r *queryResolver) TableViewDefs(ctx context.Context) ([]*model.TableViewDe
 			r.Services.Repositories.PostgresRepositories.TableViewDefinitionRepository.CreateTableViewDefinition(ctx, tvDef)
 		}
 	}
+
 
 	if viewsUpdated {
 		updatedResult := r.Services.Repositories.PostgresRepositories.TableViewDefinitionRepository.GetTableViewDefinitions(ctx, tenant, userId)

--- a/packages/server/customer-os-common-module/services/table_view/view_helper.go
+++ b/packages/server/customer-os-common-module/services/table_view/view_helper.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ColumnView represents a column in a table view with type and width.
-func DefaultTableViewDefinitions(hasSharedPresets bool) []postgres_entity.TableViewDefinition {
+func DefaultTableViewDefinitions(hasSharedPresets bool, userId string) []postgres_entity.TableViewDefinition {
 	upcomingInvoicesTableViewDefinition, err := DefaultTableViewDefinitionUpcomingInvoices()
 	if err != nil {
 		fmt.Println("Error: ", err)
@@ -82,11 +82,13 @@ func DefaultTableViewDefinitions(hasSharedPresets bool) []postgres_entity.TableV
 		return []postgres_entity.TableViewDefinition{}
 	}
 
-	tasksTableViewDefinition, err := DefaultTableViewDefinitionTasks()
+	tasksTableViewDefinition, err := DefaultTableViewDefinitionMyTasks(userId)
 	if err != nil {
 		fmt.Println("Error: ", err)
 		return []postgres_entity.TableViewDefinition{}
 	}
+
+
 
 	var defaultViewDefinitions []postgres_entity.TableViewDefinition
 	defaultViewDefinitions = append(defaultViewDefinitions, upcomingInvoicesTableViewDefinition)
@@ -101,9 +103,9 @@ func DefaultTableViewDefinitions(hasSharedPresets bool) []postgres_entity.TableV
 	defaultViewDefinitions = append(defaultViewDefinitions, flowsTableViewDefinition)
 	defaultViewDefinitions = append(defaultViewDefinitions, flowContactsTableViewDefinition)
 	defaultViewDefinitions = append(defaultViewDefinitions, tasksTableViewDefinition)
-	if !hasSharedPresets {
-		defaultViewDefinitions = append(defaultViewDefinitions, opportunitiesTableViewDefinition)
-	}
+        if !hasSharedPresets {
+            defaultViewDefinitions = append(defaultViewDefinitions, opportunitiesTableViewDefinition)
+        }
 
 	return defaultViewDefinitions
 }
@@ -407,7 +409,7 @@ func DefaultTableViewDefinitionFlowContactsV2(flowId string) (postgres_entity.Ta
 	}, nil
 }
 
-func DefaultTableViewDefinitionTasks() (postgres_entity.TableViewDefinition, error) {
+func DefaultTableViewDefinitionMyTasks(userId string) (postgres_entity.TableViewDefinition, error) {
 	columns := DefaultColumns(postgres_entity.TableIDTypeTasks)
 	jsonData, err := json.Marshal(columns)
 	if err != nil {
@@ -423,12 +425,14 @@ func DefaultTableViewDefinitionTasks() (postgres_entity.TableViewDefinition, err
 		Order:          10,
 		Icon:           "ClipboardCheck",
 		Filters:        ``,
-		DefaultFilters: ``,
+		DefaultFilters: fmt.Sprintf(`{"AND":[{"filter":{"property":"TASKS_ASSIGNEES","active":true,"operation":"IN","value":["%s"]}}]}`, userId),
 		Sorting:        `{"id": "TASKS_UPDATED_AT", "desc": true}`,
 		IsPreset:       true,
 		IsShared:       false,
 	}, nil
 }
+
+
 
 func DefaultColumns(tableId postgres_entity.TableIdType) postgres_entity.Columns {
 	switch tableId {


### PR DESCRIPTION
- Updated DefaultTableViewDefinitions and related functions to accept userId, allowing for user-specific task view definitions.
- Changed method calls in TableViewDefs resolver to utilize the new userId parameter for task definitions.
- Improved handling of default table view definitions based on user context.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor table view definitions to include `userId` for user-specific task views in `view_helper.go` and `view.resolvers.go`.
> 
>   - **Behavior**:
>     - Updated `DefaultTableViewDefinitions` and `DefaultTableViewDefinitionMyTasks` in `view_helper.go` to accept `userId`, enabling user-specific task view definitions.
>     - Modified `TableViewDefs` in `view.resolvers.go` to use `userId` for task definitions.
>   - **Functions**:
>     - Changed `DefaultTableViewDefinitions` to include `userId` parameter.
>     - Renamed `DefaultTableViewDefinitionTasks` to `DefaultTableViewDefinitionMyTasks` and added `userId` parameter.
>   - **Misc**:
>     - Improved handling of default table view definitions based on user context in `view.resolvers.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 91a0161120e948c55b6b84ff9431fd95668b395b. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->