### PR TITLE
patch: check outbox events

### DIFF
--- a/packages/runner/integrity-checker/cron/cron.go
+++ b/packages/runner/integrity-checker/cron/cron.go
@@ -51,5 +51,5 @@ func neo4jIntegrityCheckerJob(cont *container.Container) {
 }
 
 func postgresIntegrityCheckerJob(cont *container.Container) {
-	service.NewIntegrityCheckerService(cont.Cfg, cont.Log, cont.Neo4j, cont.Postgres, cont.Cache).RunPostgresIntegrityCheckerQueries()
+	service.NewIntegrityCheckerService(cont.Cfg, cont.Log, cont.Neo4j, cont.Postgres, cont.Cache).RunOpenlinePostgresIntegrityCheckerQueries()
 }

--- a/packages/runner/integrity-checker/postgres-openline-integrity-checker-queries.json
+++ b/packages/runner/integrity-checker/postgres-openline-integrity-checker-queries.json
@@ -10,13 +10,13 @@
       ]
     },
     {
-      "name": "Common",
+      "name": "OutboxEvents",
       "queries": [
         {
-          "name": "Test",
-          "query": "SELECT 1 as count"
+          "name": "Uncompleted outbox events older than 5 minutes",
+          "query": "select count(*) from outbox_events where status <> 'completed' and created_at < now() - interval '5 minutes' and created_at > now() - interval '3 days'"
         }
       ]
     }
   ]
-} 
+}

--- a/packages/runner/integrity-checker/service/integrity_checker_service.go
+++ b/packages/runner/integrity-checker/service/integrity_checker_service.go
@@ -34,7 +34,7 @@ const (
 
 type IntegrityCheckerService interface {
 	RunNeo4jIntegrityCheckerQueries()
-	RunPostgresIntegrityCheckerQueries()
+	RunOpenlinePostgresIntegrityCheckerQueries()
 }
 
 type integrityCheckerService struct {
@@ -86,21 +86,21 @@ func (s *integrityCheckerService) RunNeo4jIntegrityCheckerQueries() {
 	_ = s.alertInSlack(ctx, result, Neo4j)
 }
 
-func (s *integrityCheckerService) RunPostgresIntegrityCheckerQueries() {
+func (s *integrityCheckerService) RunOpenlinePostgresIntegrityCheckerQueries() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Cancel context on exit
 
-	spans, ctx := telemetry.StartSpan(ctx, "IntegrityCheckerService.RunPostgresIntegrityCheckerQueries")
+	spans, ctx := telemetry.StartSpan(ctx, "IntegrityCheckerService.RunOpenlinePostgresIntegrityCheckerQueries")
 	defer spans.Finish()
 
-	integrityCheckerQueries, err := s.getQueriesFromS3(ctx, "postgres-integrity-checker-queries.json")
+	integrityCheckerQueries, err := s.getQueriesFromS3(ctx, "postgres-openline-integrity-checker-queries.json")
 	if err != nil {
 		spans.TraceError(err)
 		s.log.Errorf("Error getting queries from S3: %v", err)
 	}
 	result := s.executePostgresQueries(ctx, integrityCheckerQueries)
 	spans.LogObjectAsJson("integrityCheckerResult", result)
-	s.log.Infof("Postgres integrity checker result: %v", result)
+	s.log.Infof("Postgres (openline DB) integrity checker result: %v", result)
 
 	_ = s.alertInSlack(ctx, result, Postgres)
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Renames Postgres integrity check functions and files to include 'Openline' and adds a query for uncompleted outbox events older than 5 minutes.
> 
>   - **Behavior**:
>     - Renames `RunPostgresIntegrityCheckerQueries()` to `RunOpenlinePostgresIntegrityCheckerQueries()` in `integrity_checker_service.go` and `cron.go`.
>     - Adds query for "Uncompleted outbox events older than 5 minutes" in `postgres-openline-integrity-checker-queries.json`.
>   - **Files**:
>     - Renames `postgres-integrity-checker-queries.json` to `postgres-openline-integrity-checker-queries.json`.
>   - **Logging**:
>     - Updates log message in `RunOpenlinePostgresIntegrityCheckerQueries()` to "Postgres (openline DB) integrity checker result".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for bcaf9357de6baad303d7a96e4f52f63004b11796. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->