### PR TITLE
patch: use direct consumer for nats messages

### DIFF
--- a/packages/server/customer-os-common-module/nats/nats.go
+++ b/packages/server/customer-os-common-module/nats/nats.go
@@ -26,6 +26,7 @@ type NatsHeader string
 
 const (
 	CORE_STREAM           = "core"
+	LEADS_STREAM          = "leads"
 	MAX_STREAM_RECONNECTS = -1 // never stop trying to reconnect
 
 	NATS_HEADER_TENANT NatsHeader = "X-Tenant"

--- a/packages/server/customer-os-common-module/services/organization/consumer.go
+++ b/packages/server/customer-os-common-module/services/organization/consumer.go
@@ -1,7 +1,12 @@
 package organization
 
 import (
+	"context"
 	"fmt"
+	"log"
+	"time"
+
+	nats_common "github.com/customeros/customeros/packages/server/customer-os-common-module/nats"
 
 	"github.com/customeros/mailsherpa/mailvalidate"
 
@@ -15,61 +20,151 @@ import (
 	leads_pb "github.com/customeros/leads/proto/pb"
 	"github.com/nats-io/nats.go"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/protobuf/proto"
 )
 
 var ORGANIZATION_SUBJECT = "core.organization.>"
 var WEBTRACKER_VISITOR_IDENTIFIED_SUBJECT = string(leads_enum.EventWebtrackerVisitorIdentified)
 
-const QUEUE_GROUP = "organization-service"
+const (
+	// queue groups
+	QUEUE_GROUP = "organization-service"
+
+	// consumer configs
+	ORGANIZATION_CONSUMER_NAME = "organization-service-consumer"
+	WEBTRACKER_CONSUMER_NAME   = "organization-service-webtracker-consumer"
+	ACK_WAIT                   = 30 * time.Second
+	MAX_DELIVERY_ATTEMPTS      = 5
+	MAX_ACK_PENDING            = 100
+	FETCH_BATCH_SIZE           = 50
+	MAX_FETCH_WAIT             = 500 * time.Millisecond
+	ERR_BACKOFF                = 100 * time.Millisecond
+)
 
 func (s *organizationService) Start(ctx context.Context) error {
 	if s.natsConn == nil {
 		return fmt.Errorf("NATS connection is nil")
 	}
 
-	// Create subscriptions for handling requests
-	subs := []*nats.Subscription{}
-
-	// Subscribe to organization subject
-	orgSub, err := s.natsConn.Conn.QueueSubscribe(ORGANIZATION_SUBJECT, QUEUE_GROUP, func(msg *nats.Msg) {
-		s.handleOrganizationMessage(ctx, msg)
+	// Create durable consumers for both subjects
+	_, err := s.natsConn.JS.AddConsumer(nats_common.CORE_STREAM, &nats.ConsumerConfig{
+		Durable:       ORGANIZATION_CONSUMER_NAME,
+		DeliverGroup:  QUEUE_GROUP,
+		AckPolicy:     nats.AckExplicitPolicy,
+		AckWait:       ACK_WAIT,
+		MaxDeliver:    MAX_DELIVERY_ATTEMPTS,
+		FilterSubject: ORGANIZATION_SUBJECT,
+		MaxAckPending: MAX_ACK_PENDING,
+		DeliverPolicy: nats.DeliverAllPolicy,
 	})
+	if err != nil {
+		return fmt.Errorf("failed to create organization consumer: %w", err)
+	}
+
+	_, err = s.natsConn.JS.AddConsumer(nats_common.LEADS_STREAM, &nats.ConsumerConfig{
+		Durable:       WEBTRACKER_CONSUMER_NAME,
+		DeliverGroup:  QUEUE_GROUP,
+		AckPolicy:     nats.AckExplicitPolicy,
+		AckWait:       ACK_WAIT,
+		MaxDeliver:    MAX_DELIVERY_ATTEMPTS,
+		FilterSubject: WEBTRACKER_VISITOR_IDENTIFIED_SUBJECT,
+		MaxAckPending: MAX_ACK_PENDING,
+		DeliverPolicy: nats.DeliverAllPolicy,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create webtracker consumer: %w", err)
+	}
+
+	// Create pull subscriptions
+	orgSub, err := s.natsConn.JS.PullSubscribe(
+		ORGANIZATION_SUBJECT,
+		ORGANIZATION_CONSUMER_NAME,
+		nats.Bind("CUSTOMER_OS_STREAM", ORGANIZATION_CONSUMER_NAME),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create organization subscription: %w", err)
 	}
-	subs = append(subs, orgSub)
 
-	// Subscribe to webtracker subject
-	webSub, err := s.natsConn.Conn.QueueSubscribe(WEBTRACKER_VISITOR_IDENTIFIED_SUBJECT, QUEUE_GROUP, func(msg *nats.Msg) {
-		s.handleWebtrackerMessage(ctx, msg)
-	})
+	webSub, err := s.natsConn.JS.PullSubscribe(
+		WEBTRACKER_VISITOR_IDENTIFIED_SUBJECT,
+		WEBTRACKER_CONSUMER_NAME,
+		nats.Bind("CUSTOMER_OS_STREAM", WEBTRACKER_CONSUMER_NAME),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create webtracker subscription: %w", err)
 	}
-	subs = append(subs, webSub)
 
 	// Keep track of subscriptions for cleanup
-	s.subscriptions = subs
+	s.subscriptions = []*nats.Subscription{orgSub, webSub}
 
-	// Listen for context cancellation to clean up
-	go func() {
-		<-ctx.Done()
-		for _, sub := range s.subscriptions {
-			sub.Unsubscribe()
-		}
-	}()
+	// Start processing for both subscriptions
+	go s.processOrganizationEvents(ctx, orgSub)
+	go s.processWebtrackerEvents(ctx, webSub)
 
 	return nil
 }
 
-// Close gracefully shuts down the service
-func (s *organizationService) Stop() {
-	if s.natsConn != nil {
-		s.natsConn.Close()
+func (s *organizationService) processOrganizationEvents(ctx context.Context, sub *nats.Subscription) {
+	log.Println("Organization event processor started")
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Organization event processor shutting down")
+			return
+		default:
+			s.processOrganizationBatch(ctx, sub)
+		}
 	}
-	return
+}
+
+func (s *organizationService) processWebtrackerEvents(ctx context.Context, sub *nats.Subscription) {
+	log.Println("Webtracker event processor started")
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Webtracker event processor shutting down")
+			return
+		default:
+			s.processWebtrackerBatch(ctx, sub)
+		}
+	}
+}
+
+func (s *organizationService) processOrganizationBatch(ctx context.Context, sub *nats.Subscription) {
+	msgs, err := sub.Fetch(FETCH_BATCH_SIZE, nats.MaxWait(MAX_FETCH_WAIT))
+	if err != nil {
+		s.handleFetchError(err)
+		return
+	}
+
+	for _, msg := range msgs {
+		msgCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		s.handleOrganizationMessage(msgCtx, msg)
+		cancel()
+	}
+}
+
+func (s *organizationService) processWebtrackerBatch(ctx context.Context, sub *nats.Subscription) {
+	msgs, err := sub.Fetch(FETCH_BATCH_SIZE, nats.MaxWait(MAX_FETCH_WAIT))
+	if err != nil {
+		s.handleFetchError(err)
+		return
+	}
+
+	for _, msg := range msgs {
+		msgCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		s.handleWebtrackerMessage(msgCtx, msg)
+		cancel()
+	}
+}
+
+func (s *organizationService) handleFetchError(err error) {
+	if errors.Is(err, nats.ErrTimeout) {
+		// No messages available, this is normal
+		return
+	}
+	log.Printf("Fetch error: %v", err)
+	time.Sleep(ERR_BACKOFF)
 }
 
 func (s *organizationService) handleOrganizationMessage(ctx context.Context, msg *nats.Msg) {
@@ -89,17 +184,17 @@ func (s *organizationService) handleOrganizationMessage(ctx context.Context, msg
 	request := &core_crm_pb.OrganizationSaveRequest{}
 	err := proto.Unmarshal(msg.Data, request)
 	if err != nil {
-		s.sendOrganizationResponse(ctx, msg, resp)
-		spans.TraceError(err)
+		s.handleProcessingError(ctx, msg, err)
 		return
 	}
 
 	if resp == nil {
-		spans.TraceError(errors.New("empty response"))
+		s.handleProcessingError(ctx, msg, errors.New("empty response"))
 		return
 	}
 
 	s.sendOrganizationResponse(ctx, msg, resp)
+	msg.Ack()
 }
 
 func (s *organizationService) handleWebtrackerMessage(ctx context.Context, msg *nats.Msg) {
@@ -117,14 +212,14 @@ func (s *organizationService) handleWebtrackerMessage(ctx context.Context, msg *
 	// validate tenant
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {
-		span.TraceError(errors.New("tenant not set in nats message"))
+		s.handleProcessingError(ctx, msg, errors.New("tenant not set in nats message"))
 		return
 	}
 
 	request := &leads_pb.WebtrackerVisitorIdentified{}
 	err := proto.Unmarshal(msg.Data, request)
 	if err != nil {
-		span.TraceError(errors.Wrap(err, "failed to unmarshal webtracker visitor identified request"))
+		s.handleProcessingError(ctx, msg, errors.Wrap(err, "failed to unmarshal webtracker visitor identified request"))
 		return
 	}
 	span.LogObjectAsJson("msg.webtracker.visitor.identified", request)
@@ -180,6 +275,21 @@ func (s *organizationService) handleWebtrackerMessage(ctx context.Context, msg *
 		}
 		span.LogKV("result.orgId", orgId)
 		return
+	}
+
+	msg.Ack()
+}
+
+func (s *organizationService) handleProcessingError(ctx context.Context, msg *nats.Msg, err error) {
+	metadata, _ := msg.Metadata()
+
+	// Check if we should retry
+	if metadata.NumDelivered <= uint64(MAX_DELIVERY_ATTEMPTS) {
+		// Negative acknowledgment triggers redelivery
+		msg.Nak()
+	} else {
+		// Max retries reached, acknowledge but could publish to dead letter
+		msg.Ack()
 	}
 }
 

--- a/packages/server/customer-os-common-module/services/organization/consumer.go
+++ b/packages/server/customer-os-common-module/services/organization/consumer.go
@@ -79,7 +79,7 @@ func (s *organizationService) Start(ctx context.Context) error {
 	orgSub, err := s.natsConn.JS.PullSubscribe(
 		ORGANIZATION_SUBJECT,
 		ORGANIZATION_CONSUMER_NAME,
-		nats.Bind("CUSTOMER_OS_STREAM", ORGANIZATION_CONSUMER_NAME),
+		nats.Bind(nats_common.CORE_STREAM, ORGANIZATION_CONSUMER_NAME),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create organization subscription: %w", err)
@@ -88,14 +88,11 @@ func (s *organizationService) Start(ctx context.Context) error {
 	webSub, err := s.natsConn.JS.PullSubscribe(
 		WEBTRACKER_VISITOR_IDENTIFIED_SUBJECT,
 		WEBTRACKER_CONSUMER_NAME,
-		nats.Bind("CUSTOMER_OS_STREAM", WEBTRACKER_CONSUMER_NAME),
+		nats.Bind(nats_common.LEADS_STREAM, WEBTRACKER_CONSUMER_NAME),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create webtracker subscription: %w", err)
 	}
-
-	// Keep track of subscriptions for cleanup
-	s.subscriptions = []*nats.Subscription{orgSub, webSub}
 
 	// Start processing for both subscriptions
 	go s.processOrganizationEvents(ctx, orgSub)
@@ -303,4 +300,11 @@ func (s *organizationService) sendOrganizationResponse(ctx context.Context, req 
 		return
 	}
 	req.Respond(respMessage)
+}
+
+// Stop gracefully shuts down the service
+func (s *organizationService) Stop() {
+	if s.natsConn != nil {
+		s.natsConn.Close()
+	}
 }

--- a/packages/server/customer-os-common-module/services/organization/service.go
+++ b/packages/server/customer-os-common-module/services/organization/service.go
@@ -26,7 +26,6 @@ type organizationService struct {
 	currencyService interfaces.CurrencyService
 	contractService interfaces.ContractService
 	emailService    interfaces.EmailService
-	subscriptions   []*nats.Subscription
 }
 
 func NewOrganizationService(
@@ -54,7 +53,6 @@ func NewOrganizationService(
 		social:          social,
 		currencyService: currencyService,
 		emailService:    emailService,
-		subscriptions:   make([]*nats.Subscription, 0),
 	}
 }
 

--- a/packages/server/customer-os-common-module/services/organization/service.go
+++ b/packages/server/customer-os-common-module/services/organization/service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4j_repository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
-	"github.com/nats-io/nats.go"
 )
 
 type organizationService struct {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Switch to direct NATS consumers for organization and webtracker events, improving message handling and error management.
> 
>   - **Behavior**:
>     - Switch from queue subscriptions to durable consumers and pull subscriptions in `consumer.go`.
>     - Add durable consumers for `ORGANIZATION_SUBJECT` and `WEBTRACKER_VISITOR_IDENTIFIED_SUBJECT`.
>     - Implement pull subscription processing with `processOrganizationEvents` and `processWebtrackerEvents`.
>     - Introduce error handling with retries and acknowledgments in `handleProcessingError`.
>   - **NATS Configuration**:
>     - Add `LEADS_STREAM` constant in `nats.go`.
>     - Configure consumer settings like `ACK_WAIT`, `MAX_DELIVERY_ATTEMPTS`, and `FETCH_BATCH_SIZE`.
>   - **Misc**:
>     - Remove unused `subscriptions` field from `organizationService` in `service.go`.
>     - Add logging for event processor start and shutdown.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 83d16c6d5a5b503cfe6467d7dcf5338ff7c7ae40. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->