### PR TITLE
patch: use telemetry in mailsherpa api

### DIFF
--- a/packages/server/customer-os-common-module/tracing/utils.go
+++ b/packages/server/customer-os-common-module/tracing/utils.go
@@ -24,23 +24,17 @@ import (
 )
 
 const (
-	SpanTagTenant         = "tenant"
-	SpanTagUserId         = "user-id"
-	SpanTagUserEmail      = "user-email"
-	SpanTagEntityId       = "entity-id"
-	SpanTagComponent      = "component"
-	SpanTagExternalSystem = "external-system"
-	SpanTagExternalId     = "external-id"
+	SpanTagTenant    = "tenant"
+	SpanTagUserId    = "user-id"
+	SpanTagUserEmail = "user-email"
+	SpanTagEntityId  = "entity-id"
+	SpanTagComponent = "component"
 )
 
 const (
 	SpanTagComponentPostgresRepository = "postgresRepository"
 	SpanTagComponentNeo4jRepository    = "neo4jRepository"
-	SpanTagComponentRest               = "rest"
-	SpanTagComponentCronJob            = "cronJob"
 	SpanTagComponentService            = "service"
-	SpanTagComponentListener           = "listener"
-	SpanTagComponentAgentCapability    = "agentCapability"
 )
 
 func TracingEnhancer(ctx context.Context, endpoint string) func(c *gin.Context) {

--- a/packages/server/mailsherpa-api/mailsherpa_api_main.go
+++ b/packages/server/mailsherpa-api/mailsherpa_api_main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/caarlos0/env/v6"
 	commonconf "github.com/customeros/customeros/packages/server/customer-os-common-module/config"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -33,7 +32,7 @@ func main() {
 	if tracingCloser != nil {
 		defer tracingCloser.Close()
 	}
-	defer tracing.RecoverAndLogToJaeger(appLogger)
+	defer telemetry.RecoveryWithTelemetry(appLogger)
 
 	ctx := context.Background()
 

--- a/packages/server/mailsherpa-api/route/rest_tracing_enhancer.go
+++ b/packages/server/mailsherpa-api/route/rest_tracing_enhancer.go
@@ -1,0 +1,16 @@
+package route
+
+import (
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/net/context"
+)
+
+func RestTracingEnhancer(ctx context.Context, endpoint string) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		spans, ctx := telemetry.StartHttpServerTracerSpanWithHeader(ctx, endpoint, c.Request.Header)
+		defer spans.Finish()
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}

--- a/packages/server/mailsherpa-api/route/routes.go
+++ b/packages/server/mailsherpa-api/route/routes.go
@@ -2,13 +2,12 @@ package route
 
 import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/security"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/mailsherpa-api/config"
 	"github.com/customeros/customeros/packages/server/mailsherpa-api/logger"
 	"github.com/customeros/customeros/packages/server/mailsherpa-api/model"
 	"github.com/customeros/customeros/packages/server/mailsherpa-api/service"
 	"github.com/gin-gonic/gin"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"net/http"
@@ -27,11 +26,11 @@ func healthCheckHandler(c *gin.Context) {
 
 func validateEmail(ctx context.Context, r *gin.Engine, services *service.Services, cfg *config.Config, l logger.Logger) {
 	r.POST("/validateEmail",
-		tracing.TracingEnhancer(ctx, "POST /validateEmail"),
+		RestTracingEnhancer(ctx, "POST /validateEmail"),
 		security.ApiKeyCheckerHTTP(services.PostgresRepositories.TenantWebhookApiKeyRepository, cfg.AppKey, security.WithCache(services.Cache)),
 		func(c *gin.Context) {
-			span, ctx := opentracing.StartSpanFromContext(c.Request.Context(), "ValidateEmailV2")
-			defer span.Finish()
+			spans, ctx := telemetry.StartRestSpan(c.Request.Context(), "ValidateEmailV2")
+			defer spans.Finish()
 
 			var request model.ValidateEmailRequestWithOptions
 
@@ -43,11 +42,11 @@ func validateEmail(ctx context.Context, r *gin.Engine, services *service.Service
 				})
 				return
 			}
-			tracing.LogObjectAsJson(span, "request", request)
+			spans.LogObjectAsJson("request", request)
 
 			// check email is present
 			if request.Email == "" {
-				tracing.TraceErr(span, errors.New("Missing email parameter"))
+				spans.TraceError(errors.New("Missing email parameter"))
 				l.Errorf("Missing email parameter")
 				c.JSON(http.StatusBadRequest, model.ValidateEmailResponse{
 					Status:  "error",
@@ -55,11 +54,11 @@ func validateEmail(ctx context.Context, r *gin.Engine, services *service.Service
 				})
 				return
 			}
-			span.SetTag("email", request.Email)
+			spans.TagString("email", request.Email)
 
 			emailValidationData, err := services.MailsherpaService.ValidateEmailWithMailSherpa(ctx, request.Email)
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				l.Errorf("Error on : %v", err.Error())
 				c.JSON(http.StatusInternalServerError, model.ValidateEmailResponse{
 					Status:          "error",
@@ -69,7 +68,7 @@ func validateEmail(ctx context.Context, r *gin.Engine, services *service.Service
 				return
 			}
 
-			tracing.LogObjectAsJson(span, "output", emailValidationData)
+			spans.LogObjectAsJson("output", emailValidationData)
 			c.JSON(http.StatusOK, model.ValidateEmailResponse{
 				Status: "success",
 				Data:   emailValidationData,

--- a/packages/server/mailsherpa-api/service/mailsherpa.go
+++ b/packages/server/mailsherpa-api/service/mailsherpa.go
@@ -3,19 +3,18 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"github.com/opentracing/opentracing-go/log"
 	"strings"
 	"time"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/verify"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgres_entity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
 	mailsherpa "github.com/customeros/mailsherpa/mailvalidate"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/server/mailsherpa-api/config"
@@ -38,9 +37,9 @@ func NewMailSherpaService(log logger.Logger, config *config.Config, postgres *po
 const MaxDurationCallMailSherpa = 10 * time.Second
 
 func (s *MailSherpaService) ValidateEmailWithMailSherpa(ctx context.Context, email string) (*interfaces.ValidateEmailMailSherpaData, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MailsherpaAPI.ValidateEmailWithMailSherpa")
-	defer span.Finish()
-	span.LogKV("email", email)
+	spans, ctx := telemetry.StartServiceSpan(ctx, "MailsherpaAPI.ValidateEmailWithMailSherpa")
+	defer spans.Finish()
+	spans.TagString("email", email)
 
 	result := &interfaces.ValidateEmailMailSherpaData{
 		Email: email,
@@ -62,7 +61,7 @@ func (s *MailSherpaService) ValidateEmailWithMailSherpa(ctx context.Context, ema
 
 	domainValidation, domainCheckTimeoutOccurred, err := s.getDomainValidationWithTimeout(ctx, syntaxValidation.Domain, email)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to validate email domain"))
+		spans.TraceError(errors.Wrap(err, "failed to validate email domain"))
 		return nil, err
 	}
 	if domainCheckTimeoutOccurred {
@@ -103,7 +102,7 @@ func (s *MailSherpaService) ValidateEmailWithMailSherpa(ctx context.Context, ema
 	if len(providersToSkip) == 0 || !utils.Contains(providersToSkip, domainValidation.Provider) {
 		emailValidation, emailCheckTimeoutOccurred, err := s.getEmailValidationWithTimeout(ctx, email, syntaxValidation, utils.BoolDefaultIfNil(domainValidation.IsPrimaryDomain, true), domainValidation.PrimaryDomain)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to validate email"))
+			spans.TraceError(errors.Wrap(err, "failed to validate email"))
 			return nil, err
 		}
 		if emailCheckTimeoutOccurred {
@@ -115,7 +114,7 @@ func (s *MailSherpaService) ValidateEmailWithMailSherpa(ctx context.Context, ema
 		if emailValidation.AlternateEmail != "" {
 			alternateEmailValidation, _, err = s.getEmailValidationWithTimeout(ctx, emailValidation.AlternateEmail, syntaxValidation, true, "")
 			if err != nil {
-				tracing.TraceErr(span, errors.Wrap(err, "failed to validate alternate email"))
+				spans.TraceError(errors.Wrap(err, "failed to validate alternate email"))
 			}
 		}
 		result.EmailData.Deliverable = emailValidation.Deliverable
@@ -169,13 +168,13 @@ func (s *MailSherpaService) getDomainValidationWithTimeout(ctx context.Context, 
 }
 
 func (s *MailSherpaService) getDomainValidation(ctx context.Context, domain, email string) (postgres_entity.CacheEmailValidationDomain, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailValidationService.getDomainValidation")
-	defer span.Finish()
-	span.LogKV("domain", domain, "email", email)
+	spans, ctx := telemetry.StartServiceSpan(ctx, "EmailValidationService.getDomainValidation")
+	defer spans.Finish()
+	spans.LogKV("domain", domain, "email", email)
 
 	cacheDomain, err := s.postgres.CacheEmailValidationDomainRepository.Get(ctx, domain)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to get cache data"))
+		spans.TraceError(errors.Wrap(err, "failed to get cache data"))
 	}
 
 	if cacheDomain == nil || cacheDomain.IsPrimaryDomain == nil || cacheDomain.UpdatedAt.AddDate(0, 0, s.cfg.EmailConfig.EmailDomainValidationCacheTtlDays).Before(utils.Now()) {
@@ -186,7 +185,7 @@ func (s *MailSherpaService) getDomainValidation(ctx context.Context, domain, ema
 		})
 		jsonData, err := json.Marshal(domainValidation)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to marshal domain validation data"))
+			spans.TraceError(errors.Wrap(err, "failed to marshal domain validation data"))
 		}
 		cacheDomain, err = s.postgres.CacheEmailValidationDomainRepository.Save(ctx, postgres_entity.CacheEmailValidationDomain{
 			Domain:              domain,
@@ -212,7 +211,7 @@ func (s *MailSherpaService) getDomainValidation(ctx context.Context, domain, ema
 			Data:                utils.SanitizeUTF8(string(jsonData)),
 		})
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to save domain data"))
+			spans.TraceError(errors.Wrap(err, "failed to save domain data"))
 			return postgres_entity.CacheEmailValidationDomain{}, err
 		}
 	}
@@ -254,16 +253,16 @@ func (s *MailSherpaService) getEmailValidationWithTimeout(ctx context.Context, e
 }
 
 func (s *MailSherpaService) getEmailValidation(ctx context.Context, email string, syntaxValidation mailsherpa.SyntaxValidation, isPrimaryDomain bool, primaryDomain string) (postgres_entity.CacheEmailValidation, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailValidationService.getEmailValidation")
-	defer span.Finish()
-	span.LogFields(
+	spans, ctx := telemetry.StartServiceSpan(ctx, "EmailValidationService.getEmailValidation")
+	defer spans.Finish()
+	spans.LogFields(
 		log.String("email", email),
 		log.Bool("isPrimaryDomain", isPrimaryDomain),
 		log.String("primaryDomain", primaryDomain))
 
 	cachedEmail, err := s.postgres.CacheEmailValidationRepository.Get(ctx, email)
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to get cache data"))
+		spans.TraceError(errors.Wrap(err, "failed to get cache data"))
 	}
 
 	// if no cached data found, or last time fetched > 90 days ago, or is retry validation
@@ -282,12 +281,12 @@ func (s *MailSherpaService) getEmailValidation(ctx context.Context, email string
 
 		emailValidation := mailsherpa.ValidateEmail(emailValidationRequest)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to get email data with mailsherpa"))
+			spans.TraceError(errors.Wrap(err, "failed to get email data with mailsherpa"))
 			return postgres_entity.CacheEmailValidation{}, err
 		}
 		jsonData, err := json.Marshal(emailValidation)
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to marshal email validation data"))
+			spans.TraceError(errors.Wrap(err, "failed to marshal email validation data"))
 		}
 
 		cacheEmailValidationEntity := postgres_entity.CacheEmailValidation{
@@ -321,7 +320,7 @@ func (s *MailSherpaService) getEmailValidation(ctx context.Context, email string
 			cachedEmail, err = s.postgres.CacheEmailValidationRepository.Save(ctx, cacheEmailValidationEntity)
 		}
 		if err != nil {
-			tracing.TraceErr(span, errors.Wrap(err, "failed to save email data"))
+			spans.TraceError(errors.Wrap(err, "failed to save email data"))
 			return postgres_entity.CacheEmailValidation{}, err
 		}
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Integrate telemetry into the mailsherpa API, replacing the existing tracing system with updated functions and imports.
> 
>   - **Telemetry Integration**:
>     - Replace `tracing` with `telemetry` in `mailsherpa_api_main.go`, `routes.go`, and `mailsherpa.go`.
>     - Use `telemetry.RecoveryWithTelemetry` instead of `tracing.RecoverAndLogToJaeger` in `mailsherpa_api_main.go`.
>     - Implement `RestTracingEnhancer` in `rest_tracing_enhancer.go` using `telemetry`.
>   - **Function Updates**:
>     - Update `validateEmail` in `routes.go` to use `telemetry.StartRestSpan`.
>     - Update `ValidateEmailWithMailSherpa` in `mailsherpa.go` to use `telemetry.StartServiceSpan`.
>     - Replace `tracing.TraceErr` with `spans.TraceError` in `mailsherpa.go`.
>   - **Miscellaneous**:
>     - Remove unused span tag constants in `utils.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 60407fa31c045a3a45d8772e2cac3879ee4b4276. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->