### PR TITLE
patch: update dependencies

### DIFF
--- a/packages/runner/customer-os-data-upkeeper/go.mod
+++ b/packages/runner/customer-os-data-upkeeper/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/coocood/freecache v1.2.4 // indirect
 	github.com/customeros/customeros/packages/server/core-crm v0.0.0-20250504171220-a3d354c2ec9a // indirect
-	github.com/customeros/leads v0.0.54 // indirect
+	github.com/customeros/leads v0.0.68 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/packages/runner/customer-os-data-upkeeper/go.sum
+++ b/packages/runner/customer-os-data-upkeeper/go.sum
@@ -90,8 +90,8 @@ github.com/cucumber/godog v0.15.0 h1:51AL8lBXF3f0cyA5CV4TnJFCTHpgiy+1x1Hb3TtZUmo
 github.com/cucumber/godog v0.15.0/go.mod h1:FX3rzIDybWABU4kuIXLZ/qtqEe1Ac5RdXmqvACJOces=
 github.com/cucumber/messages/go/v21 v21.0.1 h1:wzA0LxwjlWQYZd32VTlAVDTkW6inOFmSM+RuOwHZiMI=
 github.com/cucumber/messages/go/v21 v21.0.1/go.mod h1:zheH/2HS9JLVFukdrsPWoPdmUtmYQAQPLk7w5vWsk5s=
-github.com/customeros/leads v0.0.54 h1:pcbdGsdnyTPPHkQYq4o/jQI/hBWbH4t9Vnef3r167XY=
-github.com/customeros/leads v0.0.54/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
+github.com/customeros/leads v0.0.68 h1:/do96OREhR6/KlVFiudplZ65n2UACcEcjJ7onGvOUiM=
+github.com/customeros/leads v0.0.68/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
 github.com/customeros/mailsherpa v0.3.9 h1:i+usip3f5A3IgryzeiYTzZWDxI1fRxp4VxXWGpTDd7c=
 github.com/customeros/mailsherpa v0.3.9/go.mod h1:3PVCXCWUQQ6lTjxFtPs4KlFKteME14hD5GFNiElB7Fk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/packages/server/core-crm/go.mod
+++ b/packages/server/core-crm/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/coocood/freecache v1.2.4 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
-	github.com/customeros/leads v0.0.54 // indirect
+	github.com/customeros/leads v0.0.68 // indirect
 	github.com/customeros/mailsherpa v0.3.9 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect

--- a/packages/server/core-crm/go.sum
+++ b/packages/server/core-crm/go.sum
@@ -97,8 +97,8 @@ github.com/cucumber/godog v0.15.0 h1:51AL8lBXF3f0cyA5CV4TnJFCTHpgiy+1x1Hb3TtZUmo
 github.com/cucumber/godog v0.15.0/go.mod h1:FX3rzIDybWABU4kuIXLZ/qtqEe1Ac5RdXmqvACJOces=
 github.com/cucumber/messages/go/v21 v21.0.1 h1:wzA0LxwjlWQYZd32VTlAVDTkW6inOFmSM+RuOwHZiMI=
 github.com/cucumber/messages/go/v21 v21.0.1/go.mod h1:zheH/2HS9JLVFukdrsPWoPdmUtmYQAQPLk7w5vWsk5s=
-github.com/customeros/leads v0.0.54 h1:pcbdGsdnyTPPHkQYq4o/jQI/hBWbH4t9Vnef3r167XY=
-github.com/customeros/leads v0.0.54/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
+github.com/customeros/leads v0.0.68 h1:/do96OREhR6/KlVFiudplZ65n2UACcEcjJ7onGvOUiM=
+github.com/customeros/leads v0.0.68/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
 github.com/customeros/mailsherpa v0.3.9 h1:i+usip3f5A3IgryzeiYTzZWDxI1fRxp4VxXWGpTDd7c=
 github.com/customeros/mailsherpa v0.3.9/go.mod h1:3PVCXCWUQQ6lTjxFtPs4KlFKteME14hD5GFNiElB7Fk=
 github.com/customeros/mailstack v0.2.23 h1:ZqI9ccrHcclV0sOBQZeU1mfm4VmGES2EAVjhju+LSdg=

