### PR TITLE
patch: Fix script path in realtime deploy workflow

### DIFF
--- a/.github/workflows/realtime-deploy.yaml
+++ b/.github/workflows/realtime-deploy.yaml
@@ -43,7 +43,7 @@ jobs:
           echo "$HOME/.bun/bin" >> $GITHUB_PATH
 
       - name: Make build.sh executable
-        run: chmod +x ./packages/server/realtime/build.sh
+        run: chmod +x ./packages/server/realtime/build-image.sh
 
       - name: Build Phoenix app
         run: |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix script path in `realtime-deploy.yaml` from `build.sh` to `build-image.sh`.
> 
>   - **Fix**:
>     - Corrects script path in `realtime-deploy.yaml` from `build.sh` to `build-image.sh` for the `chmod +x` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 023418b247f963acf9be0d48415afff226f525d3. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->