### PR TITLE
patch: organization created event

### DIFF
--- a/packages/server/core-crm/service/outbox_processor/process_event.go
+++ b/packages/server/core-crm/service/outbox_processor/process_event.go
@@ -20,6 +20,8 @@ func (s *OutboxProcessor) processEvent(ctx context.Context, outboxEvent *postgre
 	switch {
 	case outboxEvent.EventType == enums.EventTenantCreated:
 		return s.processTenantCreatedEvent(ctx, outboxEvent)
+	case outboxEvent.EventType == enums.EventOrganizationCreated:
+		return s.processOrganizationCreatedEvent(ctx, outboxEvent)
 
 	default:
 		err := errors.New("event type not implemented")
@@ -37,6 +39,17 @@ func (s *OutboxProcessor) processTenantCreatedEvent(ctx context.Context, event *
 	// TODO write event to data warehouse
 
 	return s.publishEvent(ctx, event, enums.StreamTenant)
+}
+
+func (s *OutboxProcessor) processOrganizationCreatedEvent(ctx context.Context, event *postgres_entity.OutboxEvent) error {
+	span, ctx := telemetry.StartServiceSpan(ctx, "OutboxProcessor.processOrganizationCreatedEvent")
+	defer span.Finish()
+	span.TagEventType(event.EventType.String())
+	span.TagEntity(event.ID)
+
+	// TODO write event to data warehouse
+
+	return s.publishEvent(ctx, event, enums.StreamOrganization)
 }
 
 func (s *OutboxProcessor) publishEvent(ctx context.Context, event *postgres_entity.OutboxEvent, stream enums.NatsStream) error {

--- a/packages/server/customer-os-common-module/services/organization/organization.go
+++ b/packages/server/customer-os-common-module/services/organization/organization.go
@@ -3,6 +3,9 @@ package organization
 import (
 	"context"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/proto/pb"
+	"github.com/customeros/customeros/packages/server/enums"
+	"google.golang.org/protobuf/proto"
 	"strings"
 	"time"
 
@@ -545,6 +548,41 @@ func (s *organizationService) Save(ctx context.Context, txWithPostCommit *utils.
 				}
 
 				s.events.Publisher.PublishNotification(ctx, tenant, organizationId, model.ORGANIZATION, utils.NewEventCompletedDetails().WithUpdate())
+			}
+			return nil
+		})
+
+		// send to outbox
+		txWithPostCommit.AddPostCommitAction(func(ctx context.Context) error {
+			if createFlow {
+				organizationCreatedEvent := &pb.CompanyCreated{
+					CompanyId:      organizationId,
+					OrganizationId: organizationId,
+					Tenant:         tenant,
+					PrimaryDomain:  primaryDomain,
+				}
+				payload, err := proto.Marshal(organizationCreatedEvent)
+				if err != nil {
+					spans.TraceError(err)
+					return nil
+				}
+
+				outboxEvent := &postgres_entity.OutboxEvent{
+					EntityID:  tenant,
+					EventType: enums.EventOrganizationCreated,
+					Tenant:    tenant,
+					Payload:   payload,
+					Publisher: "organization",
+					Status:    postgres_entity.OutboxPending,
+				}
+				_, err = s.postgres.OutboxRepository.Create(ctx, outboxEvent)
+				if err != nil {
+					spans.TraceError(err)
+				}
+
+				return nil
+			} else {
+				// send update event to outbox
 			}
 			return nil
 		})

--- a/packages/server/customer-os-postgres-repository/repository/outbox_repository.go
+++ b/packages/server/customer-os-postgres-repository/repository/outbox_repository.go
@@ -2,16 +2,17 @@ package postgres_repository
 
 import (
 	"context"
+	"time"
+
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
-	"time"
 
 	"gorm.io/gorm"
 )
 
 type OutboxRepository interface {
-	Create(ctx context.Context, event *postgres_entity.OutboxEvent) error
+	Create(ctx context.Context, event *postgres_entity.OutboxEvent) (*postgres_entity.OutboxEvent, error)
 	CreateWithTxn(ctx context.Context, txn *gorm.DB, event *postgres_entity.OutboxEvent) error
 	GetPendingEvents(ctx context.Context, limit int) ([]*postgres_entity.OutboxEvent, error)
 	MarkAsProcessing(ctx context.Context, id string, lockDuration time.Duration) error
@@ -31,17 +32,17 @@ func NewOutboxRepository(gormDb *gorm.DB) OutboxRepository {
 	}
 }
 
-func (r *outboxRepository) Create(ctx context.Context, event *postgres_entity.OutboxEvent) error {
+func (r *outboxRepository) Create(ctx context.Context, event *postgres_entity.OutboxEvent) (*postgres_entity.OutboxEvent, error) {
 	span, ctx := telemetry.StartPostgresSpan(ctx, "outboxRepository.Create")
 	defer span.Finish()
 
 	err := r.gormDb.WithContext(ctx).Create(event).Error
 	if err != nil {
 		span.TraceError(err)
-		return err
+		return nil, err
 	}
 
-	return nil
+	return event, nil
 }
 
 func (r *outboxRepository) CreateWithTxn(ctx context.Context, txn *gorm.DB, event *postgres_entity.OutboxEvent) error {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add handling for 'Organization Created' events in outbox processor and organization service, and modify outbox repository to return created events.
> 
>   - **Behavior**:
>     - Add `processOrganizationCreatedEvent()` in `process_event.go` to handle `EventOrganizationCreated`.
>     - Modify `Save()` in `organization.go` to send `EventOrganizationCreated` to outbox.
>   - **Outbox Repository**:
>     - Change `Create()` in `outbox_repository.go` to return the created `OutboxEvent`.
>   - **Misc**:
>     - Rename `outbox_event_repository.go` to `outbox_repository.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 1af04644ca6d6f2a83cd847a8bbed0b3c9b21001. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->