### PR TITLE
patch: clear user photo

### DIFF
--- a/packages/server/customer-os-api/graphql/generated/generated.go
+++ b/packages/server/customer-os-api/graphql/generated/generated.go
@@ -19095,6 +19095,7 @@ input UserUpdateInput {
   id: ID!
   name: String
   profilePhotoUrl: String @deprecated
+  profilePhotoUrlV2: String
 }
 
 input UserOnboardingDetailsInput {
@@ -128070,7 +128071,7 @@ func (ec *executionContext) unmarshalInputUserUpdateInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "name", "profilePhotoUrl"}
+	fieldsInOrder := [...]string{"id", "name", "profilePhotoUrl", "profilePhotoUrlV2"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -128098,6 +128099,13 @@ func (ec *executionContext) unmarshalInputUserUpdateInput(ctx context.Context, o
 				return it, err
 			}
 			it.ProfilePhotoURL = data
+		case "profilePhotoUrlV2":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("profilePhotoUrlV2"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ProfilePhotoURLV2 = data
 		}
 	}
 

--- a/packages/server/customer-os-api/graphql/model/models_gen.go
+++ b/packages/server/customer-os-api/graphql/model/models_gen.go
@@ -3350,9 +3350,10 @@ func (UserParticipant) IsIssueParticipant() {}
 func (UserParticipant) IsMeetingParticipant() {}
 
 type UserUpdateInput struct {
-	ID              string  `json:"id"`
-	Name            *string `json:"name,omitempty"`
-	ProfilePhotoURL *string `json:"profilePhotoUrl,omitempty"`
+	ID                string  `json:"id"`
+	Name              *string `json:"name,omitempty"`
+	ProfilePhotoURL   *string `json:"profilePhotoUrl,omitempty"`
+	ProfilePhotoURLV2 *string `json:"profilePhotoUrlV2,omitempty"`
 }
 
 type WebsiteCheckDetails struct {

--- a/packages/server/customer-os-api/graphql/resolver/user.resolvers.go
+++ b/packages/server/customer-os-api/graphql/resolver/user.resolvers.go
@@ -61,6 +61,9 @@ func (r *mutationResolver) UserUpdate(ctx context.Context, input *model.UserUpda
 	userData := data_fields.UserFields{
 		ProfilePhotoUrl: input.ProfilePhotoURL,
 	}
+	if input.ProfilePhotoURLV2 != nil && *input.ProfilePhotoURLV2 == "" {
+		userData.ProfilePhotoKey = utils.StringPtr("")
+	}
 	if input.Name != nil {
 		firstName, lastName := utils.SplitFullName(*input.Name)
 		userData.FirstName = &firstName

--- a/packages/server/customer-os-api/graphql/schemas/user.graphqls
+++ b/packages/server/customer-os-api/graphql/schemas/user.graphqls
@@ -149,6 +149,7 @@ input UserUpdateInput {
   id: ID!
   name: String
   profilePhotoUrl: String @deprecated
+  profilePhotoUrlV2: String
 }
 
 input UserOnboardingDetailsInput {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `profilePhotoUrlV2` to handle user profile photo updates, allowing clearing of the photo by setting it to an empty string.
> 
>   - **GraphQL Schema**:
>     - Add `profilePhotoUrlV2` to `User` and `UserUpdateInput` in `user.graphqls`.
>     - Deprecate `profilePhotoUrl` in favor of `profilePhotoUrlV2`.
>   - **Generated Models**:
>     - Add `profilePhotoUrlV2` to `UserUpdateInput` in `models_gen.go`.
>   - **Resolvers**:
>     - Update `UserUpdate` in `user.resolvers.go` to handle `profilePhotoUrlV2`.
>     - If `profilePhotoUrlV2` is an empty string, set `ProfilePhotoKey` to an empty string in `userData`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for bc96e8466036734512e99688203759a3dbd48c33. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->