### PR TITLE
patch: revert container file path

### DIFF
--- a/deployment/runners/build-and-push-image.sh
+++ b/deployment/runners/build-and-push-image.sh
@@ -10,7 +10,7 @@ ARCH=${5:-"arm64"}
 REPO=$6
 APP_PATH=$7
 
-CONTAINERFILE_PATH="$APP_PATH/Containerfile"
+CONTAINERFILE_PATH="$APP_PATH/deployments/build/Containerfile"
 
 # Ensure required variables are set
 if [ -z "$REGISTRY" ] || [ -z "$IMAGE_NAME" ] || [ -z "$VERSION" ]; then

--- a/packages/server/core/.gitignore
+++ b/packages/server/core/.gitignore
@@ -46,3 +46,5 @@ priv/scripts/*
 
 .env*
 .mise*
+
+.*.bun-build


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Revert `Containerfile` path in `build-and-push-image.sh` and update `.gitignore` to ignore `.bun-build` files.
> 
>   - **Scripts**:
>     - Revert `CONTAINERFILE_PATH` in `build-and-push-image.sh` to `$APP_PATH/deployments/build/Containerfile`.
>   - **Gitignore**:
>     - Add `.*.bun-build` to `.gitignore` to ignore bun build files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for c247725b42f64f22a7f22031ca152c72181c525f. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->