--- a/packages/server/customer-os-api/go.mod
+++ b/packages/server/customer-os-api/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/customeros/customeros/packages/server/core-crm v0.0.0-20250504171220-a3d354c2ec9a // indirect
-	github.com/customeros/leads v0.0.54 // indirect
+	github.com/customeros/leads v0.0.68 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/packages/server/customer-os-api/go.sum
+++ b/packages/server/customer-os-api/go.sum
@@ -104,8 +104,8 @@ github.com/cucumber/godog v0.15.0 h1:51AL8lBXF3f0cyA5CV4TnJFCTHpgiy+1x1Hb3TtZUmo
 github.com/cucumber/godog v0.15.0/go.mod h1:FX3rzIDybWABU4kuIXLZ/qtqEe1Ac5RdXmqvACJOces=
 github.com/cucumber/messages/go/v21 v21.0.1 h1:wzA0LxwjlWQYZd32VTlAVDTkW6inOFmSM+RuOwHZiMI=
 github.com/cucumber/messages/go/v21 v21.0.1/go.mod h1:zheH/2HS9JLVFukdrsPWoPdmUtmYQAQPLk7w5vWsk5s=
-github.com/customeros/leads v0.0.54 h1:pcbdGsdnyTPPHkQYq4o/jQI/hBWbH4t9Vnef3r167XY=
-github.com/customeros/leads v0.0.54/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
+github.com/customeros/leads v0.0.68 h1:/do96OREhR6/KlVFiudplZ65n2UACcEcjJ7onGvOUiM=
+github.com/customeros/leads v0.0.68/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
 github.com/customeros/mailsherpa v0.3.9 h1:i+usip3f5A3IgryzeiYTzZWDxI1fRxp4VxXWGpTDd7c=
 github.com/customeros/mailsherpa v0.3.9/go.mod h1:3PVCXCWUQQ6lTjxFtPs4KlFKteME14hD5GFNiElB7Fk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -18089,16 +18089,6 @@ enum OrganizationStage {
     OPPORTUNITY
     CUSTOMER
     NOT_A_FIT
-
-    ENGAGED @deprecated
-    INITIAL_VALUE @deprecated
-    LEAD @deprecated
-    MAX_VALUE @deprecated
-    ONBOARDING @deprecated
-    PENDING_CHURN @deprecated
-    RECURRING_VALUE @deprecated
-    TRIAL @deprecated
-    UNQUALIFIED @deprecated
 }
 
 input OrganizationSaveInputFromGlobalOrg {

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -5978,23 +5978,14 @@ func (e OrganizationRelationship) MarshalJSON() ([]byte, error) {
 type OrganizationStage string
 
 const (
-	OrganizationStageTarget         OrganizationStage = "TARGET"
-	OrganizationStageEducation      OrganizationStage = "EDUCATION"
-	OrganizationStageSolution       OrganizationStage = "SOLUTION"
-	OrganizationStageEvaluation     OrganizationStage = "EVALUATION"
-	OrganizationStageReadyToBuy     OrganizationStage = "READY_TO_BUY"
-	OrganizationStageOpportunity    OrganizationStage = "OPPORTUNITY"
-	OrganizationStageCustomer       OrganizationStage = "CUSTOMER"
-	OrganizationStageNotAFit        OrganizationStage = "NOT_A_FIT"
-	OrganizationStageEngaged        OrganizationStage = "ENGAGED"
-	OrganizationStageInitialValue   OrganizationStage = "INITIAL_VALUE"
-	OrganizationStageLead           OrganizationStage = "LEAD"
-	OrganizationStageMaxValue       OrganizationStage = "MAX_VALUE"
-	OrganizationStageOnboarding     OrganizationStage = "ONBOARDING"
-	OrganizationStagePendingChurn   OrganizationStage = "PENDING_CHURN"
-	OrganizationStageRecurringValue OrganizationStage = "RECURRING_VALUE"
-	OrganizationStageTrial          OrganizationStage = "TRIAL"
-	OrganizationStageUnqualified    OrganizationStage = "UNQUALIFIED"
+	OrganizationStageTarget      OrganizationStage = "TARGET"
+	OrganizationStageEducation   OrganizationStage = "EDUCATION"
+	OrganizationStageSolution    OrganizationStage = "SOLUTION"
+	OrganizationStageEvaluation  OrganizationStage = "EVALUATION"
+	OrganizationStageReadyToBuy  OrganizationStage = "READY_TO_BUY"
+	OrganizationStageOpportunity OrganizationStage = "OPPORTUNITY"
+	OrganizationStageCustomer    OrganizationStage = "CUSTOMER"
+	OrganizationStageNotAFit     OrganizationStage = "NOT_A_FIT"
 )
 
 var AllOrganizationStage = []OrganizationStage{
@@ -6006,20 +5997,11 @@ var AllOrganizationStage = []OrganizationStage{
 	OrganizationStageOpportunity,
 	OrganizationStageCustomer,
 	OrganizationStageNotAFit,
-	OrganizationStageEngaged,
-	OrganizationStageInitialValue,
-	OrganizationStageLead,
-	OrganizationStageMaxValue,
-	OrganizationStageOnboarding,
-	OrganizationStagePendingChurn,
-	OrganizationStageRecurringValue,
-	OrganizationStageTrial,
-	OrganizationStageUnqualified,
 }
 
 func (e OrganizationStage) IsValid() bool {
 	switch e {
-	case OrganizationStageTarget, OrganizationStageEducation, OrganizationStageSolution, OrganizationStageEvaluation, OrganizationStageReadyToBuy, OrganizationStageOpportunity, OrganizationStageCustomer, OrganizationStageNotAFit, OrganizationStageEngaged, OrganizationStageInitialValue, OrganizationStageLead, OrganizationStageMaxValue, OrganizationStageOnboarding, OrganizationStagePendingChurn, OrganizationStageRecurringValue, OrganizationStageTrial, OrganizationStageUnqualified:
+	case OrganizationStageTarget, OrganizationStageEducation, OrganizationStageSolution, OrganizationStageEvaluation, OrganizationStageReadyToBuy, OrganizationStageOpportunity, OrganizationStageCustomer, OrganizationStageNotAFit:
 		return true
 	}
 	return false

--- a/packages/server/customer-os-api/graphql/schemas/organization.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/organization.graphqls
@@ -445,16 +445,6 @@ enum OrganizationStage {
     OPPORTUNITY
     CUSTOMER
     NOT_A_FIT
-
-    ENGAGED @deprecated
-    INITIAL_VALUE @deprecated
-    LEAD @deprecated
-    MAX_VALUE @deprecated
-    ONBOARDING @deprecated
-    PENDING_CHURN @deprecated
-    RECURRING_VALUE @deprecated
-    TRIAL @deprecated
-    UNQUALIFIED @deprecated
 }
 
 input OrganizationSaveInputFromGlobalOrg {

--- a/packages/server/customer-os-api/mapper/enum/organization_stage_mapper.go
+++ b/packages/server/customer-os-api/mapper/enum/organization_stage_mapper.go
@@ -16,16 +16,6 @@ var stageByModel = map[model.OrganizationStage]commonenum.OrganizationStage{
 	model.OrganizationStageOpportunity: commonenum.Opportunity,
 	model.OrganizationStageCustomer:    commonenum.Customer,
 	model.OrganizationStageNotAFit:     commonenum.NotAFit,
-
-	model.OrganizationStageLead:           commonenum.Lead,
-	model.OrganizationStageEngaged:        commonenum.Engaged,
-	model.OrganizationStageUnqualified:    commonenum.Unqualified,
-	model.OrganizationStageOnboarding:     commonenum.Onboarding,
-	model.OrganizationStageInitialValue:   commonenum.InitialValue,
-	model.OrganizationStageRecurringValue: commonenum.RecurringValue,
-	model.OrganizationStageMaxValue:       commonenum.MaxValue,
-	model.OrganizationStagePendingChurn:   commonenum.PendingChurn,
-	model.OrganizationStageTrial:          commonenum.Trial,
 }
 
 var stageByValue = utils.ReverseMap(stageByModel)

--- a/packages/server/customer-os-common-module/enum/organization_stage.go
+++ b/packages/server/customer-os-common-module/enum/organization_stage.go
@@ -11,25 +11,6 @@ const (
 	Opportunity OrganizationStage = "OPPORTUNITY"
 	Customer    OrganizationStage = "CUSTOMER"
 	NotAFit     OrganizationStage = "NOT_A_FIT"
-
-	// Deprecated
-	Lead OrganizationStage = "LEAD"
-	// Deprecated
-	Engaged OrganizationStage = "ENGAGED"
-	// Deprecated
-	Unqualified OrganizationStage = "UNQUALIFIED"
-	// Deprecated
-	Onboarding OrganizationStage = "ONBOARDING"
-	// Deprecated
-	InitialValue OrganizationStage = "INITIAL_VALUE"
-	// Deprecated
-	RecurringValue OrganizationStage = "RECURRING_VALUE"
-	// Deprecated
-	MaxValue OrganizationStage = "MAX_VALUE"
-	// Deprecated
-	PendingChurn OrganizationStage = "PENDING_CHURN"
-	// Deprecated
-	Trial OrganizationStage = "TRIAL"
 )
 
 func (e OrganizationStage) String() string {
@@ -54,25 +35,6 @@ func DecodeOrganizationStage(str string) OrganizationStage {
 		return Customer
 	case NotAFit.String():
 		return NotAFit
-
-	case Lead.String():
-		return Lead
-	case Engaged.String():
-		return Engaged
-	case Unqualified.String():
-		return Unqualified
-	case Onboarding.String():
-		return Onboarding
-	case InitialValue.String():
-		return InitialValue
-	case RecurringValue.String():
-		return RecurringValue
-	case MaxValue.String():
-		return MaxValue
-	case PendingChurn.String():
-		return PendingChurn
-	case Trial.String():
-		return Trial
 	default:
 		return ""
 	}

--- a/packages/server/customer-os-common-module/go.sum
+++ b/packages/server/customer-os-common-module/go.sum
@@ -92,8 +92,6 @@ github.com/cucumber/godog v0.15.0 h1:51AL8lBXF3f0cyA5CV4TnJFCTHpgiy+1x1Hb3TtZUmo
 github.com/cucumber/godog v0.15.0/go.mod h1:FX3rzIDybWABU4kuIXLZ/qtqEe1Ac5RdXmqvACJOces=
 github.com/cucumber/messages/go/v21 v21.0.1 h1:wzA0LxwjlWQYZd32VTlAVDTkW6inOFmSM+RuOwHZiMI=
 github.com/cucumber/messages/go/v21 v21.0.1/go.mod h1:zheH/2HS9JLVFukdrsPWoPdmUtmYQAQPLk7w5vWsk5s=
-github.com/customeros/leads v0.0.54 h1:pcbdGsdnyTPPHkQYq4o/jQI/hBWbH4t9Vnef3r167XY=
-github.com/customeros/leads v0.0.54/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
 github.com/customeros/leads v0.0.68 h1:/do96OREhR6/KlVFiudplZ65n2UACcEcjJ7onGvOUiM=
 github.com/customeros/leads v0.0.68/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
 github.com/customeros/mailsherpa v0.3.9 h1:i+usip3f5A3IgryzeiYTzZWDxI1fRxp4VxXWGpTDd7c=

--- a/packages/server/customer-os-webhooks/go.mod
+++ b/packages/server/customer-os-webhooks/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/cloudflare/cloudflare-go v0.115.0 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/customeros/customeros/packages/server/core-crm v0.0.0-20250504171220-a3d354c2ec9a // indirect
-	github.com/customeros/leads v0.0.54 // indirect
+	github.com/customeros/leads v0.0.68 // indirect
 	github.com/customeros/mailsherpa v0.3.9 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect

--- a/packages/server/customer-os-webhooks/go.sum
+++ b/packages/server/customer-os-webhooks/go.sum
@@ -92,8 +92,8 @@ github.com/cucumber/godog v0.15.0 h1:51AL8lBXF3f0cyA5CV4TnJFCTHpgiy+1x1Hb3TtZUmo
 github.com/cucumber/godog v0.15.0/go.mod h1:FX3rzIDybWABU4kuIXLZ/qtqEe1Ac5RdXmqvACJOces=
 github.com/cucumber/messages/go/v21 v21.0.1 h1:wzA0LxwjlWQYZd32VTlAVDTkW6inOFmSM+RuOwHZiMI=
 github.com/cucumber/messages/go/v21 v21.0.1/go.mod h1:zheH/2HS9JLVFukdrsPWoPdmUtmYQAQPLk7w5vWsk5s=
-github.com/customeros/leads v0.0.54 h1:pcbdGsdnyTPPHkQYq4o/jQI/hBWbH4t9Vnef3r167XY=
-github.com/customeros/leads v0.0.54/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
+github.com/customeros/leads v0.0.68 h1:/do96OREhR6/KlVFiudplZ65n2UACcEcjJ7onGvOUiM=
+github.com/customeros/leads v0.0.68/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
 github.com/customeros/mailsherpa v0.3.9 h1:i+usip3f5A3IgryzeiYTzZWDxI1fRxp4VxXWGpTDd7c=
 github.com/customeros/mailsherpa v0.3.9/go.mod h1:3PVCXCWUQQ6lTjxFtPs4KlFKteME14hD5GFNiElB7Fk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/packages/server/events-subscribers/go.mod
+++ b/packages/server/events-subscribers/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/coocood/freecache v1.2.4 // indirect
 	github.com/customeros/customeros/packages/server/core-crm v0.0.0-20250504171220-a3d354c2ec9a // indirect
-	github.com/customeros/leads v0.0.54 // indirect
+	github.com/customeros/leads v0.0.68 // indirect
 	github.com/customeros/mailsherpa v0.3.9 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect

--- a/packages/server/events-subscribers/go.sum
+++ b/packages/server/events-subscribers/go.sum
@@ -90,8 +90,8 @@ github.com/cucumber/godog v0.15.0 h1:51AL8lBXF3f0cyA5CV4TnJFCTHpgiy+1x1Hb3TtZUmo
 github.com/cucumber/godog v0.15.0/go.mod h1:FX3rzIDybWABU4kuIXLZ/qtqEe1Ac5RdXmqvACJOces=
 github.com/cucumber/messages/go/v21 v21.0.1 h1:wzA0LxwjlWQYZd32VTlAVDTkW6inOFmSM+RuOwHZiMI=
 github.com/cucumber/messages/go/v21 v21.0.1/go.mod h1:zheH/2HS9JLVFukdrsPWoPdmUtmYQAQPLk7w5vWsk5s=
-github.com/customeros/leads v0.0.54 h1:pcbdGsdnyTPPHkQYq4o/jQI/hBWbH4t9Vnef3r167XY=
-github.com/customeros/leads v0.0.54/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
+github.com/customeros/leads v0.0.68 h1:/do96OREhR6/KlVFiudplZ65n2UACcEcjJ7onGvOUiM=
+github.com/customeros/leads v0.0.68/go.mod h1:Xue8ATAIsWImBsOsLxqsNmF4+ZD/j5Dk2wsYK3I3z58=
 github.com/customeros/mailsherpa v0.3.9 h1:i+usip3f5A3IgryzeiYTzZWDxI1fRxp4VxXWGpTDd7c=
 github.com/customeros/mailsherpa v0.3.9/go.mod h1:3PVCXCWUQQ6lTjxFtPs4KlFKteME14hD5GFNiElB7Fk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `github.com/customeros/leads` dependency and remove deprecated organization stages.
> 
>   - **Dependencies**:
>     - Update `github.com/customeros/leads` from `v0.0.54` to `v0.0.68` in `go.mod` and `go.sum` files across multiple modules.
>   - **Code Cleanup**:
>     - Remove deprecated organization stages from `OrganizationStage` enum in `generated.go`, `models_gen.go`, `organization.graphqls`, `organization_stage_mapper.go`, and `organization_stage.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 2a3cb2bdb44cbd2fe428caadd9abbfbdd2160cb9. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->