### PR TITLE
patch: fix docker path

### DIFF
--- a/packages/server/realtime/build-image.sh
+++ b/packages/server/realtime/build-image.sh
@@ -10,7 +10,7 @@ ARCH=${5:-"arm64"}
 REPO=$6
 APP_PATH=$7
 
-CONTAINERFILE_PATH="./Dockerfile"
+CONTAINERFILE_PATH="${APP_PATH}/Dockerfile"
 
 # Ensure required variables are set
 if [ -z "$REGISTRY" ] || [ -z "$IMAGE_NAME" ] || [ -z "$VERSION" ]; then


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix Dockerfile path in `build-image.sh` by setting `CONTAINERFILE_PATH` to `${APP_PATH}/Dockerfile`.
> 
>   - **Path Update**:
>     - In `build-image.sh`, update `CONTAINERFILE_PATH` to `${APP_PATH}/Dockerfile` to correctly set the Dockerfile path relative to `APP_PATH`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for cc1debdcffb9bdc8d3f89d60994afd16a198a367. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->