### PR TITLE
patch: fix domain check

### DIFF
--- a/packages/server/customer-os-common-module/services/domain/service.go
+++ b/packages/server/customer-os-common-module/services/domain/service.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"context"
-	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/opentracing/opentracing-go/log"
 	"strings"
@@ -286,14 +285,23 @@ func (s *domainService) GetDomain(ctx context.Context, domain string) (*neo4jent
 func (s *domainService) IsAcceptedDomainForOrganization(ctx context.Context, domain string) bool {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "DomainService.IsAcceptedDomainForOrganization")
 	defer spans.Finish()
-
 	spans.TagEntity(domain)
 
 	personalEmailProviders := s.cache.GetPersonalEmailProviders()
-	if personalEmailProviders == nil || len(personalEmailProviders) == 0 {
-		err := fmt.Errorf("personal email providers not loaded")
-		spans.TraceError(err)
-		return false
+	if len(personalEmailProviders) == 0 {
+		// get personal email providers from personal_email_providers table
+		personalEmailProviderEntities, err := s.postgres.PersonalEmailProviderRepository.GetPersonalEmailProviders(ctx)
+		if err != nil {
+			spans.TraceError(err)
+			return false
+		}
+		// convert to slice of strings
+		personalEmailProviders = make([]string, 0, len(personalEmailProviderEntities))
+		for _, v := range personalEmailProviderEntities {
+			personalEmailProviders = append(personalEmailProviders, v.ProviderDomain)
+		}
+		// set personal email providers in cache
+		s.cache.SetPersonalEmailProviders(personalEmailProviders)
 	}
 
 	if s.cache.IsPersonalEmailProvider(domain) {

--- a/packages/server/customer-os-common-module/services/organization/consumer.go
+++ b/packages/server/customer-os-common-module/services/organization/consumer.go
@@ -173,7 +173,7 @@ func (s *organizationService) handleFetchError(err error) {
 
 func (s *organizationService) handleOrganizationMessage(ctx context.Context, msg *nats.Msg) {
 	ctx = common.WithCustomContextFromNats(ctx, msg)
-	spans, ctx := telemetry.StartListenerSpan(ctx, "organizationService.handleOrganizationMessage", telemetry.WithNewRoot())
+	spans, ctx := telemetry.StartListenerSpan(ctx, "OrganizationService.handleOrganizationMessage", telemetry.WithNewRoot())
 	defer spans.Finish()
 
 	if msg == nil {
@@ -205,7 +205,7 @@ func (s *organizationService) handleOrganizationMessage(ctx context.Context, msg
 
 func (s *organizationService) handleWebtrackerVisitorIdentifiedMessage(ctx context.Context, msg *nats.Msg) {
 	ctx = common.WithCustomContextFromNats(ctx, msg)
-	span, ctx := telemetry.StartListenerSpan(ctx, "organizationService.handleWebtrackerVisitorIdentifiedMessage", telemetry.WithNewRoot())
+	span, ctx := telemetry.StartListenerSpan(ctx, "OrganizationService.handleWebtrackerVisitorIdentifiedMessage", telemetry.WithNewRoot())
 	defer span.Finish()
 
 	if msg == nil {
@@ -306,7 +306,7 @@ func (s *organizationService) handleProcessingError(msg *nats.Msg) {
 }
 
 func (s *organizationService) sendOrganizationResponse(ctx context.Context, req *nats.Msg, resp *core_crm_pb.OrganizationSaveResponse) {
-	spans, _ := telemetry.StartServiceSpan(ctx, "organizationService.sendOrganizationResponse")
+	spans, _ := telemetry.StartServiceSpan(ctx, "OrganizationService.sendOrganizationResponse")
 	defer spans.Finish()
 
 	respMessage, err := proto.Marshal(resp)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes domain check in `service.go` by fetching personal email providers from the database if not cached and updates telemetry span names in `consumer.go`.
> 
>   - **Behavior**:
>     - Fixes domain check in `IsAcceptedDomainForOrganization()` in `service.go` by fetching personal email providers from the database if not cached.
>     - Updates cache with fetched personal email providers.
>   - **Telemetry**:
>     - Renames telemetry span names in `consumer.go` for `handleOrganizationMessage()`, `handleWebtrackerVisitorIdentifiedMessage()`, and `sendOrganizationResponse()` to use `OrganizationService` prefix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 437e8ee0a92b7858c9b2700679a137b3d2a06c2d. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->