### PR TITLE
patch: create request stream in common module

### DIFF
--- a/packages/server/customer-os-common-module/nats/nats_server.go
+++ b/packages/server/customer-os-common-module/nats/nats_server.go
@@ -15,8 +15,9 @@ import (
 type NatsHeader string
 
 const (
-	MAX_STREAM_RECONNECTS            = -1 // never stop trying to reconnect
-	NATS_HEADER_TENANT    NatsHeader = "X-Tenant"
+	MAX_STREAM_RECONNECTS                  = -1 // never stop trying to reconnect
+	NATS_HEADER_TENANT    NatsHeader       = "X-Tenant"
+	REQUEST_STREAM        enums.NatsStream = enums.StreamRequest
 )
 
 // NATSConnection represents a single NATS connection with its associated JetStream context
@@ -116,7 +117,17 @@ func InitNats(config *config.NATSConfig, environment string, streams []enums.Nat
 		}
 		log.Printf("✅ NATS connection established for stream %s", streamName)
 
-		// Create JetStream context for each stream
+		// Special handling for request stream - use core NATS only
+		if streamName == REQUEST_STREAM {
+			streamConns[streamName] = &NATSConnection{
+				Conn: conn,
+				Name: streamName,
+			}
+			log.Printf("✅ Request stream configured for core NATS (no JetStream)")
+			continue
+		}
+
+		// For all other streams, create JetStream context
 		js, err := conn.JetStream()
 		if err != nil {
 			for _, c := range streamConns {
@@ -134,7 +145,7 @@ func InitNats(config *config.NATSConfig, environment string, streams []enums.Nat
 		}
 
 		// Set up stream
-		err = setupWorkQueueStream(js, streamName.String(), []string{streamName.String() + ".>"}, replicas)
+		err = setupJetStream(js, streamName.String(), []string{streamName.String() + ".>"}, replicas)
 		if err != nil {
 			for _, c := range streamConns {
 				c.Close()
@@ -151,7 +162,7 @@ func InitNats(config *config.NATSConfig, environment string, streams []enums.Nat
 	}, nil
 }
 
-func setupWorkQueueStream(js nats.JetStreamContext, streamName string, subjects []string, replicas int) error {
+func setupJetStream(js nats.JetStreamContext, streamName string, subjects []string, replicas int) error {
 	streamInfo, err := js.StreamInfo(streamName)
 	if err != nil {
 		// Stream doesn't exist, create it


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Special handling for `REQUEST_STREAM` in NATS initialization to use core NATS without JetStream, and rename of `setupWorkQueueStream()` to `setupJetStream()`.
> 
>   - **Behavior**:
>     - Special handling for `REQUEST_STREAM` in `InitNats()` in `nats_server.go` to use core NATS without JetStream.
>     - Logs configuration success for `REQUEST_STREAM`.
>   - **Functions**:
>     - Renames `setupWorkQueueStream()` to `setupJetStream()` in `nats_server.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for e5ee094a6eaa06ae2ff72e3894c52d33a2b551a3. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->