### PR TITLE
patch: Refactor configuration to use consistent :core namespace

### DIFF
--- a/packages/server/core/config/config.exs
+++ b/packages/server/core/config/config.exs
@@ -2,20 +2,19 @@ import Config
 
 # Core application configuration
 config :core,
-  ecto_repos: [Core.Repo],
+  ecto_repos: [Core.Realtime.Repo],
   generators: [timestamp_type: :utc_datetime]
 
 # Web endpoint configuration
-config(:core, Web.Endpoint,
+config :core, Web.Endpoint,
   url: [host: "localhost"],
   adapter: Bandit.PhoenixAdapter,
   render_errors: [
     formats: [html: Web.ErrorHTML, json: Web.ErrorJSON],
     layout: false
   ],
-  pubsub_server: Realtime.PubSub,
+  pubsub_server: Core.Realtime.PubSub,
   live_view: [signing_salt: "jVLoUB9r"]
-)
 
 # Logger configuration
 config :logger, :console,

--- a/packages/server/core/config/runtime.exs
+++ b/packages/server/core/config/runtime.exs
@@ -33,7 +33,7 @@ end
 if get_env.("PHX_SERVER", nil), do: config(:realtime, Web.Endpoint, server: true)
 
 # Database configuration
-config(:core, Core.Repo,
+config :core, Core.Repo,
   username: get_env.("POSTGRES_USER", "postgres"),
   password: get_env.("POSTGRES_PASSWORD", "password"),
   hostname: get_env.("POSTGRES_HOST", "localhost"),
@@ -42,7 +42,6 @@ config(:core, Core.Repo,
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
-)
 
 # OpenTelemetry configuration
 config :opentelemetry, :resource, service: %{name: "Realtime"}
@@ -63,15 +62,15 @@ config :opentelemetry, :processors,
 # Nats configuration
 if config_env() == :prod do
   # Set NATS environment to production in production mode
-  config :nats, environment: "production"
+  config :core, :nats, environment: "production"
 end
 
 # Configure NATS hosts if environment variables are set
 Enum.each(1..3, fn node ->
   host_var = "NATS_HOST_NODE_#{node}"
 
-  if host = get_env.(host_var, "") do
-    if host != "", do: config(:nats, String.to_atom("nats_node_#{node}"), host)
+  if host = get_env.(host_var, "localhost") do
+    if host != "", do: config(:core, :nats, String.to_atom("nats_node_#{node}"))
   end
 end)
 

--- a/packages/server/core/lib/core/nats/config.ex
+++ b/packages/server/core/lib/core/nats/config.ex
@@ -16,12 +16,8 @@ defmodule Core.Nats.Config do
   ]
 
   def from_env do
-    nats_config = Application.get_env(:core, :nats, %{})
-    environment = Map.get(nats_config, :environment)
-    nats_node_1 = Map.get(nats_config, :nats_node_1)
-    nats_node_2 = Map.get(nats_config, :nats_node_2)
-    nats_node_3 = Map.get(nats_config, :nats_node_3)
-    nats_port = Map.get(nats_config, :nats_port)
+    [{_, environment}, {_, nats_node_1}, {_, nats_node_2}, {_, nats_node_3}, {_, nats_port}] =
+      Application.get_env(:core, :nats)
 
     %__MODULE__{
       environment: environment,

--- a/packages/server/core/lib/core/nats/nats_supervisor.ex
+++ b/packages/server/core/lib/core/nats/nats_supervisor.ex
@@ -7,13 +7,13 @@ defmodule Core.Nats.Supervisor do
   @impl true
   def init(_init_args) do
     children = [
-      Nats.Connection,
-      {Nats.Consumer,
-       stream: "webtracker",
-       consumer: "realtime-webtracker-consumer",
-       deliver_group: "realtime-webtracker-group",
-       filter_subject: "webtracker.>",
-       handler: Core.Nats.Handlers.WebtrackerHandler}
+      Core.Nats.Connection
+      # {Core.Nats.Consumer,
+      #  stream: "webtracker",
+      #  consumer: "realtime-webtracker-consumer",
+      #  deliver_group: "realtime-webtracker-group",
+      #  filter_subject: "webtracker.>",
+      #  handler: Core.Nats.Handlers.WebtrackerHandler}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/packages/server/core/lib/web/endpoint.ex
+++ b/packages/server/core/lib/web/endpoint.ex
@@ -1,5 +1,5 @@
 defmodule Web.Endpoint do
-  use Phoenix.Endpoint, otp_app: :realtime
+  use Phoenix.Endpoint, otp_app: :core
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.
@@ -22,7 +22,7 @@ defmodule Web.Endpoint do
   # when deploying your static files in production.
   plug Plug.Static,
     at: "/",
-    from: :realtime,
+    from: :core,
     gzip: false,
     only: Web.static_paths()
 


### PR DESCRIPTION
- Updated module and configuration references from :realtime to :core
- Adjusted NATS configuration to align with new namespace
- Commented out unused NATS consumer in supervisor
- Updated Phoenix Endpoint to use :core as otp_app
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor configuration to use `:core` namespace, updating NATS and Phoenix Endpoint settings for consistency.
> 
>   - **Configuration Changes**:
>     - Updated module and configuration references from `:realtime` to `:core` in `config.exs` and `runtime.exs`.
>     - Adjusted NATS configuration to use `:core` namespace in `config.exs` and `runtime.exs`.
>     - Commented out unused NATS consumer in `nats_supervisor.ex`.
>   - **Phoenix Endpoint**:
>     - Updated `Web.Endpoint` to use `:core` as `otp_app` in `endpoint.ex`.
>     - Changed static file serving from `:realtime` to `:core` in `endpoint.ex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fcustomeros&utm_source=github&utm_medium=referral)<sup> for 9e3a0090a39b8d9f4411b70dfa7f755a2993cc65. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->