### PR TITLE
patch: tracing part 2

### DIFF
--- a/packages/server/customer-os-api/dataloader/action_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/action_dataloader.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -23,16 +21,17 @@ func (i *Loaders) GetActionsForInteractionEvent(ctx context.Context, interaction
 }
 
 func (b *actionBatcher) getActionsForInteractionEvents(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionDataLoader.getActionsForInteractionEvents")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ActionDataLoader.getActionsForInteractionEvents")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	actionsForNodes, err := b.actionService.GetActionsForNodes(ctx, neo4jenum.INTERACTION_EVENT, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get attachments for interaction events")}}
@@ -62,11 +61,11 @@ func (b *actionBatcher) getActionsForInteractionEvents(ctx context.Context, keys
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.ActionEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/action_item_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/action_item_dataloader.go
@@ -3,13 +3,12 @@ package dataloader
 import (
 	"context"
 	"errors"
+	"reflect"
+
 	"github.com/customeros/customeros/packages/server/customer-os-api/entity"
 	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
-	"reflect"
 )
 
 func (i *Loaders) GetActionItemsForInteractionEvent(ctx context.Context, interactionEventId string) (*entity.ActionItemEntities, error) {
@@ -23,16 +22,16 @@ func (i *Loaders) GetActionItemsForInteractionEvent(ctx context.Context, interac
 }
 
 func (b *actionItemBatcher) getActionItemsForInteractionEvents(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ActionItemDataLoader.getActionItemsForInteractionEvents")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ActionItemDataLoader.getActionItemsForInteractionEvents")
+	defer spans.Finish()
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	actionItemsForNodes, err := b.actionItemService.GetActionItemsForNodes(ctx, repository.LINKED_WITH_INTERACTION_EVENT, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get attachments for interaction events")}}
@@ -62,11 +61,10 @@ func (b *actionItemBatcher) getActionItemsForInteractionEvents(ctx context.Conte
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(entity.ActionItemEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
-
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/attachment_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/attachment_dataloader.go
@@ -6,11 +6,9 @@ import (
 	"reflect"
 
 	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 func (i *Loaders) GetAttachmentsForInteractionEvent(ctx context.Context, interactionEventId string) (*neo4j_entity.AttachmentEntities, error) {
@@ -44,16 +42,16 @@ func (i *Loaders) GetAttachmentsForContract(ctx context.Context, contractId stri
 }
 
 func (b *attachmentBatcher) getAttachmentsForInteractionEvents(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AttachmentDataLoader.getAttachmentsForInteractionEvents")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "AttachmentDataLoader.getAttachmentsForInteractionEvents")
+	defer spans.Finish()
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	attachmentEntitiesPtr, err := b.attachmentService.GetFor(ctx, commonModel.INTERACTION_EVENT, nil, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get attachments for interaction events")}}
@@ -83,27 +81,27 @@ func (b *attachmentBatcher) getAttachmentsForInteractionEvents(ctx context.Conte
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4j_entity.AttachmentEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *attachmentBatcher) getAttachmentsForMeetings(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AttachmentDataLoader.getAttachmentsForMeetings")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "AttachmentDataLoader.getAttachmentsForMeetings")
+	defer spans.Finish()
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	includes := commonModel.INCLUDES
 	attachmentEntitiesPtr, err := b.attachmentService.GetFor(ctx, commonModel.MEETING, &includes, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get attachments for interaction sessions")}}
@@ -133,26 +131,26 @@ func (b *attachmentBatcher) getAttachmentsForMeetings(ctx context.Context, keys 
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4j_entity.AttachmentEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *attachmentBatcher) getAttachmentsForContracts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "AttachmentDataLoader.getAttachmentsForContracts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "AttachmentDataLoader.getAttachmentsForContracts")
+	defer spans.Finish()
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	attachmentEntitiesPtr, err := b.attachmentService.GetFor(ctx, commonModel.CONTRACT, nil, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get attachments for contracts")}}
@@ -182,11 +180,11 @@ func (b *attachmentBatcher) getAttachmentsForContracts(ctx context.Context, keys
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4j_entity.AttachmentEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/calendar_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/calendar_dataloader.go
@@ -2,14 +2,13 @@ package dataloader
 
 import (
 	"context"
+	"reflect"
+
 	"github.com/customeros/customeros/packages/server/customer-os-api/entity"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
-	"reflect"
 )
 
 func (i *Loaders) GetCalendarsForUser(ctx context.Context, userId string) (*entity.CalendarEntities, error) {
@@ -23,10 +22,10 @@ func (i *Loaders) GetCalendarsForUser(ctx context.Context, userId string) (*enti
 }
 
 func (b *calendarBatcher) getCalendarsForUsers(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CalendarDataLoader.getCalendarsForUsers")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "CalendarDataLoader.getCalendarsForUsers")
+	defer spans.Finish()
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -35,7 +34,7 @@ func (b *calendarBatcher) getCalendarsForUsers(ctx context.Context, keys dataloa
 
 	calendarEntitiesPtr, err := b.calendarService.GetAllForUsers(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -66,11 +65,11 @@ func (b *calendarBatcher) getCalendarsForUsers(ctx context.Context, keys dataloa
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(entity.CalendarEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/comment_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/comment_dataloader.go
@@ -2,12 +2,10 @@ package dataloader
 
 import (
 	"context"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"reflect"
 )
@@ -23,10 +21,10 @@ func (i *Loaders) GetCommentsForIssue(ctx context.Context, issueId string) (*neo
 }
 
 func (b *commentBatcher) getCommentsForIssues(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommentDataLoader.getCommentsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "CommentDataLoader.getCommentsForIssues")
+	defer spans.Finish()
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -35,7 +33,7 @@ func (b *commentBatcher) getCommentsForIssues(ctx context.Context, keys dataload
 
 	commentEntitiesPtr, err := b.commentService.GetCommentsForIssues(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -65,11 +63,11 @@ func (b *commentBatcher) getCommentsForIssues(ctx context.Context, keys dataload
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.CommentEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/contact_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/contact_dataloader.go
@@ -3,13 +3,12 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"reflect"
+
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
-	"reflect"
 )
 
 func (i *Loaders) GetContactsForEmail(ctx context.Context, emailId string) (*neo4jentity.ContactEntities, error) {
@@ -57,16 +56,16 @@ func (i *Loaders) GetContactCountForOrganization(ctx context.Context, organizati
 }
 
 func (b *contactBatcher) getContactsForEmails(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactDataLoader.getContactsForEmails")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactDataLoader.getContactsForEmails")
+	defer spans.Finish()
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	contactEntitiesPtr, err := b.contactService.GetContactsForEmails(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get contacts for emails")}}
@@ -96,26 +95,26 @@ func (b *contactBatcher) getContactsForEmails(ctx context.Context, keys dataload
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.ContactEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *contactBatcher) getContactsForPhoneNumbers(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactDataLoader.getContactsForPhoneNumbers")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactDataLoader.getContactsForPhoneNumbers")
+	defer spans.Finish()
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	contactEntitiesPtr, err := b.contactService.GetContactsForPhoneNumbers(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get contacts for phone numbers")}}
@@ -145,26 +144,26 @@ func (b *contactBatcher) getContactsForPhoneNumbers(ctx context.Context, keys da
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.ContactEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *contactBatcher) getContactsForJobRoles(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactDataLoader.getContactsForJobRoles")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactDataLoader.getContactsForJobRoles")
+	defer spans.Finish()
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	contactEntities, err := b.contactService.GetContactsForJobRoles(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get contacts for job roles")}}
@@ -191,20 +190,20 @@ func (b *contactBatcher) getContactsForJobRoles(ctx context.Context, keys datalo
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.ContactEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *contactBatcher) getContactCountForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactDataLoader.getContactCountForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactDataLoader.getContactCountForOrganizations")
+	defer spans.Finish()
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -213,7 +212,7 @@ func (b *contactBatcher) getContactCountForOrganizations(ctx context.Context, ke
 
 	contactCountsPerOrg, err := b.contactService.GetContactCountByOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get contact count for organization")}}
@@ -234,7 +233,7 @@ func (b *contactBatcher) getContactCountForOrganizations(ctx context.Context, ke
 		results[ix] = &dataloader.Result{Data: 0, Error: nil}
 	}
 
-	span.LogFields(log.Int("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/contract_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/contract_dataloader.go
@@ -2,12 +2,10 @@ package dataloader
 
 import (
 	"context"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"reflect"
 )
@@ -35,10 +33,11 @@ func (i *Loaders) GetContractForInvoice(ctx context.Context, invoiceId string) (
 }
 
 func (b *contractBatcher) getContractsForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractDataLoader.getContractsForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractDataLoader.getContractsForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -47,7 +46,7 @@ func (b *contractBatcher) getContractsForOrganizations(ctx context.Context, keys
 
 	contractEntitiesPtr, err := b.commonContractService.GetContractsForOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get contracts for organizations")}}
@@ -77,20 +76,21 @@ func (b *contractBatcher) getContractsForOrganizations(ctx context.Context, keys
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.ContractEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *contractBatcher) getContractsForInvoices(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractDataLoader.getContractsForInvoices")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractDataLoader.getContractsForInvoices")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -99,7 +99,7 @@ func (b *contractBatcher) getContractsForInvoices(ctx context.Context, keys data
 
 	contractEntities, err := b.contractService.GetContractsForInvoices(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get contracts for invoices")}}
@@ -126,11 +126,11 @@ func (b *contractBatcher) getContractsForInvoices(ctx context.Context, keys data
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.ContractEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/country_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/country_dataloader.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 func (i *Loaders) GetCountryForPhoneNumber(ctx context.Context, phoneNumberId string) (*neo4j_entity.CountryEntity, error) {
@@ -26,16 +24,17 @@ func (i *Loaders) GetCountryForPhoneNumber(ctx context.Context, phoneNumberId st
 }
 
 func (b *countryBatcher) getCountriesForPhoneNumbers(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CountryDataLoader.getCountriesForPhoneNumbers")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "CountryDataLoader.getCountriesForPhoneNumbers")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	countryEntities, err := b.countryService.GetCountriesForPhoneNumbers(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get countries for phoneNumbers")}}
@@ -62,11 +61,11 @@ func (b *countryBatcher) getCountriesForPhoneNumbers(ctx context.Context, keys d
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4j_entity.CountryEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/domain_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/domain_dataloader.go
@@ -3,11 +3,9 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -22,16 +20,17 @@ func (i *Loaders) GetDomainsForOrganization(ctx context.Context, organizationId 
 }
 
 func (b *domainBatcher) getDomainsForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "DomainDataLoader.getDomainsForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "DomainDataLoader.getDomainsForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	domainEntitiesPtr, err := b.domainService.GetAllDomainsForOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get domains for organizations")}}
@@ -61,11 +60,11 @@ func (b *domainBatcher) getDomainsForOrganizations(ctx context.Context, keys dat
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.DomainEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/email_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/email_dataloader.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"errors"
 	neo4jmodel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	pkgerrors "github.com/pkg/errors"
 	"reflect"
 )
@@ -47,16 +45,17 @@ func (i *Loaders) GetPrimaryEmailForContact(ctx context.Context, contactId strin
 }
 
 func (b *emailBatcher) getEmailsForContacts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailDataLoader.getEmailsForContacts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "EmailDataLoader.getEmailsForContacts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	emailEntitiesPtr, err := b.emailService.GetAllForEntityTypeByIds(ctx, neo4jmodel.CONTACT, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get emails for contacts")}}
@@ -87,26 +86,27 @@ func (b *emailBatcher) getEmailsForContacts(ctx context.Context, keys dataloader
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.EmailEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *emailBatcher) getEmailsForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailDataLoader.getEmailsForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "EmailDataLoader.getEmailsForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	emailEntitiesPtr, err := b.emailService.GetAllForEntityTypeByIds(ctx, neo4jmodel.ORGANIZATION, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get emails for organizations")}}
@@ -137,20 +137,21 @@ func (b *emailBatcher) getEmailsForOrganizations(ctx context.Context, keys datal
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.EmailEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *emailBatcher) getPrimaryEmailForContacts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailDataLoader.getPrimaryEmailForContacts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "EmailDataLoader.getPrimaryEmailForContacts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -159,7 +160,7 @@ func (b *emailBatcher) getPrimaryEmailForContacts(ctx context.Context, keys data
 
 	emailEntities, err := b.commonEmailService.GetPrimaryEmailsForEntityIds(ctx, neo4jmodel.CONTACT, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: pkgerrors.Wrap(err, "context deadline exceeded")}}
@@ -186,11 +187,11 @@ func (b *emailBatcher) getPrimaryEmailForContacts(ctx context.Context, keys data
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.EmailEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/external_system_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/external_system_dataloader.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -73,92 +71,101 @@ func (i *Loaders) GetExternalSystemsForInteractionEvent(ctx context.Context, ieI
 }
 
 func (b *externalSystemBatcher) getExternalSystemsForComments(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemDataLoader.getExternalSystemsForComments")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ExternalSystemDataLoader.getExternalSystemsForComments")
+	defer spans.Finish()
 
-	return b.getExternalSystemsFor(ctx, keys, commonModel.COMMENT, span)
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
+
+	return b.getExternalSystemsFor(ctx, keys, commonModel.COMMENT, spans)
 }
 
 func (b *externalSystemBatcher) getExternalSystemsForIssues(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemDataLoader.getExternalSystemsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ExternalSystemDataLoader.getExternalSystemsForIssues")
+	defer spans.Finish()
 
-	return b.getExternalSystemsFor(ctx, keys, commonModel.ISSUE, span)
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
+
+	return b.getExternalSystemsFor(ctx, keys, commonModel.ISSUE, spans)
 }
 
 func (b *externalSystemBatcher) getExternalSystemsForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemDataLoader.getExternalSystemsForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ExternalSystemDataLoader.getExternalSystemsForOrganizations")
+	defer spans.Finish()
 
-	return b.getExternalSystemsFor(ctx, keys, commonModel.ORGANIZATION, span)
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
+
+	return b.getExternalSystemsFor(ctx, keys, commonModel.ORGANIZATION, spans)
 }
 
 func (b *externalSystemBatcher) getExternalSystemsForContracts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemDataLoader.getExternalSystemsForContracts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ExternalSystemDataLoader.getExternalSystemsForContracts")
+	defer spans.Finish()
 
-	return b.getExternalSystemsFor(ctx, keys, commonModel.CONTRACT, span)
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
+
+	return b.getExternalSystemsFor(ctx, keys, commonModel.CONTRACT, spans)
 }
 
 func (b *externalSystemBatcher) getExternalSystemsForOpportunities(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemDataLoader.getExternalSystemsForOpportunities")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ExternalSystemDataLoader.getExternalSystemsForOpportunities")
+	defer spans.Finish()
 
-	return b.getExternalSystemsFor(ctx, keys, commonModel.OPPORTUNITY, span)
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
+
+	return b.getExternalSystemsFor(ctx, keys, commonModel.OPPORTUNITY, spans)
 }
 
 func (b *externalSystemBatcher) getExternalSystemsForServiceLineItems(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemDataLoader.getExternalSystemsForServiceLineItems")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ExternalSystemDataLoader.getExternalSystemsForServiceLineItems")
+	defer spans.Finish()
 
-	return b.getExternalSystemsFor(ctx, keys, commonModel.SERVICE_LINE_ITEM, span)
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
+
+	return b.getExternalSystemsFor(ctx, keys, commonModel.SERVICE_LINE_ITEM, spans)
 }
 
 func (b *externalSystemBatcher) getExternalSystemsForLogEntries(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemDataLoader.getExternalSystemsForLogEntries")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ExternalSystemDataLoader.getExternalSystemsForLogEntries")
+	defer spans.Finish()
 
-	return b.getExternalSystemsFor(ctx, keys, commonModel.LOG_ENTRY, span)
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
+
+	return b.getExternalSystemsFor(ctx, keys, commonModel.LOG_ENTRY, spans)
 }
 
 func (b *externalSystemBatcher) getExternalSystemsForMeetings(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemDataLoader.getExternalSystemsForMeetings")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ExternalSystemDataLoader.getExternalSystemsForMeetings")
+	defer spans.Finish()
 
-	return b.getExternalSystemsFor(ctx, keys, commonModel.MEETING, span)
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
+
+	return b.getExternalSystemsFor(ctx, keys, commonModel.MEETING, spans)
 }
 
 func (b *externalSystemBatcher) getExternalSystemsForInteractionEvents(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemDataLoader.getExternalSystemsForInteractionEvents")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ExternalSystemDataLoader.getExternalSystemsForInteractionEvents")
+	defer spans.Finish()
 
-	return b.getExternalSystemsFor(ctx, keys, commonModel.INTERACTION_EVENT, span)
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
+
+	return b.getExternalSystemsFor(ctx, keys, commonModel.INTERACTION_EVENT, spans)
 }
 
-func (b *externalSystemBatcher) getExternalSystemsFor(ctx context.Context, keys dataloader.Keys, entityType commonModel.EntityType, span opentracing.Span) []*dataloader.Result {
+func (b *externalSystemBatcher) getExternalSystemsFor(ctx context.Context, keys dataloader.Keys, entityType commonModel.EntityType, spans *telemetry.Spans) []*dataloader.Result {
 	ids, keyOrder := sortKeys(keys)
 
 	ExternalSystemsPtr, err := b.externalSystemService.GetExternalSystemsForEntities(ctx, ids, entityType)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get external systems for entities")}}
@@ -188,11 +195,11 @@ func (b *externalSystemBatcher) getExternalSystemsFor(ctx context.Context, keys 
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.ExternalSystemEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/flow_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/flow_dataloader.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -73,16 +71,17 @@ func (i *Loaders) GetExecutionsForParticipant(ctx context.Context, participantId
 }
 
 func (b *flowBatcher) getFlowParticipantsForFlow(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowDataLoader.getFlowParticipantsForFlow")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "FlowDataLoader.getFlowParticipantsForFlow")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	flowSequenceContactEntitiesPtr, err := b.flowService.FlowParticipantGetList(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get tags for organizations")}}
@@ -112,26 +111,27 @@ func (b *flowBatcher) getFlowParticipantsForFlow(ctx context.Context, keys datal
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.FlowParticipantEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *flowBatcher) getFlowSendersForFlow(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowDataLoader.getFlowSendersForFlow")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "FlowDataLoader.getFlowSendersForFlow")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	flowSequenceSenderEntitiesPtr, err := b.flowService.FlowSenderGetList(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get tags for organizations")}}
@@ -161,26 +161,27 @@ func (b *flowBatcher) getFlowSendersForFlow(ctx context.Context, keys dataloader
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.FlowSenderEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *flowBatcher) getFlowActionsForFlow(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowDataLoader.getFlowActionsForFlow")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "FlowDataLoader.getFlowActionsForFlow")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	flowSequenceStepEntitiesPtr, err := b.flowService.FlowActionGetList(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get flow sequece steps for flow sequence")}}
@@ -210,26 +211,27 @@ func (b *flowBatcher) getFlowActionsForFlow(ctx context.Context, keys dataloader
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.FlowActionEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *flowBatcher) getFlowsWithContact(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowDataLoader.getFlowsWithContact")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "FlowDataLoader.getFlowsWithContact")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	flowSequenceEntitiesPtr, err := b.flowService.FlowsGetListWithParticipant(ctx, ids, model.CONTACT)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get flow sequece steps for contact")}}
@@ -259,26 +261,27 @@ func (b *flowBatcher) getFlowsWithContact(ctx context.Context, keys dataloader.K
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.FlowEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *flowBatcher) getFlowsWithSender(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowDataLoader.getFlowsWithSender")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "FlowDataLoader.getFlowsWithSender")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	flowEntitiesPtr, err := b.flowService.FlowsGetListWithSender(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get flow sequece steps for contact")}}
@@ -308,26 +311,27 @@ func (b *flowBatcher) getFlowsWithSender(ctx context.Context, keys dataloader.Ke
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.FlowEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *flowBatcher) getFlowExecutionsForParticipant(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FlowDataLoader.getFlowExecutionsForParticipant")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "FlowDataLoader.getFlowExecutionsForParticipant")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	flowEntitiesPtr, err := b.flowExecutionService.GetFlowActionExecutionsForParticipants(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get flow sequece steps for contact")}}
@@ -357,11 +361,11 @@ func (b *flowBatcher) getFlowExecutionsForParticipant(ctx context.Context, keys 
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.FlowActionExecutionEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/interaction_event_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/interaction_event_dataloader.go
@@ -2,12 +2,10 @@ package dataloader
 
 import (
 	"context"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"reflect"
 )
@@ -53,10 +51,11 @@ func (i *Loaders) GetInteractionEventsForInteractionEvent(ctx context.Context, i
 }
 
 func (b *interactionEventBatcher) getInteractionEventsForInteractionSessions(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventDataLoader.getInteractionEventsForInteractionSessions")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InteractionEventDataLoader.getInteractionEventsForInteractionSessions")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -65,7 +64,7 @@ func (b *interactionEventBatcher) getInteractionEventsForInteractionSessions(ctx
 
 	interactionEventEntitiesPtr, err := b.interactionEventService.GetInteractionEventsForInteractionSessions(ctx, ids, true)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get interaction events for interaction sessions")}}
@@ -95,26 +94,27 @@ func (b *interactionEventBatcher) getInteractionEventsForInteractionSessions(ctx
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.InteractionEventEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *interactionEventBatcher) getInteractionEventsForMeetings(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventDataLoader.getInteractionEventsForMeetings")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InteractionEventDataLoader.getInteractionEventsForMeetings")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	interactionEventEntitiesPtr, err := b.interactionEventService.GetInteractionEventsForMeetings(ctx, ids, true)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get interaction events for meetings")}}
@@ -144,20 +144,21 @@ func (b *interactionEventBatcher) getInteractionEventsForMeetings(ctx context.Co
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.InteractionEventEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *interactionEventBatcher) getInteractionEventsForIssues(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventDataLoader.getInteractionEventsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InteractionEventDataLoader.getInteractionEventsForIssues")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -166,7 +167,7 @@ func (b *interactionEventBatcher) getInteractionEventsForIssues(ctx context.Cont
 
 	interactionEventEntitiesPtr, err := b.interactionEventService.GetInteractionEventsForIssues(ctx, ids, true)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -196,26 +197,27 @@ func (b *interactionEventBatcher) getInteractionEventsForIssues(ctx context.Cont
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.InteractionEventEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *interactionEventBatcher) getReplyToInteractionEventsForInteractionEvents(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventDataLoader.getReplyToInteractionEventsForInteractionEvents")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InteractionEventDataLoader.getReplyToInteractionEventsForInteractionEvents")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	interactionEventEntitiesPtr, err := b.interactionEventService.GetReplyToInteractionsEventForInteractionEvents(ctx, ids, true)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get interaction event participants")}}
@@ -246,11 +248,11 @@ func (b *interactionEventBatcher) getReplyToInteractionEventsForInteractionEvent
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.InteractionEventEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/interaction_event_participant_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/interaction_event_participant_dataloader.go
@@ -3,11 +3,9 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -32,16 +30,17 @@ func (i *Loaders) GetSentToParticipantsForInteractionEvent(ctx context.Context, 
 }
 
 func (b *interactionEventParticipantBatcher) getSentByParticipantsForInteractionEvents(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventParticipantDataLoader.getSentByParticipantsForInteractionEvents")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InteractionEventParticipantDataLoader.getSentByParticipantsForInteractionEvents")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	participantEntitiesPtr, err := b.interactionEventService.GetSentByParticipantsForInteractionEvents(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get interaction event participants")}}
@@ -72,26 +71,27 @@ func (b *interactionEventParticipantBatcher) getSentByParticipantsForInteraction
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.InteractionEventParticipants{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *interactionEventParticipantBatcher) getSentToParticipantsForInteractionEvents(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionEventParticipantDataLoader.getSentToParticipantsForInteractionEvents")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InteractionEventParticipantDataLoader.getSentToParticipantsForInteractionEvents")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	participantEntitiesPtr, err := b.interactionEventService.GetSentToParticipantsForInteractionEvents(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get interaction event participants")}}
@@ -122,11 +122,11 @@ func (b *interactionEventParticipantBatcher) getSentToParticipantsForInteraction
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.InteractionEventParticipants{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/interaction_session_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/interaction_session_dataloader.go
@@ -3,11 +3,9 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -25,16 +23,17 @@ func (i *Loaders) GetInteractionSessionForInteractionEvent(ctx context.Context, 
 }
 
 func (b *interactionSessionBatcher) getInteractionSessionsForInteractionEvents(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionSessionDataLoader.getInteractionSessionsForInteractionEvents")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InteractionSessionDataLoader.getInteractionSessionsForInteractionEvents")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	interactionSessionEntities, err := b.interactionSessionService.GetInteractionSessionsForInteractionEvents(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get interaction sessions for interaction events")}}
@@ -61,11 +60,11 @@ func (b *interactionSessionBatcher) getInteractionSessionsForInteractionEvents(c
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.InteractionSessionEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/interaction_session_participant_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/interaction_session_participant_dataloader.go
@@ -3,11 +3,9 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -22,16 +20,17 @@ func (i *Loaders) GetAttendedByParticipantsForInteractionSession(ctx context.Con
 }
 
 func (b *interactionSessionParticipantBatcher) getAttendedByParticipantsForInteractionSessions(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InteractionSessionParticipantDataLoader.getAttendedByParticipantsForInteractionSessions")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InteractionSessionParticipantDataLoader.getAttendedByParticipantsForInteractionSessions")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	participantEntitiesPtr, err := b.interactionSessionService.GetAttendedByParticipantsForInteractionSessions(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get interaction event participants")}}
@@ -62,11 +61,11 @@ func (b *interactionSessionParticipantBatcher) getAttendedByParticipantsForInter
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.InteractionSessionParticipants{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/invoice_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/invoice_dataloader.go
@@ -2,12 +2,10 @@ package dataloader
 
 import (
 	"context"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"reflect"
 )
@@ -43,10 +41,11 @@ func (i *Loaders) GetInvoicesForServiceLineItem(ctx context.Context, sliId strin
 }
 
 func (b *invoiceBatcher) getInvoiceLinesForInvoice(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceDataLoader.getInvoiceLinesForInvoice")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InvoiceDataLoader.getInvoiceLinesForInvoice")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -55,7 +54,7 @@ func (b *invoiceBatcher) getInvoiceLinesForInvoice(ctx context.Context, keys dat
 
 	invoiceLinesEntitiesPtr, err := b.invoiceService.GetInvoiceLinesForInvoices(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get invoice lines for invoices")}}
@@ -85,20 +84,21 @@ func (b *invoiceBatcher) getInvoiceLinesForInvoice(ctx context.Context, keys dat
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.InvoiceLineEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *invoiceBatcher) getInvoicesForContract(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceDataLoader.getInvoicesForContract")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InvoiceDataLoader.getInvoicesForContract")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -107,7 +107,7 @@ func (b *invoiceBatcher) getInvoicesForContract(ctx context.Context, keys datalo
 
 	invoiceEntitiesPtr, err := b.invoiceService.GetInvoicesForContracts(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get invoices for contracts")}}
@@ -137,20 +137,21 @@ func (b *invoiceBatcher) getInvoicesForContract(ctx context.Context, keys datalo
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.InvoiceEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *invoiceBatcher) getInvoicesForServiceLineItem(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceDataLoader.getInvoicesForServiceLineItem")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InvoiceDataLoader.getInvoicesForServiceLineItem")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -159,7 +160,7 @@ func (b *invoiceBatcher) getInvoicesForServiceLineItem(ctx context.Context, keys
 
 	invoiceEntitiesPtr, err := b.invoiceService.GetInvoicesForServiceLineItems(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get invoices for service line items")}}
@@ -189,11 +190,11 @@ func (b *invoiceBatcher) getInvoicesForServiceLineItem(ctx context.Context, keys
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.InvoiceEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/issue_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/issue_dataloader.go
@@ -3,11 +3,9 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -25,16 +23,17 @@ func (i *Loaders) GetIssueForInteractionEvent(ctx context.Context, interactionEv
 }
 
 func (b *issueBatcher) getIssuesForInteractionEvents(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueDataLoader.getIssuesForInteractionEvents")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueDataLoader.getIssuesForInteractionEvents")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	issueEntities, err := b.issueService.GetIssuesForInteractionEvents(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get issues for interaction events")}}
@@ -61,11 +60,11 @@ func (b *issueBatcher) getIssuesForInteractionEvents(ctx context.Context, keys d
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.IssueEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/issue_participant_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/issue_participant_dataloader.go
@@ -2,12 +2,10 @@ package dataloader
 
 import (
 	"context"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"reflect"
 )
@@ -53,10 +51,11 @@ func (i *Loaders) GetFollowerParticipantsForIssue(ctx context.Context, issueId s
 }
 
 func (b *issueParticipantBatcher) getSubmitterParticipantsForIssues(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueParticipantDataLoader.getSubmitterParticipantsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueParticipantDataLoader.getSubmitterParticipantsForIssues")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -65,7 +64,7 @@ func (b *issueParticipantBatcher) getSubmitterParticipantsForIssues(ctx context.
 
 	participantEntitiesPtr, err := b.issueService.GetSubmitterParticipantsForIssues(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -96,20 +95,21 @@ func (b *issueParticipantBatcher) getSubmitterParticipantsForIssues(ctx context.
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.IssueParticipants{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *issueParticipantBatcher) getReporterParticipantsForIssues(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueParticipantDataLoader.getReporterParticipantsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueParticipantDataLoader.getReporterParticipantsForIssues")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -118,7 +118,7 @@ func (b *issueParticipantBatcher) getReporterParticipantsForIssues(ctx context.C
 
 	participantEntitiesPtr, err := b.issueService.GetReporterParticipantsForIssues(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get issue participants")}}
@@ -149,20 +149,21 @@ func (b *issueParticipantBatcher) getReporterParticipantsForIssues(ctx context.C
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.IssueParticipants{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *issueParticipantBatcher) getAssigneeParticipantsForIssues(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueParticipantDataLoader.getAssigneeParticipantsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueParticipantDataLoader.getAssigneeParticipantsForIssues")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -171,7 +172,7 @@ func (b *issueParticipantBatcher) getAssigneeParticipantsForIssues(ctx context.C
 
 	participantEntitiesPtr, err := b.issueService.GetAssigneeParticipantsForIssues(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get issue participants")}}
@@ -202,20 +203,21 @@ func (b *issueParticipantBatcher) getAssigneeParticipantsForIssues(ctx context.C
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.IssueParticipants{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *issueParticipantBatcher) getFollowerParticipantsForIssues(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueParticipantDataLoader.getFollowerParticipantsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueParticipantDataLoader.getFollowerParticipantsForIssues")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -224,7 +226,7 @@ func (b *issueParticipantBatcher) getFollowerParticipantsForIssues(ctx context.C
 
 	participantEntitiesPtr, err := b.issueService.GetFollowerParticipantsForIssues(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get issue participants")}}
@@ -255,11 +257,11 @@ func (b *issueParticipantBatcher) getFollowerParticipantsForIssues(ctx context.C
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.IssueParticipants{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/job_role_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/job_role_dataloader.go
@@ -3,11 +3,9 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -42,16 +40,17 @@ func (i *Loaders) GetJobRolesForUser(ctx context.Context, userId string) (*neo4j
 }
 
 func (b *jobRoleBatcher) getJobRolesForContacts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleDataLoader.getJobRolesForContacts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "JobRoleDataLoader.getJobRolesForContacts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	jobRoleEntitiesPtr, err := b.jobRoleService.GetAllForContacts(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get job roles for contacts")}}
@@ -82,26 +81,27 @@ func (b *jobRoleBatcher) getJobRolesForContacts(ctx context.Context, keys datalo
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.JobRoleEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *jobRoleBatcher) getJobRolesForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleDataLoader.getJobRolesForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "JobRoleDataLoader.getJobRolesForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	jobRoleEntitiesPtr, err := b.jobRoleService.GetAllForOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get job roles for organizations")}}
@@ -132,26 +132,27 @@ func (b *jobRoleBatcher) getJobRolesForOrganizations(ctx context.Context, keys d
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.JobRoleEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *jobRoleBatcher) getJobRolesForUsers(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "JobRoleDataLoader.getJobRolesForUsers")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "JobRoleDataLoader.getJobRolesForUsers")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	jobRoleEntitiesPtr, err := b.jobRoleService.GetAllForUsers(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get job roles for contacts")}}
@@ -182,11 +183,11 @@ func (b *jobRoleBatcher) getJobRolesForUsers(ctx context.Context, keys dataloade
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.JobRoleEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/location_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/location_dataloader.go
@@ -3,11 +3,9 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -32,16 +30,17 @@ func (i *Loaders) GetLocationsForOrganization(ctx context.Context, organizationI
 }
 
 func (b *locationBatcher) getLocationsForContacts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationDataLoader.getLocationsForContacts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "LocationDataLoader.getLocationsForContacts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	locationEntitiesPtr, err := b.locationCommonService.GetAllForContacts(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get locations for contacts")}}
@@ -72,26 +71,27 @@ func (b *locationBatcher) getLocationsForContacts(ctx context.Context, keys data
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.LocationEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *locationBatcher) getLocationsForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationDataLoader.getLocationsForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "LocationDataLoader.getLocationsForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	locationEntitiesPtr, err := b.locationCommonService.GetAllForOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get locations for organizations")}}
@@ -122,11 +122,11 @@ func (b *locationBatcher) getLocationsForOrganizations(ctx context.Context, keys
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.LocationEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/meeting_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/meeting_dataloader.go
@@ -3,11 +3,9 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -25,16 +23,17 @@ func (i *Loaders) GetMeetingForInteractionEvent(ctx context.Context, interaction
 }
 
 func (b *meetingBatcher) getMeetingsForInteractionEvents(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MeetingDataLoader.getMeetingsForInteractionEvents")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingDataLoader.getMeetingsForInteractionEvents")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	meetingEntities, err := b.meetingService.GetMeetingsForInteractionEvents(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get interaction sessions for interaction events")}}
@@ -61,11 +60,11 @@ func (b *meetingBatcher) getMeetingsForInteractionEvents(ctx context.Context, ke
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.MeetingEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/meeting_participant_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/meeting_participant_dataloader.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"github.com/customeros/customeros/packages/server/customer-os-api/entity"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -33,16 +31,17 @@ func (i *Loaders) GetAttendedByParticipantsForMeeting(ctx context.Context, conta
 }
 
 func (b *meetingParticipantBatcher) getCreatedByParticipantsForMeeting(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MeetingParticipantDataLoader.getCreatedByParticipantsForMeeting")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingParticipantDataLoader.getCreatedByParticipantsForMeeting")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	participantEntitiesPtr, err := b.meetingService.GetParticipantsForMeetings(ctx, ids, entity.CREATED_BY)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get meeting created participants")}}
@@ -73,26 +72,27 @@ func (b *meetingParticipantBatcher) getCreatedByParticipantsForMeeting(ctx conte
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.MeetingParticipants{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *meetingParticipantBatcher) getAttendedByParticipantsForMeeting(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MeetingParticipantDataLoader.getAttendedByParticipantsForMeeting")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingParticipantDataLoader.getAttendedByParticipantsForMeeting")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	participantEntitiesPtr, err := b.meetingService.GetParticipantsForMeetings(ctx, ids, entity.ATTENDED_BY)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get meeting attended participants")}}
@@ -123,11 +123,11 @@ func (b *meetingParticipantBatcher) getAttendedByParticipantsForMeeting(ctx cont
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.MeetingParticipants{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/note_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/note_dataloader.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 	"github.com/customeros/customeros/packages/server/customer-os-api/entity"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -22,16 +20,17 @@ func (i *Loaders) GetNotesForMeeting(ctx context.Context, meetingId string) (*en
 }
 
 func (b *noteBatcher) getNotesForMeetings(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "NoteDataLoader.getNotesForMeetings")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "NoteDataLoader.getNotesForMeetings")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	noteEntitiesPtr, err := b.noteService.GetNotesForMeetings(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get noted entities for notes")}}
@@ -61,11 +60,11 @@ func (b *noteBatcher) getNotesForMeetings(ctx context.Context, keys dataloader.K
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(entity.NoteEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/opportunity_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/opportunity_dataloader.go
@@ -3,12 +3,10 @@ package dataloader
 import (
 	"context"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"reflect"
 )
@@ -44,10 +42,11 @@ func (i *Loaders) GetOpportunitiesForOrganization(ctx context.Context, orgId str
 }
 
 func (b *opportunityBatcher) getOpportunitiesForContracts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityDataLoader.getOpportunitiesForContracts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OpportunityDataLoader.getOpportunitiesForContracts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -58,7 +57,7 @@ func (b *opportunityBatcher) getOpportunitiesForContracts(ctx context.Context, k
 
 	opportunityEntitiesPtr, err := b.opportunityService.GetOpportunitiesForContracts(ctx, tenant, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get opportunities for contracts")}}
@@ -88,20 +87,21 @@ func (b *opportunityBatcher) getOpportunitiesForContracts(ctx context.Context, k
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.OpportunityEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *opportunityBatcher) getOpportunitiesForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityDataLoader.getOpportunitiesForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OpportunityDataLoader.getOpportunitiesForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -112,7 +112,7 @@ func (b *opportunityBatcher) getOpportunitiesForOrganizations(ctx context.Contex
 
 	opportunityEntitiesPtr, err := b.opportunityService.GetOpportunitiesForOrganizations(ctx, tenant, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get opportunities for organizations")}}
@@ -142,20 +142,21 @@ func (b *opportunityBatcher) getOpportunitiesForOrganizations(ctx context.Contex
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.OpportunityEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *opportunityBatcher) getOpportunitiesForTasks(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityDataLoader.getOpportunitiesForTasks")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OpportunityDataLoader.getOpportunitiesForTasks")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -164,7 +165,7 @@ func (b *opportunityBatcher) getOpportunitiesForTasks(ctx context.Context, keys 
 
 	opportunityEntitiesPtr, err := b.opportunityService.GetOpportunitiesForTasks(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get opportunities for tasks")}}
@@ -194,11 +195,11 @@ func (b *opportunityBatcher) getOpportunitiesForTasks(ctx context.Context, keys 
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.OpportunityEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("result.count", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/organization_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/organization_dataloader.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 )
 
@@ -148,16 +146,17 @@ func (i *Loaders) GetLatestOrganizationWithJobRoleForContact(ctx context.Context
 }
 
 func (b *organizationBatcher) getOrganizationsForEmails(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getOrganizationsForEmails")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getOrganizationsForEmails")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	organizationEntitiesPtr, err := b.organizationService.GetOrganizationsForEmails(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get organizations for emails")}}
@@ -187,26 +186,27 @@ func (b *organizationBatcher) getOrganizationsForEmails(ctx context.Context, key
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.OrganizationEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *organizationBatcher) getOrganizationsForPhoneNumbers(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getOrganizationsForPhoneNumbers")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getOrganizationsForPhoneNumbers")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	organizationEntitiesPtr, err := b.organizationService.GetOrganizationsForPhoneNumbers(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get organizations for phone numbers")}}
@@ -236,26 +236,27 @@ func (b *organizationBatcher) getOrganizationsForPhoneNumbers(ctx context.Contex
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.OrganizationEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *organizationBatcher) getSubsidiariesForOrganization(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getSubsidiariesForOrganization")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getSubsidiariesForOrganization")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	organizationEntitiesPtr, err := b.organizationService.GetSubsidiariesForOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get subsidiaries for organizations")}}
@@ -285,26 +286,27 @@ func (b *organizationBatcher) getSubsidiariesForOrganization(ctx context.Context
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.OrganizationEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *organizationBatcher) getSubsidiariesOfForOrganization(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getSubsidiariesOfForOrganization")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getSubsidiariesOfForOrganization")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	organizationEntitiesPtr, err := b.organizationService.GetSubsidiariesOfForOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get subsidiaries of for organizations")}}
@@ -334,26 +336,27 @@ func (b *organizationBatcher) getSubsidiariesOfForOrganization(ctx context.Conte
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.OrganizationEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *organizationBatcher) getOrganizationsForJobRoles(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getOrganizationsForJobRoles")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getOrganizationsForJobRoles")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	organizationEntities, err := b.organizationService.GetOrganizationsForJobRoles(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get organizations for job roles")}}
@@ -380,26 +383,27 @@ func (b *organizationBatcher) getOrganizationsForJobRoles(ctx context.Context, k
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.OrganizationEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *organizationBatcher) getSuggestedMergeToForOrganization(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getSuggestedMergeToForOrganization")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getSuggestedMergeToForOrganization")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	organizationEntitiesPtr, err := b.organizationService.GetSuggestedMergeToForOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get suggested merges for organizations")}}
@@ -429,26 +433,27 @@ func (b *organizationBatcher) getSuggestedMergeToForOrganization(ctx context.Con
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.OrganizationEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *organizationBatcher) getOrganizationsForInvoices(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getOrganizationsForInvoices")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getOrganizationsForInvoices")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	organizationEntities, err := b.commonOrganizationService.GetOrganizationsForInvoices(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get organizations for invoices")}}
@@ -475,26 +480,27 @@ func (b *organizationBatcher) getOrganizationsForInvoices(ctx context.Context, k
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.OrganizationEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *organizationBatcher) getOrganizationsForContracts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getOrganizationsForContracts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getOrganizationsForContracts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	organizationEntities, err := b.commonOrganizationService.GetOrganizationsForContracts(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get organizations for contracts")}}
@@ -521,26 +527,27 @@ func (b *organizationBatcher) getOrganizationsForContracts(ctx context.Context, 
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.OrganizationEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *organizationBatcher) getOrganizationsForSlackChannels(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getOrganizationsForSlackChannels")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getOrganizationsForSlackChannels")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	organizationEntities, err := b.organizationService.GetOrganizationsForSlackChannels(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get organizations for slack channels")}}
@@ -567,20 +574,21 @@ func (b *organizationBatcher) getOrganizationsForSlackChannels(ctx context.Conte
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.OrganizationEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *organizationBatcher) getOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -589,7 +597,7 @@ func (b *organizationBatcher) getOrganizations(ctx context.Context, keys dataloa
 
 	organizationEntities, err := b.organizationService.GetOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -616,20 +624,21 @@ func (b *organizationBatcher) getOrganizations(ctx context.Context, keys dataloa
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.OrganizationEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *organizationBatcher) getOrganizationsForOpportunities(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getOrganizationsForOpportunities")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getOrganizationsForOpportunities")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -638,7 +647,7 @@ func (b *organizationBatcher) getOrganizationsForOpportunities(ctx context.Conte
 
 	organizationEntities, err := b.organizationService.GetOrganizationsForOpportunities(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -665,20 +674,21 @@ func (b *organizationBatcher) getOrganizationsForOpportunities(ctx context.Conte
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.OrganizationEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *organizationBatcher) getLatestOrganizationWithJobRoleForContacts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationDataLoader.getLatestOrganizationWithJobRoleForContacts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OrganizationDataLoader.getLatestOrganizationWithJobRoleForContacts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -687,7 +697,7 @@ func (b *organizationBatcher) getLatestOrganizationWithJobRoleForContacts(ctx co
 
 	organizationEntities, err := b.commonOrganizationService.GetPrimaryOrganizationsWithJobRoleForContacts(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get latest organization for contacts")}}
@@ -714,11 +724,11 @@ func (b *organizationBatcher) getLatestOrganizationWithJobRoleForContacts(ctx co
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.OrganizationWithJobRole{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/phone_number_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/phone_number_dataloader.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -43,16 +41,17 @@ func (i *Loaders) GetPhoneNumbersForContact(ctx context.Context, contactId strin
 }
 
 func (b *phoneNumberBatcher) getPhoneNumbersForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberDataLoader.getPhoneNumbersForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "PhoneNumberDataLoader.getPhoneNumbersForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	phoneNumberEntitiesPtr, err := b.phoneNumberService.GetAllForEntityTypeByIds(ctx, commonModel.ORGANIZATION, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get phone numbers for organizations")}}
@@ -83,26 +82,27 @@ func (b *phoneNumberBatcher) getPhoneNumbersForOrganizations(ctx context.Context
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.PhoneNumberEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *phoneNumberBatcher) getPhoneNumbersForUsers(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberDataLoader.getPhoneNumbersForUsers")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "PhoneNumberDataLoader.getPhoneNumbersForUsers")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	phoneNumberEntitiesPtr, err := b.phoneNumberService.GetAllForEntityTypeByIds(ctx, commonModel.USER, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get phone numbers for users")}}
@@ -133,26 +133,27 @@ func (b *phoneNumberBatcher) getPhoneNumbersForUsers(ctx context.Context, keys d
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.PhoneNumberEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *phoneNumberBatcher) getPhoneNumbersForContacts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "PhoneNumberDataLoader.getPhoneNumbersForContacts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "PhoneNumberDataLoader.getPhoneNumbersForContacts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	phoneNumberEntitiesPtr, err := b.phoneNumberService.GetAllForEntityTypeByIds(ctx, commonModel.CONTACT, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get phone numbers for users")}}
@@ -183,11 +184,11 @@ func (b *phoneNumberBatcher) getPhoneNumbersForContacts(ctx context.Context, key
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.PhoneNumberEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/service_line_item_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/service_line_item_dataloader.go
@@ -2,12 +2,10 @@ package dataloader
 
 import (
 	"context"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"reflect"
 )
@@ -35,10 +33,11 @@ func (i *Loaders) GetServiceLineItemForInvoiceLine(ctx context.Context, invoiceL
 }
 
 func (b *serviceLineItemBatcher) getServiceLineItemsForContracts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemDataLoader.getServiceLineItemsForContracts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ServiceLineItemDataLoader.getServiceLineItemsForContracts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -47,7 +46,7 @@ func (b *serviceLineItemBatcher) getServiceLineItemsForContracts(ctx context.Con
 
 	serviceLineItemEntitiesPtr, err := b.serviceLineItemService.GetServiceLineItemsForContracts(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get service line items for contracts")}}
@@ -77,20 +76,21 @@ func (b *serviceLineItemBatcher) getServiceLineItemsForContracts(ctx context.Con
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.ServiceLineItemEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *serviceLineItemBatcher) getServiceLineItemForInvoiceLine(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemDataLoader.getServiceLineItemsForInvoiceLines")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ServiceLineItemDataLoader.getServiceLineItemsForInvoiceLines")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -99,7 +99,7 @@ func (b *serviceLineItemBatcher) getServiceLineItemForInvoiceLine(ctx context.Co
 
 	sliEntities, err := b.serviceLineItemService.GetServiceLineItemsForInvoiceLines(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get service line items for invoice lines")}}
@@ -126,11 +126,11 @@ func (b *serviceLineItemBatcher) getServiceLineItemForInvoiceLine(ctx context.Co
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.ServiceLineItemEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/social_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/social_dataloader.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -34,16 +32,17 @@ func (i *Loaders) GetSocialsForOrganization(ctx context.Context, organizationId 
 }
 
 func (b *socialBatcher) getSocialsForContacts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialDataLoader.getSocialsForContacts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "SocialDataLoader.getSocialsForContacts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	socialEntitiesPtr, err := b.socialService.GetAllForEntities(ctx, common.GetTenantFromContext(ctx), neo4jenum.CONTACT, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get socials for contacts")}}
@@ -74,26 +73,27 @@ func (b *socialBatcher) getSocialsForContacts(ctx context.Context, keys dataload
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.SocialEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *socialBatcher) getSocialsForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SocialDataLoader.getSocialsForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "SocialDataLoader.getSocialsForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	socialEntitiesPtr, err := b.socialService.GetAllForEntities(ctx, common.GetTenantFromContext(ctx), neo4jenum.ORGANIZATION, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get socials for organizations")}}
@@ -124,11 +124,11 @@ func (b *socialBatcher) getSocialsForOrganizations(ctx context.Context, keys dat
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.SocialEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/tag_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/tag_dataloader.go
@@ -3,11 +3,9 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -52,16 +50,17 @@ func (i *Loaders) GetTagsForLogEntry(ctx context.Context, logEntryId string) (*n
 }
 
 func (b *tagBatcher) getTagsForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagDataLoader.getTagsForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "TagDataLoader.getTagsForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	tagEntitiesPtr, err := b.tagService.GetTagsForOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get tags for organizations")}}
@@ -91,26 +90,27 @@ func (b *tagBatcher) getTagsForOrganizations(ctx context.Context, keys dataloade
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.TagEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *tagBatcher) getTagsForContacts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagDataLoader.getTagsForContacts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "TagDataLoader.getTagsForContacts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	tagEntitiesPtr, err := b.tagService.GetTagsForContacts(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get tags for contacts")}}
@@ -140,26 +140,27 @@ func (b *tagBatcher) getTagsForContacts(ctx context.Context, keys dataloader.Key
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.TagEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *tagBatcher) getTagsForIssues(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagDataLoader.getTagsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "TagDataLoader.getTagsForIssues")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	tagEntitiesPtr, err := b.tagService.GetTagsForIssues(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get tags for issues")}}
@@ -189,26 +190,27 @@ func (b *tagBatcher) getTagsForIssues(ctx context.Context, keys dataloader.Keys)
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.TagEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *tagBatcher) getTagsForLogEntries(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TagDataLoader.getTagsForLogEntries")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "TagDataLoader.getTagsForLogEntries")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	tagEntitiesPtr, err := b.tagService.GetTagsForLogEntries(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get tags for log entries")}}
@@ -238,11 +240,11 @@ func (b *tagBatcher) getTagsForLogEntries(ctx context.Context, keys dataloader.K
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.TagEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/task_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/task_dataloader.go
@@ -3,11 +3,9 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"reflect"
 )
 
@@ -22,16 +20,17 @@ func (i *Loaders) GetTasksForOpportunity(ctx context.Context, opportunityId stri
 }
 
 func (b *taskBatcher) getTasksForOpportunities(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TaskDataLoader.getTasksForOpportunities")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "TaskDataLoader.getTasksForOpportunities")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	taskEntitiesPtr, err := b.taskService.GetTasksForOpportunities(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get tasks for opportunities")}}
@@ -61,11 +60,11 @@ func (b *taskBatcher) getTasksForOpportunities(ctx context.Context, keys dataloa
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.TaskEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/timeline_event_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/timeline_event_dataloader.go
@@ -3,12 +3,10 @@ package dataloader
 import (
 	"context"
 	"errors"
-	"github.com/graph-gophers/dataloader"
 	"github.com/customeros/customeros/packages/server/customer-os-api/entity"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/graph-gophers/dataloader"
 )
 
 func (i *Loaders) GetTimelineEventForTimelineEventId(ctx context.Context, timelineEventId string) (*entity.TimelineEvent, error) {
@@ -48,16 +46,17 @@ func (i *Loaders) GetOutboundCommsCountForOrganization(ctx context.Context, orga
 }
 
 func (b *timelineEventBatcher) getTimelineEventsForTimelineEventIds(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventDataLoader.getTimelineEventsForTimelineEventIds")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "TimelineEventDataLoader.getTimelineEventsForTimelineEventIds")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	timelineEventsPtr, err := b.timelineEventService.GetTimelineEventsWithIds(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if ctx.Err() == context.DeadlineExceeded {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get timeline events for timeline event ids")}}
@@ -83,16 +82,17 @@ func (b *timelineEventBatcher) getTimelineEventsForTimelineEventIds(ctx context.
 		results[ix] = &dataloader.Result{Data: nil, Error: nil}
 	}
 
-	span.LogFields(log.Int("results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *timelineEventBatcher) getInboundCommsCountForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventBatcher.getInboundCommsCountForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "TimelineEventBatcher.getInboundCommsCountForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -101,7 +101,7 @@ func (b *timelineEventBatcher) getInboundCommsCountForOrganizations(ctx context.
 
 	countsPerOrg, err := b.timelineEventService.GetInboundCommsCountCountByOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get inbound comms count for organization")}}
@@ -122,16 +122,17 @@ func (b *timelineEventBatcher) getInboundCommsCountForOrganizations(ctx context.
 		results[ix] = &dataloader.Result{Data: 0, Error: nil}
 	}
 
-	span.LogFields(log.Int("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *timelineEventBatcher) getOutboundCommsCountForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventBatcher.getInboundCommsCountForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "TimelineEventBatcher.getInboundCommsCountForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -140,7 +141,7 @@ func (b *timelineEventBatcher) getOutboundCommsCountForOrganizations(ctx context
 
 	countsPerOrg, err := b.timelineEventService.GetOutboundCommsCountCountByOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.New("deadline exceeded to get outbound comms count for organization")}}
@@ -161,7 +162,7 @@ func (b *timelineEventBatcher) getOutboundCommsCountForOrganizations(ctx context
 		results[ix] = &dataloader.Result{Data: 0, Error: nil}
 	}
 
-	span.LogFields(log.Int("result.length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/dataloader/user_dataloader.go
+++ b/packages/server/customer-os-api/dataloader/user_dataloader.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/graph-gophers/dataloader"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 )
 
@@ -174,16 +172,17 @@ func (i *Loaders) GetUserCreatorForTask(ctx context.Context, taskId string) (*ne
 }
 
 func (b *userBatcher) getUsersConnectedForContact(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUsersConnectedForContact")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUsersConnectedForContact")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	userEntitiesPtr, err := b.userCommonService.GetUsersConnectedForContacts(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -213,26 +212,27 @@ func (b *userBatcher) getUsersConnectedForContact(ctx context.Context, keys data
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.UserEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUsersForEmails(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUsersForEmails")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUsersForEmails")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	userEntitiesPtr, err := b.userCommonService.GetUsersByEmailIds(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -262,26 +262,27 @@ func (b *userBatcher) getUsersForEmails(ctx context.Context, keys dataloader.Key
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.UserEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUsersForTasks(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUsersForTasks")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUsersForTasks")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	userEntitiesPtr, err := b.userCommonService.GetUserAssigneesForTasks(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -311,25 +312,26 @@ func (b *userBatcher) getUsersForTasks(ctx context.Context, keys dataloader.Keys
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.UserEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("result.count", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUsersForPhoneNumbers(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUsersForPhoneNumbers")
-	defer span.Finish()
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUsersForPhoneNumbers")
+	defer spans.Finish()
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	userEntitiesPtr, err := b.userCommonService.GetUsersForPhoneNumbers(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -359,26 +361,27 @@ func (b *userBatcher) getUsersForPhoneNumbers(ctx context.Context, keys dataload
 	}
 
 	if err = assertEntitiesType(results, reflect.TypeOf(neo4jentity.UserEntities{})); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUserOwnersForOrganizations(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUserOwnersForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUserOwnersForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	userEntities, err := b.userCommonService.GetUserOwnersForOrganizations(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -405,20 +408,21 @@ func (b *userBatcher) getUserOwnersForOrganizations(ctx context.Context, keys da
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.UserEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUserOwnersForOpportunities(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUserOwnersForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUserOwnersForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -427,7 +431,7 @@ func (b *userBatcher) getUserOwnersForOpportunities(ctx context.Context, keys da
 
 	userEntities, err := b.userCommonService.GetUserOwnersForOpportunities(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -454,20 +458,21 @@ func (b *userBatcher) getUserOwnersForOpportunities(ctx context.Context, keys da
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.UserEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUserCreatorsForOpportunities(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUserOwnersForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUserOwnersForOrganizations")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -476,7 +481,7 @@ func (b *userBatcher) getUserCreatorsForOpportunities(ctx context.Context, keys 
 
 	userEntities, err := b.userCommonService.GetUserCreatorsForOpportunities(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -503,20 +508,21 @@ func (b *userBatcher) getUserCreatorsForOpportunities(ctx context.Context, keys 
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.UserEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUserCreatorsForServiceLineItems(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUserCreatorsForServiceLineItems")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUserCreatorsForServiceLineItems")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -525,7 +531,7 @@ func (b *userBatcher) getUserCreatorsForServiceLineItems(ctx context.Context, ke
 
 	userEntities, err := b.userCommonService.GetUserCreatorsForServiceLineItems(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -552,20 +558,21 @@ func (b *userBatcher) getUserCreatorsForServiceLineItems(ctx context.Context, ke
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.UserEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUserCreatorsForContracts(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUserCreatorsForContracts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUserCreatorsForContracts")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -574,7 +581,7 @@ func (b *userBatcher) getUserCreatorsForContracts(ctx context.Context, keys data
 
 	userEntities, err := b.userCommonService.GetUserCreatorsForContracts(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -601,20 +608,21 @@ func (b *userBatcher) getUserCreatorsForContracts(ctx context.Context, keys data
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.UserEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUserCreatorsForTasks(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUserCreatorsForTasks")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUserCreatorsForTasks")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -623,7 +631,7 @@ func (b *userBatcher) getUserCreatorsForTasks(ctx context.Context, keys dataload
 
 	userEntities, err := b.userCommonService.GetUserCreatorsForTasks(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -650,26 +658,27 @@ func (b *userBatcher) getUserCreatorsForTasks(ctx context.Context, keys dataload
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.UserEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("result.count", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUsers(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUsers")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUsers")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
 	userEntities, err := b.userCommonService.GetUsers(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -696,20 +705,21 @@ func (b *userBatcher) getUsers(ctx context.Context, keys dataloader.Keys) []*dat
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.UserEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUserAuthorsForLogEntries(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUserAuthorsForLogEntries")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUserAuthorsForLogEntries")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -718,7 +728,7 @@ func (b *userBatcher) getUserAuthorsForLogEntries(ctx context.Context, keys data
 
 	userEntities, err := b.userCommonService.GetUserAuthorsForLogEntries(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -745,20 +755,21 @@ func (b *userBatcher) getUserAuthorsForLogEntries(ctx context.Context, keys data
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.UserEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUserAuthorsForComments(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUserAuthorsForLogEntries")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUserAuthorsForLogEntries")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -767,7 +778,7 @@ func (b *userBatcher) getUserAuthorsForComments(ctx context.Context, keys datalo
 
 	userEntities, err := b.userCommonService.GetUserAuthorsForComments(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -794,20 +805,21 @@ func (b *userBatcher) getUserAuthorsForComments(ctx context.Context, keys datalo
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.UserEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }
 
 func (b *userBatcher) getUserForFlowSenders(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "UserDataLoader.getUserForFlowSenders")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("keys", keys), log.Int("keys_length", len(keys)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserDataLoader.getUserForFlowSenders")
+	defer spans.Finish()
+
+	spans.LogObjectAsJson("keys", keys)
+	spans.LogKV("keys_length", len(keys))
 
 	ids, keyOrder := sortKeys(keys)
 
@@ -816,7 +828,7 @@ func (b *userBatcher) getUserForFlowSenders(ctx context.Context, keys dataloader
 
 	userEntities, err := b.userCommonService.GetUserForFlowSenders(ctx, ids)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		// check if context deadline exceeded error occurred
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return []*dataloader.Result{{Data: nil, Error: errors.Wrap(err, "context deadline exceeded")}}
@@ -843,11 +855,11 @@ func (b *userBatcher) getUserForFlowSenders(ctx context.Context, keys dataloader
 	}
 
 	if err = assertEntitiesPtrType(results, reflect.TypeOf(neo4jentity.UserEntity{}), true); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
-	span.LogFields(log.Object("output - results_length", len(results)))
+	spans.LogKV("result.length", len(results))
 
 	return results
 }

--- a/packages/server/customer-os-api/services/bank_account/service.go
+++ b/packages/server/customer-os-api/services/bank_account/service.go
@@ -6,11 +6,9 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 )
 
@@ -27,13 +25,12 @@ func NewBankAccountService(log logger.Logger, repository *repository.Repositorie
 }
 
 func (s *bankAccountService) GetTenantBankAccounts(ctx context.Context) (*neo4jentity.BankAccountEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BankAccountService.GetTenantBankAccounts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
+	spans, ctx := telemetry.StartServiceSpan(ctx, "BankAccountService.GetTenantBankAccounts")
+	defer spans.Finish()
 
 	dbNodes, err := s.repositories.Neo4jRepositories.BankAccountReadRepository.GetBankAccounts(ctx, common.GetTenantFromContext(ctx))
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, fmt.Errorf("GetTenantBankAccounts: %s", err.Error())
 	}
 
@@ -46,14 +43,13 @@ func (s *bankAccountService) GetTenantBankAccounts(ctx context.Context) (*neo4je
 }
 
 func (s *bankAccountService) GetTenantBankAccount(ctx context.Context, id string) (*neo4jentity.BankAccountEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BankAccountService.GetTenantBankAccount")
+	span, ctx := telemetry.StartServiceSpan(ctx, "BankAccountService.GetTenantBankAccount")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("bankAccountId", id))
+	span.LogKV("bankAccountId", id)
 
 	dbNode, err := s.repositories.Neo4jRepositories.BankAccountReadRepository.GetBankAccountById(ctx, common.GetTenantFromContext(ctx), id)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return nil, fmt.Errorf("GetTenantBankAccount: %s", err.Error())
 	}
 

--- a/packages/server/customer-os-api/services/billable/service.go
+++ b/packages/server/customer-os-api/services/billable/service.go
@@ -2,10 +2,9 @@ package api_billable
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
@@ -26,13 +25,12 @@ func NewBillableService(log logger.Logger, repositories *repository.Repositories
 }
 
 func (s *billableService) GetBillableDetails(ctx context.Context) (*model.TenantBillableInfo, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BillableService.GetBillableDetails")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
+	spans, ctx := telemetry.StartServiceSpan(ctx, "BillableService.GetBillableDetails")
+	defer spans.Finish()
 
 	dbRecord, err := s.repositories.ContactRepository.GetBillableContactStats(ctx)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, errors.Wrap(err, "GetBillableDetails")
 	}
 	return &model.TenantBillableInfo{

--- a/packages/server/customer-os-api/services/calendar/service.go
+++ b/packages/server/customer-os-api/services/calendar/service.go
@@ -2,19 +2,17 @@ package api_calendar
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/entity"
 	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 )
 
 type calendarService struct {
@@ -34,10 +32,9 @@ func (s *calendarService) getDriver() neo4j.DriverWithContext {
 }
 
 func (s *calendarService) GetAllForUsers(ctx context.Context, userIds []string) (*entity.CalendarEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CalendarService.GetAllForUsers")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("userIds", userIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "CalendarService.GetAllForUsers")
+	defer spans.Finish()
+	spans.LogKV("userIds", userIds)
 
 	calendars, err := s.repositories.CalendarRepository.GetAllForUsers(ctx, common.GetTenantFromContext(ctx), userIds)
 	if err != nil {

--- a/packages/server/customer-os-api/services/comment/comment_service.go
+++ b/packages/server/customer-os-api/services/comment/comment_service.go
@@ -3,11 +3,9 @@ package api_comment
 import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 
 	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
@@ -27,14 +25,13 @@ func NewCommentService(log logger.Logger, repositories *repository.Repositories)
 }
 
 func (s *commentService) GetCommentsForIssues(ctx context.Context, issueIds []string) (*neo4jentity.CommentEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CommentService.GetCommentsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("issueIds", issueIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "CommentService.GetCommentsForIssues")
+	defer spans.Finish()
+	spans.LogObjectAsJson("issueIds", issueIds)
 
 	comments, err := s.repositories.Neo4jRepositories.CommentReadRepository.GetAllForIssues(ctx, common.GetTenantFromContext(ctx), issueIds)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	commentEntities := neo4jentity.CommentEntities{}
@@ -43,6 +40,6 @@ func (s *commentService) GetCommentsForIssues(ctx context.Context, issueIds []st
 		commentEntity.DataloaderKey = v.LinkedNodeId
 		commentEntities = append(commentEntities, *commentEntity)
 	}
-	span.LogFields(log.Int("result count", len(commentEntities)))
+	spans.LogKV("result count", len(commentEntities))
 	return &commentEntities, nil
 }

--- a/packages/server/customer-os-api/services/contact/contact_service.go
+++ b/packages/server/customer-os-api/services/contact/contact_service.go
@@ -12,14 +12,12 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	common_srv "github.com/customeros/customeros/packages/server/customer-os-common-module/services/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
 	neo4jmodel "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
@@ -55,16 +53,15 @@ func (s *contactService) getNeo4jDriver() neo4j.DriverWithContext {
 }
 
 func (s *contactService) Create(ctx context.Context, contactDetails *cosapi_interfaces.ContactCreateData) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.Create")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("contactDetails", contactDetails))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactService.Create")
+	defer spans.Finish()
+	spans.LogObjectAsJson("contactDetails", contactDetails)
 
 	tenant := common.GetTenantFromContext(ctx)
 
 	if contactDetails.ContactEntity == nil {
 		err := fmt.Errorf("contact entity is nil")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return "", err
 	}
 
@@ -99,7 +96,7 @@ func (s *contactService) Create(ctx context.Context, contactDetails *cosapi_inte
 				Timezone:        utils.StringPtr(contactDetails.ContactEntity.Timezone),
 			}, false)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Failed to create contact: %s", err.Error())
 			return "", err
 		}
@@ -117,7 +114,7 @@ func (s *contactService) Create(ctx context.Context, contactDetails *cosapi_inte
 				Id:   contactId,
 			})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return contactId, err
 		}
 	}
@@ -125,18 +122,18 @@ func (s *contactService) Create(ctx context.Context, contactDetails *cosapi_inte
 	if contactDetails.PhoneNumberEntity != nil {
 		phoneNumberId, err := s.phoneNumber.Merge(ctx, contactDetails.PhoneNumberEntity.RawPhoneNumber, neo4jentity.DataSourceOpenline)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return contactId, err
 		}
 
 		err = s.repositories.Neo4jRepositories.PhoneNumberWriteRepository.LinkWithContact(ctx, tenant, contactId, phoneNumberId, contactDetails.PhoneNumberEntity.Label, contactDetails.PhoneNumberEntity.Primary)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return contactId, err
 		}
 	}
 
-	span.LogFields(log.String("output - createdContactId", contactId))
+	spans.LogKV("result.createdContactId", contactId)
 	return contactId, nil
 }
 
@@ -161,10 +158,9 @@ func (s *contactService) RestoreFromArchive(ctx context.Context, contactId strin
 }
 
 func (s *contactService) GetById(ctx context.Context, contactId string) (*neo4jentity.ContactEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.GetById")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("contactId", contactId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactService.GetById")
+	defer spans.Finish()
+	spans.LogKV("contactId", contactId)
 
 	if contactDbNode, err := s.repositories.ContactRepository.GetById(ctx, common.GetContext(ctx).Tenant, contactId); err != nil {
 		wrappedErr := errors.Wrap(err, fmt.Sprintf("Contact with id {%s} not found", contactId))
@@ -221,10 +217,9 @@ func (s *contactService) FindAll(ctx context.Context, page, limit int, filter *m
 }
 
 func (s *contactService) GetContactsForJobRoles(ctx context.Context, jobRoleIds []string) (*neo4jentity.ContactEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.GetContactsForJobRoles")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("jobRoleIds", jobRoleIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactService.GetContactsForJobRoles")
+	defer spans.Finish()
+	spans.LogObjectAsJson("jobRoleIds", jobRoleIds)
 
 	contacts, err := s.repositories.ContactRepository.GetAllForJobRoles(ctx, common.GetTenantFromContext(ctx), jobRoleIds)
 	if err != nil {
@@ -240,15 +235,16 @@ func (s *contactService) GetContactsForJobRoles(ctx context.Context, jobRoleIds 
 }
 
 func (s *contactService) GetContactsForOrganization(ctx context.Context, organizationId string, page, limit int, filter *model.Filter, sortBy []*commonModel.SortBy) (*utils.Pagination, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.GetContactsForOrganization")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("organizationId", organizationId), log.Int("page", page), log.Int("limit", limit))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactService.GetContactsForOrganization")
+	defer spans.Finish()
+	spans.LogKV("organizationId", organizationId)
+	spans.LogKV("page", page)
+	spans.LogKV("limit", limit)
 	if filter != nil {
-		span.LogFields(log.Object("filter", filter))
+		spans.LogObjectAsJson("filter", filter)
 	}
 	if sortBy != nil {
-		span.LogFields(log.Object("sortBy", sortBy))
+		spans.LogObjectAsJson("sortBy", sortBy)
 	}
 
 	session := utils.NewNeo4jReadSession(ctx, s.getNeo4jDriver())
@@ -289,10 +285,10 @@ func (s *contactService) GetContactsForOrganization(ctx context.Context, organiz
 }
 
 func (s *contactService) Merge(ctx context.Context, primaryContactId, mergedContactId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.Merge")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("primaryContactId", primaryContactId), log.String("mergedContactId", mergedContactId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactService.Merge")
+	defer spans.Finish()
+	spans.LogKV("primaryContactId", primaryContactId)
+	spans.LogKV("mergedContactId", mergedContactId)
 
 	session := utils.NewNeo4jWriteSession(ctx, *s.repositories.Drivers.Neo4jDriver)
 	defer session.Close(ctx)
@@ -335,10 +331,9 @@ func (s *contactService) Merge(ctx context.Context, primaryContactId, mergedCont
 }
 
 func (s *contactService) GetContactsForEmails(ctx context.Context, emailIds []string) (*neo4jentity.ContactEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.GetContactsForEmails")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("emailIds", emailIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactService.GetContactsForEmails")
+	defer spans.Finish()
+	spans.LogObjectAsJson("emailIds", emailIds)
 
 	contacts, err := s.repositories.ContactRepository.GetAllForEmails(ctx, common.GetTenantFromContext(ctx), emailIds)
 	if err != nil {
@@ -354,10 +349,9 @@ func (s *contactService) GetContactsForEmails(ctx context.Context, emailIds []st
 }
 
 func (s *contactService) GetContactsForPhoneNumbers(ctx context.Context, phoneNumberIds []string) (*neo4jentity.ContactEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.GetContactsForPhoneNumbers")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("phoneNumberIds", phoneNumberIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactService.GetContactsForPhoneNumbers")
+	defer spans.Finish()
+	spans.LogObjectAsJson("phoneNumberIds", phoneNumberIds)
 
 	contacts, err := s.repositories.ContactRepository.GetAllForPhoneNumbers(ctx, common.GetTenantFromContext(ctx), phoneNumberIds)
 	if err != nil {
@@ -373,9 +367,8 @@ func (s *contactService) GetContactsForPhoneNumbers(ctx context.Context, phoneNu
 }
 
 func (s *contactService) CustomerContactCreate(ctx context.Context, data *cosapi_interfaces.CustomerContactCreateData) (*model.CustomerContact, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.CustomerContactCreate")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactService.CustomerContactCreate")
+	defer spans.Finish()
 
 	result := &model.CustomerContact{}
 
@@ -389,7 +382,7 @@ func (s *contactService) CustomerContactCreate(ctx context.Context, data *cosapi
 			AppSource:   utils.StringPtr(data.ContactEntity.AppSource),
 		}, false)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	result.ID = contactId
@@ -406,7 +399,7 @@ func (s *contactService) CustomerContactCreate(ctx context.Context, data *cosapi
 				Id:   contactId,
 			})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return result, err
 		}
 		result.Email = &model.CustomerEmail{
@@ -417,10 +410,10 @@ func (s *contactService) CustomerContactCreate(ctx context.Context, data *cosapi
 }
 
 func (s *contactService) RemoveLocation(ctx context.Context, contactId string, locationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.RemoveLocation")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("contactId", contactId), log.String("locationId", locationId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactService.RemoveLocation")
+	defer spans.Finish()
+	spans.LogKV("contactId", contactId)
+	spans.LogKV("locationId", locationId)
 
 	// TODO implement
 	panic("implement me")
@@ -432,10 +425,9 @@ func (s *contactService) RemoveLocation(ctx context.Context, contactId string, l
 }
 
 func (s *contactService) GetContactCountByOrganizations(ctx context.Context, ids []string) (map[string]int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContactService.GetContactCountByOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("organizationIds", ids))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContactService.GetContactCountByOrganizations")
+	defer spans.Finish()
+	spans.LogObjectAsJson("organizationIds", ids)
 
 	return s.repositories.Neo4jRepositories.ContactReadRepository.GetContactCountByOrganizations(ctx, common.GetTenantFromContext(ctx), ids)
 }

--- a/packages/server/customer-os-api/services/contract/contract_service.go
+++ b/packages/server/customer-os-api/services/contract/contract_service.go
@@ -11,13 +11,11 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	model2 "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
 	neo4jmodel "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
-	neo4jrepository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
@@ -330,13 +328,12 @@ func (s *contractService) Update(ctx context.Context, input model.ContractUpdate
 }
 
 func (s *contractService) GetById(ctx context.Context, contractId string) (*neo4jentity.ContractEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractService.GetById")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("contractId", contractId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractService.GetById")
+	defer spans.Finish()
+	spans.LogKV("contractId", contractId)
 
 	if contractDbNode, err := s.repositories.Neo4jRepositories.ContractReadRepository.GetContractById(ctx, common.GetContext(ctx).Tenant, contractId); err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		wrappedErr := errors.Wrap(err, fmt.Sprintf("Contract with id {%s} not found", contractId))
 		return nil, wrappedErr
 	} else {
@@ -345,9 +342,9 @@ func (s *contractService) GetById(ctx context.Context, contractId string) (*neo4
 }
 
 func (s *contractService) GetContractsForInvoices(ctx context.Context, invoiceIds []string) (*neo4jentity.ContractEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractService.GetContractsForInvoices")
-	defer span.Finish()
-	span.LogFields(log.Object("invoiceIds", invoiceIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractService.GetContractsForInvoices")
+	defer spans.Finish()
+	spans.LogObjectAsJson("invoiceIds", invoiceIds)
 
 	contracts, err := s.repositories.Neo4jRepositories.ContractReadRepository.GetContractsForInvoices(ctx, common.GetTenantFromContext(ctx), invoiceIds)
 	if err != nil {
@@ -363,8 +360,8 @@ func (s *contractService) GetContractsForInvoices(ctx context.Context, invoiceId
 }
 
 func (s *contractService) ContractsExistForTenant(ctx context.Context) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractService.ContractsExistForTenant")
-	defer span.Finish()
+	spans, ctx := opentracing.StartSpanFromContext(ctx, "ContractService.ContractsExistForTenant")
+	defer spans.Finish()
 
 	contractsExistForTenant, err := s.repositories.Neo4jRepositories.ContractReadRepository.TenantsHasAtLeastOneContract(ctx, common.GetTenantFromContext(ctx))
 	if err != nil {
@@ -374,63 +371,56 @@ func (s *contractService) ContractsExistForTenant(ctx context.Context) (bool, er
 }
 
 func (s *contractService) CountContracts(ctx context.Context, tenant string) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractService.CountContracts")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagTenant, tenant)
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractService.CountContracts")
+	defer spans.Finish()
 
 	return s.repositories.Neo4jRepositories.ContractReadRepository.CountContracts(ctx, tenant)
 }
 
 func (s *contractService) SoftDeleteContract(ctx context.Context, contractId string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractService.SoftDeleteContract")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractService.SoftDeleteContract")
+	defer spans.Finish()
+	spans.TagEntity(contractId)
 
 	// check contract exists
-	if err := s.validateContractExists(ctx, contractId, span); err != nil {
+	if err := s.validateContractExists(ctx, contractId, spans); err != nil {
 		return false, err
 	}
 
 	// check contract has no invoices
 	countInvoices, err := s.repositories.Neo4jRepositories.InvoiceReadRepository.CountNonDryRunInvoicesForContract(ctx, common.GetTenantFromContext(ctx), contractId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("error on counting invoices for contract: %s", err.Error())
 		return false, err
 	}
 	if countInvoices > 0 {
 		err := fmt.Errorf("contract with id {%s} has invoices", contractId)
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf(err.Error())
 		return false, err
 	}
 
 	err = s.contract.SoftDelete(ctx, contractId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Failed to delete contract: %s", err.Error())
 		return false, nil
 	}
-
-	// wait for contract to be deleted from graph db
-	neo4jrepository.WaitForNodeDeletedFromNeo4j(ctx, s.repositories.Neo4jRepositories, contractId, model2.NodeLabelContract, span)
 
 	return false, nil
 }
 
 func (s *contractService) RenewContract(ctx context.Context, contractId string, renewalDate *time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractService.RenewContract")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagEntityId, contractId)
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractService.RenewContract")
+	defer spans.Finish()
+	spans.TagEntity(contractId)
 	if renewalDate != nil {
-		span.LogFields(log.Object("renewalDate", renewalDate.String()))
+		spans.LogFields(log.Object("renewalDate", renewalDate.String()))
 	}
 
 	// check contract exists
-	if err := s.validateContractExists(ctx, contractId, span); err != nil {
+	if err := s.validateContractExists(ctx, contractId, spans); err != nil {
 		return err
 	}
 
@@ -441,7 +431,7 @@ func (s *contractService) RenewContract(ctx context.Context, contractId string, 
 
 	// if contract is not renewable - return
 	if contractEntity.LengthInMonths == 0 {
-		span.LogFields(log.Bool("result.contractRenewable", false))
+		spans.LogFields(log.Bool("result.contractRenewable", false))
 		return nil
 	}
 
@@ -457,7 +447,7 @@ func (s *contractService) RenewContract(ctx context.Context, contractId string, 
 			RenewedAt:       renewalDate,
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error creating renewal opportunity: %s", err.Error())
 			return err
 		}
@@ -472,7 +462,7 @@ func (s *contractService) RenewContract(ctx context.Context, contractId string, 
 			RenewedAt:       renewalDate,
 		})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("Error approving renewal opportunity: %s", err.Error())
 			return err
 		}
@@ -487,7 +477,7 @@ func (s *contractService) RenewContract(ctx context.Context, contractId string, 
 				RenewedAt: renewalDate,
 			})
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				s.log.Errorf("Error from events processing: %s", err.Error())
 				return err
 			}
@@ -495,7 +485,7 @@ func (s *contractService) RenewContract(ctx context.Context, contractId string, 
 		}
 		err = s.opportunity.RolloutRenewalOpportunity(ctx, contractId)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			s.log.Errorf("failed to rollout renewal opportunity: %s", err.Error())
 			return err
 		}
@@ -504,54 +494,52 @@ func (s *contractService) RenewContract(ctx context.Context, contractId string, 
 	return nil
 }
 
-func (s *contractService) validateContractExists(ctx context.Context, contractId string, span opentracing.Span) error {
+func (s *contractService) validateContractExists(ctx context.Context, contractId string, spans *telemetry.Spans) error {
 	if contractId == "" {
 		err := fmt.Errorf("contract id is missing")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Error(err.Error())
 		return err
 	}
 
 	contractExists, err := s.repositories.Neo4jRepositories.CommonReadRepository.ExistsById(ctx, common.GetTenantFromContext(ctx), contractId, model2.NodeLabelContract)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Error(err.Error())
 		return err
 	}
 	if !contractExists {
 		err := fmt.Errorf("contract with id {%s} not found", contractId)
 		s.log.Error(err.Error())
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	return nil
 }
 
 func (s *contractService) GetContractByServiceLineItem(ctx context.Context, serviceLineItemId string) (*neo4jentity.ContractEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractService.GetContractByServiceLineItem")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("serviceLineItemId", serviceLineItemId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractService.GetContractByServiceLineItem")
+	defer spans.Finish()
+	spans.LogFields(log.String("serviceLineItemId", serviceLineItemId))
 
 	contract, err := s.repositories.Neo4jRepositories.ContractReadRepository.GetContractByServiceLineItemId(ctx, common.GetTenantFromContext(ctx), serviceLineItemId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Errorf("Error on getting contract by service line item: %s", err.Error())
 		return nil, err
 	}
 	if contract == nil {
 		err = fmt.Errorf("Contract not found for service line item: %s", serviceLineItemId)
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return &neo4jentity.ContractEntity{}, err
 	}
 	return neo4jmapper.MapDbNodeToContractEntity(contract), nil
 }
 
 func (s *contractService) GetPaginatedContracts(ctx context.Context, page int, limit int) (*utils.Pagination, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ContractService.GetContractByServiceLineItem")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Int("page", page), log.Int("limit", limit))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractService.GetContractByServiceLineItem")
+	defer spans.Finish()
+	spans.LogFields(log.Int("page", page), log.Int("limit", limit))
 
 	paginatedResult := utils.Pagination{
 		Limit: limit,

--- a/packages/server/customer-os-api/services/contract/contract_service.go
+++ b/packages/server/customer-os-api/services/contract/contract_service.go
@@ -16,8 +16,6 @@ import (
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
 	neo4jmodel "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/model"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
@@ -360,7 +358,7 @@ func (s *contractService) GetContractsForInvoices(ctx context.Context, invoiceId
 }
 
 func (s *contractService) ContractsExistForTenant(ctx context.Context) (bool, error) {
-	spans, ctx := opentracing.StartSpanFromContext(ctx, "ContractService.ContractsExistForTenant")
+	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractService.ContractsExistForTenant")
 	defer spans.Finish()
 
 	contractsExistForTenant, err := s.repositories.Neo4jRepositories.ContractReadRepository.TenantsHasAtLeastOneContract(ctx, common.GetTenantFromContext(ctx))
@@ -416,7 +414,7 @@ func (s *contractService) RenewContract(ctx context.Context, contractId string, 
 	defer spans.Finish()
 	spans.TagEntity(contractId)
 	if renewalDate != nil {
-		spans.LogFields(log.Object("renewalDate", renewalDate.String()))
+		spans.LogKV("renewalDate", renewalDate.String())
 	}
 
 	// check contract exists
@@ -431,7 +429,7 @@ func (s *contractService) RenewContract(ctx context.Context, contractId string, 
 
 	// if contract is not renewable - return
 	if contractEntity.LengthInMonths == 0 {
-		spans.LogFields(log.Bool("result.contractRenewable", false))
+		spans.LogKV("result.contractRenewable", false)
 		return nil
 	}
 
@@ -520,7 +518,7 @@ func (s *contractService) validateContractExists(ctx context.Context, contractId
 func (s *contractService) GetContractByServiceLineItem(ctx context.Context, serviceLineItemId string) (*neo4jentity.ContractEntity, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractService.GetContractByServiceLineItem")
 	defer spans.Finish()
-	spans.LogFields(log.String("serviceLineItemId", serviceLineItemId))
+	spans.LogKV("serviceLineItemId", serviceLineItemId)
 
 	contract, err := s.repositories.Neo4jRepositories.ContractReadRepository.GetContractByServiceLineItemId(ctx, common.GetTenantFromContext(ctx), serviceLineItemId)
 	if err != nil {
@@ -539,7 +537,7 @@ func (s *contractService) GetContractByServiceLineItem(ctx context.Context, serv
 func (s *contractService) GetPaginatedContracts(ctx context.Context, page int, limit int) (*utils.Pagination, error) {
 	spans, ctx := telemetry.StartServiceSpan(ctx, "ContractService.GetContractByServiceLineItem")
 	defer spans.Finish()
-	spans.LogFields(log.Int("page", page), log.Int("limit", limit))
+	spans.LogKV("page", page, "limit", limit)
 
 	paginatedResult := utils.Pagination{
 		Limit: limit,

--- a/packages/server/customer-os-api/services/country/country_service.go
+++ b/packages/server/customer-os-api/services/country/country_service.go
@@ -5,12 +5,10 @@ import (
 
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4j_entity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
@@ -29,10 +27,9 @@ func NewCountryService(log logger.Logger, repository *repository.Repositories) c
 }
 
 func (s *countryService) GetCountriesForPhoneNumbers(ctx context.Context, ids []string) (*neo4j_entity.CountryEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CountryService.GetCountriesForOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("ids", ids))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "CountryService.GetCountriesForOrganizations")
+	defer spans.Finish()
+	spans.LogObjectAsJson("ids", ids)
 
 	countryDbNodes, err := s.repositories.Neo4jRepositories.CountryReadRepository.GetAllForPhoneNumbers(ctx, common.GetTenantFromContext(ctx), ids)
 	if err != nil {

--- a/packages/server/customer-os-api/services/dashboard/dashboard_service.go
+++ b/packages/server/customer-os-api/services/dashboard/dashboard_service.go
@@ -5,13 +5,10 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/entity"
 	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
@@ -60,16 +57,12 @@ func (s *dashboardService) GetDashboardViewOrganizationsData(ctx context.Context
 }
 
 func (s *dashboardService) GetDashboardViewRenewalsData(ctx context.Context, requestDetails cosapi_interfaces.DashboardViewRenewalsRequest) (*utils.Pagination, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "DashboardService.GetDashboardViewRenewalsData")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Int("page", requestDetails.Page), log.Int("limit", requestDetails.Limit))
-	if requestDetails.Where != nil {
-		span.LogFields(log.Object("filter", *requestDetails.Where))
-	}
-	if requestDetails.Sort != nil {
-		span.LogFields(log.Object("sort", *requestDetails.Sort))
-	}
+	spans, ctx := telemetry.StartServiceSpan(ctx, "DashboardService.GetDashboardViewRenewalsData")
+	defer spans.Finish()
+	spans.LogKV("page", requestDetails.Page)
+	spans.LogKV("limit", requestDetails.Limit)
+	spans.LogObjectAsJson("filter", requestDetails.Where)
+	spans.LogObjectAsJson("sort", requestDetails.Sort)
 
 	paginatedResult := utils.Pagination{
 		Limit: requestDetails.Limit,

--- a/packages/server/customer-os-api/services/email/service.go
+++ b/packages/server/customer-os-api/services/email/service.go
@@ -2,21 +2,18 @@ package api_email
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 
+	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
+	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
-
-	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
-	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
 )
 
 type emailService struct {
@@ -36,10 +33,9 @@ func (s *emailService) getDriver() neo4j.DriverWithContext {
 }
 
 func (s *emailService) GetAllFor(ctx context.Context, entityType commonModel.EntityType, entityId string) (*neo4jentity.EmailEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailService.GetAllFor")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("entityType", entityType.String()), log.String("entityId", entityId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "EmailService.GetAllFor")
+	defer spans.Finish()
+	spans.LogKV("entityType", entityType.String(), "entityId", entityId)
 
 	records, err := s.repositories.EmailRepository.GetAllFor(ctx, common.GetContext(ctx).Tenant, entityType, entityId)
 	if err != nil {
@@ -57,10 +53,9 @@ func (s *emailService) GetAllFor(ctx context.Context, entityType commonModel.Ent
 }
 
 func (s *emailService) GetAllForEntityTypeByIds(ctx context.Context, entityType commonModel.EntityType, entityIds []string) (*neo4jentity.EmailEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailService.GetAllForEntityTypeByIds")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("entityType", entityType.String()), log.Object("entityIds", entityIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "EmailService.GetAllForEntityTypeByIds")
+	defer spans.Finish()
+	spans.LogKV("entityType", entityType.String(), "entityIds", entityIds)
 
 	emails, err := s.repositories.Neo4jRepositories.EmailReadRepository.GetAllEmailNodesForLinkedEntityIds(ctx, common.GetContext(ctx).Tenant, entityType, entityIds)
 	if err != nil {
@@ -78,10 +73,9 @@ func (s *emailService) GetAllForEntityTypeByIds(ctx context.Context, entityType 
 }
 
 func (s *emailService) GetById(ctx context.Context, emailId string) (*neo4jentity.EmailEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailService.GetById")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("emailId", emailId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "EmailService.GetById")
+	defer spans.Finish()
+	spans.LogKV("emailId", emailId)
 
 	emailNode, err := s.repositories.Neo4jRepositories.EmailReadRepository.GetById(ctx, common.GetTenantFromContext(ctx), emailId)
 	if err != nil {
@@ -92,10 +86,9 @@ func (s *emailService) GetById(ctx context.Context, emailId string) (*neo4jentit
 }
 
 func (s *emailService) GetByEmailAddress(ctx context.Context, email string) (*neo4jentity.EmailEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "EmailService.GetByEmailAddress")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("email", email))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "EmailService.GetByEmailAddress")
+	defer spans.Finish()
+	spans.LogKV("email", email)
 
 	emailNode, err := s.repositories.Neo4jRepositories.EmailReadRepository.GetFirstByEmail(ctx, common.GetTenantFromContext(ctx), email)
 	if err != nil {

--- a/packages/server/customer-os-api/services/external_system/external_system_service.go
+++ b/packages/server/customer-os-api/services/external_system/external_system_service.go
@@ -2,16 +2,14 @@ package api_external_system
 
 import (
 	"context"
-
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
-	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 
 	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
+	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
+	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
 )
 
 type externalSystemService struct {
@@ -27,13 +25,12 @@ func NewExternalSystemService(log logger.Logger, repositories *repository.Reposi
 }
 
 func (s *externalSystemService) GetAllExternalSystemInstances(ctx context.Context) (*neo4jentity.ExternalSystemEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ExternalSystemService.GetAllExternalSystemInstances")
+	span, ctx := telemetry.StartServiceSpan(ctx, "ExternalSystemService.GetAllExternalSystemInstances")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
 
 	dbRecords, err := s.repositories.Neo4jRepositories.ExternalSystemReadRepository.GetAllForTenant(ctx, common.GetTenantFromContext(ctx))
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Error(ctx, "Error getting all external system instances", err)
 		return nil, err
 	}

--- a/packages/server/customer-os-api/services/invoice/invoice_service.go
+++ b/packages/server/customer-os-api/services/invoice/invoice_service.go
@@ -10,14 +10,11 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	model2 "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	"github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
 	neo4jrepository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
 	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
@@ -53,11 +50,9 @@ func NewInvoiceService(log logger.Logger, repositories *repository.Repositories,
 }
 
 func (s *invoiceService) CountInvoices(ctx context.Context, tenant, organizationId string, where *model.Filter) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceService.CountInvoices")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagTenant, tenant)
-	span.LogFields(log.Object("where", where))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InvoiceService.CountInvoices")
+	defer spans.Finish()
+	spans.LogObjectAsJson("where", where)
 
 	organizationFilterCypher, organizationFilterParams := "", make(map[string]interface{})
 	invoiceFilterCypher, invoiceFilterParams := "", make(map[string]interface{})
@@ -118,21 +113,20 @@ func (s *invoiceService) CountInvoices(ctx context.Context, tenant, organization
 		filter = " WHERE " + filter
 	}
 
-	span.LogFields(log.String("filter", filter))
-	span.LogFields(log.Object("params", params))
+	spans.LogObjectAsJson("filter", filter)
+	spans.LogObjectAsJson("params", params)
 
 	return s.repositories.Neo4jRepositories.InvoiceReadRepository.CountInvoices(ctx, tenant, filter, params)
 }
 
 func (s *invoiceService) GetInvoices(ctx context.Context, organizationId string, page, limit int, where *model.Filter, sortBy []*model2.SortBy) (*utils.Pagination, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InvoiceService.GetInvoices")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("organizationId", organizationId))
-	span.LogFields(log.Object("page", page))
-	span.LogFields(log.Object("limit", limit))
-	span.LogFields(log.Object("where", where))
-	span.LogFields(log.Object("sortBy", sortBy))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "InvoiceService.GetInvoices")
+	defer spans.Finish()
+	spans.LogKV("organizationId", organizationId)
+	spans.LogKV("page", page)
+	spans.LogKV("limit", limit)
+	spans.LogKV("where", where)
+	spans.LogKV("sortBy", sortBy)
 
 	paginatedResult := utils.Pagination{
 		Limit: limit,
@@ -286,8 +280,8 @@ func (s *invoiceService) GetInvoices(ctx context.Context, organizationId string,
 		filter = " WHERE " + filter
 	}
 
-	span.LogFields(log.String("filter", filter))
-	span.LogFields(log.Object("params", params))
+	spans.LogKV("filter", filter)
+	spans.LogObjectAsJson("params", params)
 
 	dbNodesWithTotalCount, err := s.repositories.Neo4jRepositories.InvoiceReadRepository.GetPaginatedInvoices(ctx, common.GetTenantFromContext(ctx),
 		paginatedResult.GetSkip(),
@@ -296,7 +290,7 @@ func (s *invoiceService) GetInvoices(ctx context.Context, organizationId string,
 		params,
 		cypherSort)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 

--- a/packages/server/customer-os-api/services/issue/service.go
+++ b/packages/server/customer-os-api/services/issue/service.go
@@ -2,18 +2,16 @@ package api_issue
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 
 	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/exp/slices"
 )
 
@@ -30,19 +28,17 @@ func NewIssueService(log logger.Logger, repositories *repository.Repositories) c
 }
 
 func (s *issueService) GetIssueSummaryByStatusForOrganization(ctx context.Context, organizationId string) (map[string]int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueService.GetIssueSummaryByStatusForOrganization")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("organizationId", organizationId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueService.GetIssueSummaryByStatusForOrganization")
+	defer spans.Finish()
+	spans.LogKV("organizationId", organizationId)
 
 	return s.repositories.Neo4jRepositories.IssueReadRepository.GetIssueCountByStatusForOrganization(ctx, common.GetTenantFromContext(ctx), organizationId)
 }
 
 func (s *issueService) GetById(ctx context.Context, issueId string) (*neo4jentity.IssueEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueService.GetById")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("issueId", issueId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueService.GetById")
+	defer spans.Finish()
+	spans.LogKV("issueId", issueId)
 
 	if issueDbNode, err := s.repositories.Neo4jRepositories.IssueReadRepository.GetById(ctx, common.GetTenantFromContext(ctx), issueId); err != nil {
 		return nil, err
@@ -52,10 +48,9 @@ func (s *issueService) GetById(ctx context.Context, issueId string) (*neo4jentit
 }
 
 func (s *issueService) GetIssuesForInteractionEvents(ctx context.Context, ids []string) (*neo4jentity.IssueEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueService.GetIssuesForInteractionEvents")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("ids", ids))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueService.GetIssuesForInteractionEvents")
+	defer spans.Finish()
+	spans.LogObjectAsJson("ids", ids)
 
 	issues, err := s.repositories.IssueRepository.GetAllForInteractionEvents(ctx, common.GetTenantFromContext(ctx), ids)
 	if err != nil {
@@ -71,10 +66,9 @@ func (s *issueService) GetIssuesForInteractionEvents(ctx context.Context, ids []
 }
 
 func (s *issueService) GetSubmitterParticipantsForIssues(ctx context.Context, issueIds []string) (*neo4jentity.IssueParticipants, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueService.GetSubmitterParticipantsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("issueIds", issueIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueService.GetSubmitterParticipantsForIssues")
+	defer spans.Finish()
+	spans.LogObjectAsJson("issueIds", issueIds)
 
 	records, err := s.repositories.IssueRepository.GetSubmitterParticipantsForIssues(ctx, common.GetTenantFromContext(ctx), issueIds)
 	if err != nil {
@@ -83,16 +77,15 @@ func (s *issueService) GetSubmitterParticipantsForIssues(ctx context.Context, is
 
 	issueParticipants := s.convertDbNodesToIssueParticipants(records)
 
-	span.LogFields(log.Int("result count", len(issueParticipants)))
+	spans.LogKV("result count", len(issueParticipants))
 
 	return &issueParticipants, nil
 }
 
 func (s *issueService) GetReporterParticipantsForIssues(ctx context.Context, issueIds []string) (*neo4jentity.IssueParticipants, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueService.GetReporterParticipantsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("issueIds", issueIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueService.GetReporterParticipantsForIssues")
+	defer spans.Finish()
+	spans.LogObjectAsJson("issueIds", issueIds)
 
 	records, err := s.repositories.IssueRepository.GetReporterParticipantsForIssues(ctx, common.GetTenantFromContext(ctx), issueIds)
 	if err != nil {
@@ -101,16 +94,15 @@ func (s *issueService) GetReporterParticipantsForIssues(ctx context.Context, iss
 
 	issueParticipants := s.convertDbNodesToIssueParticipants(records)
 
-	span.LogFields(log.Int("result count", len(issueParticipants)))
+	spans.LogKV("result count", len(issueParticipants))
 
 	return &issueParticipants, nil
 }
 
 func (s *issueService) GetAssigneeParticipantsForIssues(ctx context.Context, issueIds []string) (*neo4jentity.IssueParticipants, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueService.GetAssigneeParticipantsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("issueIds", issueIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueService.GetAssigneeParticipantsForIssues")
+	defer spans.Finish()
+	spans.LogObjectAsJson("issueIds", issueIds)
 
 	records, err := s.repositories.IssueRepository.GetAssigneeParticipantsForIssues(ctx, common.GetTenantFromContext(ctx), issueIds)
 	if err != nil {
@@ -119,16 +111,15 @@ func (s *issueService) GetAssigneeParticipantsForIssues(ctx context.Context, iss
 
 	issueParticipants := s.convertDbNodesToIssueParticipants(records)
 
-	span.LogFields(log.Int("result count", len(issueParticipants)))
+	spans.LogKV("result count", len(issueParticipants))
 
 	return &issueParticipants, nil
 }
 
 func (s *issueService) GetFollowerParticipantsForIssues(ctx context.Context, issueIds []string) (*neo4jentity.IssueParticipants, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "IssueService.GetFollowerParticipantsForIssues")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("issueIds", issueIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "IssueService.GetFollowerParticipantsForIssues")
+	defer spans.Finish()
+	spans.LogObjectAsJson("issueIds", issueIds)
 
 	records, err := s.repositories.IssueRepository.GetFollowerParticipantsForIssues(ctx, common.GetTenantFromContext(ctx), issueIds)
 	if err != nil {
@@ -137,7 +128,7 @@ func (s *issueService) GetFollowerParticipantsForIssues(ctx context.Context, iss
 
 	issueParticipants := s.convertDbNodesToIssueParticipants(records)
 
-	span.LogFields(log.Int("result count", len(issueParticipants)))
+	spans.LogKV("result count", len(issueParticipants))
 
 	return &issueParticipants, nil
 }

--- a/packages/server/customer-os-api/services/location/location_service.go
+++ b/packages/server/customer-os-api/services/location/location_service.go
@@ -2,20 +2,17 @@ package api_location
 
 import (
 	"context"
-
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
-	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/entity"
 	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/coserrors"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
+	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
+	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
+	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
 )
 
 type locationService struct {
@@ -50,10 +47,9 @@ func (s *locationService) Update(ctx context.Context, entity neo4jentity.Locatio
 }
 
 func (s *locationService) DetachFromEntity(ctx context.Context, entityType commonModel.EntityType, entityId, locationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LocationService.DetachFromEntity")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("emailId", locationId), log.String("entityId", entityId), log.String("entityType", string(entityType)))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "LocationService.DetachFromEntity")
+	defer spans.Finish()
+	spans.LogKV("emailId", locationId, "entityId", entityId, "entityType", string(entityType))
 
 	err := s.repositories.LocationRepository.RemoveRelationshipAndDeleteOrphans(ctx, entityType, entityId, locationId)
 

--- a/packages/server/customer-os-api/services/log_entry/log_entry_service.go
+++ b/packages/server/customer-os-api/services/log_entry/log_entry_service.go
@@ -2,17 +2,14 @@ package api_log_entry
 
 import (
 	"context"
-
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
-	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 
 	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
+	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
+	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
 )
 
 type logEntryService struct {
@@ -28,14 +25,13 @@ func NewLogEntryService(log logger.Logger, repositories *repository.Repositories
 }
 
 func (s *logEntryService) GetById(ctx context.Context, logEntryId string) (*neo4jentity.LogEntryEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LogEntryService.GetById")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("logEntryId", logEntryId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "LogEntryService.GetById")
+	defer spans.Finish()
+	spans.LogKV("logEntryId", logEntryId)
 
 	logEntryDbNode, err := s.repositories.Neo4jRepositories.LogEntryReadRepository.GetById(ctx, common.GetTenantFromContext(ctx), logEntryId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 	return neo4jmapper.MapDbNodeToLogEntryEntity(logEntryDbNode), nil

--- a/packages/server/customer-os-api/services/meeting/service.go
+++ b/packages/server/customer-os-api/services/meeting/service.go
@@ -3,20 +3,18 @@ package api_meeting
 import (
 	"context"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"reflect"
 	"time"
 
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"golang.org/x/exp/slices"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/entity"
@@ -50,9 +48,8 @@ func NewMeetingService(
 }
 
 func (s *meetingService) Create(ctx context.Context, newMeeting *cosapi_interfaces.MeetingCreateData) (*neo4jentity.MeetingEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MeetingService.Create")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
+	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.Create")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jWriteSession(ctx, s.getNeo4jDriver())
 	defer session.Close(ctx)
@@ -83,9 +80,8 @@ func (s *meetingService) Create(ctx context.Context, newMeeting *cosapi_interfac
 }
 
 func (s *meetingService) Update(ctx context.Context, input *cosapi_interfaces.MeetingUpdateData) (*neo4jentity.MeetingEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MeetingService.Update")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
+	spans, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.Update")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jWriteSession(ctx, s.getNeo4jDriver())
 	defer session.Close(ctx)
@@ -304,10 +300,9 @@ func (s *meetingService) GetMeetingForInteractionEvent(ctx context.Context, inte
 }
 
 func (s *meetingService) GetMeetingsForInteractionEvents(ctx context.Context, ids []string) (*neo4jentity.MeetingEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MeetingService.GetMeetingsForInteractionEvents")
+	span, ctx := telemetry.StartServiceSpan(ctx, "MeetingService.GetMeetingsForInteractionEvents")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("ids", ids))
+	span.LogObjectAsJson("ids", ids)
 
 	issues, err := s.repositories.MeetingRepository.GetAllForInteractionEvents(ctx, common.GetTenantFromContext(ctx), ids)
 	if err != nil {

--- a/packages/server/customer-os-api/services/note/note_service.go
+++ b/packages/server/customer-os-api/services/note/note_service.go
@@ -2,22 +2,19 @@ package api_note
 
 import (
 	"context"
-
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
-	neo4jrepository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/entity"
 	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
+	commonModel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
+	neo4jrepository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 )
 
 type noteService struct {
@@ -37,12 +34,12 @@ func (s *noteService) getNeo4jDriver() neo4j.DriverWithContext {
 }
 
 func (s *noteService) GetById(ctx context.Context, id string) (*entity.NoteEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "NoteService.GetById")
-	defer span.Finish()
+	spans, ctx := telemetry.StartServiceSpan(ctx, "NoteService.GetById")
+	defer spans.Finish()
 
 	byId, err := s.repositories.Neo4jRepositories.CommonReadRepository.GetById(ctx, common.GetTenantFromContext(ctx), id, commonModel.NodeLabelNote)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return nil, err
 	}
 
@@ -54,10 +51,9 @@ func (s *noteService) GetById(ctx context.Context, id string) (*entity.NoteEntit
 }
 
 func (s *noteService) NoteLinkAttachment(ctx context.Context, noteID string, attachmentID string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "NoteService.NoteLinkAttachment")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("noteID", noteID), log.String("attachmentID", attachmentID))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "NoteService.NoteLinkAttachment")
+	defer spans.Finish()
+	spans.LogKV("noteID", noteID, "attachmentID", attachmentID)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -69,7 +65,7 @@ func (s *noteService) NoteLinkAttachment(ctx context.Context, noteID string, att
 		ToEntityType:   commonModel.ATTACHMENT,
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -77,10 +73,9 @@ func (s *noteService) NoteLinkAttachment(ctx context.Context, noteID string, att
 }
 
 func (s *noteService) NoteUnlinkAttachment(ctx context.Context, noteID string, attachmentID string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "NoteService.NoteUnlinkAttachment")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("noteID", noteID), log.String("attachmentID", attachmentID))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "NoteService.NoteUnlinkAttachment")
+	defer spans.Finish()
+	spans.LogKV("noteID", noteID, "attachmentID", attachmentID)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -92,7 +87,7 @@ func (s *noteService) NoteUnlinkAttachment(ctx context.Context, noteID string, a
 		ToEntityType:   commonModel.ATTACHMENT,
 	})
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -126,9 +121,8 @@ func (s *noteService) convertDbNodesToNotes(records []*utils.DbNodeAndId) entity
 }
 
 func (s *noteService) UpdateNote(ctx context.Context, entity *entity.NoteEntity) (*entity.NoteEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "NoteService.UpdateNote")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
+	spans, ctx := telemetry.StartServiceSpan(ctx, "NoteService.UpdateNote")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jWriteSession(ctx, s.getNeo4jDriver())
 	defer session.Close(ctx)
@@ -142,10 +136,9 @@ func (s *noteService) UpdateNote(ctx context.Context, entity *entity.NoteEntity)
 	return emailEntity, nil
 }
 func (s *noteService) CreateNoteForMeeting(ctx context.Context, meetingId string, entity *entity.NoteEntity) (*entity.NoteEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "NoteService.CreateNoteForMeeting")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("meetingId", meetingId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "NoteService.CreateNoteForMeeting")
+	defer spans.Finish()
+	spans.LogKV("meetingId", meetingId)
 
 	dbNodePtr, err := s.repositories.NoteRepository.CreateNoteForMeeting(ctx, common.GetContext(ctx).Tenant, meetingId, entity)
 	if err != nil {
@@ -161,10 +154,9 @@ func (s *noteService) CreateNoteForMeeting(ctx context.Context, meetingId string
 }
 
 func (s *noteService) DeleteNote(ctx context.Context, noteId string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "NoteService.DeleteNote")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("noteId", noteId))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "NoteService.DeleteNote")
+	defer spans.Finish()
+	spans.LogKV("noteId", noteId)
 
 	err := s.repositories.NoteRepository.Delete(ctx, common.GetTenantFromContext(ctx), noteId)
 	if err != nil {

--- a/packages/server/customer-os-api/services/opportunity/opportunity_service.go
+++ b/packages/server/customer-os-api/services/opportunity/opportunity_service.go
@@ -3,23 +3,20 @@ package api_opportunity
 import (
 	"context"
 	"fmt"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 
+	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
+	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
+	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	model2 "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
-
-	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
-	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
-	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
 )
 
 type opportunityService struct {
@@ -39,15 +36,18 @@ func NewOpportunityService(log logger.Logger, repositories *repository.Repositor
 }
 
 func (s *opportunityService) UpdateRenewal(ctx context.Context, opportunityId string, renewalLikelihood neo4jenum.RenewalLikelihood, amount *float64, comments *string, ownerUserId *string, adjustedRate *int64, appSource string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityService.UpdateRenewal")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("opportunityId", opportunityId), log.Object("renewalLikelihood", renewalLikelihood), log.Object("amount", amount), log.Object("comments", comments), log.String("appSource", appSource))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "OpportunityService.UpdateRenewal")
+	defer spans.Finish()
+	spans.LogKV("opportunityId", opportunityId,
+		"renewalLikelihood", renewalLikelihood,
+		"amount", amount,
+		"comments", comments,
+		"appSource", appSource)
 
 	if opportunityId == "" {
 		err := fmt.Errorf("(OpportunityService.UpdateRenewal) opportunity id is missing")
 		s.log.Error(err.Error())
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -55,7 +55,7 @@ func (s *opportunityService) UpdateRenewal(ctx context.Context, opportunityId st
 	if !opportunityExists {
 		err := fmt.Errorf("(OpportunityService.UpdateRenewal) opportunity with id {%s} not found", opportunityId)
 		s.log.Error(err.Error())
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -69,7 +69,7 @@ func (s *opportunityService) UpdateRenewal(ctx context.Context, opportunityId st
 
 	_, err := s.opportunity.Save(ctx, nil, &opportunityId, &dataFields)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		s.log.Error("error while updating renewal opportunity: ", err.Error())
 		return err
 	}
@@ -78,29 +78,30 @@ func (s *opportunityService) UpdateRenewal(ctx context.Context, opportunityId st
 }
 
 func (s *opportunityService) UpdateRenewalsForOrganization(ctx context.Context, organizationId string, renewalLikelihood neo4jenum.RenewalLikelihood, renewalAdjustedRate *int64) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityService.UpdateRenewalsForOrganization")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OpportunityService.UpdateRenewalsForOrganization")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("organizationId", organizationId), log.String("renewalLikelihood", renewalLikelihood.String()), log.Object("renewalAdjustedRate", renewalAdjustedRate))
+	span.LogKV("organizationId", organizationId,
+		"renewalLikelihood", renewalLikelihood.String(),
+		"renewalAdjustedRate", renewalAdjustedRate)
 
 	tenant := common.GetTenantFromContext(ctx)
 
 	_, err := s.organization.GetById(ctx, tenant, organizationId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return err
 	}
 
 	opportunityDbNodes, err := s.repositories.Neo4jRepositories.OpportunityReadRepository.GetActiveRenewalOpportunitiesForOrganization(ctx, common.GetTenantFromContext(ctx), organizationId, true)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return err
 	}
 
 	for _, opportunityDbNode := range opportunityDbNodes {
 		opportunity := neo4jmapper.MapDbNodeToOpportunityEntity(opportunityDbNode)
 		if err := s.UpdateRenewal(ctx, opportunity.Id, renewalLikelihood, nil, nil, nil, renewalAdjustedRate, constants.AppSourceCustomerOsApi); err != nil {
-			tracing.TraceErr(span, err)
+			span.TraceError(err)
 			return err
 		}
 	}
@@ -109,10 +110,9 @@ func (s *opportunityService) UpdateRenewalsForOrganization(ctx context.Context, 
 }
 
 func (s *opportunityService) GetPaginatedOrganizationOpportunities(ctx context.Context, page int, limit int) (*utils.Pagination, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OpportunityService.GetPaginatedOrganizationOpportunities")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OpportunityService.GetPaginatedOrganizationOpportunities")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Int("page", page), log.Int("limit", limit))
+	span.LogKV("page", page, "limit", limit)
 
 	paginatedResult := utils.Pagination{
 		Limit: limit,

--- a/packages/server/customer-os-api/services/organization/organization_service.go
+++ b/packages/server/customer-os-api/services/organization/organization_service.go
@@ -12,15 +12,12 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	commonmodel "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/services/events"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
 	neo4jrepository "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/repository"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
@@ -52,19 +49,17 @@ func NewOrganizationService(log logger.Logger, repositories *repository.Reposito
 }
 
 func (s *organizationService) CountOrganizations(ctx context.Context, tenant string) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.CountOrganizations")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.CountOrganizations")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.SetTag(tracing.SpanTagTenant, tenant)
 
 	return s.repositories.Neo4jRepositories.OrganizationReadRepository.CountByTenant(ctx, tenant)
 }
 
 func (s *organizationService) UpdateLastTouchpointByContactId(ctx context.Context, contactID string) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.UpdateLastTouchpointByContactId")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.UpdateLastTouchpointByContactId")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("contactID", contactID))
+
+	span.LogKV("contactID", contactID)
 
 	if contactID == "" {
 		return
@@ -73,19 +68,19 @@ func (s *organizationService) UpdateLastTouchpointByContactId(ctx context.Contex
 }
 
 func (s *organizationService) ExistsById(ctx context.Context, organizationId string) (bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.ExistsById")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.ExistsById")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("organizationId", organizationId))
+
+	span.LogKV("organizationId", organizationId)
 
 	return s.repositories.Neo4jRepositories.CommonReadRepository.ExistsById(ctx, common.GetTenantFromContext(ctx), organizationId, commonmodel.NodeLabelOrganization)
 }
 
 func (s *organizationService) GetByCustomerOsId(ctx context.Context, customerOsId string) (*neo4jentity.OrganizationEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.GetByCustomerOsId")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.GetByCustomerOsId")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("customerOsId", customerOsId))
+
+	span.LogKV("customerOsId", customerOsId)
 
 	dbNode, err := s.repositories.Neo4jRepositories.OrganizationReadRepository.GetOrganizationByCustomerOsId(ctx, common.GetTenantFromContext(ctx), customerOsId)
 	if err != nil {
@@ -99,10 +94,10 @@ func (s *organizationService) GetByCustomerOsId(ctx context.Context, customerOsI
 }
 
 func (s *organizationService) GetByReferenceId(ctx context.Context, referenceId string) (*neo4jentity.OrganizationEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.GetByReferenceId")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.GetByReferenceId")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("referenceId", referenceId))
+
+	span.LogKV("referenceId", referenceId)
 
 	dbNode, err := s.repositories.Neo4jRepositories.OrganizationReadRepository.GetOrganizationByReferenceId(ctx, common.GetTenantFromContext(ctx), referenceId)
 	if err != nil {
@@ -116,15 +111,15 @@ func (s *organizationService) GetByReferenceId(ctx context.Context, referenceId 
 }
 
 func (s *organizationService) GetSubsidiariesForOrganizations(ctx context.Context, parentOrganizationIds []string) (*neo4jentity.OrganizationEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.GetSubsidiariesForOrganizations")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.GetSubsidiariesForOrganizations")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("parentOrganizationIds", parentOrganizationIds))
+
+	span.LogObjectAsJson("parentOrganizationIds", parentOrganizationIds)
 
 	dbEntries, err := s.repositories.Neo4jRepositories.OrganizationReadRepository.GetLinkedSubOrganizations(ctx, common.GetTenantFromContext(ctx), parentOrganizationIds, neo4jrepository.Relationship_Subsidiary)
 	if err != nil {
 		s.log.Errorf("(organizationService.GetSubsidiariesForOrganizations) Error getting linked organizations: {%v}", err.Error())
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return nil, err
 	}
 	organizationEntities := make(neo4jentity.OrganizationEntities, 0, len(dbEntries))
@@ -142,38 +137,38 @@ func (s *organizationService) GetSubsidiariesForOrganizations(ctx context.Contex
 }
 
 func (s *organizationService) AddSubsidiary(ctx context.Context, parentOrganizationId, subsidiaryOrganizationId, subsidiaryType string, removeExisting bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.AddSubsidiary")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.AddSubsidiary")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(
-		log.String("parentOrganizationId", parentOrganizationId),
-		log.String("subsidiaryOrganizationId", subsidiaryOrganizationId),
-		log.String("subsidiaryType", subsidiaryType),
-		log.Bool("removeExisting", removeExisting))
+
+	span.LogKV(
+		"parentOrganizationId", parentOrganizationId,
+		"subsidiaryOrganizationId", subsidiaryOrganizationId,
+		"subsidiaryType", subsidiaryType,
+		"removeExisting", removeExisting)
 
 	parentExists, err := s.repositories.Neo4jRepositories.CommonReadRepository.ExistsById(ctx, common.GetTenantFromContext(ctx), parentOrganizationId, commonmodel.NodeLabelOrganization)
 	if err != nil {
 		s.log.Errorf("error checking if parent organization exists: {%v}", err.Error())
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return err
 	}
 	if !parentExists {
 		err = fmt.Errorf("Parent organization with id {%s} not found", parentOrganizationId)
 		s.log.Errorf("%v", err.Error())
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return err
 	}
 
 	subExists, err := s.repositories.Neo4jRepositories.CommonReadRepository.ExistsById(ctx, common.GetTenantFromContext(ctx), subsidiaryOrganizationId, commonmodel.NodeLabelOrganization)
 	if err != nil {
 		s.log.Errorf("error checking if sub organization exists: {%v}", err.Error())
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return err
 	}
 	if !subExists {
 		err = fmt.Errorf("subsidiary organization with id {%s} not found", subsidiaryOrganizationId)
 		s.log.Errorf("%v", err.Error())
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return err
 	}
 
@@ -181,7 +176,7 @@ func (s *organizationService) AddSubsidiary(ctx context.Context, parentOrganizat
 		// fetch existing subsidiaries of the parent organization
 		existingSubsidiaries, err := s.GetSubsidiariesForOrganizations(ctx, []string{parentOrganizationId})
 		if err != nil {
-			tracing.TraceErr(span, err)
+			span.TraceError(err)
 			s.log.Errorf("error fetching existing subsidiaries: {%v}", err.Error())
 			return err
 		}
@@ -189,7 +184,7 @@ func (s *organizationService) AddSubsidiary(ctx context.Context, parentOrganizat
 			if subsidiary.ID != subsidiaryOrganizationId {
 				err = s.RemoveSubsidiary(ctx, parentOrganizationId, subsidiary.ID)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					span.TraceError(err)
 					s.log.Errorf("error removing existing subsidiary: {%v}", err.Error())
 				}
 			}
@@ -198,62 +193,62 @@ func (s *organizationService) AddSubsidiary(ctx context.Context, parentOrganizat
 
 	err = s.organization.AddParentOrganization(ctx, nil, parentOrganizationId, subsidiaryOrganizationId, subsidiaryType)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("error adding parent organization: {%v}", err.Error())
 	}
 	return err
 }
 
 func (s *organizationService) RemoveSubsidiary(ctx context.Context, parentOrganizationId, subsidiaryOrganizationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.AddSubsidiary")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.AddSubsidiary")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("parentOrganizationId", parentOrganizationId), log.String("subsidiaryOrganizationId", subsidiaryOrganizationId))
+
+	span.LogKV("parentOrganizationId", parentOrganizationId, "subsidiaryOrganizationId", subsidiaryOrganizationId)
 
 	parentExists, err := s.repositories.Neo4jRepositories.CommonReadRepository.ExistsById(ctx, common.GetTenantFromContext(ctx), parentOrganizationId, commonmodel.NodeLabelOrganization)
 	if err != nil {
 		s.log.Errorf("error checking if parent organization exists: {%v}", err.Error())
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return err
 	}
 	if !parentExists {
 		err = fmt.Errorf("Parent organization with id {%s} not found", parentOrganizationId)
 		s.log.Errorf("%v", err.Error())
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return err
 	}
 
 	subExists, err := s.repositories.Neo4jRepositories.CommonReadRepository.ExistsById(ctx, common.GetTenantFromContext(ctx), subsidiaryOrganizationId, commonmodel.NodeLabelOrganization)
 	if err != nil {
 		s.log.Errorf("error checking if sub organization exists: {%v}", err.Error())
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return err
 	}
 	if !subExists {
 		err = fmt.Errorf("sub organization with id {%s} not found", subsidiaryOrganizationId)
 		s.log.Errorf("%v", err.Error())
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return err
 	}
 
 	err = s.organization.RemoveParentOrganization(ctx, nil, parentOrganizationId, subsidiaryOrganizationId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("error removing parent organization: {%v}", err.Error())
 	}
 	return err
 }
 
 func (s *organizationService) GetSubsidiariesOfForOrganizations(ctx context.Context, organizationIds []string) (*neo4jentity.OrganizationEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.GetSubsidiariesOfForOrganizations")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.GetSubsidiariesOfForOrganizations")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("organizationIds", organizationIds))
+
+	span.LogObjectAsJson("organizationIds", organizationIds)
 
 	dbEntries, err := s.repositories.Neo4jRepositories.OrganizationReadRepository.GetLinkedParentOrganizations(ctx, common.GetTenantFromContext(ctx), organizationIds, neo4jrepository.Relationship_Subsidiary)
 	if err != nil {
 		s.log.Errorf("(organizationService.GetSubsidiariesOfForOrganizations) Error getting linked parent organizations: {%v}", err.Error())
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return nil, err
 	}
 	organizationEntities := make(neo4jentity.OrganizationEntities, 0, len(dbEntries))
@@ -267,10 +262,9 @@ func (s *organizationService) GetSubsidiariesOfForOrganizations(ctx context.Cont
 }
 
 func (s *organizationService) UpdateLastTouchpoint(ctx context.Context, organizationID string) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.UpdateLastTouchpoint")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.UpdateLastTouchpoint")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("organizationID", organizationID))
+	span.LogKV("organizationID", organizationID)
 
 	if organizationID == "" {
 		return
@@ -291,10 +285,9 @@ func (s *organizationService) addSuggestedMergeRelationshipToOrganizationEntity(
 }
 
 func (s *organizationService) GetOrganizationsForSlackChannels(ctx context.Context, slackChannelIds []string) (*neo4jentity.OrganizationEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.GetOrganizationsForSlackChannels")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.GetOrganizationsForSlackChannels")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("slackChannelIds", slackChannelIds))
+	span.LogObjectAsJson("slackChannelIds", slackChannelIds)
 
 	organizations, err := s.repositories.Neo4jRepositories.OrganizationReadRepository.GetAllForSlackChannels(ctx, common.GetTenantFromContext(ctx), slackChannelIds)
 	if err != nil {
@@ -310,10 +303,9 @@ func (s *organizationService) GetOrganizationsForSlackChannels(ctx context.Conte
 }
 
 func (s *organizationService) GetOrganizationsForOpportunities(ctx context.Context, opportunityIds []string) (*neo4jentity.OrganizationEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.GetOrganizationsForOpportunities")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.GetOrganizationsForOpportunities")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("opportunityIds", opportunityIds))
+	span.LogObjectAsJson("opportunityIds", opportunityIds)
 
 	organizations, err := s.repositories.Neo4jRepositories.OrganizationReadRepository.GetAllForOpportunities(ctx, common.GetTenantFromContext(ctx), opportunityIds)
 	if err != nil {
@@ -329,15 +321,15 @@ func (s *organizationService) GetOrganizationsForOpportunities(ctx context.Conte
 }
 
 func (s *organizationService) updateLastTouchpointByContactId(ctx context.Context, contactID string) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.updateLastTouchpointByContactId")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.updateLastTouchpointByContactId")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("contactID", contactID))
+
+	span.LogKV("contactID", contactID)
 
 	dbNodesWithTotalCount, err := s.repositories.OrganizationRepository.GetPaginatedOrganizationsForContact(ctx, common.GetTenantFromContext(ctx), contactID, 0, 1000, &utils.CypherFilter{}, &utils.CypherSort{})
 	if err != nil {
 		s.log.Errorf("(organizationService.updateLastTouchpointByContactId) Failed to get organizations for contact: {%v}", err.Error())
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return
 	}
 	for _, dbNode := range dbNodesWithTotalCount.Nodes {
@@ -350,13 +342,12 @@ func (s *organizationService) updateLastTouchpointByContactId(ctx context.Contex
 }
 
 func (s *organizationService) GetMinMaxRenewalForecastArr(ctx context.Context) (float64, float64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.GetMinMaxRenewalForecastArr")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.GetMinMaxRenewalForecastArr")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
 
 	minArr, maxArr, err := s.repositories.OrganizationRepository.GetMinMaxRenewalForecastArr(ctx)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error getting min and max renewal forecast ARR: %s", err.Error())
 		return 0, 0, err
 	}
@@ -399,14 +390,14 @@ func (s *organizationService) GetOrganizationsForContact(ctx context.Context, co
 }
 
 func (s *organizationService) RemoveOwner(ctx context.Context, organizationID string) (*neo4jentity.OrganizationEntity, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.RemoveOwner")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.RemoveOwner")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("organizationID", organizationID))
+
+	span.LogKV("organizationID", organizationID)
 
 	dbNode, err := s.repositories.OrganizationRepository.RemoveOwner(ctx, common.GetTenantFromContext(ctx), organizationID)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return nil, err
 	}
 	return neo4jmapper.MapDbNodeToOrganizationEntity(dbNode), nil
@@ -447,10 +438,10 @@ func (s *organizationService) FindAll(ctx context.Context, page, limit int, filt
 }
 
 func (s *organizationService) Merge(ctx context.Context, primaryOrganizationId, mergedOrganizationId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.Merge")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.Merge")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("primaryOrganizationId", primaryOrganizationId), log.String("mergedOrganizationId", mergedOrganizationId))
+
+	span.LogKV("primaryOrganizationId", primaryOrganizationId, "mergedOrganizationId", mergedOrganizationId)
 
 	tenant := common.GetTenantFromContext(ctx)
 
@@ -496,7 +487,7 @@ func (s *organizationService) Merge(ctx context.Context, primaryOrganizationId, 
 			TargetOrgId: primaryOrganizationId,
 		})
 	if err != nil {
-		tracing.TraceErr(span, errors.Wrap(err, "failed to publish event to RabbitMQ"))
+		span.TraceError(errors.Wrap(err, "failed to publish event to RabbitMQ"))
 	}
 
 	// Update last touchpoint
@@ -504,13 +495,13 @@ func (s *organizationService) Merge(ctx context.Context, primaryOrganizationId, 
 
 	err = s.repositories.Neo4jRepositories.OrganizationWriteRepository.UpdateArr(ctx, tenant, primaryOrganizationId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error while updating ARR for organization %s: %s", primaryOrganizationId, err.Error())
 	}
 
 	err = s.organization.UpdateRenewalSummary(ctx, primaryOrganizationId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error while updating renewal summary for organization %s: %s", primaryOrganizationId, err.Error())
 	}
 
@@ -563,10 +554,10 @@ func (s *organizationService) GetOrganizationsForPhoneNumbers(ctx context.Contex
 }
 
 func (s *organizationService) GetOrganizationsForJobRoles(ctx context.Context, jobRoleIds []string) (*neo4jentity.OrganizationEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.GetOrganizationsForJobRoles")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.GetOrganizationsForJobRoles")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("jobRoleIds", jobRoleIds))
+
+	span.LogObjectAsJson("jobRoleIds", jobRoleIds)
 
 	organizations, err := s.repositories.OrganizationRepository.GetAllForJobRoles(ctx, common.GetTenantFromContext(ctx), jobRoleIds)
 	if err != nil {
@@ -582,14 +573,14 @@ func (s *organizationService) GetOrganizationsForJobRoles(ctx context.Context, j
 }
 
 func (s *organizationService) GetSuggestedMergeToForOrganizations(ctx context.Context, organizationIds []string) (*neo4jentity.OrganizationEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "OrganizationService.GetSuggestedMergeToForOrganizations")
+	span, ctx := telemetry.StartServiceSpan(ctx, "OrganizationService.GetSuggestedMergeToForOrganizations")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("organizationIds", organizationIds))
+
+	span.LogObjectAsJson("organizationIds", organizationIds)
 
 	dbEntries, err := s.repositories.OrganizationRepository.GetSuggestedMergePrimaryOrganizations(ctx, organizationIds)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error getting suggested merge primary organizations: {%v}", err.Error())
 		return nil, err
 	}

--- a/packages/server/customer-os-api/services/service_line_item/service_line_item_service.go
+++ b/packages/server/customer-os-api/services/service_line_item/service_line_item_service.go
@@ -12,13 +12,10 @@ import (
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/data_fields"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
 	neo4jenum "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/enum"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/constants"
@@ -321,7 +318,7 @@ func (s *serviceLineItemService) Update(ctx context.Context, serviceLineItemDeta
 			diffAbs := math.Abs(float64(diff))
 			// if diff is less than 10 min, skip update
 			if diffAbs < float64(600) {
-				spans.LogFields(log.String("result", "No changes recorded, start date is close to current timestamp"))
+				spans.LogKV("result", "No changes recorded, start date is close to current timestamp")
 				return nil
 			}
 		}
@@ -389,7 +386,7 @@ func (s *serviceLineItemService) Update(ctx context.Context, serviceLineItemDeta
 		}
 	}
 
-	spans.LogFields(log.Bool("result.isRetroactiveCorrection", isRetroactiveCorrection))
+	spans.LogKV("result.isRetroactiveCorrection", isRetroactiveCorrection)
 
 	if isRetroactiveCorrection == true {
 		sliDataFields := data_fields.SLIFields{
@@ -462,14 +459,13 @@ func (s *serviceLineItemService) Update(ctx context.Context, serviceLineItemDeta
 }
 
 func (s *serviceLineItemService) Delete(ctx context.Context, serviceLineItemId string) (completed bool, err error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemService.Delete")
+	span, ctx := telemetry.StartServiceSpan(ctx, "ServiceLineItemService.Delete")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("serviceLineItemId", serviceLineItemId))
+	span.LogKV("serviceLineItemId", serviceLineItemId)
 
 	sliEntity, err := s.sli.GetById(ctx, serviceLineItemId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error on getting service line item by id {%s}: %s", serviceLineItemId, err.Error())
 		return false, err
 	}
@@ -477,13 +473,13 @@ func (s *serviceLineItemService) Delete(ctx context.Context, serviceLineItemId s
 	// Check SLI is not invoiced
 	sliInvoiced, err := s.repositories.Neo4jRepositories.ServiceLineItemReadRepository.WasServiceLineItemInvoiced(ctx, common.GetTenantFromContext(ctx), serviceLineItemId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error on checking if service line item was invoiced: %s", err.Error())
 		return false, err
 	}
 	if sliInvoiced {
 		err := fmt.Errorf("service line item with id {%s} is included in invoice and cannot be deleted", serviceLineItemId)
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf(err.Error())
 		return false, err
 	}
@@ -491,19 +487,19 @@ func (s *serviceLineItemService) Delete(ctx context.Context, serviceLineItemId s
 	// if contract is not draft prevent removing current or past SLIs
 	contractEntity, err := s.contract.GetContractByServiceLineItem(ctx, serviceLineItemId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error on getting contract by service line item id {%s}: %s", serviceLineItemId, err.Error())
 		return false, err
 	}
 	if contractEntity.ContractStatus != neo4jenum.ContractStatusDraft && !sliEntity.StartedAt.After(utils.Today()) {
 		err = fmt.Errorf("cannot delete contract line item with id {%s} in the past", serviceLineItemId)
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return false, err
 	}
 
 	err = s.sli.Delete(ctx, nil, serviceLineItemId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error from events processing: %s", err.Error())
 		return false, err
 	}
@@ -512,15 +508,13 @@ func (s *serviceLineItemService) Delete(ctx context.Context, serviceLineItemId s
 }
 
 func (s *serviceLineItemService) Close(ctx context.Context, serviceLineItemId string, endedAt *time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ServiceLineItemService.Close")
+	span, ctx := telemetry.StartServiceSpan(ctx, "ServiceLineItemService.Close")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("serviceLineItemId", serviceLineItemId))
-	span.SetTag(tracing.SpanTagEntityId, serviceLineItemId)
+	span.LogKV("serviceLineItemId", serviceLineItemId)
 
 	contractEntity, err := s.contract.GetContractByServiceLineItem(ctx, serviceLineItemId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error on getting contract by service line item id {%s}: %s", serviceLineItemId, err.Error())
 		return err
 	}
@@ -533,7 +527,7 @@ func (s *serviceLineItemService) Close(ctx context.Context, serviceLineItemId st
 
 	currentSliEntity, err := s.sli.GetById(ctx, serviceLineItemId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error on getting service line item by id {%s}: %s", serviceLineItemId, err.Error())
 		return err
 	}
@@ -547,14 +541,14 @@ func (s *serviceLineItemService) Close(ctx context.Context, serviceLineItemId st
 	// closing past SLIs not allowed
 	if currentSliEntity.EndedAt != nil && currentSliEntity.EndedAt.Before(utils.Today()) {
 		err = fmt.Errorf("contract line item with id {%s} is already closed", serviceLineItemId)
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		return err
 	}
 
 	// First remove any future SLI with same parent ID
 	sliEntities, err := s.sli.GetServiceLineItemsByParentId(ctx, currentSliEntity.ParentID)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error on getting service line items by parent id {%s}: %s", currentSliEntity.ParentID, err.Error())
 		return err
 	}
@@ -569,7 +563,7 @@ func (s *serviceLineItemService) Close(ctx context.Context, serviceLineItemId st
 
 	err = s.sli.Close(ctx, nil, serviceLineItemId, utils.IfNotNilTimeWithDefault(endedAt, utils.Now()))
 	if err != nil {
-		tracing.TraceErr(span, err)
+		span.TraceError(err)
 		s.log.Errorf("Error from events processing: %s", err.Error())
 		return err
 	}

--- a/packages/server/customer-os-api/services/tenant_settings/tenant_settings_service.go
+++ b/packages/server/customer-os-api/services/tenant_settings/tenant_settings_service.go
@@ -3,9 +3,8 @@ package api_tenant_settings
 import (
 	"fmt"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/opentracing/opentracing-go"
-
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	postgresentity "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/entity"
 	postgres_repository "github.com/customeros/customeros/packages/server/customer-os-postgres-repository/repository"
@@ -130,7 +129,7 @@ func NewTenantSettingsService(log logger.Logger, cfg *config.Config, postgres *p
 }
 
 func (s *tenantSettingsService) GetForTenant(ctx context.Context) (*postgresentity.TenantSettings, map[string]bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantSettingsService.GetForTenant")
+	span, ctx := telemetry.StartServiceSpan(ctx, "TenantSettingsService.GetForTenant")
 	defer span.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
@@ -160,7 +159,7 @@ func (s *tenantSettingsService) GetForTenant(ctx context.Context) (*postgresenti
 }
 
 func (s *tenantSettingsService) SaveIntegrationData(ctx context.Context, request map[string]interface{}) (*postgresentity.TenantSettings, map[string]bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantSettingsService.SaveIntegrationData")
+	span, ctx := telemetry.StartServiceSpan(ctx, "TenantSettingsService.SaveIntegrationData")
 	defer span.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
@@ -1320,7 +1319,7 @@ func (s *tenantSettingsService) SaveIntegrationData(ctx context.Context, request
 }
 
 func (s *tenantSettingsService) ClearIntegrationData(ctx context.Context, identifier string) (*postgresentity.TenantSettings, map[string]bool, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TenantSettingsService.ClearIntegrationData")
+	span, ctx := telemetry.StartServiceSpan(ctx, "TenantSettingsService.ClearIntegrationData")
 	defer span.Finish()
 
 	tenantSettings, _, err := s.GetForTenant(ctx)

--- a/packages/server/customer-os-api/services/timeline_event/timeline_event_service.go
+++ b/packages/server/customer-os-api/services/timeline_event/timeline_event_service.go
@@ -2,17 +2,15 @@ package api_timeline_event
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"time"
 
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
 	model2 "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"golang.org/x/exp/slices"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/entity"
@@ -34,12 +32,11 @@ func NewTimelineEventService(log logger.Logger, repositories *repository.Reposit
 }
 
 func (s *timelineEventService) GetTimelineEventsForContact(ctx context.Context, contactId string, from *time.Time, size int, types []model.TimelineEventType) (*entity.TimelineEventEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventService.GetTimelineEventsForContact")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("contactId", contactId), log.Int("size", size), log.Object("types", types))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "TimelineEventService.GetTimelineEventsForContact")
+	defer spans.Finish()
+	spans.LogKV("contactId", contactId, "size", size, "types", types)
 	if from != nil {
-		span.LogFields(log.String("from", from.String()))
+		spans.LogKV("from", from.String())
 	}
 
 	nodeLabels := []string{}
@@ -70,15 +67,14 @@ func (s *timelineEventService) GetTimelineEventsForContact(ctx context.Context, 
 }
 
 func (s *timelineEventService) GetTimelineEventsForOrganization(ctx context.Context, organizationId string, from *time.Time, size int, types []model.TimelineEventType) (*entity.TimelineEventEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventService.GetTimelineEventsForOrganization")
+	span, ctx := telemetry.StartServiceSpan(ctx, "TimelineEventService.GetTimelineEventsForOrganization")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("organizationId", organizationId), log.Int("size", size), log.Object("types", types))
+	span.LogKV("organizationId", organizationId, "size", size, "types", types)
 	if from != nil {
-		span.LogFields(log.String("from", from.String()))
+		span.LogKV("from", from.String())
 	}
 
-	nodeLabels := []string{}
+	var nodeLabels []string
 	for _, v := range types {
 		nodeLabels = append(nodeLabels, entity.NodeLabelsByTimelineEventType[v.String()])
 	}
@@ -105,10 +101,9 @@ func (s *timelineEventService) GetTimelineEventsForOrganization(ctx context.Cont
 }
 
 func (s *timelineEventService) GetTimelineEventsTotalCountForContact(ctx context.Context, contactId string, types []model.TimelineEventType) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventService.GetTimelineEventsTotalCountForContact")
+	span, ctx := telemetry.StartServiceSpan(ctx, "TimelineEventService.GetTimelineEventsTotalCountForContact")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("contactId", contactId), log.Object("types", types))
+	span.LogKV("contactId", contactId, "types", types)
 
 	nodeLabels := []string{}
 	for _, v := range types {
@@ -129,12 +124,11 @@ func (s *timelineEventService) GetTimelineEventsTotalCountForContact(ctx context
 }
 
 func (s *timelineEventService) GetTimelineEventsTotalCountForOrganization(ctx context.Context, organizationId string, types []model.TimelineEventType) (int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventService.GetTimelineEventsTotalCountForOrganization")
+	span, ctx := telemetry.StartServiceSpan(ctx, "TimelineEventService.GetTimelineEventsTotalCountForOrganization")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.String("organizationId", organizationId), log.Object("types", types))
+	span.LogKV("organizationId", organizationId, "types", types)
 
-	nodeLabels := []string{}
+	var nodeLabels []string
 	for _, value := range types {
 		nodeLabels = append(nodeLabels, entity.NodeLabelsByTimelineEventType[value.String()])
 	}
@@ -178,10 +172,9 @@ func (s *timelineEventService) convertDbNodeToTimelineEvent(dbNode *dbtype.Node)
 }
 
 func (s *timelineEventService) GetTimelineEventsWithIds(ctx context.Context, ids []string) (*entity.TimelineEventEntities, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventService.GetTimelineEventsWithIds")
+	span, ctx := telemetry.StartServiceSpan(ctx, "TimelineEventService.GetTimelineEventsWithIds")
 	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
-	span.LogFields(log.Object("ids", ids))
+	span.LogObjectAsJson("ids", ids)
 
 	dbNodes, err := s.repositories.Neo4jRepositories.TimelineEventReadRepository.GetTimelineEventsWithIds(ctx, common.GetTenantFromContext(ctx), ids)
 	if err != nil {
@@ -199,19 +192,17 @@ func (s *timelineEventService) GetTimelineEventsWithIds(ctx context.Context, ids
 }
 
 func (s *timelineEventService) GetInboundCommsCountCountByOrganizations(ctx context.Context, organizationIds []string) (map[string]int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventService.GetInboundCommsCountCountByOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("organizationIds", organizationIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "TimelineEventService.GetInboundCommsCountCountByOrganizations")
+	defer spans.Finish()
+	spans.LogObjectAsJson("organizationIds", organizationIds)
 
 	return s.repositories.Neo4jRepositories.TimelineEventReadRepository.GetInboundCommsTimelineEventsCountByOrganizations(ctx, common.GetTenantFromContext(ctx), organizationIds)
 }
 
 func (s *timelineEventService) GetOutboundCommsCountCountByOrganizations(ctx context.Context, organizationIds []string) (map[string]int64, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "TimelineEventService.GetOutboundCommsCountCountByOrganizations")
-	defer span.Finish()
-	tracing.SetDefaultNeo4jRepositorySpanTags(ctx, span)
-	span.LogFields(log.Object("organizationIds", organizationIds))
+	spans, ctx := telemetry.StartServiceSpan(ctx, "TimelineEventService.GetOutboundCommsCountCountByOrganizations")
+	defer spans.Finish()
+	spans.LogObjectAsJson("organizationIds", organizationIds)
 
 	return s.repositories.Neo4jRepositories.TimelineEventReadRepository.GetOutboundCommsTimelineEventsCountByOrganizations(ctx, common.GetTenantFromContext(ctx), organizationIds)
 }

--- a/packages/server/customer-os-api/services/user/user_service.go
+++ b/packages/server/customer-os-api/services/user/user_service.go
@@ -2,23 +2,21 @@ package api_user
 
 import (
 	"context"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"reflect"
-
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
-	model2 "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
-	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
-	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
 
 	"github.com/customeros/customeros/packages/server/customer-os-api/graphql/model"
 	cosapi_interfaces "github.com/customeros/customeros/packages/server/customer-os-api/interfaces"
 	"github.com/customeros/customeros/packages/server/customer-os-api/repository"
 	api_filters "github.com/customeros/customeros/packages/server/customer-os-api/services/filters"
 	api_sort "github.com/customeros/customeros/packages/server/customer-os-api/services/sort"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/logger"
+	model2 "github.com/customeros/customeros/packages/server/customer-os-common-module/model"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
+	neo4jentity "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/entity"
+	neo4jmapper "github.com/customeros/customeros/packages/server/customer-os-neo4j-repository/mapper"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
 type userService struct {
@@ -43,9 +41,8 @@ func (s *userService) getNeo4jDriver() neo4j.DriverWithContext {
 }
 
 func (s *userService) ContainsRole(parentCtx context.Context, allowedRoles []model.Role) bool {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserService.ContainsRole")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
+	spans, ctx := telemetry.StartServiceSpan(parentCtx, "UserService.ContainsRole")
+	defer spans.Finish()
 
 	myRoles := common.GetRolesFromContext(ctx)
 	for _, allowedRole := range allowedRoles {
@@ -59,9 +56,8 @@ func (s *userService) ContainsRole(parentCtx context.Context, allowedRoles []mod
 }
 
 func (s *userService) CanAddRemoveRole(parentCtx context.Context, role model.Role) bool {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserService.CanAddRemoveRole")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
+	spans, ctx := telemetry.StartServiceSpan(parentCtx, "UserService.CanAddRemoveRole")
+	defer spans.Finish()
 
 	switch role {
 	case model.RoleAdmin:
@@ -78,10 +74,9 @@ func (s *userService) CanAddRemoveRole(parentCtx context.Context, role model.Rol
 	}
 }
 
-func (s *userService) GetAll(parentCtx context.Context, page, limit int, filter *model.Filter, sortBy []*model2.SortBy) (*utils.Pagination, error) {
-	span, ctx := opentracing.StartSpanFromContext(parentCtx, "UserService.GetAll")
-	defer span.Finish()
-	tracing.SetDefaultServiceSpanTags(ctx, span)
+func (s *userService) GetAll(ctx context.Context, page, limit int, filter *model.Filter, sortBy []*model2.SortBy) (*utils.Pagination, error) {
+	spans, ctx := telemetry.StartServiceSpan(ctx, "UserService.GetAll")
+	defer spans.Finish()
 
 	session := utils.NewNeo4jReadSession(ctx, s.getNeo4jDriver())
 	defer session.Close(ctx)

--- a/packages/server/customer-os-common-module/utils/slack_utils.go
+++ b/packages/server/customer-os-common-module/utils/slack_utils.go
@@ -4,16 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/tracing"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"io"
 	"net/http"
 )
 
 func SendSlackMessage(c context.Context, slackWehbookUrl, text string) error {
-	span, _ := opentracing.StartSpanFromContext(c, "SlackUtils.SendSlackMessage")
-	defer span.Finish()
+	spans, _ := telemetry.StartServiceSpan(c, "SlackUtils.SendSlackMessage")
+	defer spans.Finish()
 
 	// Create a struct to hold the JSON data
 	type SlackMessage struct {
@@ -24,25 +22,25 @@ func SendSlackMessage(c context.Context, slackWehbookUrl, text string) error {
 	// Convert struct to JSON
 	jsonData, err := json.Marshal(message)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	// Send POST request
 	resp, err := http.Post(slackWehbookUrl, "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 	defer resp.Body.Close()
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
-	span.LogFields(log.String("response.body", string(responseBody)))
+	spans.LogKV("response.body", string(responseBody))
 
 	return nil
 }

--- a/packages/server/customer-os-neo4j-repository/repository/utils.go
+++ b/packages/server/customer-os-neo4j-repository/repository/utils.go
@@ -1,39 +1,11 @@
 package neo4j_repository
 
 import (
-	"fmt"
-	"github.com/cenkalti/backoff/v4"
-	"github.com/customeros/customeros/packages/server/customer-os-common-module/common"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/telemetry"
 	"github.com/customeros/customeros/packages/server/customer-os-common-module/utils"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
-
-	"github.com/pkg/errors"
 	"golang.org/x/net/context"
-	"time"
 )
-
-func WaitForNodeDeletedFromNeo4j(ctx context.Context, repositories *Repositories, id, nodeLabel string, span opentracing.Span) {
-	operation := func() error {
-		found, findErr := repositories.CommonReadRepository.ExistsById(ctx, common.GetTenantFromContext(ctx), id, nodeLabel)
-		if findErr != nil {
-			return findErr
-		}
-		if found {
-			return errors.New(fmt.Sprintf("Node %s with id %s still exists in Neo4j", nodeLabel, id))
-		}
-		return nil
-	}
-
-	err := backoff.Retry(operation, utils.BackOffConfig(100*time.Millisecond, 1.5, 1*time.Second, 5*time.Second, 10))
-	if err != nil {
-		span.LogFields(log.Bool("result.deleted", false))
-	} else {
-		span.LogFields(log.Bool("result.deleted", true))
-	}
-}
 
 func LogAndExecuteWriteQuery(ctx context.Context, driver neo4j.DriverWithContext, cypher string, params map[string]any, spans *telemetry.Spans) error {
 	spans.LogKV("cypher", cypher)

--- a/packages/server/events-subscribers/listeners/events/mailstack_provision_buy_request.go
+++ b/packages/server/events-subscribers/listeners/events/mailstack_provision_buy_request.go
@@ -51,23 +51,22 @@ func (l *MailstackProvisionBuyRequestListener) Handle(ctx context.Context, baseE
 }
 
 func (l *MailstackProvisionBuyRequestListener) handle(ctx context.Context, entityId string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MailstackProvisionBuyRequestListener.handle")
-	defer span.Finish()
-	tracing.SetDefaultListenerSpanTags(ctx, span)
+	spans, ctx := telemetry.StartListenerSpan(ctx, "MailstackProvisionBuyRequestListener.handle")
+	defer spans.Finish()
 
 	mailstackBuyRequest, err := l.dependencies.PostgresRepositories.MailstackBuyRequestRepository.GetById(ctx, entityId)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	if mailstackBuyRequest == nil {
 		err = errors.New("mailstack buy request not found")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
-	span.LogKV("mailstackBuyRequest.Status", mailstackBuyRequest.Status)
+	spans.LogKV("mailstackBuyRequest.Status", mailstackBuyRequest.Status)
 
 	if mailstackBuyRequest.Status != postgres_entity.MailstackBuyRequestStatusPending {
 		return nil
@@ -75,20 +74,20 @@ func (l *MailstackProvisionBuyRequestListener) handle(ctx context.Context, entit
 
 	err = l.processDomains(ctx, mailstackBuyRequest)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	err = l.processMailboxes(ctx, mailstackBuyRequest)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	// reload latest state for domains
 	domains, err := l.dependencies.PostgresRepositories.MailstackBuyRequestRepository.GetDomains(ctx, mailstackBuyRequest.ID)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -99,12 +98,12 @@ func (l *MailstackProvisionBuyRequestListener) handle(ctx context.Context, entit
 
 		statusCode, errMessage, mailboxes, err := l.dependencies.CommonServices.MailstackService.GetMailboxes(ctx, domain.Tenant, domain.Domain, "")
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 		if statusCode != http.StatusOK {
 			err = errors.New(errMessage)
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 			return err
 		}
 
@@ -115,7 +114,7 @@ func (l *MailstackProvisionBuyRequestListener) handle(ctx context.Context, entit
 
 			err := l.dependencies.CommonServices.Events.Publisher.PublishFanoutEvent(ctx, mailbox.ID, common_model.MAILBOX, dto.MailstackProvisionMailbox{})
 			if err != nil {
-				tracing.TraceErr(span, err)
+				spans.TraceError(err)
 				return err
 			}
 		}
@@ -138,7 +137,7 @@ func (l *MailstackProvisionBuyRequestListener) handle(ctx context.Context, entit
 
 		_, err = l.dependencies.PostgresRepositories.MailstackBuyRequestRepository.Store(ctx, nil, mailstackBuyRequest)
 		if err != nil {
-			tracing.TraceErr(span, err)
+			spans.TraceError(err)
 		}
 	}
 
@@ -146,26 +145,25 @@ func (l *MailstackProvisionBuyRequestListener) handle(ctx context.Context, entit
 }
 
 func (l *MailstackProvisionBuyRequestListener) configureDomainInMailstack(ctx context.Context, domain string, website string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MailstackProvisionBuyRequestListener.configureDomainInMailstack")
-	defer span.Finish()
-	tracing.SetDefaultListenerSpanTags(ctx, span)
+	spans, ctx := telemetry.StartListenerSpan(ctx, "MailstackProvisionBuyRequestListener.configureDomainInMailstack")
+	defer spans.Finish()
 
 	tenant := common.GetTenantFromContext(ctx)
 	if tenant == "" {
 		err := errors.New("missing tenant in context")
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	statusCode, errorMsg, _, err := l.dependencies.CommonServices.MailstackService.ConfigureDomain(ctx, tenant, domain, website)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	if statusCode != http.StatusOK {
 		err := errors.New(errorMsg)
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -173,19 +171,18 @@ func (l *MailstackProvisionBuyRequestListener) configureDomainInMailstack(ctx co
 }
 
 func (l *MailstackProvisionBuyRequestListener) purchaseDomainInMailstack(ctx context.Context, tenant string, domain string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MailstackProvisionBuyRequestListener.purchaseDomainInMailstack")
-	defer span.Finish()
-	tracing.SetDefaultListenerSpanTags(ctx, span)
+	spans, ctx := telemetry.StartListenerSpan(ctx, "MailstackProvisionBuyRequestListener.purchaseDomainInMailstack")
+	defer spans.Finish()
 
 	statusCode, errorMsg, err := l.dependencies.CommonServices.MailstackService.PurchaseDomain(ctx, tenant, domain)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
 	if statusCode != http.StatusOK {
 		err := errors.New(errorMsg)
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -193,13 +190,12 @@ func (l *MailstackProvisionBuyRequestListener) purchaseDomainInMailstack(ctx con
 }
 
 func (l *MailstackProvisionBuyRequestListener) processDomains(ctx context.Context, mailstackBuyRequest *postgres_entity.MailstackBuyRequest) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "MailstackProvisionBuyRequestListener.processDomains")
-	defer span.Finish()
-	tracing.SetDefaultListenerSpanTags(ctx, span)
+	spans, ctx := telemetry.StartListenerSpan(ctx, "MailstackProvisionBuyRequestListener.processDomains")
+	defer spans.Finish()
 
 	domains, err := l.dependencies.PostgresRepositories.MailstackBuyRequestRepository.GetDomains(ctx, mailstackBuyRequest.ID)
 	if err != nil {
-		tracing.TraceErr(span, err)
+		spans.TraceError(err)
 		return err
 	}
 
@@ -220,7 +216,7 @@ func (l *MailstackProvisionBuyRequestListener) processDomains(ctx context.Contex
 			if domain.Status == postgres_entity.MailstackBuyRequestDomainStatusPendingProvisioning {
 				err := l.purchaseDomainInMailstack(ctx, domain.Tenant, domain.Domain)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					mailstackBuyRequest.Status = postgres_entity.MailstackBuyRequestStatusFailed
 					domain.Status = postgres_entity.MailstackBuyRequestDomainStatusFailed
 				} else {
@@ -229,7 +225,7 @@ func (l *MailstackProvisionBuyRequestListener) processDomains(ctx context.Contex
 
 				err = l.dependencies.PostgresRepositories.CommonRepository.UpdateProperty(ctx, domain.Tenant, postgres_entity.MailstackBuyRequestDomain{}, domain.ID, "Status", domain.Status)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return // Exit the goroutine on error
 				}
 			}
@@ -238,14 +234,14 @@ func (l *MailstackProvisionBuyRequestListener) processDomains(ctx context.Contex
 			if domain.Status == postgres_entity.MailstackBuyRequestDomainStatusPendingConfiguration {
 				err := l.configureDomainInMailstack(ctx, domain.Domain, domain.RedirectWebsite)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 				} else {
 					domain.Status = postgres_entity.MailstackBuyRequestDomainStatusCompleted
 				}
 
 				err = l.dependencies.PostgresRepositories.CommonRepository.UpdateProperty(ctx, domain.Tenant, postgres_entity.MailstackBuyRequestDomain{}, domain.ID, "Status", domain.Status)
 				if err != nil {
-					tracing.TraceErr(span, err)
+					spans.TraceError(err)
 					return // Exit the goroutine on error
 				}
 			}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replaces `opentracing` with `telemetry` for span management across multiple services, enhancing error logging and span operations.
> 
>   - **Telemetry Integration**:
>     - Replaces `opentracing` with `telemetry` for span management in services like `calendar_service.go`, `contact_service.go`, and `contract_service.go`.
>     - Updates span creation from `opentracing.StartSpanFromContext` to `telemetry.StartServiceSpan`.
>     - Changes error logging from `tracing.TraceErr` to `spans.TraceError`.
>     - Modifies log field methods from `span.LogFields` to `spans.LogKV` and `spans.LogObjectAsJson`.
>   - **Service Updates**:
>     - Updates span handling in `country_service.go`, `email_service.go`, and `external_system_service.go`.
>     - Adjusts span logging in `invoice_service.go`, `issue_service.go`, and `location_service.go`.
>     - Refines span usage in `log_entry_service.go`, `meeting_service.go`, and `note_service.go`.
>     - Enhances span management in `opportunity_service.go`, `organization_service.go`, and `service_line_item_service.go`.
>     - Refactors span operations in `tenant_settings_service.go`, `timeline_event_service.go`, and `user_service.go`.
>   - **Utility and Listener Changes**:
>     - Updates `slack_utils.go` to use `telemetry` for span management.
>     - Modifies `mailstack_provision_buy_request.go` to replace `opentracing` with `telemetry` for listener spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for dfaab146a43b25e3150c14a1a080289ad1e3ec78. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->