### PR TITLE
patch: Fix script invocation to use bash instead of sh

### DIFF
--- a/.github/workflows/realtime-deploy.yaml
+++ b/.github/workflows/realtime-deploy.yaml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build and push container image
         run: |
-          sh ./packages/server/realtime/build-image.sh \
+          bash ./packages/server/realtime/build-image.sh \
             ${{ env.REGISTRY }} \
             ${{ env.IMAGE_NAME }} \
             ${{ env.VERSION }} \


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change script invocation from `sh` to `bash` in `realtime-deploy.yaml` for compatibility.
> 
>   - **Script Invocation**:
>     - Change script invocation from `sh` to `bash` in `realtime-deploy.yaml` for `build-image.sh` execution.
>     - Ensures compatibility and correct execution of the script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 1dbc2497cbef46d5919d4e096b6cc9eb9e287826. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->